### PR TITLE
Convert token strings to token id ints

### DIFF
--- a/sim/request.go
+++ b/sim/request.go
@@ -19,8 +19,8 @@ type Request struct {
 	ID          string // Unique identifier for the request
 	ArrivalTime int64  // Timestamp when the request enters the system
 
-	InputTokens  []string // Prompt tokens
-	OutputTokens []string // Pre-specified output tokens (already known for the simulation)
+	InputTokens  []int // Prompt tokens
+	OutputTokens []int // Pre-specified output tokens (already known for the simulation)
 
 	State         string // "queued", "running", "completed"
 	ProgressIndex int    // Total number of input tokens processed so far + number of output tokens generated so far

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"strconv"
 )
 
 // EventQueue implements heap.Interface and orders events by timestamp.
@@ -118,16 +117,16 @@ func (sim *Simulator) GeneratePoissonArrivals(rate float64, horizon int64, seed 
 		if currentTime > horizon {
 			break
 		}
-		// generate random input and output tokens; their lengths and contents are both random
+		// generate random input and output token ids; their lengths and contents are both random
 		// ToDo: create flags for max input and output lengths
 		// Plug them into rGen.Intn below, instead of hardcoded values
-		input := make([]string, rGen.Intn(20)+10)
-		output := make([]string, rGen.Intn(10)+5)
+		input := make([]int, rGen.Intn(20)+10)
+		output := make([]int, rGen.Intn(10)+5)
 		for i := range input {
-			input[i] = "tok" + strconv.Itoa(rGen.Intn(100000))
+			input[i] = rGen.Intn(100000)
 		}
 		for i := range output {
-			output[i] = "tok" + strconv.Itoa(rGen.Intn(100000))
+			output[i] = rGen.Intn(100000)
 		}
 
 		// form the request; it will be in the "queued" state when it arrives


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to replace token strings with int token ids for both input and output of a request. This is because vLLM operates on token_ids directly obtained from tokenizing input text sequences. Our simulator currently does not connect with a tokenizer, however, we can provide dummy token ids as request input and output (assuming known). Currently the token ids are randomly generated by the function `GeneratePoissonArrivals()` in `simulator.go`. 

## Future TODOs

Verify if vLLM hashes the tokens themselves, or a combination of block ids to form the block hash. 

## Related Issues & Documents

- Closes #10 