### PR TITLE
Agnostic to LLM name case

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -82,6 +83,8 @@ var runCmd = &cobra.Command{
 		alphaCoeffs, betaCoeffs := alphaCoeffs, betaCoeffs
 
 		if AllZeros(alphaCoeffs) && AllZeros(betaCoeffs) { // default all 0s
+			// convert model name to lowercase
+			model = strings.ToLower(model)
 			// GPU, TP, vLLM version configuration
 			hardware, tp, version := GetDefaultConfig(model) // pick default config for tp, GPU, vllmVersion
 


### PR DESCRIPTION
## Changes Implemented

Convert input model name to lowercase first and then try to find the default mapping in `coefficients.yaml`.

## Issues

Closes #125 