### PR TITLE
feat(hypotheses): H-Phase-Structure — validate latency model phase linearity (#314)

### DIFF
--- a/hypotheses/README.md
+++ b/hypotheses/README.md
@@ -23,6 +23,8 @@ This directory contains validated hypothesis experiments for BLIS. Each hypothes
 | H5 | Robustness | Token-bucket admission smooths bursts under Gamma CV=3.5 | **Confirmed with nuance** | 56-69x TTFT improvement holds, but via 96% load shedding, not burst smoothing. Calibrated bucket (cap=100K) shows <5% — wrong mechanism, not wrong direction. |
 | H10 | Structural model | Tiered KV cache reduces preemptions vs single-tier | **Confirmed** | Preemptions halved (17.5%→8.5%); `maybeOffload` preserves prefix hashes; 4 rounds to resolve |
 | H13 | Scheduler invariant | Same seed produces byte-identical output | **Confirmed** | INV-6 holds for 5 policy configurations |
+| H-Phase-Structure | Structural model | TTFT linear in input tokens, decode time linear in output tokens | **Confirmed** | R² = 1.000000 (adjusted); slopes match α/β predictions within <0.01% |
+| H-MMK | Structural model | DES matches M/M/k analytical model under matching assumptions | **Partially confirmed** | Within 3.3% at ρ ≤ 0.3; diverges 28-71% at ρ ≥ 0.5 (discrete step processing) |
 
 ## Running Experiments
 
@@ -42,7 +44,7 @@ Scripts are self-contained — they build the binary, run all experiment variant
 | Family | Done | Pending | Gaps |
 |--------|------|---------|------|
 | **Scheduler invariants** | H12 ✓, H13 ✓ | H25 | Lifecycle (INV-2), causality (INV-5) never directly tested |
-| **Structural model** | H3 ✓, H9 ✓, H10 ✓ | H26 | Event pipeline causal ordering; roofline mode |
+| **Structural model** | H3 ✓, H9 ✓, H10 ✓, H-Phase ✓, H-MMK ✓ | H26 | Event pipeline causal ordering; roofline mode |
 | **Robustness/failure-mode** | H14 ✓, H5 ✓ | H21, H22, H24 | Extreme weights, input validation, pathological combos |
 | **Cross-policy comparative** | Prefix-Affinity ✓ | H1, H2, H4, H6, H15, H17, H18, H19, H23 | **Largest gap** — 9 pending hypotheses |
 | **Performance-regime** | H8 ✓ | H7, H11 | Horizontal scaling, batch formation tradeoff |
@@ -50,7 +52,7 @@ Scripts are self-contained — they build the binary, run all experiment variant
 
 ## Hypothesis Tiers (priority from research.md)
 
-- **Tier 1**: Correctness baselines (H12 ✓, H13 ✓)
+- **Tier 1**: Correctness baselines (H12 ✓, H13 ✓, H-Phase ✓, H-MMK ✓)
 - **Tier 2**: High diagnostic value (H3 ✓, H9 ✓, H14 ✓, Prefix-Affinity ✓)
 - **Tier 3**: System understanding (H1, H5 ✓, H10 ✓, H11)
 - **Tier 4**: Research questions (H15, H17, H19)

--- a/hypotheses/h-phase-structure/FINDINGS.md
+++ b/hypotheses/h-phase-structure/FINDINGS.md
@@ -1,0 +1,200 @@
+# H-Phase-Structure: Latency Model Phase Linearity Validation
+
+**Status:** Confirmed
+**Resolution:** Clean confirmation — TTFT is perfectly linear in input tokens and decode time is perfectly linear in output tokens. Adjusted R² = 1.000000 across all seeds for both phases. Measured slopes match analytical predictions from alpha/beta coefficients within 0.01%.
+**Family:** Structural model
+**VV&UQ:** Validation
+**Tier:** Tier 1 (foundational — grounds all latency-based experiments)
+**Type:** Statistical (Monotonicity — linearity is strict monotonicity with constant slope)
+**Date:** 2026-02-21
+**Rounds:** 1
+
+## Hypothesis
+
+> Component: latency model. Assumption: prefill cost is proportional to prompt token count and decode cost is proportional to generated token count. Observable: TTFT should be linear in input_tokens (R² > 0.95 for linear fit) with output held constant, and (E2E − TTFT) should be linear in output_tokens (R² > 0.95) with input held constant.
+
+## Experiment Design
+
+**Classification:** Statistical / Monotonicity (linearity = constant slope)
+
+**Two sub-experiments:**
+
+**Experiment A — TTFT vs Input Tokens:**
+- Fixed output = 128 tokens (constant distribution)
+- Input ∈ {64, 128, 256, 512, 1024} (constant distribution at each level)
+- Single instance, `--max-num-running-reqs 1`, rate = 0.01 req/s, 20 requests per level
+- Measure mean TTFT at each level, fit linear regression, report R²
+
+**Experiment B — Decode Time (E2E − TTFT) vs Output Tokens:**
+- Fixed input = 256 tokens (constant distribution)
+- Output ∈ {64, 128, 256, 512, 1024} (constant distribution at each level)
+- Same single-instance, no-queueing configuration
+- Measure mean (E2E − TTFT) at each level, fit linear regression, report R²
+
+**Configurations compared:**
+- 5 input levels (Exp A) and 5 output levels (Exp B), all else held constant
+- Common flags: `--model meta-llama/llama-3.1-8b-instruct --num-instances 1 --max-num-running-reqs 1 --scheduler fcfs --admission-policy always-admit --total-kv-blocks 1000000`
+
+**Controlled variables:** Model (llama-3.1-8b, H100, TP=2), KV blocks (1M — no pressure), scheduler (FCFS), admission (always-admit), rate (0.01 req/s — zero queueing)
+
+**Varied variable:** Input token count (Exp A) or output token count (Exp B)
+
+**Seeds:** 42, 123, 456
+
+**Preconditions verified:**
+- Calibration: E2E for (input=1, output=128) = 1126.241 ms (matches H-MMK calibration exactly)
+- Rate 0.01 req/s → P(queueing) ≈ 1.1% for Exp A (service ~1.1s), ~8.5% for Exp B at output=1024 (service ~8.9s). Exp B is immune: E2E-TTFT cancels scheduling delay.
+- Constant distributions → all requests at a given level are identical
+
+**Reference:** `hypotheses/h-mmk-validation/run.sh` (ED-6 config diff: this experiment uses constant distributions on both input and output; H-MMK used constant input + exponential output. Rate reduced to 0.01. Single instance only.)
+
+## Results
+
+### Experiment A: TTFT vs Input Tokens
+
+#### Raw TTFT (includes scheduling/queueing delay)
+
+| Input | seed=42 | seed=123 | seed=456 | Mean |
+|------:|--------:|---------:|---------:|-----:|
+| 64 | 11.672 | 11.672 | 11.672 | 11.672 |
+| 128 | 13.027 | **42.389** | 13.027 | 22.814 |
+| 256 | 15.739 | 15.739 | 15.739 | 15.739 |
+| 512 | 21.161 | 21.161 | 21.161 | 21.161 |
+| 1024 | 32.008 | 32.008 | 32.008 | 32.008 |
+
+| Seed | Slope (ms/tok) | Intercept (ms) | R² | Pass |
+|-----:|---------------:|---------------:|---:|-----:|
+| 42 | 0.021183 | 10.316 | 1.000000 | YES |
+| 123 | 0.008234 | 21.327 | 0.065713 | NO |
+| 456 | 0.021183 | 10.316 | 1.000000 | YES |
+
+Seed 123 fails due to one Poisson arrival event at input=128 that queued behind the previous request (TTFT=42.389 vs expected 13.027). This is queueing noise, not model non-linearity.
+
+#### Adjusted TTFT (scheduling delay subtracted — pure latency model)
+
+| Input | seed=42 | seed=123 | seed=456 | Mean |
+|------:|--------:|---------:|---------:|-----:|
+| 64 | 9.846 | 9.846 | 9.846 | 9.846 |
+| 128 | 10.977 | 10.977 | 10.977 | 10.977 |
+| 256 | 13.239 | 13.239 | 13.239 | 13.239 |
+| 512 | 17.762 | 17.762 | 17.762 | 17.762 |
+| 1024 | 26.810 | 26.810 | 26.810 | 26.810 |
+
+| Seed | Slope (ms/tok) | Intercept (ms) | R² | Pass |
+|-----:|---------------:|---------------:|---:|-----:|
+| 42 | 0.017671 | 8.715 | **1.000000** | YES |
+| 123 | 0.017671 | 8.715 | **1.000000** | YES |
+| 456 | 0.017671 | 8.715 | **1.000000** | YES |
+
+**Analytical prediction:** slope = β₁ = 17.67 μs/tok = 0.01767 ms/tok; intercept = β₀ + α₂ = 8716.0 μs = 8.716 ms
+**Measured:** slope = 0.017671 ms/tok (error: <0.01%); intercept = 8.715 ms (0.01% error due to int64 truncation in `getStepTime()`)
+
+### Experiment B: Decode Time (E2E − TTFT) vs Output Tokens
+
+| Output | seed=42 | seed=123 | seed=456 | Mean |
+|-------:|--------:|---------:|---------:|-----:|
+| 64 | 557.952 | 557.952 | 557.952 | 557.952 |
+| 128 | 1115.904 | 1115.904 | 1115.904 | 1115.904 |
+| 256 | 2231.808 | 2231.808 | 2231.808 | 2231.808 |
+| 512 | 4463.616 | 4463.616 | 4463.616 | 4463.616 |
+| 1024 | 8927.232 | 8927.232 | 8927.232 | 8927.232 |
+
+| Seed | Slope (ms/tok) | Intercept (ms) | R² | Pass |
+|-----:|---------------:|---------------:|---:|-----:|
+| 42 | 8.718000 | -0.000 | **1.000000** | YES |
+| 123 | 8.718000 | -0.000 | **1.000000** | YES |
+| 456 | 8.718000 | -0.000 | **1.000000** | YES |
+
+**Analytical prediction:** slope = β₀ + β₂ + α₂ = 6910.42 + 2.84 + 1805.54 = 8718.80 μs/tok = 8.719 ms/tok
+**Measured:** slope = 8.718 ms/tok (error: <0.01% — int64 truncation: `int64(6913.26)` = 6913, `int64(1805.54)` = 1805, total 8718 vs 8718.80); intercept = -0.000 ms
+
+## Root Cause Analysis
+
+### Why the latency model is perfectly linear (RCV-1)
+
+The DES step time formula is `stepTime = beta0 + beta1*cacheMissTokens + beta2*decodeTokens` (`sim/simulator.go:379-381`). With `max-num-running-reqs=1`:
+- Prefill step: cacheMissTokens = input_tokens, decodeTokens = 0 → stepTime = β₀ + β₁×input
+- Decode step: cacheMissTokens = 0, decodeTokens = 1 → stepTime = β₀ + β₂
+
+Both are exactly linear in the token count. The TTFT additionally includes `getOutputTokenProcessingTime()` which returns α₂ = 1805.54 μs (`sim/simulator.go:631`), a constant. Each ITL entry adds `currStepAdvance + getOutputTokenProcessingTime()` (`sim/simulator.go:627,659`).
+
+### Why raw TTFT has queueing noise (RCV-3)
+
+TTFT is defined as `now + currStepAdvance + alpha2 - ArrivalTime` (`sim/simulator.go:631`). The `(now - ArrivalTime)` component includes both:
+1. **Alpha model delay:** α₀ + α₁×input = deterministic, linear in input
+2. **Actual queue wait:** stochastic, depends on Poisson inter-arrival timing
+
+At rate=0.01 with Poisson arrivals, P(next request arrives during ~1.1s service) ≈ 1 - e^(-0.01×1.13) ≈ 1.1%. Seed 123 hit this at input=128, adding ~29.4ms mean queueing delay. Subtracting the per-request scheduling delay (`sim/metrics.go:158`) removes both components, leaving only the step time + α₂.
+
+### Why E2E - TTFT is immune to queueing noise (RCV-3)
+
+Decode time = E2E - TTFT = Σ(ITL). Each ITL = stepAdvance + α₂. The scheduling delay appears in both E2E and TTFT and cancels in the subtraction. This is why Experiment B shows zero seed-to-seed variation.
+
+### Control experiment confirmation (RCV-4)
+
+Seeds 42 and 456 had zero queueing (R² = 1.000000 for raw TTFT). This serves as a natural control — the same configuration with different Poisson realizations that happened to avoid queueing shows perfect linearity, confirming that the non-linearity in seed 123 is purely from queueing, not from the latency model.
+
+## Devil's Advocate (RCV-5)
+
+**If this is "Confirmed," argue why it might be Refuted:**
+The R² = 1.000000 results are suspiciously perfect — this could indicate that the DES is too simple rather than that the model is correct. A real LLM serving system has non-linear effects (attention scaling as O(n²), memory bandwidth saturation, batch scheduling overhead) that the alpha/beta linear model ignores by design. Confirming linearity at the model level says nothing about whether the model accurately predicts real system behavior. This experiment validates internal consistency, not external validity.
+
+**Counter-counter:** True, but internal consistency is the prerequisite. If the DES didn't even implement its own coefficients correctly (e.g., off-by-one in token counting, integer truncation), no amount of coefficient fitting would produce accurate predictions. This experiment confirms the math is correct; coefficient accuracy is a separate validation question.
+
+## Findings Classification
+
+| Finding | Type | Action |
+|---------|------|--------|
+| TTFT is perfectly linear in input tokens (R² = 1.000000, slope matches β₁) | Confirmation | Documented here |
+| Decode time is perfectly linear in output tokens (R² = 1.000000, slope matches β₀+β₂+α₂) | Confirmation | Documented here |
+| Raw TTFT contaminated by Poisson queueing noise at rate=0.01 | Design limitation | Documented here — users should use adjusted TTFT for phase analysis |
+| Scheduling delay subtraction cleanly isolates latency model from queueing effects | Confirmation | Documented here — useful technique for future experiments |
+| Analytical slope predictions match measured slopes within 0.01% | Confirmation | Validates analytical prediction formulas in `docs/standards/experiments.md` |
+
+## Standards Audit
+
+Findings checked against docs/standards/:
+- [x] Any violations of existing rules? **None found**
+- [x] Any new rules needed? **None** — the queueing noise finding is a methodological insight, not a new rule
+- [x] Any new invariants needed? **None** — phase structure linearity is already documented in `docs/standards/experiments.md` (cross-validation section)
+- [x] Any existing rules/invariants confirmed? **Yes** — INV-6 (determinism) confirmed: adjusted TTFT identical across all seeds. Phase structure cross-validation from `docs/standards/experiments.md` confirmed with R² > 0.95 (actually = 1.0)
+
+## Scope and Limitations (RCV-6)
+
+- **Operating point tested:** Single instance, max-running-reqs=1, rate=0.01 req/s, FCFS scheduler, always-admit, 1M KV blocks (no pressure), llama-3.1-8b/H100/TP=2
+- **Parameters findings depend on:** max-num-running-reqs=1 (eliminates batching effects), constant distributions (eliminates stochastic variation in token counts), low rate (minimizes queueing)
+- **What was NOT tested:**
+  - Batched execution (max-running-reqs > 1): with multiple requests in a batch, the per-request share of step time is non-trivial. The linear relationship may not hold per-request in batched mode.
+  - Variable distributions (Gaussian, exponential): the per-request relationship is still linear, but averaging across requests with different token counts would show the mean relationship.
+  - Roofline mode: analytical FLOPs/bandwidth estimation may have different non-linearities (e.g., attention quadratic scaling). This is hypothesis H19.
+  - Very large token counts (>1024): the linear beta model may break down at extreme sequence lengths due to memory bandwidth saturation not modeled by the coefficients.
+- **Generalizability:** The phase structure linearity holds for any alpha/beta coefficient set and any token count range where the coefficient model is used. This is a **structural claim** about the code (a linear combination of inputs produces linear output), not an empirical generalization from testing multiple coefficient sets. The claim follows from the code at `sim/simulator.go:379-381` being a 3-term linear combination.
+- **Uncertainty quantification:** UQ not applicable — the relationship is deterministic under controlled conditions. The reported R² = 1.000000 is a display artifact of `:.6f` formatting; the true value is approximately 0.9999999 due to sub-microsecond residuals from `int64()` truncation in `getStepTime()`. The only macroscopic uncertainty is the queueing noise in raw TTFT, which is fully explained by Poisson arrival statistics.
+
+## Evidence Quality
+
+| Metric | Value | Confidence |
+|--------|-------|------------|
+| Adjusted TTFT R² | 1.000000 (all 3 seeds) | High — deterministic given constant distributions |
+| Decode R² | 1.000000 (all 3 seeds) | High — deterministic given constant distributions |
+| TTFT slope vs β₁ | 0.0% error | High — exact match |
+| Decode slope vs β₀+β₂+α₂ | 0.0% error | High — exact match |
+| Sample size | 3 seeds × 5 levels × 20 requests = 300 requests per experiment | Adequate (constant distributions make >1 request per level redundant) |
+| Mechanism | Linear beta coefficient model (sim/simulator.go:378-380) | High — code-traced, analytically predicted, experimentally confirmed |
+
+## Implications for Users
+
+1. **TTFT prediction:** For single-request inference, TTFT ≈ (α₀ + β₀ + α₂) + (α₁ + β₁) × input_tokens. For llama-3.1-8b on H100/TP=2: TTFT ≈ 10.317 ms + 0.02118 ms × input_tokens.
+
+2. **Decode time prediction:** Total decode time ≈ output_tokens × (β₀ + β₂ + α₂). For llama-3.1-8b on H100/TP=2: decode ≈ 8.719 ms × output_tokens.
+
+3. **E2E prediction:** E2E ≈ TTFT + decode ≈ 10.317 + 0.02118 × input + 8.719 × output (milliseconds). At the calibration point (input=1, output=128): 10.317 + 0.021 + 1116.0 = 1126.3 ms — matches the 1126.241 ms calibration.
+
+4. **Methodological note:** When analyzing TTFT in experiments with queueing, subtract the per-request scheduling delay (`scheduling_delay_ms / 1000` in the per-request JSON) to isolate the latency model from queueing effects.
+
+## Reproducing
+
+```bash
+cd hypotheses/h-phase-structure
+./run.sh
+```

--- a/hypotheses/h-phase-structure/analyze.py
+++ b/hypotheses/h-phase-structure/analyze.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Analysis script for H-Phase-Structure: Latency Model Phase Linearity.
+
+Parses per-request JSON from BLIS --results-path output.
+Computes linear regression (R²) for:
+  A. TTFT vs input tokens (output held constant)
+  B. (E2E - TTFT) vs output tokens (input held constant)
+
+BLIS per-request JSON fields (see sim/metrics_utils.go:19-31):
+  - num_prefill_tokens: int (input tokens)
+  - num_decode_tokens: int (output tokens)
+  - ttft_ms: float (milliseconds, converted from ticks by /1e3)
+  - e2e_ms: float (milliseconds, converted from ticks by /1e3)
+
+NOTE: scheduling_delay_ms is in TICKS (not ms) despite the field name.
+      This script does not use scheduling_delay_ms.
+
+Analytical predictions from trained coefficients (defaults.yaml):
+  Alpha coefficients: [1601.35, 3.51, 1805.54]
+    alpha0 = 1601.35 us (base queue delay)
+    alpha1 = 3.51 us/token (per-input-token queue delay)
+    alpha2 = 1805.54 us (output processing time)
+
+  Beta coefficients: [6910.42, 17.67, 2.84]
+    beta0 = 6910.42 us (base step time)
+    beta1 = 17.67 us/token (per-cache-miss-token step time)
+    beta2 = 2.84 us/token (per-decode-token step time)
+
+  Expected TTFT = (alpha0 + alpha1*input) + (beta0 + beta1*input) + alpha2
+                = (alpha0 + beta0 + alpha2) + (alpha1 + beta1)*input
+                ≈ 10317 us + 21.18 us/token * input
+                ≈ 10.317 ms + 0.02118 ms/token * input
+
+  Expected decode_time = output_tokens * (beta0 + beta2 + alpha2)
+                       = output_tokens * 8718.80 us
+                       ≈ output_tokens * 8.719 ms
+  Each ITL entry = currStepAdvance + getOutputTokenProcessingTime()
+                 = (beta0 + beta2*1) + alpha2 = 8718.80 us  (simulator.go:627,659)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def linear_regression(xs, ys):
+    """Compute least-squares linear regression.
+
+    Returns (slope, intercept, r_squared).
+    """
+    n = len(xs)
+    if n < 2:
+        return 0.0, 0.0, 0.0
+
+    sum_x = sum(xs)
+    sum_y = sum(ys)
+    sum_xy = sum(x * y for x, y in zip(xs, ys))
+    sum_x2 = sum(x * x for x in xs)
+    denom = n * sum_x2 - sum_x * sum_x
+    if abs(denom) < 1e-15:
+        return 0.0, sum_y / n, 0.0
+
+    slope = (n * sum_xy - sum_x * sum_y) / denom
+    intercept = (sum_y - slope * sum_x) / n
+
+    # R² = 1 - SS_res / SS_tot
+    y_mean = sum_y / n
+    ss_tot = sum((y - y_mean) ** 2 for y in ys)
+    ss_res = sum((y - (slope * x + intercept)) ** 2 for x, y in zip(xs, ys))
+
+    if ss_tot < 1e-15:
+        r_squared = 1.0  # Perfect fit (all y values identical)
+    else:
+        r_squared = 1.0 - ss_res / ss_tot
+
+    return slope, intercept, r_squared
+
+
+def parse_requests(filepath):
+    """Parse per-request metrics from a BLIS --results-path JSON file.
+
+    Returns list of dicts with keys: input_tokens, output_tokens, ttft_ms, e2e_ms, decode_ms.
+    Filters to completed requests only (e2e_ms > 0).
+    """
+    try:
+        with open(filepath) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"  WARNING: could not parse {filepath}: {e}", file=sys.stderr)
+        return []
+
+    results = []
+    for r in data.get("requests", []):
+        if r.get("e2e_ms", 0) <= 0:
+            continue
+        ttft = r["ttft_ms"]
+        e2e = r["e2e_ms"]
+        # scheduling_delay_ms field is in TICKS (μs), not ms — divide by 1000
+        sched_delay_ms = r.get("scheduling_delay_ms", 0) / 1000.0
+        results.append({
+            "input_tokens": r["num_prefill_tokens"],
+            "output_tokens": r["num_decode_tokens"],
+            "ttft_ms": ttft,
+            "e2e_ms": e2e,
+            "decode_ms": e2e - ttft,
+            "sched_delay_ms": sched_delay_ms,
+            "ttft_adjusted_ms": ttft - sched_delay_ms,  # Pure latency model (no queueing)
+        })
+    return results
+
+
+def analyze_experiment_a(results_dir, input_levels, fixed_output, seeds):
+    """Experiment A: TTFT vs Input Tokens (output held constant)."""
+    print("=" * 78)
+    print("  Experiment A: TTFT vs Input Tokens")
+    print(f"  Fixed output = {fixed_output} tokens")
+    print("=" * 78)
+    print()
+
+    # Collect per-seed data: both raw TTFT and adjusted (minus scheduling delay)
+    per_seed_raw = {}
+    per_seed_adj = {}
+    for seed in seeds:
+        xs = []
+        ys_raw = []
+        ys_adj = []
+        for input_tok in input_levels:
+            filepath = Path(results_dir) / f"expA_in{input_tok}_s{seed}.json"
+            reqs = parse_requests(filepath)
+            if not reqs:
+                print(f"  WARNING: no data for input={input_tok} seed={seed}", file=sys.stderr)
+                continue
+
+            mean_ttft = sum(r["ttft_ms"] for r in reqs) / len(reqs)
+            mean_adj = sum(r["ttft_adjusted_ms"] for r in reqs) / len(reqs)
+            xs.append(input_tok)
+            ys_raw.append(mean_ttft)
+            ys_adj.append(mean_adj)
+
+        if len(xs) >= 2:
+            sl_r, ic_r, r2_r = linear_regression(xs, ys_raw)
+            per_seed_raw[seed] = {
+                "xs": xs, "ys": ys_raw,
+                "slope": sl_r, "intercept": ic_r, "r_squared": r2_r,
+            }
+            sl_a, ic_a, r2_a = linear_regression(xs, ys_adj)
+            per_seed_adj[seed] = {
+                "xs": xs, "ys": ys_adj,
+                "slope": sl_a, "intercept": ic_a, "r_squared": r2_a,
+            }
+
+    # ── Raw TTFT table ──
+    print("  Per-level mean TTFT (ms) — raw (includes queueing delay):")
+    print(f"  {'Input':>8s}", end="")
+    for seed in seeds:
+        print(f"  {'seed=' + str(seed):>12s}", end="")
+    print(f"  {'Mean':>10s}")
+    print("  " + "-" * (8 + 12 * len(seeds) + 10 + 2 * (len(seeds) + 1)))
+
+    for i, input_tok in enumerate(input_levels):
+        print(f"  {input_tok:8d}", end="")
+        vals = []
+        for seed in seeds:
+            if seed in per_seed_raw and i < len(per_seed_raw[seed]["ys"]):
+                v = per_seed_raw[seed]["ys"][i]
+                print(f"  {v:12.3f}", end="")
+                vals.append(v)
+            else:
+                print(f"  {'N/A':>12s}", end="")
+        if vals:
+            print(f"  {sum(vals)/len(vals):10.3f}", end="")
+        print()
+
+    print()
+
+    # ── Raw regression ──
+    print("  Raw Linear Regression: TTFT = slope * input_tokens + intercept")
+    print(f"  {'Seed':>8s}  {'Slope (ms/tok)':>14s}  {'Intercept (ms)':>15s}  {'R²':>10s}  {'Pass':>6s}")
+    print("  " + "-" * 60)
+
+    raw_pass = True
+    for seed in seeds:
+        if seed not in per_seed_raw:
+            print(f"  {seed:8d}  {'N/A':>14s}  {'N/A':>15s}  {'N/A':>10s}  {'N/A':>6s}")
+            raw_pass = False
+            continue
+        r = per_seed_raw[seed]
+        passed = r["r_squared"] >= 0.95
+        if not passed:
+            raw_pass = False
+        print(f"  {seed:8d}  {r['slope']:14.6f}  {r['intercept']:15.3f}  {r['r_squared']:10.6f}  {'YES' if passed else 'NO':>6s}")
+
+    print()
+
+    # ── Adjusted TTFT table (TTFT - scheduling_delay) ──
+    print("  Per-level mean adjusted TTFT (ms) — scheduling delay subtracted:")
+    print("  (Isolates latency model: step_time + alpha2, no queueing)")
+    print(f"  {'Input':>8s}", end="")
+    for seed in seeds:
+        print(f"  {'seed=' + str(seed):>12s}", end="")
+    print(f"  {'Mean':>10s}")
+    print("  " + "-" * (8 + 12 * len(seeds) + 10 + 2 * (len(seeds) + 1)))
+
+    for i, input_tok in enumerate(input_levels):
+        print(f"  {input_tok:8d}", end="")
+        vals = []
+        for seed in seeds:
+            if seed in per_seed_adj and i < len(per_seed_adj[seed]["ys"]):
+                v = per_seed_adj[seed]["ys"][i]
+                print(f"  {v:12.3f}", end="")
+                vals.append(v)
+            else:
+                print(f"  {'N/A':>12s}", end="")
+        if vals:
+            print(f"  {sum(vals)/len(vals):10.3f}", end="")
+        print()
+
+    print()
+
+    # ── Adjusted regression ──
+    print("  Adjusted Linear Regression: (TTFT - sched_delay) = slope * input + intercept")
+    print(f"  {'Seed':>8s}  {'Slope (ms/tok)':>14s}  {'Intercept (ms)':>15s}  {'R²':>10s}  {'Pass':>6s}")
+    print("  " + "-" * 60)
+
+    adj_pass = True
+    for seed in seeds:
+        if seed not in per_seed_adj:
+            print(f"  {seed:8d}  {'N/A':>14s}  {'N/A':>15s}  {'N/A':>10s}  {'N/A':>6s}")
+            adj_pass = False
+            continue
+        r = per_seed_adj[seed]
+        passed = r["r_squared"] >= 0.95
+        if not passed:
+            adj_pass = False
+        print(f"  {seed:8d}  {r['slope']:14.6f}  {r['intercept']:15.3f}  {r['r_squared']:10.6f}  {'YES' if passed else 'NO':>6s}")
+
+    print()
+
+    # Analytical predictions
+    alpha0, alpha1, alpha2 = 1601.35, 3.51, 1805.54
+    beta0, beta1 = 6910.42, 17.67
+
+    # Raw TTFT: slope = alpha1 + beta1, intercept = alpha0 + beta0 + alpha2
+    raw_slope_us = alpha1 + beta1
+    raw_intercept_us = alpha0 + beta0 + alpha2
+    # Adjusted TTFT (minus scheduling delay): slope = beta1, intercept = beta0 + alpha2
+    adj_slope_us = beta1
+    adj_intercept_us = beta0 + alpha2
+
+    print(f"  Analytical predictions:")
+    print(f"    Raw TTFT:      slope = alpha1+beta1 = {raw_slope_us:.2f} μs/tok = {raw_slope_us/1000:.6f} ms/tok")
+    print(f"                   intercept = alpha0+beta0+alpha2 = {raw_intercept_us:.2f} μs = {raw_intercept_us/1000:.3f} ms")
+    print(f"    Adjusted TTFT: slope = beta1 = {adj_slope_us:.2f} μs/tok = {adj_slope_us/1000:.6f} ms/tok")
+    print(f"                   intercept = beta0+alpha2 = {adj_intercept_us:.2f} μs = {adj_intercept_us/1000:.3f} ms")
+    print()
+
+    if per_seed_raw:
+        mean_raw_slope = sum(r["slope"] for r in per_seed_raw.values()) / len(per_seed_raw)
+        raw_err = abs(mean_raw_slope - raw_slope_us / 1000) / (raw_slope_us / 1000) * 100
+        print(f"    Raw measured slope:      {mean_raw_slope:.6f} ms/tok (error: {raw_err:.1f}%)")
+    if per_seed_adj:
+        mean_adj_slope = sum(r["slope"] for r in per_seed_adj.values()) / len(per_seed_adj)
+        adj_err = abs(mean_adj_slope - adj_slope_us / 1000) / (adj_slope_us / 1000) * 100
+        print(f"    Adjusted measured slope: {mean_adj_slope:.6f} ms/tok (error: {adj_err:.1f}%)")
+    print()
+
+    # Verdicts
+    print(f"  Raw TTFT:      {'PASS' if raw_pass else 'FAIL'} (R² ≥ 0.95 all seeds: {raw_pass})")
+    print(f"  Adjusted TTFT: {'PASS' if adj_pass else 'FAIL'} (R² ≥ 0.95 all seeds: {adj_pass})")
+    if not raw_pass and adj_pass:
+        print("  → Queueing noise contaminates raw TTFT but the latency model is perfectly linear")
+    print()
+
+    return {"raw": per_seed_raw, "adjusted": per_seed_adj, "raw_pass": raw_pass, "adj_pass": adj_pass}
+
+
+def analyze_experiment_b(results_dir, output_levels, fixed_input, seeds):
+    """Experiment B: Decode Time (E2E - TTFT) vs Output Tokens (input held constant)."""
+    print("=" * 78)
+    print("  Experiment B: Decode Time (E2E − TTFT) vs Output Tokens")
+    print(f"  Fixed input = {fixed_input} tokens")
+    print("=" * 78)
+    print()
+
+    # Collect per-seed data
+    per_seed_results = {}
+    for seed in seeds:
+        xs = []  # output token levels
+        ys = []  # mean decode time at each level
+        for output_tok in output_levels:
+            filepath = Path(results_dir) / f"expB_out{output_tok}_s{seed}.json"
+            reqs = parse_requests(filepath)
+            if not reqs:
+                print(f"  WARNING: no data for output={output_tok} seed={seed}", file=sys.stderr)
+                continue
+
+            mean_decode = sum(r["decode_ms"] for r in reqs) / len(reqs)
+            xs.append(output_tok)
+            ys.append(mean_decode)
+
+        if len(xs) >= 2:
+            slope, intercept, r2 = linear_regression(xs, ys)
+            per_seed_results[seed] = {
+                "xs": xs, "ys": ys,
+                "slope": slope, "intercept": intercept, "r_squared": r2,
+            }
+
+    # Print per-level table
+    print("  Per-level mean decode time (E2E − TTFT) (ms):")
+    print(f"  {'Output':>8s}", end="")
+    for seed in seeds:
+        print(f"  {'seed=' + str(seed):>12s}", end="")
+    print(f"  {'Mean':>10s}")
+    print("  " + "-" * (8 + 12 * len(seeds) + 10 + 2 * (len(seeds) + 1)))
+
+    for i, output_tok in enumerate(output_levels):
+        print(f"  {output_tok:8d}", end="")
+        vals = []
+        for seed in seeds:
+            if seed in per_seed_results and i < len(per_seed_results[seed]["ys"]):
+                v = per_seed_results[seed]["ys"][i]
+                print(f"  {v:12.3f}", end="")
+                vals.append(v)
+            else:
+                print(f"  {'N/A':>12s}", end="")
+        if vals:
+            print(f"  {sum(vals)/len(vals):10.3f}", end="")
+        print()
+
+    print()
+
+    # Print regression results per seed
+    print("  Linear Regression: decode_time = slope * output_tokens + intercept")
+    print(f"  {'Seed':>8s}  {'Slope (ms/tok)':>14s}  {'Intercept (ms)':>15s}  {'R²':>10s}  {'Pass':>6s}")
+    print("  " + "-" * 60)
+
+    all_pass = True
+    for seed in seeds:
+        if seed not in per_seed_results:
+            print(f"  {seed:8d}  {'N/A':>14s}  {'N/A':>15s}  {'N/A':>10s}  {'N/A':>6s}")
+            all_pass = False
+            continue
+        r = per_seed_results[seed]
+        passed = r["r_squared"] >= 0.95
+        if not passed:
+            all_pass = False
+        print(f"  {seed:8d}  {r['slope']:14.6f}  {r['intercept']:15.3f}  {r['r_squared']:10.6f}  {'YES' if passed else 'NO':>6s}")
+
+    print()
+
+    # Analytical prediction
+    # Each decode token's ITL = currStepAdvance + getOutputTokenProcessingTime()
+    #   currStepAdvance = beta0 + beta2*1 (batch=1, one decode token)
+    #   getOutputTokenProcessingTime() = alpha2
+    # So per-token decode cost = beta0 + beta2 + alpha2
+    # See simulator.go:627 and simulator.go:659 — both add currStepAdvance + alpha2
+    alpha2 = 1805.54
+    beta0, beta2 = 6910.42, 2.84
+    expected_step_us = beta0 + beta2 + alpha2  # 8718.80 us per decode token
+    expected_slope_ms = expected_step_us / 1000.0  # ms per output token
+
+    print(f"  Analytical prediction (from alpha/beta coefficients):")
+    print(f"    Per-token decode cost: {expected_slope_ms:.6f} ms/token ({expected_step_us:.2f} μs/token)")
+    print(f"    (beta0 + beta2*1 + alpha2 = {beta0} + {beta2} + {alpha2} = {expected_step_us:.2f} μs)")
+    print(f"    Slope should ≈ {expected_slope_ms:.3f} ms/token")
+    print()
+
+    if per_seed_results:
+        mean_slope = sum(r["slope"] for r in per_seed_results.values()) / len(per_seed_results)
+        slope_error = abs(mean_slope - expected_slope_ms) / expected_slope_ms * 100
+        mean_intercept = sum(r["intercept"] for r in per_seed_results.values()) / len(per_seed_results)
+        print(f"    Measured mean slope: {mean_slope:.6f} ms/token")
+        print(f"    Slope error vs analytical: {slope_error:.1f}%")
+        print(f"    Measured mean intercept: {mean_intercept:.3f} ms")
+        print(f"    (Non-zero intercept indicates offset from first-token / prefill step)")
+    print()
+
+    # Verdict
+    if all_pass:
+        print("  ✓ PASS: R² ≥ 0.95 for all seeds — decode time is linear in output tokens")
+    else:
+        print("  ✗ FAIL: R² < 0.95 for at least one seed — decode time is NOT linear in output tokens")
+    print()
+
+    return per_seed_results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="H-Phase-Structure analysis")
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--input-levels", required=True, help="Space-separated input token levels")
+    parser.add_argument("--output-levels", required=True, help="Space-separated output token levels")
+    parser.add_argument("--fixed-output", type=int, required=True)
+    parser.add_argument("--fixed-input", type=int, required=True)
+    parser.add_argument("--seeds", required=True, help="Space-separated seed values")
+    args = parser.parse_args()
+
+    input_levels = [int(x) for x in args.input_levels.split()]
+    output_levels = [int(x) for x in args.output_levels.split()]
+    seeds = [int(x) for x in args.seeds.split()]
+
+    exp_a = analyze_experiment_a(args.results_dir, input_levels, args.fixed_output, seeds)
+    exp_b = analyze_experiment_b(args.results_dir, output_levels, args.fixed_input, seeds)
+
+    # Overall summary
+    print("=" * 78)
+    print("  Overall Summary")
+    print("=" * 78)
+    print()
+
+    a_raw_pass = exp_a.get("raw_pass", False)
+    a_adj_pass = exp_a.get("adj_pass", False)
+    a_adj = exp_a.get("adjusted", {})
+    b_pass = all(r["r_squared"] >= 0.95 for r in exp_b.values()) if exp_b else False
+
+    a_adj_r2s = [r["r_squared"] for r in a_adj.values()] if a_adj else []
+    b_r2s = [r["r_squared"] for r in exp_b.values()] if exp_b else []
+
+    print(f"  Experiment A — raw TTFT vs input:      {'PASS' if a_raw_pass else 'FAIL'}")
+    print(f"  Experiment A — adjusted TTFT vs input:  {'PASS' if a_adj_pass else 'FAIL'}")
+    if a_adj_r2s:
+        print(f"    Adjusted R² range: [{min(a_adj_r2s):.6f}, {max(a_adj_r2s):.6f}]")
+    print()
+    print(f"  Experiment B — decode time vs output:   {'PASS' if b_pass else 'FAIL'}")
+    if b_r2s:
+        print(f"    R² range: [{min(b_r2s):.6f}, {max(b_r2s):.6f}]")
+    print()
+
+    # The adjusted TTFT is the true test of the latency model's phase structure
+    if a_adj_pass and b_pass:
+        print("  ✓ HYPOTHESIS CONFIRMED: Both phase relationships are linear (R² ≥ 0.95)")
+        print("    TTFT ∝ input_tokens and (E2E − TTFT) ∝ output_tokens")
+        if not a_raw_pass:
+            print("    (Raw TTFT contaminated by Poisson queueing noise; adjusted TTFT confirms linearity)")
+    elif a_adj_pass or b_pass:
+        print("  ~ PARTIALLY CONFIRMED: One phase is linear, the other is not")
+        if not a_adj_pass:
+            print("    TTFT vs input_tokens: non-linear even after removing scheduling delay")
+        if not b_pass:
+            print("    Decode vs output_tokens: non-linear — investigate step time model")
+    else:
+        print("  ✗ HYPOTHESIS REFUTED: Neither phase relationship is linear")
+        print("    The alpha/beta coefficient model may have fundamental non-linearities")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/hypotheses/h-phase-structure/run.sh
+++ b/hypotheses/h-phase-structure/run.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# H-Phase-Structure: TTFT Linearity in Input Tokens, Decode Linearity in Output Tokens
+#
+# Hypothesis: Prefill cost is proportional to prompt token count and decode cost
+# is proportional to generated token count. TTFT should be linear in input_tokens
+# (R² > 0.95) with output held constant, and (E2E − TTFT) should be linear in
+# output_tokens (R² > 0.95) with input held constant.
+#
+# Classification: Statistical / Monotonicity (linearity = constant slope)
+# Family: Structural model
+# VV&UQ: Validation
+#
+# Two sub-experiments:
+#   A. Fix output=128, vary input ∈ {64, 128, 256, 512, 1024} → TTFT vs input_tokens
+#   B. Fix input=256, vary output ∈ {64, 128, 256, 512, 1024} → (E2E−TTFT) vs output_tokens
+#
+# Design notes:
+#   ED-1: Controlled comparison — only one token dimension varies per sub-experiment
+#   ED-2: Low rate (0.01 req/s) eliminates queueing → isolates latency model
+#   ED-3: Precondition — max-num-running-reqs=1, rate << service rate → zero queueing
+#   ED-5: Reproducible — builds binary, runs all variants, no manual steps
+#   ED-6: Reference: hypotheses/h-mmk-validation/run.sh (calibration approach, beta coefficients)
+#         Config diff: this experiment uses single instance, constant distributions on both
+#         input and output (H-MMK used constant input only + exponential output).
+#         Rate set to 0.01 req/s (same as H-MMK calibration step).
+#
+# Reference: https://github.com/inference-sim/inference-sim/issues/314
+#
+# Usage: ./run.sh [--rebuild]
+#
+# Requires: Go 1.24+, Python 3 (standard library only)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$REPO_ROOT/simulation_worker"
+
+# Build if needed
+if [[ "${1:-}" == "--rebuild" ]] || [[ ! -x "$BINARY" ]]; then
+    echo "Building simulation_worker..."
+    (cd "$REPO_ROOT" && go build -o simulation_worker main.go)
+fi
+
+MODEL="meta-llama/llama-3.1-8b-instruct"
+SEEDS=(42 123 456)
+RATE=0.01  # Very low rate → zero queueing (P(queue) ≈ 1% at longest service time)
+NUM_REQUESTS=20  # Per level. Constant distributions → all requests identical within level.
+
+# Token levels for sweeps
+INPUT_LEVELS=(64 128 256 512 1024)
+OUTPUT_LEVELS=(64 128 256 512 1024)
+
+# Fixed dimensions
+FIXED_OUTPUT=128   # Held constant in Experiment A
+FIXED_INPUT=256    # Held constant in Experiment B
+
+RESULTS_DIR=$(mktemp -d)
+trap "rm -rf $RESULTS_DIR" EXIT
+
+# Generate workload YAML with constant input and output distributions
+make_workload() {
+    local input_tokens=$1
+    local output_tokens=$2
+    local seed=$3
+    local outfile=$4
+
+    cat > "$outfile" << YAMLEOF
+version: "1"
+seed: $seed
+category: language
+aggregate_rate: $RATE
+num_requests: $NUM_REQUESTS
+clients:
+  - id: "phase-structure"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: $input_tokens
+    output_distribution:
+      type: constant
+      params:
+        value: $output_tokens
+YAMLEOF
+}
+
+run_sim() {
+    local results_json=$1
+    local stdout_file=$2
+    local workload_yaml=$3
+    local seed=$4
+
+    timeout 300 "$BINARY" run \
+        --model "$MODEL" \
+        --num-instances 1 \
+        --max-num-running-reqs 1 \
+        --workload-spec "$workload_yaml" \
+        --seed "$seed" \
+        --scheduler fcfs \
+        --admission-policy always-admit \
+        --total-kv-blocks 1000000 \
+        --log error \
+        --results-path "$results_json" \
+        2>/dev/null \
+        > "$stdout_file" \
+        || echo "    WARNING: timeout or error"
+}
+
+echo "============================================================================"
+echo "  H-Phase-Structure: Latency Model Phase Linearity Validation"
+echo "  Reference: issue #314, docs/standards/experiments.md (phase structure)"
+echo "  Type: Statistical / Monotonicity (R² > 0.95)"
+echo "  Family: Structural model | VV&UQ: Validation"
+echo "============================================================================"
+echo ""
+echo "  Config: single instance, max-num-running-reqs=1, rate=${RATE} req/s"
+echo "  Requests per level: ${NUM_REQUESTS} (constant distributions → identical)"
+echo "  Seeds: ${SEEDS[*]}"
+echo ""
+
+# ── Step 0: Calibration sanity check ────────────────────────────────────────
+# Run one request at a known config to verify beta coefficient behavior.
+# Expected: E2E for (input=1, output=128) ≈ 1126 ms (from H-MMK calibration)
+
+echo "Step 0: Calibration sanity check..."
+echo "  (Verifying against H-MMK: input=1, output=128 → E2E ≈ 1126 ms)"
+
+make_workload 1 128 42 "$RESULTS_DIR/cal_wl.yaml"
+# Override for calibration: only 10 requests at very low rate
+cat > "$RESULTS_DIR/cal_wl.yaml" << YAMLEOF
+version: "1"
+seed: 42
+category: language
+aggregate_rate: 0.01
+num_requests: 10
+clients:
+  - id: "calibrate"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 1
+    output_distribution:
+      type: constant
+      params:
+        value: 128
+YAMLEOF
+
+run_sim "$RESULTS_DIR/cal.json" "$RESULTS_DIR/cal_stdout.txt" "$RESULTS_DIR/cal_wl.yaml" 42
+
+CAL_E2E=$(python3 -c "
+import json
+data = json.load(open('$RESULTS_DIR/cal.json'))
+reqs = [r for r in data['requests'] if r['e2e_ms'] > 0]
+mean_e2e = sum(r['e2e_ms'] for r in reqs) / len(reqs)
+print(f'{mean_e2e:.3f}')
+")
+echo "  Measured E2E (input=1, output=128): ${CAL_E2E} ms"
+echo "  H-MMK reference: 1126.241 ms"
+echo ""
+
+# ── Experiment A: TTFT vs Input Tokens ──────────────────────────────────────
+# Fixed output=128, vary input ∈ {64, 128, 256, 512, 1024}
+
+echo "============================================================================"
+echo "  Experiment A: TTFT vs Input Tokens"
+echo "  Fixed output=${FIXED_OUTPUT}, varying input ∈ {${INPUT_LEVELS[*]}}"
+echo "============================================================================"
+echo ""
+
+for input in "${INPUT_LEVELS[@]}"; do
+    for seed in "${SEEDS[@]}"; do
+        echo "  Running: input=${input} output=${FIXED_OUTPUT} seed=${seed} ..."
+        wl="$RESULTS_DIR/expA_in${input}_s${seed}_wl.yaml"
+        make_workload "$input" "$FIXED_OUTPUT" "$seed" "$wl"
+        run_sim \
+            "$RESULTS_DIR/expA_in${input}_s${seed}.json" \
+            "$RESULTS_DIR/expA_in${input}_s${seed}_stdout.txt" \
+            "$wl" "$seed"
+    done
+done
+
+echo ""
+
+# ── Experiment B: (E2E − TTFT) vs Output Tokens ────────────────────────────
+# Fixed input=256, vary output ∈ {64, 128, 256, 512, 1024}
+
+echo "============================================================================"
+echo "  Experiment B: Decode Time (E2E − TTFT) vs Output Tokens"
+echo "  Fixed input=${FIXED_INPUT}, varying output ∈ {${OUTPUT_LEVELS[*]}}"
+echo "============================================================================"
+echo ""
+
+for output in "${OUTPUT_LEVELS[@]}"; do
+    for seed in "${SEEDS[@]}"; do
+        echo "  Running: input=${FIXED_INPUT} output=${output} seed=${seed} ..."
+        wl="$RESULTS_DIR/expB_out${output}_s${seed}_wl.yaml"
+        make_workload "$FIXED_INPUT" "$output" "$seed" "$wl"
+        run_sim \
+            "$RESULTS_DIR/expB_out${output}_s${seed}.json" \
+            "$RESULTS_DIR/expB_out${output}_s${seed}_stdout.txt" \
+            "$wl" "$seed"
+    done
+done
+
+echo ""
+echo "============================================================================"
+echo "  Analysis"
+echo "============================================================================"
+echo ""
+
+python3 "$SCRIPT_DIR/analyze.py" \
+    --results-dir "$RESULTS_DIR" \
+    --input-levels "${INPUT_LEVELS[*]}" \
+    --output-levels "${OUTPUT_LEVELS[*]}" \
+    --fixed-output "$FIXED_OUTPUT" \
+    --fixed-input "$FIXED_INPUT" \
+    --seeds "${SEEDS[*]}"
+
+echo ""
+echo "============================================================================"
+echo "  See FINDINGS.md for detailed analysis"
+echo "============================================================================"


### PR DESCRIPTION
## Summary

- **Hypothesis #314**: TTFT should scale linearly with input tokens (R² > 0.95) and E2E−TTFT linearly with output tokens
- **Result**: Confirmed — R² = 1.000000 (adjusted) for both phases across all 3 seeds
- Measured slopes match analytical α/β predictions within <0.01% (int64 truncation only)
- Introduces **scheduling-delay subtraction technique** to isolate latency model from Poisson queueing noise
- Updates `hypotheses/README.md` coverage table with H-Phase-Structure and H-MMK

## Test plan

- [ ] `cd hypotheses/h-phase-structure && ./run.sh` reproduces results
- [ ] Verify R² ≥ 0.95 for adjusted TTFT (Experiment A) and decode time (Experiment B)
- [ ] Confirm calibration step matches H-MMK reference (E2E = 1126.241 ms)

**Closes:** #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)