### PR TITLE
Added simple Python sweep script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ go.work.sum
 # data files
 *.json
 *.txt
+
+# binaries
+simulation_worker
+
+# results
+results/

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -1,0 +1,75 @@
+import subprocess
+import threading
+import os
+import shutil
+import sys
+import platform
+
+GO_BINARY_NAME = "simulation_worker"
+
+GO_BINARY_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), GO_BINARY_NAME)
+OUTPUT_DIR = "results/sweep_request_rate"
+
+print_lock = threading.Lock()
+
+def save_results(filename, output):
+    with open (filename, "w+") as f:
+        f.write(output)
+
+def run_go_binary(thread_id, arguments):
+    result = subprocess.run(
+        [GO_BINARY_PATH] + arguments,
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding='utf-8'
+    )
+    with print_lock:
+        request_rate = int(float(arguments[2])*1e6)
+        output_filename = f"{OUTPUT_DIR}/output_rr={request_rate}.txt"
+        save_results(output_filename, result.stdout)
+        if result.stderr:
+            print(f"[Thread {thread_id}] Go binary error output:\n{result.stderr}")
+
+if __name__ == "__main__":
+    if os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR)
+
+    print("--- Starting request rate sweep ---")
+
+    if not os.path.exists(GO_BINARY_PATH):
+        print(f"Error: Go binary not found at '{GO_BINARY_PATH}'.")
+
+    args_template = [
+        "run",
+        "--rate", "0.000034",
+        "--max-num-running-reqs", "256",
+        "--total-kv-blocks", "94060",
+        "--max-num-scheduled-tokens", "2048",
+        "--block-size-in-tokens", "16",
+        "--horizon", "10000000000",
+        "--regression-coeffs", "7.00524792e-05,1.95214710e-08,1.09916161e-08,2.84607896e-03,0.004977576410358687",
+        "--requests-file-path", "output_tokens_2025-06-26_tokenized.json",
+    ]
+
+    rates = [25, 30, 32, 34, 35, 38]
+
+    tasks = []
+    for idx, rate in enumerate(rates):
+        tasks.append({"thread_id": idx+1, "args": args_template[:2] + [str(rate/1e6)] + args_template[3:]})
+
+    threads = []
+    for task in tasks:
+        thread = threading.Thread(
+            target=run_go_binary,
+            args=(task["thread_id"], task["args"])
+        )
+        threads.append(thread)
+        thread.start() # Start the thread
+
+    # Wait for all threads to complete.
+    for thread in threads:
+        thread.join()
+
+    print("--- All Go binary executions completed ---")

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -120,6 +120,9 @@ func (m *Metrics) Print(horizon int64, totalBlocks int, startTime time.Time) {
 		fmt.Printf("P99 TPOT(ms)      : %.3f\n", p99TPOT/1000)
 		fmt.Printf("Avg KV Blocks Usage : %.3f\n", float64(m.KVBlocksUsed)/float64(m.SimEndedTime))
 		fmt.Printf("Peak KV Usage       : %d blocks\n", m.PeakKVBlocksUsed)
+
+		fmt.Println("=== Saturation Metrics ===")
+		fmt.Printf("Throughput to arrival rate ratio:  : %.3f\n", reqThroughput/(m.RequestRate*1e6))
 	}
 
 	// sanity checks

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -171,8 +171,8 @@ func (sim *Simulator) getStepTime() int64 {
 	totalStepTime += sim.RegressionCoeffs[1] * float64(sim.RunningBatchFeatures.TotalPrefillTokens)
 	totalStepTime += sim.RegressionCoeffs[2] * float64(sim.RunningBatchFeatures.MaxPrefillTokens*sim.RunningBatchFeatures.MaxPrefillTokens)
 	totalStepTime += sim.RegressionCoeffs[3] * float64(sim.RunningBatchFeatures.NumPrefillRequests)
-	totalStepTime += sim.RegressionCoeffs[4] // intercept
-	return int64(totalStepTime * 1e6)        // convert from seconds to microseconds, need to verify with Satyam
+	totalStepTime += (sim.RegressionCoeffs[4]) // intercept
+	return int64(totalStepTime * 1e6)          // convert from seconds to microseconds, need to verify with Satyam
 }
 
 func (sim *Simulator) makeRunningBatch() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to sweep over different request rates to find where the ratio of throughput (req/s) to arrival rate (req/s) exceeds 1 in the simulator. This is the saturation point. 

## Implemented Changes

Modified `metrics.go` and `simulator.go` to log the throughput-to-arrival rate ratio and wrote a multi-threaded Python script  `request_rate_sweep.py` to sweep over multiple request rates parallely in different threads. This Python script runs the Go binary generated as written below. 

## How to Run

Run the following commands: 

`go build -o simulation_worker main.go` 
`python request_rate_sweep.py`.

Outputs are saved in the directory `results/sweep_request_rate`. 


## Related Issues & Documents

- Closes #39