### PR TITLE
n_trials in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ __pycache__/*
 # data files
 *.json
 data/
+*.txt
 
 # binaries
 simulation_worker

--- a/run_optimizer.py
+++ b/run_optimizer.py
@@ -35,7 +35,7 @@ def main():
     if args.n_trials is not None:
         optimizer.optimize(n_trials=args.n_trials)
     else:
-        optimizer.optimize()
+        optimizer.optimize(n_trials=optimizer.n_trials)
 
     # Evaluate the optimizer
     optimizer.evaluate()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR aims to add n_trials to the optimizer_config as a default value, which can also be overridden by the user through the cmdline arg `--n_trials`. The idea is to provide the user a best n_trials for the optimizer in the config, and allow them to bypass if needed.

## How to Run:

Follow instructions in `README.md`.


## Related Issues & Documents

- Closes #74