### PR TITLE
Added token budget and max running reqs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,14 +11,15 @@ import (
 
 var (
 	// CLI flags for simulation configuration
-	totalKVBlocks     int     // Total number of KV blocks available on GPU
-	simulationHorizon int64   // Total simulation time (in ticks)
-	rate              float64 // Poisson arrival rate (requests per tick)
-	logLevel          string  // Log verbosity level
-	seed              int64   // Random seed for reproducibility
-	stepDuration      int64   // Duration of each Step Event (in ticks)
-	maxBatchSize      int64   // Maximum number of requests per batch
-	blockSizeTokens   int     // Number of tokens per KV block
+	totalKVBlocks      int     // Total number of KV blocks available on GPU
+	simulationHorizon  int64   // Total simulation time (in ticks)
+	rate               float64 // Poisson arrival rate (requests per tick)
+	logLevel           string  // Log verbosity level
+	seed               int64   // Random seed for reproducibility
+	stepDuration       int64   // Duration of each forward pass step (in ticks)
+	maxRunningReqs     int64   // Maximum number of requests in the Running batch
+	maxScheduledTokens int64   // Maximum total number of tokens across requests in the Running batch
+	blockSizeTokens    int     // Number of tokens per KV block
 )
 
 // rootCmd is the base command for the CLI
@@ -49,7 +50,8 @@ var runCmd = &cobra.Command{
 			stepDuration,
 			totalKVBlocks,
 			blockSizeTokens,
-			maxBatchSize,
+			maxRunningReqs,
+			maxScheduledTokens,
 		)
 		s.GeneratePoissonArrivals(rate, simulationHorizon, seed)
 		s.Run()
@@ -73,7 +75,8 @@ func init() {
 	runCmd.Flags().Float64Var(&rate, "rate", 0.02, "Poisson arrival rate (requests per tick)")
 	runCmd.Flags().StringVar(&logLevel, "log", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	runCmd.Flags().Int64Var(&stepDuration, "step", 100, "Step duration (in ticks)")
-	runCmd.Flags().Int64Var(&maxBatchSize, "max-batch", 35, "Maximum batch size")
+	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")
+	runCmd.Flags().Int64Var(&maxScheduledTokens, "max-num-scheduled-tokens", 8192, "Maximum total number of new tokens across running requests")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block size in tokens", 16, "Number of tokens contained in a KV cache block")
 
 	// Attach `run` as a subcommand to `root`

--- a/sim/request.go
+++ b/sim/request.go
@@ -3,6 +3,10 @@
 
 package sim
 
+import (
+	"fmt"
+)
+
 // Request models a single request's lifecycle in the simulation.
 // Each request has:
 // - input tokens (prompt)
@@ -23,4 +27,9 @@ type Request struct {
 
 	TTFTSet        bool  // Tracks whether TTFT has been set
 	FirstTokenTime int64 // Timestamp when first token was generated
+}
+
+// This method returns a human-readable string representation of a Request.
+func (req Request) String() string {
+	return fmt.Sprintf("Request: (ID: %s, State: %s, ProgressIndex: %v)", req.ID, req.State, req.ProgressIndex)
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to bridge the gap between vLLM and our simulator in terms of checking for maximum number of running requests and token budget. They are defined in the following ways:

* tokenBudget: The total number of new (excluding cached) tokens across all requests in RunningBatch. It has a maximum value of MaxScheduledTokens (currently set to 8192, similar to vLLM), and the budget is refreshed every Step. If, for the requests in the running batch, the total number of new tokens exceeds this token budget, the simulator waits for the budget to be refreshed in the next Step. 

NOTE: In this PR, our simulator prioritizes prefill over decode when it comes to memory allocations and token budget. This is different from vLLM and will be addressed while closing #8.

* MaxRunningReqs: The max number of requests RunningBatch can hold. 

## New features 

- Implemented checks for both tokenBudget and MaxRunningReqs in `simulator.go`. The default values for these are defined in `root.go` and can also be modified through command line arguments. 
- Implemented a String function for requests for ease of debugging and enhancing logging and readability of simulator internals.

## Related Issues & Documents

- Closes #7 