### PR TITLE
Bugfix in hardware_config

### DIFF
--- a/hardware_config.json
+++ b/hardware_config.json
@@ -10,8 +10,8 @@
 		"allReduceLatency": 20.0
 	},
 	"A100-SXM": {
-		"TFlopsEff":        312,      
-		"BwEffTBs":         2.039,
+		"TFlopsPeak":        312,      
+		"BwPeakTBs":         2.039,
         "BwEffConstant": 0.72,
 		"TOverheadMicros":  500.0,
 		"perLayerOverhead": 20.0,


### PR DESCRIPTION
## Issue

Typo fix for "A100-SXM" in `hardware_config.json`

## Changes

* `TFlopsEff` should be `TFlopsPeak`
* `BwEffTBs` should be `BwPeakTBs`