### PR TITLE
feat(metrics): add explicit InstanceID field to per-request metrics (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,22 @@ This requires the HuggingFace `config.json` for the model saved under the `model
 - **Tokens/sec**: Aggregate throughput across all completed requests
 - `_p90`, `_p95`, `_p99` suffixes indicate percentile values
 
+When using `--results-path`, the JSON output also includes a `requests` array with per-request details:
+
+| Field | Description |
+|-------|-------------|
+| `requestID` | Unique request identifier |
+| `arrived_at` | Arrival time (seconds) |
+| `num_prefill_tokens` | Input token count |
+| `num_decode_tokens` | Output token count |
+| `ttft_ms` | Time to first token (ms) |
+| `itl_ms` | Mean inter-token latency (ms) |
+| `e2e_ms` | End-to-end latency (ms) |
+| `scheduling_delay_ms` | Queue wait time (ms) |
+| `handled_by` | Instance ID that processed this request (meaningful when `--num-instances` > 1) |
+| `slo_class` | SLO class label (if workload-spec provides one) |
+| `tenant_id` | Tenant identifier (if workload-spec provides one) |
+
 ---
 
 ## Debugging and Observability

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -162,6 +162,9 @@ func (e *RoutingDecisionEvent) Execute(cs *ClusterSimulator) {
 		e.request.Priority = decision.Priority
 	}
 
+	// #181: Stamp request with assigned instance for per-request metrics
+	e.request.AssignedInstance = decision.TargetInstance
+
 	// Record routing decision if tracing is enabled (BC-3, BC-4, BC-5, BC-6)
 	// Placed after priority assignment to minimize diff; recording reads decision, not request.Priority
 	if cs.trace != nil {

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -30,8 +30,9 @@ type RequestMetrics struct {
 	ITL              float64 `json:"itl_ms"`
 	E2E              float64 `json:"e2e_ms"`
 	SchedulingDelay  float64 `json:"scheduling_delay_ms"`
-	SLOClass         string  `json:"slo_class,omitempty"` // PR10: for per-SLO-class metrics
-	TenantID         string  `json:"tenant_id,omitempty"` // PR10: for per-tenant fairness
+	SLOClass         string  `json:"slo_class,omitempty"`   // PR10: for per-SLO-class metrics
+	TenantID         string  `json:"tenant_id,omitempty"`  // PR10: for per-tenant fairness
+	HandledBy        string  `json:"handled_by,omitempty"` // #181: instance that processed this request
 }
 
 // MetricsOutput defines the JSON structure for the saved metrics

--- a/sim/request.go
+++ b/sim/request.go
@@ -47,6 +47,10 @@ type Request struct {
 	AudioTokenCount int     // Audio input tokens
 	VideoTokenCount int     // Video input tokens
 	ReasonRatio     float64 // reason_tokens / total_output_tokens (part of OutputTokens, not additional)
+
+	// Cluster routing metadata. Set by RoutingDecisionEvent; zero-value when
+	// Request is used outside the cluster routing pipeline (e.g., direct sim.Simulator tests).
+	AssignedInstance string // Instance ID this request was routed to
 }
 
 // This method returns a human-readable string representation of a Request.

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -261,6 +261,7 @@ func (sim *Simulator) InjectArrival(req *Request) {
 		NumDecodeTokens:  len(req.OutputTokens),
 		SLOClass:         req.SLOClass,
 		TenantID:         req.TenantID,
+		HandledBy:        req.AssignedInstance,
 	}
 }
 
@@ -276,6 +277,7 @@ func (sim *Simulator) InjectArrivalAt(req *Request, eventTime int64) {
 		NumDecodeTokens:  len(req.OutputTokens),
 		SLOClass:         req.SLOClass,
 		TenantID:         req.TenantID,
+		HandledBy:        req.AssignedInstance,
 	}
 }
 

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -265,6 +265,31 @@ func TestInjectArrival_RequestCompletes(t *testing.T) {
 	}
 }
 
+// TestInjectArrival_HandledByEmpty_StandaloneMode verifies #181 standalone boundary:
+// GIVEN a standalone simulator (no cluster routing)
+// WHEN a request is injected and completes
+// THEN HandledBy in RequestMetrics is empty (no routing happened)
+func TestInjectArrival_HandledByEmpty_StandaloneMode(t *testing.T) {
+	sim := NewSimulator(newTestSimConfig())
+	req := &Request{
+		ID:           "request_0",
+		ArrivalTime:  0,
+		InputTokens:  make([]int, 10),
+		OutputTokens: make([]int, 5),
+		State:        "queued",
+	}
+	sim.InjectArrival(req)
+	sim.Run()
+
+	rm, ok := sim.Metrics.Requests["request_0"]
+	if !ok {
+		t.Fatal("request_0 not found in Metrics.Requests")
+	}
+	if rm.HandledBy != "" {
+		t.Errorf("HandledBy: got %q, want empty (standalone mode)", rm.HandledBy)
+	}
+}
+
 // TestInjectArrival_MultipleRequests verifies that multiple injected requests
 // at staggered arrival times all complete successfully.
 func TestInjectArrival_MultipleRequests(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `AssignedInstance` field to `Request` and `HandledBy` field to `RequestMetrics` so per-request JSON output explicitly identifies which instance processed each request
- Stamp at routing time in `RoutingDecisionEvent.Execute()`, propagate through `InjectArrival`/`InjectArrivalAt` with `omitempty` for backward compatibility
- Add 3 behavioral tests (multi-instance, single-instance, standalone boundary)
- Document per-request output fields in README.md and add contributor guide in CLAUDE.md

Closes #181

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestClusterSimulator_HandledBy_PopulatedInMetrics` — verifies all requests have valid `HandledBy` and per-instance consistency
- [x] `TestClusterSimulator_HandledBy_SingleInstance` — verifies N=1 boundary
- [x] `TestInjectArrival_HandledByEmpty_StandaloneMode` — verifies standalone mode produces empty `HandledBy`

## Discovered issues

Filed during code review (not fixed in this PR to avoid scope creep):
- #189 — CSV path constructs `RequestMetrics` inline, missing field propagation
- #190 — `SaveResults` silently drops incomplete requests from JSON
- #191 — `aggregateMetrics()` missing PR12 fields
- #192 — `pendingRequests` false decrement on preemption
- #193 — Silent failures: small horizon / all-rejected scenarios
- #194 — Stale "planned for PR10+" comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)