### PR TITLE
Improved path for results server side

### DIFF
--- a/analyze_sim_results.py
+++ b/analyze_sim_results.py
@@ -54,7 +54,7 @@ def aggregate_results():
                 row = {"model": MODEL, "spec": spec, "rr": rr, "mbnt": mbnt}
                 vllm_filename = f"vllm_{rr}r_{spec}_{mbnt}.json"
                 sim_filename = f"exp_test_{rr}r_{spec}_{mbnt}.json"
-                vllm_results_folder = f"../vllm-data-collection/scenario4/results_server_side/test/{MODEL}"
+                vllm_results_folder = f"../vllm-data-collection/scenario4/results_server_side/{MODEL}/test"
                 vllm_metrics = get_metrics_from_file(vllm_results_folder, vllm_filename)
                 if vllm_metrics[3] >= SATURATION_PERCENTAGE * rr:
                     print(f"{spec}, {rr}, {mbnt}")


### PR DESCRIPTION
Earlier we were saving processed vllm server-side results in paths of format `results_server_side/{mode}/{model_name}`. However, in all our other results paths the format is `results/{model_name}/{mode}`. To maintain consistency, let us change the server side results path to the format `results_server_side/{model_name}/{mode}`.