### PR TITLE
Added more cmdline arguments

### DIFF
--- a/arrival_times_generation.py
+++ b/arrival_times_generation.py
@@ -16,7 +16,7 @@ def generate_arrival_times(num_reqs, arrival_rate, burstiness = 1.0, seed=None):
 
 import json
 
-def add_arrival_delta(json_filepath, arrival_deltas_list, output_filepath=None):
+def add_arrival_delta(json_filepath, arrival_deltas_list, num_requests, output_filepath=None):
     """
     Adds an 'arrival delta' field to each entry in a JSON file.
 
@@ -39,7 +39,7 @@ def add_arrival_delta(json_filepath, arrival_deltas_list, output_filepath=None):
         print(f"Error: Could not decode JSON from '{json_filepath}'. Please check the file format.")
         return
 
-    data = data[:400]
+    data = data[:num_requests]
     if len(data) != len(arrival_deltas_list):
         print(f"Warning: The number of entries in the JSON file ({len(data)}) "
               f"does not match the number of arrival delta values ({len(arrival_deltas_list)}). "
@@ -76,12 +76,18 @@ def main():
         help="Input ShareGPT requests filename"
     )
 
+    parser.add_argument(
+        "--num_requests",
+        type=int,
+        help="Number of requests to process"
+    )
+
     args = parser.parse_args()
     rates = [2, 4, 8, 16, 32, 45, 64]
     for rate in rates:
         output_filename = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
-        inter_arrival_times = list(generate_arrival_times(399, rate, seed = args.seed))
-        add_arrival_delta(args.input_filename, inter_arrival_times, output_filename)
+        inter_arrival_times = list(generate_arrival_times(args.num_requests - 1, rate, seed = args.seed))
+        add_arrival_delta(args.input_filename, inter_arrival_times, args.num_requests, output_filename)
 
 
 if __name__=="__main__":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,10 @@ var (
 	blockSizeTokens    int       // Number of tokens per KV block
 	requestsFilePath   string    // Path to requests workload file path, default ShareGPT
 	regressionCoeffs   []float64 // List of regression coeffs corresponding to features
+	scheduleTime       int64     // Time in millisec to do schedule.schedule()
+	updateTime         int64     // Time in millisec to do update_from_output()
+	queueOverheadTime  int64     // Time in millisec to queue
+	vLLMOverheadTime   int64     // Time in millisec for vLLM overheads
 )
 
 // rootCmd is the base command for the CLI
@@ -59,6 +63,10 @@ var runCmd = &cobra.Command{
 			regressionCoeffs,
 			rate,
 			requests,
+			scheduleTime,
+			updateTime,
+			queueOverheadTime,
+			vLLMOverheadTime,
 		)
 		s.GeneratePoissonArrivals(rate, simulationHorizon)
 		s.Run()
@@ -86,6 +94,10 @@ func init() {
 	runCmd.Flags().Float64SliceVar(&regressionCoeffs, "regression-coeffs", []float64{1.0, 2.0}, "List of regression coefficients")
 	runCmd.Flags().StringVar(&requestsFilePath, "requests-file-path", "ShareGPT_V3_tokenized.json", "Path to workload tokenized JSON file")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block-size-in-tokens", 16, "Number of tokens contained in a KV cache block")
+	runCmd.Flags().Int64Var(&scheduleTime, "schedule-time", 544, "Time in millisec to do schedule.schedule()")
+	runCmd.Flags().Int64Var(&updateTime, "update-time", 80, "Time in millisec to do update_from_output()")
+	runCmd.Flags().Int64Var(&queueOverheadTime, "queue-overhead-time", 1000, "Time in millisec to queue")
+	runCmd.Flags().Int64Var(&vLLMOverheadTime, "vllm-overhead-time", 6000, "Time in millisec for vLLM overheads")
 
 	// Attach `run` as a subcommand to `root`
 	rootCmd.AddCommand(runCmd)

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -51,12 +51,16 @@ if __name__ == "__main__":
         "--horizon", "10000000000",
         "--regression-coeffs", "3.38283913e-05,9.82346868e-06,-3.11237143e-06,1.50291993e-03,4.24173346e-08,-1.06897441e-07,1.92844617e-07,2.60430816e-05,-7.72212201e-09,2.67059068e-08,7.20303280e-06,-1.06904337e-08,-1.05254706e-05,-9.19828725e-04,0.005708624032334771",
         "--requests-file-path", "data/output_tokens_2025-06-30_arrivaldeltas.json",
+        "--schedule-time", "544",
+        "--update-time", "80",
+        "--queue-overhead-time", "1000",
+        "--vllm-overhead-time", "6000",
     ]
 
     rates = [2, 4, 8, 16, 32, 45, 64]
 
     tasks = []
-    for idx, rate in enumerate(rates):x
+    for idx, rate in enumerate(rates):
         args_template[16] = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
         tasks.append({"thread_id": idx+1, "args": args_template[:2] + [str(rate/1e6)] + args_template[3:]})
 

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -31,6 +31,7 @@ type Metrics struct {
 
 	RequestTTFTs []float64 // list of all requests' TTFT
 	RequestTPOTs []float64 // list of all requests' TPOT
+	RequestE2Es  []float64 // list of all requests' latencies
 
 	NumWaitQRequests        []int // number of requests in waitQ over different steps
 	NumRunningBatchRequests []int // number of request in runningBatch over different steps
@@ -112,12 +113,15 @@ func (m *Metrics) Print(horizon int64, totalBlocks int, startTime time.Time) {
 		reqThroughput := float64(m.CompletedRequests) / float64(m.SimEndedTime/1e6)
 
 		fmt.Printf("Request throughput (req/s):  : %.3f\n", reqThroughput)
+		fmt.Printf("TTFTs             : %v\n", m.RequestTTFTs)
 		fmt.Printf("Mean TTFT(ms)     : %.3f\n", avgTTFT/1000)
-		fmt.Printf("Median TTFT(ms)   : %.3f\n", medianTTFT/1000)
-		fmt.Printf("P99 TTFT(ms)      : %.3f\n", p99TTFT/1000)
+		fmt.Printf("Median TTFT(ms)   : %.3f\n", medianTTFT)
+		fmt.Printf("P99 TTFT(ms)      : %.3f\n", p99TTFT)
+		fmt.Printf("TPOTs             : %v\n", m.RequestTPOTs)
 		fmt.Printf("Mean TPOT(ms)     : %.3f\n", avgTPOT/1000)
-		fmt.Printf("Median TPOT(ms)   : %.3f\n", medianTPOT/1000)
-		fmt.Printf("P99 TPOT(ms)      : %.3f\n", p99TPOT/1000)
+		fmt.Printf("Median TPOT(ms)   : %.3f\n", medianTPOT)
+		fmt.Printf("P99 TPOT(ms)      : %.3f\n", p99TPOT)
+		fmt.Printf("E2Es             : %v\n", m.RequestE2Es)
 		fmt.Printf("Avg KV Blocks Usage : %.3f\n", float64(m.KVBlocksUsed)/float64(m.SimEndedTime))
 		fmt.Printf("Peak KV Usage       : %d blocks\n", m.PeakKVBlocksUsed)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to remove hardcoded constants(like overhead times, num requests etc.) entirely from the Go simulator and accept them as cmdline arguments through the Python scripts. 

## Implemented Changes

* Added a cmdline parameter `num_requests` for `arrival_times_generation.py` to modify the total number of requests.
* Added cmdline parameters: schedule-time, update-time, vllm-overhead-time and queue-overhead-time to `request_rate_sweep.py` to modify overhead constants. 
* Added TTFT, TPOT and E2E latency on a per-request level in the metrics. They are printed out as full lists.

## How to Run:

- Make a `data/` directory. Put the vLLM generated non-tokenized output JSON as `output_tokens_2025-06-30.json` under it. 
- `python offline_tokenizer.py --model_name Qwen/Qwen2.5-0.5B --input_filepath data/output_tokens_2025-06-30.json --output_filepath data/output_tokens_2025-06-30_tokenized.json`
- `python arrival_times_generation.py --seed 42 --input_filename data/output_tokens_2025-06-30_tokenized.json --num_requests 400`
- `go build -o simulation_worker main.go`
- `python request_rate_sweep.py`

Results will be under `results/sweep_request_rate`.

* To make changes to request rates, update the rates in `arrival_times_generation.py`, as well as in `request_rate_sweep.py`.
* To make changes to total num requests, just change the cmdline argument in Step 2 (num_requests)
* To make changes to coefficients, change the `--regression-coeffs` in `request_rate_sweep.py`. 
* To make changes to schedule/update/other overhead times, similarly modify `request_rate_sweep.py`. 


## Related Issues & Documents

- Closes #46 