### PR TITLE
Update default horizon to MaxInt64

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"math"
 	"os"
 	"time"
 
@@ -89,7 +90,7 @@ func Execute() {
 // init sets up CLI flags and subcommands
 func init() {
 	runCmd.Flags().IntVar(&totalKVBlocks, "total-kv-blocks", 8000000, "Total number of KV cache blocks")
-	runCmd.Flags().Int64Var(&simulationHorizon, "horizon", 10000, "Total simulation horizon (in ticks)")
+	runCmd.Flags().Int64Var(&simulationHorizon, "horizon", math.MaxInt64, "Total simulation horizon (in ticks)")
 	runCmd.Flags().Float64Var(&rate, "rate", 0.02, "Poisson arrival rate (requests per tick)")
 	runCmd.Flags().StringVar(&logLevel, "log", "error", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	runCmd.Flags().Int64Var(&maxRunningReqs, "max-num-running-reqs", 35, "Maximum number of requests running together")

--- a/request_rate_sweep.py
+++ b/request_rate_sweep.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--horizon",
         type=str,
-        default="1000000000000",
+        default="922337203685477580",
         help="Horizon in micosec(ticks) the simulation runs for at max"
     )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to update `horizon` to Go's `math.MaxInt64` to ensure by default all requests can be processed. We also take the value of this MaxInt64 and update the default argparse argument value in `request_rate_sweep.py`. 

## How to Run:

- `go build -o simulation_worker main.go`
- `python request_rate_sweep.py --rates 32 --long_prefill_token_thresholds 16 32 64 128 256 512 1024 --max_num_batched_tokens 256 512 1024 2048 4096 8192 --input_filename data/output_tokens_2025-07-07_tokenized.json --num_requests 400` (this is to replicate the mini sweep proposed in https://github.com/inference-sim/pytools/issues/11)


## Related Issues & Documents

- Closes #66