### PR TITLE
Coefficients for more models, TP

### DIFF
--- a/coefficients.yaml
+++ b/coefficients.yaml
@@ -11,6 +11,14 @@ defaults:
     GPU: H100
     tensor_parallelism: 4
     vllm_version: vllm/vllm-openai:v0.8.4
+  meta-llama/llama-4-maverick-17b-128e-instruct-fp8:
+    GPU: H100
+    tensor_parallelism: 8
+    vllm_version: vllm/vllm-openai:v0.8.4
+  meta-llama/llama-4-scout-17b-16e-instruct:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
   microsoft/phi-4:
     GPU: H100
     tensor_parallelism: 2
@@ -23,9 +31,9 @@ defaults:
     GPU: H100
     tensor_parallelism: 8
     vllm_version: vllm/vllm-openai:v0.8.4
-  mistralai/mixtral-8x7b-instruct-v0.1:
+  nvidia/llama-3.1-nemotron-70b-instruct-hf:
     GPU: H100
-    tensor_parallelism: 2
+    tensor_parallelism: 4
     vllm_version: vllm/vllm-openai:v0.8.4
   openai/gpt-oss-120b:
     GPU: H100
@@ -39,6 +47,66 @@ defaults:
     GPU: H100
     tensor_parallelism: 4
     vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 2
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/llama-3.3-70b-instruct-quantized.w4a16:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/llama-3.3-70b-instruct-quantized.w8a8:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 8
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/llama-4-scout-17b-16e-instruct-quantized.w4a16:
+    GPU: H100
+    tensor_parallelism: 8
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 8
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16:
+    GPU: H100
+    tensor_parallelism: 8
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/phi-4-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 2
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/phi-4-quantized.w4a16:
+    GPU: H100
+    tensor_parallelism: 1
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/phi-4-quantized.w8a8:
+    GPU: H100
+    tensor_parallelism: 2
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/qwen2.5-7b-instruct-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/qwen2.5-7b-instruct-quantized.w4a16:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/qwen2.5-7b-instruct-quantized.w8a8:
+    GPU: H100
+    tensor_parallelism: 4
+    vllm_version: vllm/vllm-openai:v0.8.4
+  redhatai/smollm3-3b-fp8-dynamic:
+    GPU: H100
+    tensor_parallelism: 1
+    vllm_version: vllm/vllm-openai:v0.10.1.1
 models:
 - GPU: A100-80
   alpha_coeffs:
@@ -627,5 +695,929 @@ models:
   id: qwen/qwen2.5-7b-instruct
   tensor_parallelism: 4
   total_kv_blocks: 1281766
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 6933.519704638618
+  - 2.881848162088737
+  - 6024.521165831988
+  best_loss: 198.5839129752874
+  beta_coeffs:
+  - 4766.019115846135
+  - 39.93059807835496
+  - 14.107587735403516
+  id: redhatai/phi-4-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 18804
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 13079.466284493472
+  - 7.215912389086681
+  - 2274.6539180251943
+  best_loss: 300.82158077988635
+  beta_coeffs:
+  - 4766.286715677925
+  - 9.86299645197833
+  - 9.321012344742769
+  id: redhatai/phi-4-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 84794
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 18651.573657364577
+  - 0.04625616673220634
+  - 12956.648810703833
+  best_loss: 597.370078389595
+  beta_coeffs:
+  - 3510.544097555011
+  - 61.4025801465046
+  - 45.62767541348552
+  id: redhatai/phi-4-quantized.w4a16
+  tensor_parallelism: 1
+  total_kv_blocks: 20820
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2487.9775588877965
+  - 8.05350544215949
+  - 9139.684042406032
+  best_loss: 380.2953679131567
+  beta_coeffs:
+  - 1631.7752610516895
+  - 22.81435893947637
+  - 9.50395637277893
+  id: redhatai/phi-4-quantized.w4a16
+  tensor_parallelism: 2
+  total_kv_blocks: 88826
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 859.190574706613
+  - 2.022559265343577
+  - 6120.088954859821
+  best_loss: 352.3870531885642
+  beta_coeffs:
+  - 5075.8095040286225
+  - 65.61037862886394
+  - 1.3877549737125037
+  id: redhatai/phi-4-quantized.w8a8
+  tensor_parallelism: 1
+  total_kv_blocks: 18804
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 4631.343002033195
+  - 3.0464554077896544
+  - 636.3785501017303
+  best_loss: 247.9487881294254
+  beta_coeffs:
+  - 6684.011038389244
+  - 29.89642821025856
+  - 10.850768618679616
+  id: redhatai/phi-4-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 84794
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 10311.495107633149
+  - 0.9332289447492559
+  - 8460.748188484189
+  best_loss: 1681.295416465994
+  beta_coeffs:
+  - 3535.4192221312574
+  - 27.46952438596628
+  - 8.32458581099383
+  id: redhatai/smollm3-3b-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 62704
+  vllm_version: vllm/vllm-openai:v0.10.1.1
+- GPU: H100
+  alpha_coeffs:
+  - 9021.203140330224
+  - 1.1364115322613806
+  - 3516.6463619326482
+  best_loss: 269.6329465037516
+  beta_coeffs:
+  - 399.4464044288492
+  - 8.617172737322607
+  - 338.63066511178744
+  id: redhatai/smollm3-3b-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 256481
+  vllm_version: vllm/vllm-openai:v0.10.1.1
+- GPU: H100
+  alpha_coeffs:
+  - 242.32362487324562
+  - 0.5927381902381239
+  - 2121.8602921006404
+  best_loss: 734.6587099817417
+  beta_coeffs:
+  - 1165.413967107656
+  - 37.09679801811959
+  - 1.2093190204551547
+  id: redhatai/smollm3-3b-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 1037250
+  vllm_version: vllm/vllm-openai:v0.10.1.1
+- GPU: H100
+  alpha_coeffs:
+  - 7325.507356794892
+  - 8.299549141488512
+  - 19570.874153295543
+  best_loss: 309.7570222538895
+  beta_coeffs:
+  - 3570.4562895617464
+  - 117.47614691571846
+  - 11.646711409529644
+  id: redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 31261
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2997.168202567753
+  - 13.231235923477518
+  - 15653.832009669186
+  best_loss: 664.2313696703596
+  beta_coeffs:
+  - 13613.686210091935
+  - 62.88264034739483
+  - 17.396517711004773
+  id: redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 180486
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 8889.354173360616
+  - 19.146738273072497
+  - 8725.028541828095
+  best_loss: 468.41745409625446
+  beta_coeffs:
+  - 6983.641482404833
+  - 185.92052398950779
+  - 2.528921896506347
+  id: redhatai/llama-3.3-70b-instruct-quantized.w4a16
+  tensor_parallelism: 4
+  total_kv_blocks: 205774
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2557.0175879576236
+  - 5.383268829531929
+  - 66328.8630610509
+  best_loss: 1247.1977740486461
+  beta_coeffs:
+  - 10876.000686322977
+  - 63.36267098398037
+  - 16.615253482865775
+  id: redhatai/llama-3.3-70b-instruct-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 31261
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1054.4725383972955
+  - 12.906330822576138
+  - 31455.351093637022
+  best_loss: 790.3185454787372
+  beta_coeffs:
+  - 844.6097218184243
+  - 93.75555836104441
+  - 6.338546149937079
+  id: redhatai/llama-3.3-70b-instruct-quantized.w8a8
+  tensor_parallelism: 4
+  total_kv_blocks: 180486
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 320.03365040537756
+  - 10.38401521791176
+  - 20750.374152908036
+  best_loss: 388.5521218717301
+  beta_coeffs:
+  - 6185.797601517608
+  - 30.779332783660024
+  - 80.26975391990182
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 25416
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2833.218519266371
+  - 7.951971681874976
+  - 17461.6410606816
+  best_loss: 727.2237904973808
+  beta_coeffs:
+  - 869.465174238824
+  - 74.33225248091743
+  - 0.9679445030844178
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 247441
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 12996.061786812978
+  - 4.229119549394555
+  - 9644.652272650554
+  best_loss: 409.7807499969899
+  beta_coeffs:
+  - 3906.029867333609
+  - 24.56158850152771
+  - 15.330994172523104
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 8
+  total_kv_blocks: 1281314
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2695.840534102448
+  - 5.47954507514957
+  - 9801.531774405174
+  best_loss: 528.6858391963005
+  beta_coeffs:
+  - 8704.121218386741
+  - 13.714464957901942
+  - 35.728197899891256
+  id: redhatai/llama-4-scout-17b-16e-instruct-quantized.w4a16
+  tensor_parallelism: 8
+  total_kv_blocks: 1407883
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2477.106021994513
+  - 7.4851139733666745
+  - 2859.8193875203388
+  best_loss: 313.560628222043
+  beta_coeffs:
+  - 5174.311141561501
+  - 13.241358822784033
+  - 4.898541852135679
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 74768
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1625.7671787067952
+  - 1.7245393046791397
+  - 7250.552524047731
+  best_loss: 631.8567996576297
+  beta_coeffs:
+  - 1601.5445681310437
+  - 12.200742902026287
+  - 236.30336380726504
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 318058
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7238.7831899170715
+  - 7.667683069887731
+  - 6451.54833284449
+  best_loss: 523.1358286401718
+  beta_coeffs:
+  - 613.4218567515552
+  - 0.05982608601310968
+  - 228.6975025068039
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 1310202
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 775.510328023589
+  - 1.4220205920065445
+  - 14549.291991690241
+  best_loss: 2731.6695553242807
+  beta_coeffs:
+  - 6475.578210636206
+  - 91.05879232715853
+  - 1.1830721529062203
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 1
+  total_kv_blocks: 78211
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 438.60587439224946
+  - 5.376526117947915
+  - 10851.100993979371
+  best_loss: 558.851838483575
+  beta_coeffs:
+  - 154.8137928605471
+  - 21.290658651356534
+  - 316.73336819179826
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 2
+  total_kv_blocks: 324944
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 447.15250859306707
+  - 4.735061952359864
+  - 11360.79595280873
+  best_loss: 875.3398836693187
+  beta_coeffs:
+  - 2262.274039889375
+  - 9.187717402141246
+  - 24.85254760164011
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 4
+  total_kv_blocks: 1323973
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3783.7472048776544
+  - 6.241193226123162
+  - 6359.340153506826
+  best_loss: 412.7214975642909
+  beta_coeffs:
+  - 3733.3344027206685
+  - 17.644320003206666
+  - 10.016046042239083
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 1
+  total_kv_blocks: 74768
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7432.040376609093
+  - 1.693883359463155
+  - 3799.120468744639
+  best_loss: 268.3858919051193
+  beta_coeffs:
+  - 2698.139366847584
+  - 6.494121251157208
+  - 4.737791906781137
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 318058
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3730.2809630630654
+  - 1.8607317746958116
+  - 4139.539960936105
+  best_loss: 359.93071926884556
+  beta_coeffs:
+  - 2334.9050951438107
+  - 7.123744788605084
+  - 0.3826898440415789
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 4
+  total_kv_blocks: 1310202
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 14188.955380683416
+  - 31.09486766132621
+  - 3017.3852227781094
+  best_loss: 777.0944096746107
+  beta_coeffs:
+  - 8586.34210019845
+  - 28.192687526789527
+  - 30.653556157313005
+  id: meta-llama/llama-4-maverick-17b-128e-instruct-fp8
+  tensor_parallelism: 8
+  total_kv_blocks: 513007
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 877.9690629431279
+  - 11.668167572161003
+  - 65573.40313335409
+  best_loss: 3870.8829027894203
+  beta_coeffs:
+  - 34857.64418010274
+  - 18.288456091859253
+  - 90.4252805260737
+  id: meta-llama/llama-4-scout-17b-16e-instruct
+  tensor_parallelism: 4
+  total_kv_blocks: 116925
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 314.5256613413803
+  - 6.149650189128863
+  - 15090.828436539601
+  best_loss: 728.5295265908776
+  beta_coeffs:
+  - 22196.22494571111
+  - 98.19037812152163
+  - 10.21754768579602
+  id: nvidia/llama-3.1-nemotron-70b-instruct-hf
+  tensor_parallelism: 4
+  total_kv_blocks: 128273
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7325.507356794892
+  - 8.299549141488512
+  - 19570.874153295543
+  best_loss: 309.7570222538895
+  beta_coeffs:
+  - 3570.4562895617464
+  - 117.47614691571846
+  - 11.646711409529644
+  id: redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 31261
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2997.168202567753
+  - 13.231235923477518
+  - 15653.832009669186
+  best_loss: 664.2313696703596
+  beta_coeffs:
+  - 13613.686210091935
+  - 62.88264034739483
+  - 17.396517711004773
+  id: redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 180486
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 8889.354173360616
+  - 19.146738273072497
+  - 8725.028541828095
+  best_loss: 468.41745409625446
+  beta_coeffs:
+  - 6983.641482404833
+  - 185.92052398950779
+  - 2.528921896506347
+  id: redhatai/llama-3.3-70b-instruct-quantized.w4a16
+  tensor_parallelism: 4
+  total_kv_blocks: 205774
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2557.0175879576236
+  - 5.383268829531929
+  - 66328.8630610509
+  best_loss: 1247.1977740486461
+  beta_coeffs:
+  - 10876.000686322977
+  - 63.36267098398037
+  - 16.615253482865775
+  id: redhatai/llama-3.3-70b-instruct-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 31261
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1054.4725383972955
+  - 12.906330822576138
+  - 31455.351093637022
+  best_loss: 790.3185454787372
+  beta_coeffs:
+  - 844.6097218184243
+  - 93.75555836104441
+  - 6.338546149937079
+  id: redhatai/llama-3.3-70b-instruct-quantized.w8a8
+  tensor_parallelism: 4
+  total_kv_blocks: 180486
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 320.03365040537756
+  - 10.38401521791176
+  - 20750.374152908036
+  best_loss: 388.5521218717301
+  beta_coeffs:
+  - 6185.797601517608
+  - 30.779332783660024
+  - 80.26975391990182
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 25416
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2833.218519266371
+  - 7.951971681874976
+  - 17461.6410606816
+  best_loss: 727.2237904973808
+  beta_coeffs:
+  - 869.465174238824
+  - 74.33225248091743
+  - 0.9679445030844178
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 247441
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 12996.061786812978
+  - 4.229119549394555
+  - 9644.652272650554
+  best_loss: 409.7807499969899
+  beta_coeffs:
+  - 3906.029867333609
+  - 24.56158850152771
+  - 15.330994172523104
+  id: redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic
+  tensor_parallelism: 8
+  total_kv_blocks: 1281314
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2695.840534102448
+  - 5.47954507514957
+  - 9801.531774405174
+  best_loss: 528.6858391963005
+  beta_coeffs:
+  - 8704.121218386741
+  - 13.714464957901942
+  - 35.728197899891256
+  id: redhatai/llama-4-scout-17b-16e-instruct-quantized.w4a16
+  tensor_parallelism: 8
+  total_kv_blocks: 1407883
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 4971.26446032885
+  - 0.19305560604291827
+  - 9338.181986006943
+  best_loss: 501.2839581695191
+  beta_coeffs:
+  - 4322.370792752596
+  - 61.540465044005835
+  - 53.327037734180976
+  id: redhatai/phi-4-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 18804
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2614.454391408508
+  - 12.735142485552078
+  - 1873.75904530944
+  best_loss: 491.39835725182246
+  beta_coeffs:
+  - 3600.2495480171538
+  - 14.347947760360427
+  - 329.61672123459505
+  id: redhatai/phi-4-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 84794
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 6227.152053697522
+  - 4.061310813370725
+  - 34115.329136606335
+  best_loss: 4337.582614989846
+  beta_coeffs:
+  - 3842.106725968122
+  - 68.21263962137004
+  - 1108.996609306733
+  id: redhatai/phi-4-quantized.w4a16
+  tensor_parallelism: 1
+  total_kv_blocks: 20820
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2487.9775588877965
+  - 8.05350544215949
+  - 9139.684042406032
+  best_loss: 380.2953679131567
+  beta_coeffs:
+  - 1631.7752610516895
+  - 22.81435893947637
+  - 9.50395637277893
+  id: redhatai/phi-4-quantized.w4a16
+  tensor_parallelism: 2
+  total_kv_blocks: 88826
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 204.3933344229008
+  - 3.579873726691744
+  - 15642.980694646423
+  best_loss: 571.6721985792004
+  beta_coeffs:
+  - 1585.4970897117946
+  - 47.47911562846527
+  - 3.5880977271683214
+  id: redhatai/phi-4-quantized.w8a8
+  tensor_parallelism: 1
+  total_kv_blocks: 18804
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1772.1843886814258
+  - 2.615169949214441
+  - 11273.330698639225
+  best_loss: 726.1325756284621
+  beta_coeffs:
+  - 779.8763792634662
+  - 10.789300387049117
+  - 35.65944721877375
+  id: redhatai/phi-4-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 84794
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2477.106021994513
+  - 7.4851139733666745
+  - 2859.8193875203388
+  best_loss: 313.560628222043
+  beta_coeffs:
+  - 5174.311141561501
+  - 13.241358822784033
+  - 4.898541852135679
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 74768
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1625.7671787067952
+  - 1.7245393046791397
+  - 7250.552524047731
+  best_loss: 631.8567996576297
+  beta_coeffs:
+  - 1601.5445681310437
+  - 12.200742902026287
+  - 236.30336380726504
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 318058
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7238.7831899170715
+  - 7.667683069887731
+  - 6451.54833284449
+  best_loss: 523.1358286401718
+  beta_coeffs:
+  - 613.4218567515552
+  - 0.05982608601310968
+  - 228.6975025068039
+  id: redhatai/qwen2.5-7b-instruct-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 1310202
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 775.510328023589
+  - 1.4220205920065445
+  - 14549.291991690241
+  best_loss: 2731.6695553242807
+  beta_coeffs:
+  - 6475.578210636206
+  - 91.05879232715853
+  - 1.1830721529062203
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 1
+  total_kv_blocks: 78211
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 438.60587439224946
+  - 5.376526117947915
+  - 10851.100993979371
+  best_loss: 558.851838483575
+  beta_coeffs:
+  - 154.8137928605471
+  - 21.290658651356534
+  - 316.73336819179826
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 2
+  total_kv_blocks: 324944
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 447.15250859306707
+  - 4.735061952359864
+  - 11360.79595280873
+  best_loss: 875.3398836693187
+  beta_coeffs:
+  - 2262.274039889375
+  - 9.187717402141246
+  - 24.85254760164011
+  id: redhatai/qwen2.5-7b-instruct-quantized.w4a16
+  tensor_parallelism: 4
+  total_kv_blocks: 1323973
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3783.7472048776544
+  - 6.241193226123162
+  - 6359.340153506826
+  best_loss: 412.7214975642909
+  beta_coeffs:
+  - 3733.3344027206685
+  - 17.644320003206666
+  - 10.016046042239083
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 1
+  total_kv_blocks: 74768
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7432.040376609093
+  - 1.693883359463155
+  - 3799.120468744639
+  best_loss: 268.3858919051193
+  beta_coeffs:
+  - 2698.139366847584
+  - 6.494121251157208
+  - 4.737791906781137
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 318058
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3730.2809630630654
+  - 1.8607317746958116
+  - 4139.539960936105
+  best_loss: 359.93071926884556
+  beta_coeffs:
+  - 2334.9050951438107
+  - 7.123744788605084
+  - 0.3826898440415789
+  id: redhatai/qwen2.5-7b-instruct-quantized.w8a8
+  tensor_parallelism: 4
+  total_kv_blocks: 1310202
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 198.72908026412188
+  - 3.4075236517999485
+  - 2911.391545779932
+  best_loss: 345.7210154926344
+  beta_coeffs:
+  - 13285.247232112151
+  - 50.17211804536737
+  - 117.32518378096191
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic
+  tensor_parallelism: 1
+  total_kv_blocks: 19649
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3081.4449898323783
+  - 18.406370064557294
+  - 5587.463273379311
+  best_loss: 549.3221153539433
+  beta_coeffs:
+  - 4792.981292353791
+  - 48.3797164663197
+  - 108.7224272565926
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic
+  tensor_parallelism: 2
+  total_kv_blocks: 98281
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 8380.488585484709
+  - 24.381259872986305
+  - 4350.542990170461
+  best_loss: 459.1974279907131
+  beta_coeffs:
+  - 1160.8015384666837
+  - 14.258841085172062
+  - 9.620782166186935
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic
+  tensor_parallelism: 4
+  total_kv_blocks: 432492
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 443.2761731316714
+  - 0.03457936172464926
+  - 1407.8854286695278
+  best_loss: 2065.9064003320277
+  beta_coeffs:
+  - 216.23205545730542
+  - 101.61149633120225
+  - 6.990265357416206
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic
+  tensor_parallelism: 8
+  total_kv_blocks: 1808703
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 19474.627603706907
+  - 41.363587566285176
+  - 4179.151292379341
+  best_loss: 374.017691856003
+  beta_coeffs:
+  - 11279.81029693006
+  - 6.560878312503021
+  - 44.74700087365774
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16
+  tensor_parallelism: 1
+  total_kv_blocks: 23759
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 952.9798795515671
+  - 15.966748893495787
+  - 13179.673250065154
+  best_loss: 877.4785696544241
+  beta_coeffs:
+  - 1372.7256252478762
+  - 78.57418308362327
+  - 18.894371289507376
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16
+  tensor_parallelism: 2
+  total_kv_blocks: 106501
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 8653.865431006338
+  - 1.322753088781425
+  - 2265.573664752042
+  best_loss: 312.86353166620194
+  beta_coeffs:
+  - 5528.072535440055
+  - 11.164922527421961
+  - 18.126896737684294
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16
+  tensor_parallelism: 4
+  total_kv_blocks: 448932
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 3101.9185894111797
+  - 7.401843401391529
+  - 2702.317554915452
+  best_loss: 315.5064833543646
+  beta_coeffs:
+  - 4248.545959662636
+  - 11.111554937314615
+  - 22.508704093385223
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16
+  tensor_parallelism: 8
+  total_kv_blocks: 1841583
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 2627.8797323273247
+  - 19.29667088188762
+  - 8807.58014403456
+  best_loss: 1697.597801930812
+  beta_coeffs:
+  - 3772.6860716637825
+  - 11.281370906538001
+  - 1218.989521167657
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8
+  tensor_parallelism: 1
+  total_kv_blocks: 19649
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 10324.516485582115
+  - 2.1498672306757385
+  - 3356.0449653789474
+  best_loss: 1130.307015926016
+  beta_coeffs:
+  - 3324.3161543908395
+  - 119.77753575667865
+  - 49.33714587517195
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8
+  tensor_parallelism: 2
+  total_kv_blocks: 98281
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 1507.1763206593369
+  - 4.615990422787531
+  - 4112.049153792771
+  best_loss: 650.0485021868892
+  beta_coeffs:
+  - 7895.878011711422
+  - 8.059933548252612
+  - 5.761696225658012
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8
+  tensor_parallelism: 4
+  total_kv_blocks: 432492
+  vllm_version: vllm/vllm-openai:v0.8.4
+- GPU: H100
+  alpha_coeffs:
+  - 7923.824862212277
+  - 0.7052500799547552
+  - 892.9684120879926
+  best_loss: 630.0817570335912
+  beta_coeffs:
+  - 2070.248921945602
+  - 21.77086900751729
+  - 0.9439109020002547
+  id: redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8
+  tensor_parallelism: 8
+  total_kv_blocks: 1808703
   vllm_version: vllm/vllm-openai:v0.8.4
 version: 0.0.1


### PR DESCRIPTION
New model,TPs added:

```
LLM,TP,GPU,vllm_version
redhatai/smollm3-3b-fp8-dynamic,1,H100,vllm/vllm-openai:v0.10.1.1
redhatai/smollm3-3b-fp8-dynamic,2,H100,vllm/vllm-openai:v0.10.1.1
redhatai/smollm3-3b-fp8-dynamic,4,H100,vllm/vllm-openai:v0.10.1.1
redhatai/phi-4-fp8-dynamic,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w4a16,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w4a16,2,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w8a8,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w8a8,2,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-fp8-dynamic,1,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-fp8-dynamic,4,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w4a16,1,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w4a16,2,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w4a16,4,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w8a8,1,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w8a8,2,H100,vllm/vllm-openai:v0.8.4
redhatai/qwen2.5-7b-instruct-quantized.w8a8,4,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic,4,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-3.3-70b-instruct-quantized.w4a16,4,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-3.3-70b-instruct-quantized.w8a8,2,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-3.3-70b-instruct-quantized.w8a8,4,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic,4,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic,8,H100,vllm/vllm-openai:v0.8.4
redhatai/llama-4-scout-17b-16e-instruct-quantized.w4a16,8,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-fp8-dynamic,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w4a16,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w4a16,2,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w8a8,1,H100,vllm/vllm-openai:v0.8.4
redhatai/phi-4-quantized.w8a8,2,H100,vllm/vllm-openai:v0.8.4
meta-llama/llama-4-maverick-17b-128e-instruct-fp8,8,H100,vllm/vllm-openai:v0.8.4
meta-llama/llama-4-scout-17b-16e-instruct,4,H100,vllm/vllm-openai:v0.8.4
nvidia/llama-3.1-nemotron-70b-instruct-hf,4,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic,1,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic,2,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic,4,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic,8,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16,1,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16,2,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16,4,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16,8,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8,1,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8,2,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8,4,H100,vllm/vllm-openai:v0.8.4
redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8,8,H100,vllm/vllm-openai:v0.8.4
```