### PR TITLE
fix(logging): recalibrate log levels and migrate fmt.Print to logrus (#38)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -421,8 +420,8 @@ var runCmd = &cobra.Command{
 				logrus.Fatalf("Invalid fitness weights: %v", err)
 			}
 			fitness := cluster.ComputeFitness(rawMetrics, weights)
-			fmt.Printf("\n=== Fitness Evaluation ===\n")
-			fmt.Printf("Score: %.6f\n", fitness.Score)
+			logrus.Infof("=== Fitness Evaluation ===")
+			logrus.Infof("Score: %.6f", fitness.Score)
 			// Sort keys for deterministic output order
 			componentKeys := make([]string, 0, len(fitness.Components))
 			for k := range fitness.Components {
@@ -430,39 +429,39 @@ var runCmd = &cobra.Command{
 			}
 			sort.Strings(componentKeys)
 			for _, k := range componentKeys {
-				fmt.Printf("  %s: %.6f\n", k, fitness.Components[k])
+				logrus.Infof("  %s: %.6f", k, fitness.Components[k])
 			}
 		}
 
 		// Print anomaly counters if any detected
 		if rawMetrics.PriorityInversions > 0 || rawMetrics.HOLBlockingEvents > 0 || rawMetrics.RejectedRequests > 0 {
-			fmt.Printf("\n=== Anomaly Counters ===\n")
-			fmt.Printf("Priority Inversions: %d\n", rawMetrics.PriorityInversions)
-			fmt.Printf("HOL Blocking Events: %d\n", rawMetrics.HOLBlockingEvents)
-			fmt.Printf("Rejected Requests: %d\n", rawMetrics.RejectedRequests)
+			logrus.Infof("=== Anomaly Counters ===")
+			logrus.Infof("Priority Inversions: %d", rawMetrics.PriorityInversions)
+			logrus.Infof("HOL Blocking Events: %d", rawMetrics.HOLBlockingEvents)
+			logrus.Infof("Rejected Requests: %d", rawMetrics.RejectedRequests)
 		}
 
 		// Build and print trace summary if requested (BC-9)
 		if cs.Trace() != nil && summarizeTrace {
 			traceSummary := trace.Summarize(cs.Trace())
-			fmt.Printf("\n=== Trace Summary ===\n")
-			fmt.Printf("Total Decisions: %d\n", traceSummary.TotalDecisions)
-			fmt.Printf("  Admitted: %d\n", traceSummary.AdmittedCount)
-			fmt.Printf("  Rejected: %d\n", traceSummary.RejectedCount)
-			fmt.Printf("Unique Targets: %d\n", traceSummary.UniqueTargets)
+			logrus.Infof("=== Trace Summary ===")
+			logrus.Infof("Total Decisions: %d", traceSummary.TotalDecisions)
+			logrus.Infof("  Admitted: %d", traceSummary.AdmittedCount)
+			logrus.Infof("  Rejected: %d", traceSummary.RejectedCount)
+			logrus.Infof("Unique Targets: %d", traceSummary.UniqueTargets)
 			if len(traceSummary.TargetDistribution) > 0 {
-				fmt.Printf("Target Distribution:\n")
+				logrus.Infof("Target Distribution:")
 				targetKeys := make([]string, 0, len(traceSummary.TargetDistribution))
 				for k := range traceSummary.TargetDistribution {
 					targetKeys = append(targetKeys, k)
 				}
 				sort.Strings(targetKeys)
 				for _, k := range targetKeys {
-					fmt.Printf("  %s: %d\n", k, traceSummary.TargetDistribution[k])
+					logrus.Infof("  %s: %d", k, traceSummary.TargetDistribution[k])
 				}
 			}
-			fmt.Printf("Mean Regret: %.6f\n", traceSummary.MeanRegret)
-			fmt.Printf("Max Regret: %.6f\n", traceSummary.MaxRegret)
+			logrus.Infof("Mean Regret: %.6f", traceSummary.MeanRegret)
+			logrus.Infof("Max Regret: %.6f", traceSummary.MaxRegret)
 		}
 
 		logrus.Info("Simulation complete.")

--- a/docs/plans/prworkflow.md
+++ b/docs/plans/prworkflow.md
@@ -1,6 +1,6 @@
 # PR Development Workflow
 
-**Status:** Active (v2.5 - updated 2026-02-16)
+**Status:** Active (v2.6 - updated 2026-02-18)
 
 This document describes the complete workflow for implementing a PR from the macro plan.
 
@@ -515,6 +515,27 @@ Catch what GitHub Copilot, Claude, and Codex would flag.
 
 ---
 
+#### During Any Pass: Filing Pre-Existing Issues
+
+Review passes naturally surface pre-existing bugs in surrounding code. These are valuable discoveries but outside the current PR's scope.
+
+**Rule:** File a GitHub issue immediately. Do not fix in the current PR.
+
+```bash
+gh issue create --title "Bug: <concise description>" --body "<location, impact, discovery context>"
+```
+
+**Why not fix in-PR?**
+- **Scope creep** — muddies the diff, makes review harder, risks introducing regressions in unrelated code
+- **Attribution** — the fix deserves its own tests and its own commit history
+- **Tracking** — issues that aren't filed are issues that are lost
+
+**After filing:** Reference the issue number in the PR description under a "Discovered Issues" section so reviewers know it was found and tracked.
+
+**Example (from #38 log level recalibration):** Code review found that `simulator.go:593` silently drops a request on KV allocation failure — a pre-existing bug predating the PR. Filed as #183 rather than fixing in-scope.
+
+---
+
 #### After All 4 Passes: Enforced Verification Gate
 
 > **For Claude:** After fixing issues from all passes, invoke the verification skill to ensure
@@ -869,6 +890,7 @@ golangci-lint run ./path/to/modified/package/...
 **v2.3 (2026-02-16):** Step 2.5 expanded to 4 passes — added Pass 4 (structural validation: task dependencies, template completeness, executive summary clarity, under-specified task detection). Based on PR9 experience where deferred items fell through cracks in the macro plan, and an under-specified documentation task would have confused the executing agent.
 **v2.4 (2026-02-16):** Four targeted skill integrations addressing real failure modes: (1) `review-plan` as Pass 0 in Step 2.5 — external LLM review catches design bugs that self-review misses (PR9: fitness normalization bug passed 3 focused passes). (2) `superpowers:systematic-debugging` as on-failure handler in Step 4 — structured root-cause analysis instead of ad-hoc debugging. (3) `superpowers:verification-before-completion` replaces manual verification prose after Step 4.5 — makes build/test/lint gate non-skippable. (4) `commit-commands:clean_gone` as pre-cleanup in Step 1 — prevents stale branch accumulation.
 **v2.5 (2026-02-16):** Three additions from `/insights` analysis of 212 sessions: (1) Step 4.75 (pre-commit self-audit) — deliberate critical thinking step with no agent, checking logic/design/determinism/consistency/docs/edge-cases. In PR9, this step found 3 real bugs (wrong reference scale, non-deterministic output, inconsistent comments) that 4 automated passes missed. (2) Headless mode documentation for review passes — workaround for context overflow during multi-agent consolidation, the #1 recurring friction point across 212 sessions. (3) Checkpointing tip for long sessions — prevents progress loss when hitting context limits mid-PR.
+**v2.6 (2026-02-18):** Added "Filing Pre-Existing Issues" subsection to Step 4.5. Code review passes naturally surface bugs in surrounding code that predate the current PR. New rule: file a GitHub issue immediately, do not fix in-PR (avoids scope creep, preserves attribution, prevents losing discoveries). Based on #38 experience where silent-failure-hunter found a pre-existing request-loss bug in simulator.go that was filed as #183.
 
 **Key improvements in v2.0:**
 - **Simplified invocations:** No copy-pasting! Use @ file references (e.g., `@docs/plans/macroplan.md`)

--- a/sim/event.go
+++ b/sim/event.go
@@ -25,7 +25,7 @@ func (e *ArrivalEvent) Timestamp() int64 {
 
 // Execute schedules the next StepEvent, if no such event is scheduled
 func (e *ArrivalEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< Arrival: %s at %d ticks", e.Request.ID, e.time)
+	logrus.Debugf("<< Arrival: %s at %d ticks", e.Request.ID, e.time)
 
 	// Trigger queued event with processing delay
 	queued_delay := sim.getQueueingTime(e.Request) // coming from alpha model
@@ -50,7 +50,7 @@ func (e *QueuedEvent) Timestamp() int64 {
 // Execute normally just enqueues the request
 // If this is the first step, Execute calls the StepEvent
 func (e *QueuedEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< Queued: %s at %d ticks", e.Request.ID, e.time)
+	logrus.Debugf("<< Queued: %s at %d ticks", e.Request.ID, e.time)
 
 	// Enqueue the arriving request into the waiting queue
 	sim.EnqueueRequest(e.Request)
@@ -76,7 +76,7 @@ func (e *ScheduledEvent) Timestamp() int64 {
 
 // Execute does nothing
 func (e *ScheduledEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< Schedule: %s at %d ticks", e.Request.ID, e.time)
+	logrus.Debugf("<< Schedule: %s at %d ticks", e.Request.ID, e.time)
 }
 
 // PreemptionEvent represents the pre-emption of an inference request in the system.
@@ -92,7 +92,7 @@ func (e *PreemptionEvent) Timestamp() int64 {
 
 // Execute does nothing
 func (e *PreemptionEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< Preemption: %s at %d ticks", e.Request.ID, e.time)
+	logrus.Debugf("<< Preemption: %s at %d ticks", e.Request.ID, e.time)
 }
 
 // RequestLeftEvent represents the leaving of an inference request from the system.
@@ -108,7 +108,7 @@ func (e *RequestLeftEvent) Timestamp() int64 {
 
 // Execute does nothing
 func (e *RequestLeftEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< RequestLeft: %s at %d ticks", e.Request.ID, e.time)
+	logrus.Debugf("<< RequestLeft: %s at %d ticks", e.Request.ID, e.time)
 }
 
 // StepEvent represents a simulation step.
@@ -127,6 +127,6 @@ func (e *StepEvent) Timestamp() int64 {
 
 // Execute the StepEvent
 func (e *StepEvent) Execute(sim *Simulator) {
-	logrus.Infof("<< StepEvent at %d ticks", e.time)
+	logrus.Debugf("<< StepEvent at %d ticks", e.time)
 	sim.Step(e.time)
 }

--- a/sim/kvcache.go
+++ b/sim/kvcache.go
@@ -149,7 +149,7 @@ func (kvc *KVCacheState) AllocateKVBlocksPrefill(req *Request) bool {
 
 	// Cannot allocate enough KV cache blocks
 	if numRemainingBlocks > kvc.countFreeBlocks() {
-		logrus.Warnf("Not enough KV cache space to allocate %v new blocks", numRemainingBlocks)
+		logrus.Warnf("KV cache full: cannot allocate %d blocks for prefix caching", numRemainingBlocks)
 		return false
 	}
 
@@ -206,7 +206,7 @@ func (kvc *KVCacheState) AllocateKVBlocksPrefill(req *Request) bool {
 // endIndex is non-inclusive
 func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int64, endIndex int64, cachedBlocks []int64) bool {
 	reqID := req.ID
-	logrus.Infof("AllocateBlock for ReqID: %s, Num Inputs: %d, startIndex = %d, endIndex = %d\n", req.ID, len(req.InputTokens), startIndex, endIndex)
+	logrus.Debugf("AllocateBlock for ReqID: %s, Num Inputs: %d, startIndex = %d, endIndex = %d", req.ID, len(req.InputTokens), startIndex, endIndex)
 
 	var newTokens []int
 	var numNewBlocks = int64(1)
@@ -218,7 +218,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int64, endInd
 
 		// Cannot allocate enough KV cache blocks
 		if numNewBlocks > kvc.countFreeBlocks() {
-			logrus.Warnf("Not enough KV cache space to allocate %v new blocks", numNewBlocks)
+			logrus.Warnf("KV cache full: cannot allocate %d new blocks for req %s", numNewBlocks, req.ID)
 			return false
 		}
 	} else {
@@ -247,7 +247,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int64, endInd
 					kvc.removeFromFreeList(blk)
 				}
 				// allocated is the block IDs allocated for this request
-				logrus.Infof("Hit KV Cache for req: %s of length: %d\n", req.ID, Len64(cachedBlocks)*kvc.BlockSizeTokens)
+				logrus.Debugf("Hit KV Cache for req: %s of length: %d", req.ID, Len64(cachedBlocks)*kvc.BlockSizeTokens)
 				kvc.RequestMap[reqID] = append(kvc.RequestMap[reqID], blockId)
 			}
 		}
@@ -256,7 +256,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int64, endInd
 			toksToAppend := newTokens[:min(Len64(newTokens), kvc.BlockSizeTokens-Len64(latestBlk.Tokens))]
 			latestBlk.Tokens = append(latestBlk.Tokens, toksToAppend...)
 			newTokenProgressIndex += min(Len64(newTokens), kvc.BlockSizeTokens-Len64(latestBlk.Tokens))
-			logrus.Infof("Appending to latest blk: req: %s, newTokenProgressIndex = %d, endBlk=%d, tokens = %v\n", req.ID, newTokenProgressIndex, min(Len64(newTokens), kvc.BlockSizeTokens-Len64(latestBlk.Tokens)), toksToAppend)
+			logrus.Debugf("Appending to latest blk: req: %s, newTokenProgressIndex = %d, endBlk=%d, tokens = %v", req.ID, newTokenProgressIndex, min(Len64(newTokens), kvc.BlockSizeTokens-Len64(latestBlk.Tokens)), toksToAppend)
 			if Len64(latestBlk.Tokens) == kvc.BlockSizeTokens {
 				// latesBlk is full
 				fullTokens := []int{}
@@ -278,7 +278,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *Request, startIndex int64, endInd
 				// start and end are the range of tokens in blk
 				start := newTokenProgressIndex
 				end := newTokenProgressIndex + kvc.BlockSizeTokens
-				logrus.Infof("Assigning new blocks: req = %s, newTokenProgressIndex = %d, ogStartIdx= %d, ogEndIdx = %d, startBlk=%d, endBlk=%d\n", req.ID, newTokenProgressIndex, startIndex, endIndex, start, end)
+				logrus.Debugf("Assigning new blocks: req = %s, newTokenProgressIndex = %d, ogStartIdx= %d, ogEndIdx = %d, startBlk=%d, endBlk=%d", req.ID, newTokenProgressIndex, startIndex, endIndex, start, end)
 				if end > Len64(newTokens) {
 					end = Len64(newTokens)
 				}

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -4,11 +4,12 @@ package sim
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"slices"
 	"sort"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Metrics aggregates statistics about the simulation
@@ -114,13 +115,13 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 		output.TokensPerSec = float64(m.TotalOutputTokens) / vllmRuntime
 
 		// Print to Stdout
-		fmt.Println("=== Simulation Metrics ===")
+		logrus.Info("=== Simulation Metrics ===")
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			fmt.Println("Error marshalling:", err)
+			logrus.Errorf("Error marshalling metrics: %v", err)
 			return
 		}
-		fmt.Println(string(data))
+		logrus.Info(string(data))
 	}
 
 	// --- Write to JSON File ---
@@ -142,15 +143,15 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			fmt.Printf("Error marshalling metrics to JSON: %v\n", err)
+			logrus.Errorf("Error marshalling metrics to JSON: %v", err)
 			return
 		}
 
 		writeErr := os.WriteFile(outputFilePath, data, 0644)
 		if writeErr != nil {
-			fmt.Printf("Error writing JSON file: %v\n", writeErr)
+			logrus.Errorf("Error writing JSON file: %v", writeErr)
 			return
 		}
-		fmt.Printf("\nMetrics written to: %s\n", outputFilePath)
+		logrus.Infof("Metrics written to: %s", outputFilePath)
 	}
 }


### PR DESCRIPTION
Closes #38

## Summary

- Demote 12 high-frequency per-event logs from Info → Debug across `event.go`, `simulator.go`, `kvcache.go`
- Add 3 Debug logs to cluster event pipeline (`cluster_event.go`) for admission/routing/arrival traceability
- Improve 5 vague warning messages with tick timestamps, request IDs, and actionable context
- Promote impossible-path `[THIS SHOULD NEVER HAPPEN]` from Warn → Error with explanation
- Migrate 22 `fmt.Print*` calls to logrus (`metrics.go`, `cmd/root.go`)
- Add "Filing Pre-Existing Issues" subsection to PR workflow (`prworkflow.md` v2.6)

## Motivation

`--log-level info` was unusable with non-trivial workloads because per-event logs fired thousands of times. The cluster routing pipeline emitted zero log lines. 22 `fmt.Print*` calls bypassed logrus entirely, meaning `--log-level error` couldn't silence them.

## Log Level Calibration

| Level | What appears |
|-------|-------------|
| `error` | Only cache accounting bugs and marshalling failures |
| `warn` | Preemptions, KV cache full, token budget exhaustion, config fallbacks |
| `info` | Startup config, simulation metrics, fitness evaluation, trace summary, completion |
| `debug` | Per-event lifecycle, cluster pipeline decisions, KV block allocation details |

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass (no behavioral changes, tests set `logrus.SetLevel(logrus.WarnLevel)`)

## Discovered Issues

- #183 — Pre-existing bug: KV allocation failure path silently drops request from simulation (found during code review, filed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)