### PR TITLE
Read inputs from JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# data files
+*.json

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	stepDuration       int64   // Duration of each forward pass step (in ticks)
 	maxRunningReqs     int64   // Maximum number of requests in the Running batch
 	maxScheduledTokens int64   // Maximum total number of tokens across requests in the Running batch
+	requestsFilePath   string  // Path to requests workload file path, default ShareGPT
 	blockSizeTokens    int     // Number of tokens per KV block
 )
 
@@ -44,6 +45,8 @@ var runCmd = &cobra.Command{
 		logrus.Infof("Starting simulation with %d KV blocks, horizon=%dticks, rate=%.2f, step=%dticks",
 			totalKVBlocks, simulationHorizon, rate, stepDuration)
 
+		requests := ProcessInput(requestsFilePath)
+
 		// Initialize and run the simulator
 		s := sim.NewSimulator(
 			simulationHorizon,
@@ -52,6 +55,7 @@ var runCmd = &cobra.Command{
 			blockSizeTokens,
 			maxRunningReqs,
 			maxScheduledTokens,
+			requests,
 		)
 		s.GeneratePoissonArrivals(rate, simulationHorizon, seed)
 		s.Run()
@@ -77,6 +81,7 @@ func init() {
 	runCmd.Flags().Int64Var(&stepDuration, "step", 100, "Step duration (in ticks)")
 	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")
 	runCmd.Flags().Int64Var(&maxScheduledTokens, "max-num-scheduled-tokens", 8192, "Maximum total number of new tokens across running requests")
+	runCmd.Flags().StringVar(&requestsFilePath, "requests-file-path", "ShareGPT_V3_tokenized.json", "Path to workload tokenized JSON file")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block size in tokens", 16, "Number of tokens contained in a KV cache block")
 
 	// Attach `run` as a subcommand to `root`

--- a/cmd/sharegpt_parser.go
+++ b/cmd/sharegpt_parser.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+)
+
+// Conversation represents a single chat turn in the conversation.
+type Conversation struct {
+	From  string `json:"from"`
+	Value []int  `json:"value"`
+}
+
+// DataEntry represents a single top-level object in your JSON array.
+type DataEntry struct {
+	ID            string         `json:"id"`
+	Conversations []Conversation `json:"conversations"`
+}
+
+// Process input tokenized requests JSON file to extract only the first human-gpt from-value pair
+// from conversations
+func ProcessInput(requestsFilePath string) []*sim.Request {
+
+	// Read the content of the JSON file
+	fileContent, err := os.ReadFile(requestsFilePath)
+	if err != nil {
+		log.Fatalf("Error reading file %s: %v", requestsFilePath, err)
+	}
+
+	// Declare a slice of DataEntry to unmarshal the raw JSON into
+	var rawData []DataEntry
+
+	// Unmarshal the JSON data into the rawData slice
+	err = json.Unmarshal(fileContent, &rawData)
+	if err != nil {
+		log.Fatalf("Error unmarshaling raw JSON: %v", err)
+	}
+
+	var requests []*sim.Request
+
+	for _, entry := range rawData {
+		// We need to find the first human-gpt pair
+		var inputTokens []int
+		var outputTokens []int
+		pairCount := 0
+
+		for i := 0; i < len(entry.Conversations)-1 && pairCount < 2; i++ {
+			if entry.Conversations[i].From == "human" && entry.Conversations[i+1].From == "gpt" {
+				inputTokens = entry.Conversations[i].Value
+				outputTokens = entry.Conversations[i+1].Value
+
+				req := sim.Request{
+					ID:           entry.ID,
+					InputTokens:  inputTokens,
+					OutputTokens: outputTokens,
+				}
+				requests = append(requests, &req)
+				pairCount++
+				i++ // Skip the gpt conversation as it's already processed
+			}
+		}
+	}
+
+	// Print the parsed requests to verify
+	fmt.Printf("Successfully parsed requests file %s. Total number of requests: %d\n", requestsFilePath, len(requests))
+	return requests
+}

--- a/offline_tokenizer.py
+++ b/offline_tokenizer.py
@@ -1,0 +1,38 @@
+from transformers import AutoTokenizer
+import json
+
+# Load the tokenizer for facebook/opt-125m
+tokenizer = AutoTokenizer.from_pretrained("facebook/opt-125m", use_fast=False)
+filepath = "ShareGPT_V3_unfiltered_cleaned_split.json"
+output_filepath = "ShareGPT_V3_tokenized.json"
+
+try:
+    with open(filepath, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    all_conversations = []
+
+    for entry in data:
+        conversations = entry["conversations"]
+        
+        # Process only the first two turns (human-gpt)
+        if len(conversations) > 1 and conversations[0]["from"] == "human" and conversations[1]["from"] == "gpt":
+            human_value = conversations[0]["value"]
+            tokenized_human_value = tokenizer.encode(human_value, return_tensors="np").tolist()[0]
+            conversations[0]["value"] = tokenized_human_value
+        
+            gpt_value = conversations[1]["value"]
+            tokenized_gpt_value = tokenizer.encode(gpt_value, return_tensors="np").tolist()[0]
+            conversations[1]["value"] = tokenized_gpt_value
+
+            conversation_obj = {"ID": entry["id"], "conversations": []}
+            conversation_obj["conversations"].append(conversations[0])
+            conversation_obj["conversations"].append(conversations[1])
+            all_conversations.append(conversation_obj)
+
+    print (len(all_conversations))
+    with open(output_filepath, 'w', encoding='utf-8') as f:
+        json.dump(all_conversations, f, indent=2)
+
+except FileNotFoundError:
+    print(f"Error: The file at '{filepath}' was not found.")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to enable a new feature in our simulator to read requests data off JSON files instead of randomly generating request tokens. Refer to #20 for design discussions, input format and decisions.

## Implemented Changes

- Added the Python standalone script `offline_tokenizer.py` that takes ShareGPT v3 dataset from HuggingFace and tokenizes text conversations into token IDs. ShareGPT dataset is formatted as a JSON with each object being a set of conversations. Each entry in conversations has an ID and a set of "human" (prompt) and "gpt" (model output) text. Benchmarking vLLM uses only the first pair of human-gpt conversation, so we adopt the same technique. 
- Added a `sharegpt_parser.go` which parses the tokenized request file (with additional checks to only consider the first pair of human-gpt conversations) into a list of Requests readable by the simulator.
- Modified `root.go` to run this `sharegpt_parser.go` even before the simulation starts. Also added modifications to accept the tokenized ShareGPT file path as a CLI argument.
- Modified `simulator.go` to process requests one-by-one in their order as in the input file instead of randomly generating tokens.

## How to Test

- Get the ShareGPT dataset from HF: `wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json` in the `inference-sim` directory.
- To test `offline_tokenizer.py`, first do `pip install transformers` and run `python3 offline_tokenizer.py` (note: this takes a while to run). This will generate a `ShareGPT_V3_tokenized.json` file locally.
- Simulator test: `go run main.go run`

If you don't want to run the first two steps, ask @susiejojo  directly for the tokenized ShareGPT JSON file. 

## Related Issues & Documents

- Closes #11 