### PR TITLE
fix(workload): prevent infinite loop when Rate=0

### DIFF
--- a/sim/cluster/workload.go
+++ b/sim/cluster/workload.go
@@ -29,6 +29,9 @@ func (c *ClusterSimulator) generateRequests() []*sim.Request {
 func (c *ClusterSimulator) generateRequestsFromDistribution() []*sim.Request {
 	rng := c.rng.ForSubsystem(sim.SubsystemWorkload)
 	cfg := c.workload
+	if cfg.Rate <= 0 {
+		panic("generateRequestsFromDistribution: Rate must be > 0 (validate at CLI level)")
+	}
 	horizon := c.config.Horizon
 
 	var requests []*sim.Request

--- a/sim/cluster/workload_test.go
+++ b/sim/cluster/workload_test.go
@@ -1,0 +1,25 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+func TestGenerateRequestsFromDistribution_ZeroRate_Panics(t *testing.T) {
+	// GIVEN a ClusterSimulator with workload Rate = 0
+	// WHEN generateRequestsFromDistribution is called
+	// THEN it panics instead of entering an infinite loop (#202)
+	cs := &ClusterSimulator{
+		rng:     sim.NewPartitionedRNG(42),
+		workload: &sim.GuideLLMConfig{Rate: 0, MaxPrompts: 10},
+		config:  DeploymentConfig{Horizon: 1000},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero Rate, but did not panic")
+		}
+	}()
+	cs.generateRequestsFromDistribution()
+}

--- a/sim/workload_config.go
+++ b/sim/workload_config.go
@@ -118,6 +118,9 @@ func (sim *Simulator) generateRandomTokenIDs(length int) []int {
 
 // generateWorkloadDistribution generates request arrivals according to gen config
 func (sim *Simulator) generateWorkloadDistribution() {
+	if sim.Metrics.RequestRate <= 0 {
+		panic("generateWorkloadDistribution: RequestRate must be > 0 (validate at CLI level)")
+	}
 
 	currentTime := int64(0)
 	// keep track of how many requests have been generated

--- a/sim/workload_config_test.go
+++ b/sim/workload_config_test.go
@@ -1,0 +1,37 @@
+package sim
+
+import (
+	"testing"
+)
+
+func TestGenerateWorkloadDistribution_ZeroRate_Panics(t *testing.T) {
+	// GIVEN a simulator with RequestRate = 0
+	// WHEN generateWorkloadDistribution is called
+	// THEN it panics instead of entering an infinite loop (#202)
+	sim := &Simulator{
+		Metrics: &Metrics{RequestRate: 0},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero RequestRate, but did not panic")
+		}
+	}()
+	sim.generateWorkloadDistribution()
+}
+
+func TestGenerateWorkloadDistribution_NegativeRate_Panics(t *testing.T) {
+	// GIVEN a simulator with RequestRate = -1
+	// WHEN generateWorkloadDistribution is called
+	// THEN it panics
+	sim := &Simulator{
+		Metrics: &Metrics{RequestRate: -1},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative RequestRate, but did not panic")
+		}
+	}()
+	sim.generateWorkloadDistribution()
+}


### PR DESCRIPTION
## Summary

- Validate `--rate` flag at CLI level: must be finite and > 0 (catches zero, negative, NaN, Inf)
- Add defensive panic guards in `sim/workload_config.go` and `sim/cluster/workload.go` as invariant checks
- Add 3 behavioral tests (zero rate panics for both single-instance and cluster paths, negative rate panics)

## Root cause

`int64(1 / 0.0)` evaluates to `int64(+Inf)` which is `math.MinInt64` on most platforms. This makes `currentTime` jump to a huge negative value, causing the `currentTime < horizon` loop to run indefinitely with 100% CPU and no error message.

## Error handling boundary

Per project conventions: `logrus.Fatalf` at the CLI boundary (`cmd/root.go`), `panic` for invariant violations in library code (`sim/`, `sim/cluster/`).

Fixes #202

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestGenerateWorkloadDistribution_ZeroRate_Panics` — single-instance guard
- [x] `TestGenerateWorkloadDistribution_NegativeRate_Panics` — negative rate guard
- [x] `TestGenerateRequestsFromDistribution_ZeroRate_Panics` — cluster guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)