### PR TITLE
Sweep over chunked prefill parameters

### DIFF
--- a/arrival_times_generation.py
+++ b/arrival_times_generation.py
@@ -85,7 +85,7 @@ def main():
     args = parser.parse_args()
     rates = [2, 4, 8, 16, 32, 45, 64]
     for rate in rates:
-        output_filename = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
+        output_filename = f"data/output_tokens_2025-07-07_arrivaldeltas_rr={rate}.json"
         inter_arrival_times = list(generate_arrival_times(args.num_requests - 1, rate, seed = args.seed))
         add_arrival_delta(args.input_filename, inter_arrival_times, args.num_requests, output_filename)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,9 @@ import (
 var (
 	// CLI flags for simulation configuration
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> cc66f3d (Removed chunked prefill flags)
 	totalKVBlocks      int       // Total number of KV blocks available on GPU
 	simulationHorizon  int64     // Total simulation time (in ticks)
 	rate               float64   // Poisson arrival rate (requests per tick)
@@ -22,6 +25,7 @@ var (
 	blockSizeTokens    int       // Number of tokens per KV block
 	requestsFilePath   string    // Path to requests workload file path, default ShareGPT
 	regressionCoeffs   []float64 // List of regression coeffs corresponding to features
+<<<<<<< HEAD
 	scheduleTime       int64     // Time in millisec to do schedule.schedule()
 	updateTime         int64     // Time in millisec to do update_from_output()
 	queueOverheadTime  int64     // Time in millisec to queue
@@ -38,6 +42,8 @@ var (
 	requestsFilePath          string    // Path to requests workload file path, default ShareGPT
 	regressionCoeffs          []float64 // List of regression coeffs corresponding to features
 >>>>>>> b2aa9da (Same arrival times as vLLM)
+=======
+>>>>>>> cc66f3d (Removed chunked prefill flags)
 )
 
 // rootCmd is the base command for the CLI
@@ -73,7 +79,6 @@ var runCmd = &cobra.Command{
 			blockSizeTokens,
 			maxRunningReqs,
 			maxScheduledTokens,
-			longPrefillTokenThreshold,
 			regressionCoeffs,
 			rate,
 			requests,
@@ -106,9 +111,12 @@ func init() {
 	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")
 	runCmd.Flags().IntVar(&maxScheduledTokens, "max-num-scheduled-tokens", 8192, "Maximum total number of new tokens across running requests")
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 	runCmd.Flags().IntVar(&longPrefillTokenThreshold, "long-prefill-token-threshold", 8192, "Threshold prefill length beyond which chunked prefill starts")
 >>>>>>> b2aa9da (Same arrival times as vLLM)
+=======
+>>>>>>> cc66f3d (Removed chunked prefill flags)
 	runCmd.Flags().Float64SliceVar(&regressionCoeffs, "regression-coeffs", []float64{1.0, 2.0}, "List of regression coefficients")
 	runCmd.Flags().StringVar(&requestsFilePath, "requests-file-path", "ShareGPT_V3_tokenized.json", "Path to workload tokenized JSON file")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block-size-in-tokens", 16, "Number of tokens contained in a KV cache block")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ var runCmd = &cobra.Command{
 
 		startTime := time.Now() // Get current time (start)
 
-		requests := ProcessInput(requestsFilePath)
+		requests := ProcessInputShareGPT(requestsFilePath)
 
 		// Initialize and run the simulator
 		s := sim.NewSimulator(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	// CLI flags for simulation configuration
+<<<<<<< HEAD
 	totalKVBlocks      int       // Total number of KV blocks available on GPU
 	simulationHorizon  int64     // Total simulation time (in ticks)
 	rate               float64   // Poisson arrival rate (requests per tick)
@@ -25,6 +26,18 @@ var (
 	updateTime         int64     // Time in millisec to do update_from_output()
 	queueOverheadTime  int64     // Time in millisec to queue
 	vLLMOverheadTime   int64     // Time in millisec for vLLM overheads
+=======
+	totalKVBlocks             int       // Total number of KV blocks available on GPU
+	simulationHorizon         int64     // Total simulation time (in ticks)
+	rate                      float64   // Poisson arrival rate (requests per tick)
+	logLevel                  string    // Log verbosity level
+	maxRunningReqs            int64     // Maximum number of requests in the Running batch
+	maxScheduledTokens        int       // Maximum total number of tokens across requests in the Running batch
+	longPrefillTokenThreshold int       // Threshold prefill length beyond which chunked prefill starts
+	blockSizeTokens           int       // Number of tokens per KV block
+	requestsFilePath          string    // Path to requests workload file path, default ShareGPT
+	regressionCoeffs          []float64 // List of regression coeffs corresponding to features
+>>>>>>> b2aa9da (Same arrival times as vLLM)
 )
 
 // rootCmd is the base command for the CLI
@@ -60,6 +73,7 @@ var runCmd = &cobra.Command{
 			blockSizeTokens,
 			maxRunningReqs,
 			maxScheduledTokens,
+			longPrefillTokenThreshold,
 			regressionCoeffs,
 			rate,
 			requests,
@@ -91,6 +105,10 @@ func init() {
 	runCmd.Flags().StringVar(&logLevel, "log", "error", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")
 	runCmd.Flags().IntVar(&maxScheduledTokens, "max-num-scheduled-tokens", 8192, "Maximum total number of new tokens across running requests")
+<<<<<<< HEAD
+=======
+	runCmd.Flags().IntVar(&longPrefillTokenThreshold, "long-prefill-token-threshold", 8192, "Threshold prefill length beyond which chunked prefill starts")
+>>>>>>> b2aa9da (Same arrival times as vLLM)
 	runCmd.Flags().Float64SliceVar(&regressionCoeffs, "regression-coeffs", []float64{1.0, 2.0}, "List of regression coefficients")
 	runCmd.Flags().StringVar(&requestsFilePath, "requests-file-path", "ShareGPT_V3_tokenized.json", "Path to workload tokenized JSON file")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block-size-in-tokens", 16, "Number of tokens contained in a KV cache block")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,38 +12,20 @@ import (
 
 var (
 	// CLI flags for simulation configuration
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> cc66f3d (Removed chunked prefill flags)
-	totalKVBlocks      int       // Total number of KV blocks available on GPU
-	simulationHorizon  int64     // Total simulation time (in ticks)
-	rate               float64   // Poisson arrival rate (requests per tick)
-	logLevel           string    // Log verbosity level
-	maxRunningReqs     int64     // Maximum number of requests in the Running batch
-	maxScheduledTokens int       // Maximum total number of tokens across requests in the Running batch
-	blockSizeTokens    int       // Number of tokens per KV block
-	requestsFilePath   string    // Path to requests workload file path, default ShareGPT
-	regressionCoeffs   []float64 // List of regression coeffs corresponding to features
-<<<<<<< HEAD
-	scheduleTime       int64     // Time in millisec to do schedule.schedule()
-	updateTime         int64     // Time in millisec to do update_from_output()
-	queueOverheadTime  int64     // Time in millisec to queue
-	vLLMOverheadTime   int64     // Time in millisec for vLLM overheads
-=======
 	totalKVBlocks             int       // Total number of KV blocks available on GPU
 	simulationHorizon         int64     // Total simulation time (in ticks)
 	rate                      float64   // Poisson arrival rate (requests per tick)
 	logLevel                  string    // Log verbosity level
 	maxRunningReqs            int64     // Maximum number of requests in the Running batch
 	maxScheduledTokens        int       // Maximum total number of tokens across requests in the Running batch
+	scheduleTime              int64     // Time in millisec to do schedule.schedule()
+	updateTime                int64     // Time in millisec to do update_from_output()
+	queueOverheadTime         int64     // Time in millisec to queue
+	vLLMOverheadTime          int64     // Time in millisec for vLLM overheads
 	longPrefillTokenThreshold int       // Threshold prefill length beyond which chunked prefill starts
 	blockSizeTokens           int       // Number of tokens per KV block
 	requestsFilePath          string    // Path to requests workload file path, default ShareGPT
 	regressionCoeffs          []float64 // List of regression coeffs corresponding to features
->>>>>>> b2aa9da (Same arrival times as vLLM)
-=======
->>>>>>> cc66f3d (Removed chunked prefill flags)
 )
 
 // rootCmd is the base command for the CLI
@@ -79,6 +61,7 @@ var runCmd = &cobra.Command{
 			blockSizeTokens,
 			maxRunningReqs,
 			maxScheduledTokens,
+			longPrefillTokenThreshold,
 			regressionCoeffs,
 			rate,
 			requests,
@@ -110,13 +93,6 @@ func init() {
 	runCmd.Flags().StringVar(&logLevel, "log", "error", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")
 	runCmd.Flags().IntVar(&maxScheduledTokens, "max-num-scheduled-tokens", 8192, "Maximum total number of new tokens across running requests")
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-	runCmd.Flags().IntVar(&longPrefillTokenThreshold, "long-prefill-token-threshold", 8192, "Threshold prefill length beyond which chunked prefill starts")
->>>>>>> b2aa9da (Same arrival times as vLLM)
-=======
->>>>>>> cc66f3d (Removed chunked prefill flags)
 	runCmd.Flags().Float64SliceVar(&regressionCoeffs, "regression-coeffs", []float64{1.0, 2.0}, "List of regression coefficients")
 	runCmd.Flags().StringVar(&requestsFilePath, "requests-file-path", "ShareGPT_V3_tokenized.json", "Path to workload tokenized JSON file")
 	runCmd.Flags().IntVar(&blockSizeTokens, "block-size-in-tokens", 16, "Number of tokens contained in a KV cache block")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,10 +22,11 @@ var (
 	updateTime                int64     // Time in millisec to do update_from_output()
 	queueOverheadTime         int64     // Time in millisec to queue
 	vLLMOverheadTime          int64     // Time in millisec for vLLM overheads
-	longPrefillTokenThreshold int       // Threshold prefill length beyond which chunked prefill starts
 	blockSizeTokens           int       // Number of tokens per KV block
 	requestsFilePath          string    // Path to requests workload file path, default ShareGPT
 	regressionCoeffs          []float64 // List of regression coeffs corresponding to features
+	maxModelLength            int       // Max request length (input + output tokens) to be handled
+	longPrefillTokenThreshold int       // Max length of prefill beyond which chunked prefill is triggered
 )
 
 // rootCmd is the base command for the CLI
@@ -100,6 +101,9 @@ func init() {
 	runCmd.Flags().Int64Var(&updateTime, "update-time", 80, "Time in millisec to do update_from_output()")
 	runCmd.Flags().Int64Var(&queueOverheadTime, "queue-overhead-time", 1000, "Time in millisec to queue")
 	runCmd.Flags().Int64Var(&vLLMOverheadTime, "vllm-overhead-time", 6000, "Time in millisec for vLLM overheads")
+	runCmd.Flags().IntVar(&maxModelLength, "max-model-len", 2048, "Max request length (input + output tokens)")
+	// in vLLM, default longPrefillTokenThreshold is 0
+	runCmd.Flags().IntVar(&longPrefillTokenThreshold, "long-prefill-token-threshold", 0, "Max length of prefill beyond which chunked prefill is triggered")
 
 	// Attach `run` as a subcommand to `root`
 	rootCmd.AddCommand(runCmd)

--- a/cmd/sharegpt_parser.go
+++ b/cmd/sharegpt_parser.go
@@ -23,7 +23,7 @@ type DataEntry struct {
 
 // Process input tokenized requests JSON file to extract only the first human-gpt from-value pair
 // from conversations
-func ProcessInput(requestsFilePath string) []*sim.Request {
+func ProcessInputShareGPT(requestsFilePath string) []*sim.Request {
 
 	// Read the content of the JSON file
 	fileContent, err := os.ReadFile(requestsFilePath)

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         "--long-prefill-token-threshold", "32",
     ]
 
-    rates = [32]
+    rates = [4]
 
     tasks = []
     for idx, rate in enumerate(rates):

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     rates = [2, 4, 8, 16, 32, 45, 64]
 
     tasks = []
-    for idx, rate in enumerate(rates):
+    for idx, rate in enumerate(rates):x
         args_template[16] = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
         tasks.append({"thread_id": idx+1, "args": args_template[:2] + [str(rate/1e6)] + args_template[3:]})
 

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -55,12 +55,13 @@ if __name__ == "__main__":
         "--update-time", "80",
         "--queue-overhead-time", "1000",
         "--vllm-overhead-time", "6000",
+        "--long-prefill-token-threshold", "10000000",
     ]
 
-    rates = [2, 4, 8, 16, 32, 45, 64]
+    rates = [4, 64]
 
     tasks = []
-    for idx, rate in enumerate(rates):x
+    for idx, rate in enumerate(rates):
         args_template[16] = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
         tasks.append({"thread_id": idx+1, "args": args_template[:2] + [str(rate/1e6)] + args_template[3:]})
 

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         "--long-prefill-token-threshold", "10000000",
     ]
 
-    rates = [4, 64]
+    rates = [4, 32]
 
     tasks = []
     for idx, rate in enumerate(rates):

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -46,23 +46,23 @@ if __name__ == "__main__":
         "--rate", "0.000034",
         "--max-num-running-reqs", "256",
         "--total-kv-blocks", "94060",
-        "--max-num-scheduled-tokens", "2048",
+        "--max-num-scheduled-tokens", "256",
         "--block-size-in-tokens", "16",
         "--horizon", "10000000000",
         "--regression-coeffs", "3.38283913e-05,9.82346868e-06,-3.11237143e-06,1.50291993e-03,4.24173346e-08,-1.06897441e-07,1.92844617e-07,2.60430816e-05,-7.72212201e-09,2.67059068e-08,7.20303280e-06,-1.06904337e-08,-1.05254706e-05,-9.19828725e-04,0.005708624032334771",
-        "--requests-file-path", "data/output_tokens_2025-06-30_arrivaldeltas.json",
+        "--requests-file-path", "data/output_tokens_2025-07-07_arrivaldeltas.json",
         "--schedule-time", "544",
         "--update-time", "80",
         "--queue-overhead-time", "1000",
         "--vllm-overhead-time", "6000",
-        "--long-prefill-token-threshold", "10000000",
+        "--long-prefill-token-threshold", "16",
     ]
 
-    rates = [4, 32]
+    rates = [4]
 
     tasks = []
     for idx, rate in enumerate(rates):
-        args_template[16] = f"data/output_tokens_2025-06-30_arrivaldeltas_rr={rate}.json"
+        args_template[16] = f"data/output_tokens_2025-07-07_arrivaldeltas_rr={rate}.json"
         tasks.append({"thread_id": idx+1, "args": args_template[:2] + [str(rate/1e6)] + args_template[3:]})
 
     threads = []

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -83,10 +83,10 @@ if __name__ == "__main__":
         "--update-time", args.update_time,
         "--queue-overhead-time", args.queue_overhead_time,
         "--vllm-overhead-time", args.vllm_overhead_time,
-        "--long-prefill-token-threshold", "16",
+        "--long-prefill-token-threshold", "32",
     ]
 
-    rates = [4]
+    rates = [32]
 
     tasks = []
     for idx, rate in enumerate(rates):

--- a/sim/kvcache.go
+++ b/sim/kvcache.go
@@ -296,7 +296,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int, endIndex
 	return true
 }
 
-// AppendToken adds a new (decoded) token to the latest request block.
+// AllocateKVBlocksDecode adds a new (decoded) token to the latest request block.
 // If the latest block is full, a new one is allocated.
 func (kvc *KVCacheState) AllocateKVBlocksDecode(req *Request) bool {
 	// sanity check to make sure the request isn't in prefill phase

--- a/sim/kvcache.go
+++ b/sim/kvcache.go
@@ -130,7 +130,8 @@ func (kvc *KVCacheState) GetCachedBlocks(tokens []int) (blockIDs []int) {
 	return
 }
 
-// AllocateKVBlocks reserves cache blocks for a request.
+// deprecated, use AllocateKVBlocks()
+// AllocateKVBlocksPrefill reserves cache blocks for a request.
 // It reuses cached blocks and allocates new ones from the free list as needed.
 // Each full block added is hashed and recorded in the prefix table.
 func (kvc *KVCacheState) AllocateKVBlocksPrefill(req *Request) bool {
@@ -192,8 +193,8 @@ func (kvc *KVCacheState) AllocateKVBlocksPrefill(req *Request) bool {
 	return true
 }
 
-// AppendToken adds a new (decoded) token to the latest request block.
-// If the latest block is full, a new one is allocated.
+// AllocateKVBlocks handles KV Block allocation for both prefill and decode.
+// If the latest block is full, a new one is allocated. Otherwise push to latest allocated block.
 // start and endIndex are by original requests' index
 // endIndex is non-inclusive
 func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int, endIndex int, cachedBlocks []int) bool {
@@ -296,6 +297,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int, endIndex
 	return true
 }
 
+// deprecated, use AllocateKVBlocks()
 // AllocateKVBlocksDecode adds a new (decoded) token to the latest request block.
 // If the latest block is full, a new one is allocated.
 func (kvc *KVCacheState) AllocateKVBlocksDecode(req *Request) bool {

--- a/sim/kvcache.go
+++ b/sim/kvcache.go
@@ -229,6 +229,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int, endIndex
 		} else {
 			// KV cache is seeing this request for the first time (beginning of prefill)
 			// append the cached blocks to this request's ID map
+
 			for _, blockId := range cachedBlocks {
 				blk := kvc.Blocks[blockId]
 				blk.RefCount++

--- a/sim/kvcache.go
+++ b/sim/kvcache.go
@@ -229,7 +229,6 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int, endIndex
 		} else {
 			// KV cache is seeing this request for the first time (beginning of prefill)
 			// append the cached blocks to this request's ID map
-
 			for _, blockId := range cachedBlocks {
 				blk := kvc.Blocks[blockId]
 				blk.RefCount++

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -113,15 +113,15 @@ func (m *Metrics) Print(horizon int64, totalBlocks int, startTime time.Time) {
 		reqThroughput := float64(m.CompletedRequests) / float64(m.SimEndedTime/1e6)
 
 		fmt.Printf("Request throughput (req/s):  : %.3f\n", reqThroughput)
-		fmt.Printf("TTFTs             : %v\n", m.RequestTTFTs)
+		// fmt.Printf("TTFTs             : %v\n", m.RequestTTFTs)
 		fmt.Printf("Mean TTFT(ms)     : %.3f\n", avgTTFT/1000)
 		fmt.Printf("Median TTFT(ms)   : %.3f\n", medianTTFT)
 		fmt.Printf("P99 TTFT(ms)      : %.3f\n", p99TTFT)
-		fmt.Printf("TPOTs             : %v\n", m.RequestTPOTs)
+		// fmt.Printf("TPOTs             : %v\n", m.RequestTPOTs)
 		fmt.Printf("Mean TPOT(ms)     : %.3f\n", avgTPOT/1000)
 		fmt.Printf("Median TPOT(ms)   : %.3f\n", medianTPOT)
 		fmt.Printf("P99 TPOT(ms)      : %.3f\n", p99TPOT)
-		fmt.Printf("E2Es             : %v\n", m.RequestE2Es)
+		// fmt.Printf("E2Es             : %v\n", m.RequestE2Es)
 		fmt.Printf("Avg KV Blocks Usage : %.3f\n", float64(m.KVBlocksUsed)/float64(m.SimEndedTime))
 		fmt.Printf("Peak KV Usage       : %d blocks\n", m.PeakKVBlocksUsed)
 

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -121,7 +121,6 @@ func (m *Metrics) Print(horizon int64, totalBlocks int, startTime time.Time) {
 		fmt.Printf("Mean TTFT(ms)     : %.3f\n", avgTTFT/1000)
 		fmt.Printf("Median TTFT(ms)   : %.3f\n", medianTTFT)
 		fmt.Printf("P99 TTFT(ms)      : %.3f\n", p99TTFT)
-		// fmt.Printf("TPOTs             : %v\n", m.RequestTPOTs)
 		fmt.Printf("Mean TPOT(ms)     : %.3f\n", avgTPOT/1000)
 		fmt.Printf("Median TPOT(ms)   : %.3f\n", medianTPOT)
 		fmt.Printf("P99 TPOT(ms)      : %.3f\n", p99TPOT)

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -102,7 +102,7 @@ func (m *Metrics) Print(horizon int64, totalBlocks int, startTime time.Time) {
 	fmt.Printf("Total Input Tokens   : %d\n", m.TotalInputTokens)
 	fmt.Printf("Total Output Tokens  : %d\n", m.TotalOutputTokens)
 	fmt.Printf("Simulation Duration(s): %.3f\n", time.Since(startTime).Seconds())
-	fmt.Printf("vLLM estimated Duration(s): %d\n", m.SimEndedTime)
+	fmt.Printf("vLLM estimated Duration(s): %d\n", m.SimEndedTime/1e6)
 	if m.CompletedRequests > 0 {
 		avgTTFT := float64(m.TTFTSum) / float64(m.CompletedRequests)
 		medianTTFT := CalculatePercentile(m.RequestTTFTs, 50)

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -1,0 +1,150 @@
+// sim/metrics_utils.go
+package sim
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Bin represents a single completion time integral bin with its integer key and count.
+type Bin struct {
+	Key   int
+	Count int
+}
+
+// CalculatePercentile is a util function that calculates the p-th percentile of a data list
+func CalculatePercentile(data []float64, p float64) float64 {
+	n := len(data)
+
+	sortedData := make([]float64, n)
+	copy(sortedData, data)
+
+	sort.Float64s(sortedData)
+
+	rank := p / 100.0 * float64(n-1)
+	lowerIdx := int(math.Floor(rank))
+	upperIdx := int(math.Ceil(rank))
+
+	if lowerIdx == upperIdx {
+		return sortedData[lowerIdx]
+	} else {
+		lowerVal := sortedData[lowerIdx]
+		upperVal := sortedData[upperIdx]
+		if upperIdx >= n {
+			return sortedData[n-1]
+		}
+		return lowerVal + (upperVal-lowerVal)*(rank-float64(lowerIdx))
+	}
+}
+
+// Calculate Binned throughput with bins of 1 sec each
+// return mean count of completed requests per second
+func CalculateBinnedThroughput(data []float64) float64 {
+	tempBins := make(map[int]int)
+	maxBinKeyActual := 0
+	totalCompletionCounts := 0
+
+	if len(data) == 0 {
+		return 0
+	}
+
+	for _, val := range data {
+		binKey := int(val)
+		tempBins[binKey]++
+		maxBinKeyActual = max(maxBinKeyActual, binKey)
+	}
+
+	for i := 0; i <= maxBinKeyActual; i++ {
+		if _, ok := tempBins[i]; !ok {
+			tempBins[i] = 0
+		}
+	}
+
+	for _, count := range tempBins {
+		totalCompletionCounts += count
+	}
+
+	meanCompletionCount := float64(totalCompletionCounts) / float64(len(tempBins))
+
+	return meanCompletionCount
+}
+
+func (m *Metrics) SavetoFile(data []int, fileName string) {
+	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		logrus.Fatalf("Error creating file %s: %v\n", fileName, err)
+		return
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			logrus.Fatalf("Error closing file %s: %v\n", fileName, closeErr)
+		}
+	}()
+
+	writer := bufio.NewWriter(file)
+
+	defer func() {
+		if flushErr := writer.Flush(); flushErr != nil {
+			logrus.Fatalf("Error flushing writer for file %s: %v\n", fileName, flushErr)
+		}
+	}()
+
+	for _, f := range data {
+		_, writeErr := fmt.Fprint(writer, f, ", ")
+		if writeErr != nil {
+			logrus.Fatalf("Error writing int %d to file: %v\n", f, writeErr)
+			return // Stop writing on first error
+		}
+	}
+
+	logrus.Debugf("Successfully wrote to '%s'\n", fileName)
+}
+
+// keyWithIndex is a util struct to temporarily store the original key and its parsed numeric index.
+// useful for metrics parsing when requestIDs are strings of form: "request_1", "request_2" ...
+type keyWithIndex struct {
+	originalKey  string
+	numericIndex int
+}
+
+// SortRequestMetrics sorts a map of "request_N": value pairs based on the numerical part of the request key N
+// This is useful for metric maps like {"request_N": TTFT/TPOT/CompletionTime}
+// It returns a slice of RequestPair structs, sorted numerically by their Index
+func SortRequestMetrics(data map[string]float64) []float64 {
+	if len(data) == 0 {
+		return []float64{}
+	}
+
+	keysWithIndexes := make([]keyWithIndex, 0, len(data))
+	for key := range data {
+		trimmedKey := strings.TrimPrefix(key, "request_")
+		if trimmedKey == key && !strings.HasPrefix(key, "request_") {
+			return nil
+		}
+
+		numericIndex, _ := strconv.Atoi(trimmedKey)
+
+		keysWithIndexes = append(keysWithIndexes, keyWithIndex{
+			originalKey:  key,
+			numericIndex: numericIndex,
+		})
+	}
+
+	sort.Slice(keysWithIndexes, func(i, j int) bool {
+		return keysWithIndexes[i].numericIndex < keysWithIndexes[j].numericIndex
+	})
+
+	sortedValues := make([]float64, 0, len(keysWithIndexes))
+	for _, ki := range keysWithIndexes {
+		sortedValues = append(sortedValues, data[ki.originalKey])
+	}
+
+	return sortedValues
+}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -57,7 +57,7 @@ type Simulator struct {
 	MaxRunningReqs int64
 	// max total number of new tokens across all requests in RunningBatch
 	MaxScheduledTokens int
-	// Threshold prefill length beyond which chunked prefill starts
+	// regression coefficients for execute_model time prediction
 	RegressionCoeffs []float64
 	// RunningBatchFeatures is a map of form: {"num_decode_requests": a, "num_prefill_requests": b
 	// , "total_decode_tokens": c, "total_prefill_tokens": d}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -174,10 +174,6 @@ func (sim *Simulator) GeneratePoissonArrivals(rate float64, horizon int64) {
 }
 
 // Estimate Step Advance Time using regression features and coefficients
-// func (sim *Simulator) getStepTime() int64 {
-// 	return int64(sim.HardcodedStepTimes[sim.StepCount])
-// }
-
 func (sim *Simulator) getStepTime() int64 {
 	var totalStepTime float64
 	totalStepTime += sim.RegressionCoeffs[0] * float64(sim.RunningBatchFeatures.TotalDecodeTokens)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -320,8 +320,6 @@ func (sim *Simulator) Step(now int64) {
 	// Subprocess: fill running batch from wait queue, similar to vLLM's scheduler.schedule()
 	sim.makeRunningBatch()
 
-	// fmt.Printf("Scheduler output: %v\n", sim.ReqNumComputedTokens)
-
 	// save waitQ length for analysis
 	sim.Metrics.NumWaitQRequests = append(sim.Metrics.NumWaitQRequests, len(sim.WaitQ.queue))
 

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -61,35 +61,37 @@ type Simulator struct {
 	RegressionCoeffs []float64
 	// RunningBatchFeatures is a map of form: {"num_decode_requests": a, "num_prefill_requests": b
 	// , "total_decode_tokens": c, "total_prefill_tokens": d}
-	RunningBatchFeatures RegressionFeatures
-	Requests             []*Request
-	ScheduleTime         int64
-	UpdateTime           int64
-	QueueOverheadTime    int64
-	VLLMOverheadTime     int64
-	StepEvent            Event
+	RunningBatchFeatures      RegressionFeatures
+	Requests                  []*Request
+	ScheduleTime              int64
+	UpdateTime                int64
+	QueueOverheadTime         int64
+	VLLMOverheadTime          int64
+	LongPrefillTokenThreshold int
+	StepEvent                 Event
 }
 
 func NewSimulator(horizon int64, totalKVBlocks int, blockSizeTokens int, maxRunningReqs int64, maxScheduledTokens int, longPrefillTokenThreshold int,
 	regressionCoeffs []float64, rate float64, requests []*Request, scheduleTime int64, updateTime int64, queueOverheadTime int64, vLLMOverheadTime int64) *Simulator {
 	s := &Simulator{
-		Clock:                0,
-		Horizon:              horizon,
-		EventQueue:           make(EventQueue, 0),
-		WaitQ:                &WaitQueue{},
-		KVCache:              NewKVCacheState(totalKVBlocks, blockSizeTokens),
-		RunningBatch:         &Batch{},
-		Metrics:              &Metrics{RequestTTFTs: []float64{}, RequestTPOTs: []float64{}, RequestE2Es: []float64{}, NumWaitQRequests: []int{}, NumRunningBatchRequests: []int{}},
-		MaxRunningReqs:       maxRunningReqs,
-		MaxScheduledTokens:   maxScheduledTokens,
-		RegressionCoeffs:     regressionCoeffs,
-		RunningBatchFeatures: RegressionFeatures{},
-		Requests:             requests,
-		ScheduleTime:         scheduleTime,
-		UpdateTime:           updateTime,
-		QueueOverheadTime:    queueOverheadTime,
-		VLLMOverheadTime:     vLLMOverheadTime,
-		StepEvent:            nil,
+		Clock:                     0,
+		Horizon:                   horizon,
+		EventQueue:                make(EventQueue, 0),
+		WaitQ:                     &WaitQueue{},
+		KVCache:                   NewKVCacheState(totalKVBlocks, blockSizeTokens),
+		RunningBatch:              &Batch{},
+		Metrics:                   &Metrics{RequestTTFTs: []float64{}, RequestTPOTs: []float64{}, RequestE2Es: []float64{}, NumWaitQRequests: []int{}, NumRunningBatchRequests: []int{}},
+		MaxRunningReqs:            maxRunningReqs,
+		MaxScheduledTokens:        maxScheduledTokens,
+		RegressionCoeffs:          regressionCoeffs,
+		RunningBatchFeatures:      RegressionFeatures{},
+		Requests:                  requests,
+		ScheduleTime:              scheduleTime,
+		UpdateTime:                updateTime,
+		QueueOverheadTime:         queueOverheadTime,
+		VLLMOverheadTime:          vLLMOverheadTime,
+		LongPrefillTokenThreshold: longPrefillTokenThreshold,
+		StepEvent:                 nil,
 	}
 
 	s.Metrics.RequestRate = rate
@@ -193,10 +195,13 @@ func (sim *Simulator) getStepTime() int64 {
 	return int64(totalStepTime * 1e6)           // convert from seconds to microseconds, need to verify with Satyam
 }
 
-func (sim *Simulator) makeRunningBatch() {
+func (sim *Simulator) makeRunningBatch() map[string]int {
 	if sim.RunningBatch == nil {
 		sim.RunningBatch = &Batch{}
 	}
+
+	// map of request IDs to total num computed tokens (including cached tokens)
+	reqNumComputedTokens := make(map[string]int)
 
 	// allocate a max token budget at the start of each Step
 	tokenBudget := sim.MaxScheduledTokens
@@ -210,12 +215,31 @@ func (sim *Simulator) makeRunningBatch() {
 			logrus.Warnf("Simulator has run out of token budget. Trying in next step.")
 			break
 		}
-		// if a request is in running queue in this function and in prefill phase, nothing left to do,
-		// blocks have already been allocated. if it is in decode phase, then allocate blocks for the
-		// token generated in the previous Step
+		numNewTokens := len(req.InputTokens) - req.ProgressIndex
+		// if a request is in running queue in this function and in prefill phase,
+		// request must be doing chunked prefill
+		// cache hits cannot happen here
+		if numNewTokens > 0 {
+			if 0 < sim.LongPrefillTokenThreshold && sim.LongPrefillTokenThreshold < numNewTokens {
+				numNewTokens = sim.LongPrefillTokenThreshold
+			}
+			numNewTokens = min(numNewTokens, tokenBudget)
+			if ok := sim.KVCache.AllocateKVBlocks(req, req.ProgressIndex, req.ProgressIndex+numNewTokens, []int{}); !ok {
+				// Could not allocate (e.g., no free blocks)
+				logrus.Warnf("[Preemption]")
+				continue // ToDo: pre-empt this request
+			}
+			tokenBudget -= numNewTokens
+			sim.RunningBatchFeatures.NumPrefillRequests += 1
+			sim.RunningBatchFeatures.TotalPrefillTokens += numNewTokens
+			sim.RunningBatchFeatures.MaxPrefillTokens = max(sim.RunningBatchFeatures.MaxPrefillTokens, numNewTokens)
+			reqNumComputedTokens[req.ID] += numNewTokens
+
+		}
+		// if it is in decode phase, then allocate blocks for the token generated in the previous Step
 		if req.ProgressIndex >= len(req.InputTokens) && len(req.OutputTokens) > 0 {
 			// this request will go through decode phase in this batch
-			ok := sim.KVCache.AllocateKVBlocksDecode(req)
+			ok := sim.KVCache.AllocateKVBlocks(req, 0, 0, []int{})
 			if !ok {
 				// Could not allocate (e.g., no free blocks)
 				logrus.Warnf("[Preemption]")
@@ -228,6 +252,7 @@ func (sim *Simulator) makeRunningBatch() {
 			// update decode-related features in RunningBatchFeatures
 			sim.RunningBatchFeatures.NumDecodeRequests += 1
 			sim.RunningBatchFeatures.TotalDecodeTokens += 1
+			reqNumComputedTokens[req.ID] += 1
 		}
 	}
 
@@ -238,12 +263,21 @@ func (sim *Simulator) makeRunningBatch() {
 
 		next := sim.WaitQ.queue[0]
 
+		// first find cache hits. This only happens once per prefill (regardless of chunked)
 		cachedBlocks := sim.KVCache.GetCachedBlocks(next.InputTokens)
-		numRemainingTokens := len(next.InputTokens) - len(cachedBlocks)*sim.KVCache.BlockSizeTokens
+		numNewTokens := len(next.InputTokens) - len(cachedBlocks)*sim.KVCache.BlockSizeTokens
+
+		// now check for chunked prefill
+		if 0 < sim.LongPrefillTokenThreshold && sim.LongPrefillTokenThreshold < numNewTokens {
+			numNewTokens = sim.LongPrefillTokenThreshold
+		}
+		numNewTokens = min(numNewTokens, tokenBudget)
+		startIndex := len(cachedBlocks) * sim.KVCache.BlockSizeTokens
+		endIndex := startIndex + numNewTokens
 
 		// estimate the number of new blocks needed for the next request
 		// and allocate if possible
-		if ok := sim.KVCache.AllocateKVBlocksPrefill(next); !ok {
+		if ok := sim.KVCache.AllocateKVBlocks(next, startIndex, endIndex, cachedBlocks); !ok {
 			// cannot allocate enough blocks for remaining tokens, do not schedule current request
 			// vLLM maintains First-Come-First-Served order of requests, so we cannot move onto the
 			// next request.
@@ -257,15 +291,17 @@ func (sim *Simulator) makeRunningBatch() {
 		// make it part of the running batch
 		sim.RunningBatch.Requests = append(sim.RunningBatch.Requests, next)
 		// decrement the token budget
-		tokenBudget = tokenBudget - numRemainingTokens
+		tokenBudget = tokenBudget - numNewTokens
 		// change the state of the request from queued to running
 		next.State = "running"
 
 		// update prefill-related features in RunningBatchFeatures
 		sim.RunningBatchFeatures.NumPrefillRequests += 1
-		sim.RunningBatchFeatures.TotalPrefillTokens += int(numRemainingTokens)
-		sim.RunningBatchFeatures.MaxPrefillTokens = max(sim.RunningBatchFeatures.MaxPrefillTokens, numRemainingTokens)
+		sim.RunningBatchFeatures.TotalPrefillTokens += numNewTokens
+		sim.RunningBatchFeatures.MaxPrefillTokens = max(sim.RunningBatchFeatures.MaxPrefillTokens, numNewTokens)
+		reqNumComputedTokens[next.ID] = numNewTokens + len(cachedBlocks)*sim.KVCache.BlockSizeTokens
 	}
+	return reqNumComputedTokens
 }
 
 // In vllm, the processing of requests proceeds iteratively in steps.
@@ -283,7 +319,7 @@ func (sim *Simulator) Step(now int64) {
 		MaxPrefillTokens:   0,
 	}
 	// Subprocess: fill running batch from wait queue, similar to vLLM's scheduler.schedule()
-	sim.makeRunningBatch()
+	schedulerOutput := sim.makeRunningBatch()
 
 	// save waitQ length for analysis
 	sim.Metrics.NumWaitQRequests = append(sim.Metrics.NumWaitQRequests, len(sim.WaitQ.queue))
@@ -297,15 +333,15 @@ func (sim *Simulator) Step(now int64) {
 	// Subprocess: Model Execution - this could be prefill or decode depending on the request.
 	// similar to vLLM's execute_model()
 	for _, req := range sim.RunningBatch.Requests {
-		if req.ProgressIndex == 0 {
-			req.ProgressIndex = len(req.InputTokens)
+		if req.ProgressIndex < len(req.InputTokens) {
+			req.ProgressIndex = schedulerOutput[req.ID]
 			req.TTFTSet = true
 			req.FirstTokenTime = now + currStepAdvance - req.ArrivalTime + sim.VLLMOverheadTime + sim.ScheduleTime + sim.UpdateTime
 			sim.Metrics.TTFTSum += req.FirstTokenTime
 			sim.Metrics.RequestTTFTs = append(sim.Metrics.RequestTTFTs, float64(req.FirstTokenTime)/1000)
 			// ToDo: Go through the newly allocated blocks for this request;
 			// Make sure they are cached, if they're full
-		} else if req.ProgressIndex >= len(req.InputTokens) {
+		} else {
 			// this request goes through decode phase in this batch
 			req.ProgressIndex++
 			sim.Metrics.TotalOutputTokens++
@@ -329,7 +365,7 @@ func (sim *Simulator) Step(now int64) {
 		if req.ProgressIndex == len(req.InputTokens)+max(len(req.OutputTokens), 1)-1 {
 			req.State = "completed"
 			if len(req.OutputTokens) > 0 {
-				ok := sim.KVCache.AllocateKVBlocksDecode(req)
+				ok := sim.KVCache.AllocateKVBlocks(req, 0, 0, []int{})
 				if !ok {
 					// Could not allocate (e.g., no free blocks)
 					logrus.Warnf("[Preemption]")

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -82,7 +82,7 @@ func NewSimulator(horizon int64, totalKVBlocks int, blockSizeTokens int, maxRunn
 		WaitQ:                     &WaitQueue{},
 		KVCache:                   NewKVCacheState(totalKVBlocks, blockSizeTokens),
 		RunningBatch:              &Batch{},
-		Metrics:                   &Metrics{RequestTTFTs: []float64{}, RequestTPOTs: []float64{}, RequestE2Es: []float64{}, RequestCompletionTimes: []float64{}, NumWaitQRequests: []int{}, NumRunningBatchRequests: []int{}},
+		Metrics:                   &Metrics{RequestTTFTs: make(map[string]float64), RequestTPOTs: make(map[string]float64), RequestE2Es: make(map[string]float64), RequestCompletionTimes: make(map[string]float64), NumWaitQRequests: []int{}, NumRunningBatchRequests: []int{}},
 		MaxRunningReqs:            maxRunningReqs,
 		MaxScheduledTokens:        maxScheduledTokens,
 		RegressionCoeffs:          regressionCoeffs,
@@ -340,8 +340,8 @@ func (sim *Simulator) Step(now int64) {
 		if req.ProgressIndex == len(req.InputTokens) { // prefill complete, first token is generated
 			req.TTFTSet = true
 			req.FirstTokenTime = now + currStepAdvance - req.ArrivalTime + sim.VLLMOverheadTime + sim.ScheduleTime + sim.UpdateTime
-			sim.Metrics.TTFTSum += req.FirstTokenTime                                                     // in microsec
-			sim.Metrics.RequestTTFTs = append(sim.Metrics.RequestTTFTs, float64(req.FirstTokenTime)/1000) // in ms
+			sim.Metrics.TTFTSum += req.FirstTokenTime                             // in microsec
+			sim.Metrics.RequestTTFTs[req.ID] = float64(req.FirstTokenTime) / 1000 // in ms
 		}
 	}
 
@@ -372,16 +372,16 @@ func (sim *Simulator) Step(now int64) {
 			sim.KVCache.ReleaseKVBlocks(req)
 			sim.Metrics.CompletedRequests++
 			lat := now + currStepAdvance - req.ArrivalTime + sim.VLLMOverheadTime + sim.ScheduleTime + sim.UpdateTime
-			sim.Metrics.RequestE2Es = append(sim.Metrics.RequestE2Es, float64(lat)/1000) // in ms
+			sim.Metrics.RequestE2Es[req.ID] = float64(lat) / 1000 // in ms
 			logrus.Infof("Finished req: ID: %s at time: %d\n", req.ID, lat+req.ArrivalTime)
 			sim.Metrics.TotalLatency += lat
 			if len(req.OutputTokens) > 0 {
 				reqTotalOutput := lat - req.FirstTokenTime + sim.VLLMOverheadTime
 				sim.Metrics.TPOTSum += reqTotalOutput // in microsec
 				// TPOT calculation in vLLM excludes the first generated token, calculated in ms
-				sim.Metrics.RequestTPOTs = append(sim.Metrics.RequestTPOTs, float64(reqTotalOutput)/float64(max(len(req.OutputTokens)-1, 1))/1000)
+				sim.Metrics.RequestTPOTs[req.ID] = float64(reqTotalOutput) / float64(max(len(req.OutputTokens)-1, 1)) / 1000
 			}
-			sim.Metrics.RequestCompletionTimes = append(sim.Metrics.RequestCompletionTimes, float64(lat+req.ArrivalTime)/1e6) // in seconds
+			sim.Metrics.RequestCompletionTimes[req.ID] = float64(lat+req.ArrivalTime) / 1e6 // in seconds
 		} else {
 			remaining = append(remaining, req)
 		}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -58,8 +58,7 @@ type Simulator struct {
 	// max total number of new tokens across all requests in RunningBatch
 	MaxScheduledTokens int
 	// Threshold prefill length beyond which chunked prefill starts
-	LongPrefillTokenThreshold int
-	RegressionCoeffs          []float64
+	RegressionCoeffs []float64
 	// RunningBatchFeatures is a map of form: {"num_decode_requests": a, "num_prefill_requests": b
 	// , "total_decode_tokens": c, "total_prefill_tokens": d}
 	RunningBatchFeatures RegressionFeatures
@@ -207,15 +206,7 @@ func (sim *Simulator) makeRunningBatch() {
 			logrus.Warnf("Simulator has run out of token budget. Trying in next step.")
 			break
 		}
-		// if a request is in running queue in this function and in prefill phase, then it must be doing chunked prefill
-		if req.ProgressIndex < len(req.InputTokens) {
-			numNewTokens := 0
-			if sim.LongPrefillTokenThreshold > 0 && sim.LongPrefillTokenThreshold < len(req.InputTokens) {
-				numNewTokens = sim.LongPrefillTokenThreshold
-			}
-			req.ProgressIndex += min(numNewTokens, tokenBudget)
-		}
-
+		// if a request is in running queue in this function and in prefill phase, nothing left to do,
 		// blocks have already been allocated. if it is in decode phase, then allocate blocks for the
 		// token generated in the previous Step
 		if req.ProgressIndex >= len(req.InputTokens) && len(req.OutputTokens) > 0 {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -2,11 +2,7 @@
 package sim
 
 import (
-	"bufio"
 	"container/heap"
-	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
@@ -345,12 +341,7 @@ func (sim *Simulator) Step(now int64) {
 	// push the next step event as needed
 	if len(remaining) > 0 {
 		sim.RunningBatch.Requests = remaining
-<<<<<<< HEAD
 		pbe := StepEvent{time: now + currStepAdvance + sim.QueueOverheadTime + sim.ScheduleTime + sim.UpdateTime}
-=======
-		pbe := StepEvent{time: now + currStepAdvance + UpdateTime + ScheduleTime}
-		sim.StepCount += 1
->>>>>>> f7bdd75 (Exp)
 		sim.Schedule(&pbe)
 		sim.StepEvent = &pbe
 	} else {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -2,7 +2,11 @@
 package sim
 
 import (
+	"bufio"
 	"container/heap"
+	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
@@ -68,6 +72,8 @@ type Simulator struct {
 	QueueOverheadTime    int64
 	VLLMOverheadTime     int64
 	StepEvent            Event
+	StepCount            int
+	HardcodedStepTimes   []int
 }
 
 func NewSimulator(horizon int64, totalKVBlocks int, blockSizeTokens int, maxRunningReqs int64, maxScheduledTokens int, longPrefillTokenThreshold int,
@@ -90,6 +96,7 @@ func NewSimulator(horizon int64, totalKVBlocks int, blockSizeTokens int, maxRunn
 		QueueOverheadTime:    queueOverheadTime,
 		VLLMOverheadTime:     vLLMOverheadTime,
 		StepEvent:            nil,
+		StepCount:            0,
 	}
 
 	s.Metrics.RequestRate = rate
@@ -170,23 +177,7 @@ func (sim *Simulator) GeneratePoissonArrivals(rate float64, horizon int64) {
 
 // Estimate Step Advance Time using regression features and coefficients
 func (sim *Simulator) getStepTime() int64 {
-	var totalStepTime float64
-	totalStepTime += sim.RegressionCoeffs[0] * float64(sim.RunningBatchFeatures.TotalDecodeTokens)
-	totalStepTime += sim.RegressionCoeffs[1] * float64(sim.RunningBatchFeatures.TotalPrefillTokens)
-	totalStepTime += sim.RegressionCoeffs[2] * float64(sim.RunningBatchFeatures.MaxPrefillTokens)
-	totalStepTime += sim.RegressionCoeffs[3] * float64(sim.RunningBatchFeatures.NumPrefillRequests)
-	totalStepTime += sim.RegressionCoeffs[4] * float64(sim.RunningBatchFeatures.TotalDecodeTokens*sim.RunningBatchFeatures.TotalDecodeTokens)
-	totalStepTime += sim.RegressionCoeffs[5] * float64(sim.RunningBatchFeatures.TotalDecodeTokens*sim.RunningBatchFeatures.TotalPrefillTokens)
-	totalStepTime += sim.RegressionCoeffs[6] * float64(sim.RunningBatchFeatures.TotalDecodeTokens*int(sim.RunningBatchFeatures.MaxPrefillTokens))
-	totalStepTime += sim.RegressionCoeffs[7] * float64(sim.RunningBatchFeatures.TotalDecodeTokens*sim.RunningBatchFeatures.NumPrefillRequests)
-	totalStepTime += sim.RegressionCoeffs[8] * float64(sim.RunningBatchFeatures.TotalPrefillTokens*sim.RunningBatchFeatures.TotalPrefillTokens)
-	totalStepTime += sim.RegressionCoeffs[9] * float64(sim.RunningBatchFeatures.TotalPrefillTokens*int(sim.RunningBatchFeatures.MaxPrefillTokens))
-	totalStepTime += sim.RegressionCoeffs[10] * float64(sim.RunningBatchFeatures.TotalPrefillTokens*int(sim.RunningBatchFeatures.NumPrefillRequests))
-	totalStepTime += sim.RegressionCoeffs[11] * float64(int(sim.RunningBatchFeatures.MaxPrefillTokens)*int(sim.RunningBatchFeatures.MaxPrefillTokens))
-	totalStepTime += sim.RegressionCoeffs[12] * float64(int(sim.RunningBatchFeatures.MaxPrefillTokens)*int(sim.RunningBatchFeatures.NumPrefillRequests))
-	totalStepTime += sim.RegressionCoeffs[13] * float64(sim.RunningBatchFeatures.NumPrefillRequests*int(sim.RunningBatchFeatures.NumPrefillRequests))
-	totalStepTime += (sim.RegressionCoeffs[14]) // intercept
-	return int64(totalStepTime * 1e6)           // convert from seconds to microseconds, need to verify with Satyam
+	return int64(sim.HardcodedStepTimes[sim.StepCount])
 }
 
 func (sim *Simulator) makeRunningBatch() {
@@ -281,6 +272,8 @@ func (sim *Simulator) Step(now int64) {
 	// Subprocess: fill running batch from wait queue, similar to vLLM's scheduler.schedule()
 	sim.makeRunningBatch()
 
+	logrus.Warnf("Time: %d, StepCount: %d, RunningBatch: %v\n", now, sim.StepCount, sim.RunningBatch)
+
 	// save waitQ length for analysis
 	sim.Metrics.NumWaitQRequests = append(sim.Metrics.NumWaitQRequests, len(sim.WaitQ.queue))
 
@@ -352,7 +345,12 @@ func (sim *Simulator) Step(now int64) {
 	// push the next step event as needed
 	if len(remaining) > 0 {
 		sim.RunningBatch.Requests = remaining
+<<<<<<< HEAD
 		pbe := StepEvent{time: now + currStepAdvance + sim.QueueOverheadTime + sim.ScheduleTime + sim.UpdateTime}
+=======
+		pbe := StepEvent{time: now + currStepAdvance + UpdateTime + ScheduleTime}
+		sim.StepCount += 1
+>>>>>>> f7bdd75 (Exp)
 		sim.Schedule(&pbe)
 		sim.StepEvent = &pbe
 	} else {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -330,16 +330,18 @@ func (sim *Simulator) Step(now int64) {
 	for _, req := range sim.RunningBatch.Requests {
 		if req.ProgressIndex < len(req.InputTokens) {
 			req.ProgressIndex = sim.ReqNumComputedTokens[req.ID]
-			req.TTFTSet = true
-			req.FirstTokenTime = now + currStepAdvance - req.ArrivalTime + sim.VLLMOverheadTime + sim.ScheduleTime + sim.UpdateTime
-			sim.Metrics.TTFTSum += req.FirstTokenTime
-			sim.Metrics.RequestTTFTs = append(sim.Metrics.RequestTTFTs, float64(req.FirstTokenTime)/1000)
 			// ToDo: Go through the newly allocated blocks for this request;
 			// Make sure they are cached, if they're full
 		} else {
 			// this request goes through decode phase in this batch
 			req.ProgressIndex++
 			sim.Metrics.TotalOutputTokens++
+		}
+		if req.ProgressIndex == len(req.InputTokens) { // prefill complete, first token is generated
+			req.TTFTSet = true
+			req.FirstTokenTime = now + currStepAdvance - req.ArrivalTime + sim.VLLMOverheadTime + sim.ScheduleTime + sim.UpdateTime
+			sim.Metrics.TTFTSum += req.FirstTokenTime
+			sim.Metrics.RequestTTFTs = append(sim.Metrics.RequestTTFTs, float64(req.FirstTokenTime)/1000)
 		}
 	}
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to implement mechanism for easy sweep over chunked prefill parameters - `long-prefill-token-threshold` and `max-num-scheduled-tokens`, as well as request rates in `request_rate_sweep.py`. 

## Implemented Changes

* In `request_rate_sweep.py`, modified code to create a new thread for each combination of arrival rate, max-num-scheduled-tokens and long-prefill-token-threshold. The values to sweep over are given in the form of a list. In future this list can be accepted as a cmdline argument too. 

## How to Run:

- `go build -o simulation_worker main.go`
- `python request_rate_sweep.py`

Results will be under `results/sweep_request_rate`. The files are of format: `rr={<arrival_rate>}_lptt=<long-prefill-token-threshold>_mnbt=<max-num-batched-tokens>.txt`

## Related Issues & Documents

- Closes #51