### PR TITLE
feat(hypotheses): H2 Priority-FCFS — SLO-based priority equivalence

### DIFF
--- a/hypotheses/h2-priority-fcfs/FINDINGS.md
+++ b/hypotheses/h2-priority-fcfs/FINDINGS.md
@@ -1,0 +1,168 @@
+# H2-Priority-FCFS
+
+**Status:** Refuted
+**Resolution:** Refuted -- wrong mental model
+**Family:** Cross-policy comparative
+**VV&UQ:** Validation
+**Tier:** 5 (workload diversity)
+**Type:** Statistical (Dominance)
+**Date:** 2026-02-22
+**Rounds:** 1
+
+## Hypothesis
+
+> "Priority-FCFS with SLO-based priority should reduce realtime TTFT at the cost of batch TTFT"
+
+## Experiment Design
+
+**Classification:** Statistical/Dominance
+
+**Configurations compared:**
+- A (baseline): `--priority-policy constant --scheduler fcfs` -- all requests equal priority, FIFO order
+- B (prioritized): `--priority-policy slo-based --scheduler priority-fcfs` -- age-based priority with priority-aware scheduling
+
+**Controlled variables:** model (llama-3.1-8b-instruct), num-instances (4), routing (round-robin default), admission (always-admit default), workload (mixed-SLO: 33% realtime, 34% interactive, 33% batch, all identical token sizes 256 input / 128 output, Poisson arrival at 500 req/s, 500 requests)
+
+**Varied variable:** Priority policy (constant vs slo-based) and scheduler (fcfs vs priority-fcfs)
+
+**Seeds:** 42, 123, 456
+
+**Preconditions verified:**
+1. Workload YAML field names cross-referenced against `sim/workload/spec.go` struct tags (all correct)
+2. Per-request JSON field names verified against `sim/metrics_utils.go:RequestMetrics` (slo_class, ttft_ms, e2e_ms present)
+3. Priority policy names verified against `sim/priority.go:NewPriorityPolicy` factory
+4. Scheduler names verified against `sim/scheduler.go:NewScheduler` factory
+5. Binary built and tested before experiment runs
+
+## Results
+
+### Aggregate Cluster Metrics
+
+All metrics are **identical** (0.0% difference) between Config A and Config B across all 3 seeds:
+
+| Metric | Seed 42 | Seed 123 | Seed 456 |
+|--------|---------|----------|----------|
+| TTFT mean (ms) | 28.20 | 31.03 | 27.47 |
+| TTFT P99 (ms) | 41.49 | 47.98 | 43.13 |
+| E2E mean (ms) | 1458.62 | 1462.64 | 1457.35 |
+| Scheduling Delay P99 (ms) | 21.06 | 22.47 | 20.70 |
+| Completed | 500 | 500 | 500 |
+
+**No Config A vs Config B difference detected in any metric.**
+
+### Per-SLO-Class TTFT Comparison
+
+| SLO Class | Seed | Config A TTFT mean (ms) | Config B TTFT mean (ms) | Diff |
+|-----------|------|------------------------|------------------------|------|
+| realtime | 42 | 27.99 | 27.99 | 0.0% |
+| interactive | 42 | 28.32 | 28.32 | 0.0% |
+| batch | 42 | 28.28 | 28.28 | 0.0% |
+| realtime | 123 | 30.87 | 30.87 | 0.0% |
+| interactive | 123 | 30.97 | 30.97 | 0.0% |
+| batch | 123 | 31.27 | 31.27 | 0.0% |
+| realtime | 456 | 27.60 | 27.60 | 0.0% |
+| interactive | 456 | 27.32 | 27.32 | 0.0% |
+| batch | 456 | 27.52 | 27.52 | 0.0% |
+
+### Scheduling Reordering Analysis
+
+Zero reordering detected across all seeds:
+- 0 requests changed completion rank (out of 500 per seed)
+- Max rank shift: 0
+- Mean rank shift: 0.0
+
+**The two configurations produce byte-identical scheduling order.**
+
+## Root Cause Analysis
+
+The hypothesis is refuted because `SLOBasedPriority` does not differentiate by SLO class -- it is purely an age-based (waiting time) priority policy, which produces mathematically equivalent ordering to FCFS.
+
+### Mathematical proof of equivalence
+
+**Config A** (`constant` priority + `priority-fcfs` scheduler):
+1. `ConstantPriority.Compute()` returns `0.0` for all requests (`sim/priority.go:17-19`)
+2. `PriorityFCFSScheduler.OrderQueue()` sorts by priority descending, breaking ties by arrival time ascending, then ID ascending (`sim/scheduler.go:30-38`)
+3. Since all priorities are 0.0, the sort falls through to the tiebreaker: **arrival time ascending = FCFS**
+
+**Config B** (`slo-based` priority + `priority-fcfs` scheduler):
+1. `SLOBasedPriority.Compute()` returns `0.0 + 1e-6 * (clock - req.ArrivalTime)` (`sim/priority.go:32-34`)
+2. Priority is monotonically increasing with age: older requests (smaller ArrivalTime) get higher priority
+3. `PriorityFCFSScheduler.OrderQueue()` sorts by priority descending: highest priority first = **oldest request first = FCFS**
+
+Both configurations produce the same total order: requests sorted by arrival time ascending. The age-based priority `priority = age = clock - ArrivalTime` is a monotonic transformation of `ArrivalTime` (with negative sign), so sorting by priority descending is equivalent to sorting by ArrivalTime ascending.
+
+**Key code citations:**
+- `SLOBasedPriority.Compute()`: `sim/priority.go:32-34` -- `return s.BaseScore + s.AgeWeight*age`
+- `PriorityFCFSScheduler.OrderQueue()`: `sim/scheduler.go:30-38` -- priority desc, then arrival asc
+- Priority assignment: `sim/simulator.go:527` -- `req.Priority = sim.priorityPolicy.Compute(req, now)`
+- Queue reordering: `sim/simulator.go:529-531` -- `sim.scheduler.OrderQueue(reqs, now)`
+
+### Why the hypothesis contained a wrong mental model
+
+The hypothesis assumed `slo-based` priority would assign different priorities to different SLO classes (e.g., realtime > interactive > batch). In reality, `SLOBasedPriority` is documented as:
+
+> "Per-request SLO metadata is available on Request.SLOClass but not yet used by this scorer." (`sim/priority.go:26`)
+
+The `slo-based` policy is an **age-based** policy intended to prevent SLO violations by boosting stale requests. It does not assign SLO-class-dependent base scores. All SLO classes share `BaseScore: 0.0` (`sim/priority.go:62`).
+
+### Control experiment (RCV-4)
+
+To confirm the age-ordering mechanism produces exact FCFS equivalence, a control experiment that breaks the equivalence would use `inverted-slo` priority (`priority = -age`), which would produce **anti-FCFS** ordering (newest requests first). This would produce measurably different results. (Not run in this experiment but would serve as the control.)
+
+## Devil's Advocate (RCV-5)
+
+**This is "Refuted." Argue why it might be Confirmed:**
+
+One could argue that under different operating conditions (higher load causing deeper queue buildup, or variable-length requests), the dynamic age-based re-prioritization at each step might produce subtly different scheduling than static FCFS. Specifically, if a request's priority crosses another's between steps due to non-uniform step durations, the relative order could change. However, since `priority = age` is a strictly monotonic function of arrival time, and the arrival time is fixed at request creation, the ordering is stable regardless of when priorities are recomputed. The mathematical equivalence holds universally, not just at this operating point.
+
+Another potential argument: if requests from different SLO classes had different processing times (different token counts), the priority-fcfs scheduler might interact differently with batch formation. But in this experiment, all SLO classes have identical token configurations (256 input, 128 output), so this cannot produce differentiation. Even with variable token counts, the sorting key (age-based priority) would still produce FCFS ordering.
+
+## Findings Classification
+
+| Finding | Type | Action |
+|---------|------|--------|
+| `slo-based` priority + `priority-fcfs` scheduler is mathematically equivalent to `constant` + `fcfs` | Design limitation | File enhancement issue: true SLO-class-aware priority policy needed |
+| `SLOBasedPriority` does not use `Request.SLOClass` despite its name | Design limitation | The policy name is misleading; it's actually an "age-based" policy. Consider renaming or extending. |
+| Priority-FCFS scheduling framework works correctly (identical results confirm no bugs in priority propagation) | Confirmation | INV-6 (determinism) confirmed: same inputs produce same outputs even through different code paths |
+
+## Standards Audit
+
+Findings checked against docs/standards/:
+- [x] Any violations of existing rules? **None found.** The code correctly implements the age-based priority as documented.
+- [x] Any new rules needed? **Possible:** R-naming: Policy names should accurately reflect their behavior. "slo-based" suggests SLO-class differentiation, but the policy only uses request age.
+- [x] Any new invariants needed? **None.** The equivalence is by design, not a bug.
+- [x] Any existing rules/invariants confirmed? **INV-6 (Determinism)** confirmed: both configurations produce byte-identical results, demonstrating the scheduler correctly preserves deterministic ordering. **R2 (Sort map keys)** indirectly confirmed: the sorted scheduling order is reproducible.
+
+## Scope and Limitations (RCV-6)
+
+- **Operating point tested:** 4 instances, 500 req/s, 500 requests, round-robin routing, always-admit, llama-3.1-8b-instruct, H100, TP=2, uniform token sizes (256 input / 128 output)
+- **Parameters findings depend on:** The mathematical equivalence holds for ALL parameter values -- it is a structural property of the `SLOBasedPriority` formula (monotone in age), not a numerical coincidence.
+- **What was NOT tested:** Variable token lengths across SLO classes, `inverted-slo` priority (which would break the equivalence), a hypothetical true SLO-class-aware priority policy (which does not yet exist in BLIS)
+- **Generalizability:** This finding generalizes universally. The equivalence between age-based priority ordering and FCFS ordering is mathematical, not empirical. It holds for any workload, any rate, any number of instances, and any token distribution.
+- **Uncertainty quantification:** UQ not applicable. The finding is deterministic (0.0% difference), not statistical. The equivalence is proven by algebraic argument, not estimated from samples.
+
+## Evidence Quality
+
+| Metric | Value | Confidence |
+|--------|-------|------------|
+| TTFT difference (all SLO classes) | 0.0% | High -- exact mathematical equivalence, not sampling noise |
+| Completion order difference | 0 reordered requests (0%) | High -- exhaustive comparison of all 500 requests x 3 seeds |
+| Mechanism | Age-based priority is monotone transform of arrival time | High -- proven algebraically from source code, no control needed |
+| Sample size | 3 seeds x 2 configs x 500 requests = 3000 request-config pairs | High for detecting any non-equivalence |
+
+## Implications for Users
+
+1. **Do not use `slo-based` + `priority-fcfs` expecting SLO differentiation.** This combination produces exactly the same behavior as `constant` + `fcfs`. There is no performance benefit or cost.
+
+2. **True SLO-class-aware scheduling requires a new priority policy** that assigns different base scores per SLO class (e.g., `realtime: 100.0, interactive: 50.0, batch: 0.0`). This does not yet exist in BLIS.
+
+3. **The `slo-based` policy name is misleading.** It is actually an "age-based" or "waiting-time" priority policy. The SLO metadata on the request (`SLOClass` field) is explicitly documented as "not yet used" (`sim/priority.go:26`).
+
+4. **The `priority-fcfs` scheduler works correctly.** It faithfully sorts by priority and produces deterministic results. The issue is that the priority scores from `slo-based` do not encode SLO class information.
+
+## Reproducing
+
+```bash
+cd hypotheses/h2-priority-fcfs
+./run.sh
+```

--- a/hypotheses/h2-priority-fcfs/analyze.py
+++ b/hypotheses/h2-priority-fcfs/analyze.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Analysis script for H2-Priority-FCFS: SLO-Based+Priority-FCFS vs Constant+FCFS.
+
+Parses BLIS multi-block stdout output and per-request JSON results to produce
+comparison tables.
+
+BLIS output format (see cmd/root.go and sim/metrics_utils.go):
+- Per-instance and cluster JSON blocks, each preceded by "=== Simulation Metrics ==="
+- Cluster block has "instance_id": "cluster"
+- Per-SLO metrics block:
+    === Per-SLO Metrics ===
+      <class>:
+        TTFT: mean=<val> p99=<val> (n=<count>)
+        E2E:  mean=<val> p99=<val> (n=<count>)
+- Per-request JSON (via --results-path): has slo_class, ttft_ms, e2e_ms,
+  scheduling_delay_ms (in TICKS/us, NOT ms), num_prefill_tokens
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+SEEDS = [42, 123, 456]
+CONFIG_A = "Constant+FCFS"
+CONFIG_B = "SLO-Based+PriFCFS"
+
+
+def parse_cluster_metrics(filepath):
+    """Parse BLIS stdout -> cluster-level JSON metrics."""
+    content = Path(filepath).read_text()
+
+    # Extract cluster-level JSON block (matches "instance_id": "cluster")
+    cluster = None
+    for match in re.finditer(
+        r"=== Simulation Metrics ===\s*\n(\{.*?\n\})", content, re.DOTALL
+    ):
+        try:
+            block = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if block.get("instance_id") == "cluster":
+            cluster = block
+
+    if cluster is None:
+        print(f"WARNING: no cluster metrics found in {filepath}", file=sys.stderr)
+        return None
+    return cluster
+
+
+def parse_per_slo_metrics(filepath):
+    """Parse Per-SLO Metrics from BLIS stdout.
+
+    Expected format (cmd/root.go):
+        === Per-SLO Metrics ===
+          <class>:
+            TTFT: mean=<val> p99=<val> (n=<count>)
+            E2E:  mean=<val> p99=<val> (n=<count>)
+    """
+    content = Path(filepath).read_text()
+    result = {}
+
+    # Find the Per-SLO block
+    slo_block = re.search(r"=== Per-SLO Metrics ===(.*?)(?:===|\Z)", content, re.DOTALL)
+    if not slo_block:
+        return result
+
+    block_text = slo_block.group(1)
+
+    # Parse each SLO class
+    for m in re.finditer(
+        r"^\s+(\S+):\s*\n"
+        r"\s+TTFT:\s+mean=([0-9.]+)\s+p99=([0-9.]+)\s+\(n=(\d+)\)\s*\n"
+        r"\s+E2E:\s+mean=([0-9.]+)\s+p99=([0-9.]+)\s+\(n=(\d+)\)",
+        block_text,
+        re.MULTILINE,
+    ):
+        cls = m.group(1).rstrip(":")
+        result[cls] = {
+            "ttft_mean": float(m.group(2)),
+            "ttft_p99": float(m.group(3)),
+            "ttft_n": int(m.group(4)),
+            "e2e_mean": float(m.group(5)),
+            "e2e_p99": float(m.group(6)),
+            "e2e_n": int(m.group(7)),
+        }
+    return result
+
+
+def parse_per_request_json(filepath):
+    """Parse per-request JSON results file (from --results-path).
+
+    Returns list of request dicts with slo_class, ttft_ms (in ms), e2e_ms (in ms),
+    scheduling_delay_ms (NOTE: actually in TICKS/us, not ms).
+    """
+    content = Path(filepath).read_text()
+    data = json.loads(content)
+    requests = data.get("requests", [])
+    if not requests:
+        print(f"WARNING: no per-request data in {filepath}", file=sys.stderr)
+    return requests
+
+
+def pct_diff(a, b):
+    """Percentage difference: (b - a) / a * 100. Positive = b is higher."""
+    if a == 0:
+        return float("inf") if b != 0 else 0.0
+    return (b - a) / a * 100.0
+
+
+def mean(vals):
+    """Safe mean computation."""
+    return sum(vals) / len(vals) if vals else 0.0
+
+
+def percentile(vals, p):
+    """Compute p-th percentile (0-100 scale)."""
+    if not vals:
+        return 0.0
+    sorted_vals = sorted(vals)
+    n = len(sorted_vals)
+    rank = p / 100.0 * (n - 1)
+    lower = int(rank)
+    upper = min(lower + 1, n - 1)
+    frac = rank - lower
+    return sorted_vals[lower] * (1 - frac) + sorted_vals[upper] * frac
+
+
+def analyze_aggregate(a_files, b_files):
+    """Compare aggregate cluster metrics between Config A and Config B."""
+    print(f"Aggregate Cluster Metrics: {CONFIG_A} vs {CONFIG_B}")
+    print("-" * 90)
+    print(f"{'Metric':<25} {'Seed':>6} {CONFIG_A:>16} {CONFIG_B:>16} {'Diff%':>10}")
+    print("-" * 90)
+
+    metrics_to_compare = [
+        ("ttft_mean_ms", "TTFT mean (ms)"),
+        ("ttft_p99_ms", "TTFT P99 (ms)"),
+        ("e2e_mean_ms", "E2E mean (ms)"),
+        ("e2e_p99_ms", "E2E P99 (ms)"),
+        ("scheduling_delay_p99_ms", "Sched Delay P99 (ms)"),
+        ("completed_requests", "Completed"),
+        ("responses_per_sec", "Responses/sec"),
+    ]
+
+    for metric_key, metric_label in metrics_to_compare:
+        for i, seed in enumerate(SEEDS):
+            a = parse_cluster_metrics(a_files[i])
+            b = parse_cluster_metrics(b_files[i])
+            if a is None or b is None:
+                continue
+            aval = a.get(metric_key, 0)
+            bval = b.get(metric_key, 0)
+            diff = pct_diff(aval, bval)
+            print(f"{metric_label:<25} {seed:>6} {aval:>16.2f} {bval:>16.2f} {diff:>+9.1f}%")
+        print()
+
+
+def analyze_per_slo(a_files, b_files):
+    """Compare per-SLO-class metrics between Config A and Config B."""
+    print(f"Per-SLO-Class Metrics: {CONFIG_A} vs {CONFIG_B}")
+    print("-" * 100)
+    print(f"{'SLO Class':<14} {'Metric':<16} {'Seed':>6} {CONFIG_A:>16} {CONFIG_B:>16} {'Diff%':>10}")
+    print("-" * 100)
+
+    for i, seed in enumerate(SEEDS):
+        a_slo = parse_per_slo_metrics(a_files[i])
+        b_slo = parse_per_slo_metrics(b_files[i])
+
+        all_classes = sorted(set(list(a_slo.keys()) + list(b_slo.keys())))
+        for cls in all_classes:
+            a = a_slo.get(cls, {})
+            b = b_slo.get(cls, {})
+            for metric_key, label in [
+                ("ttft_mean", "TTFT mean"),
+                ("ttft_p99", "TTFT P99"),
+                ("e2e_mean", "E2E mean"),
+                ("e2e_p99", "E2E P99"),
+            ]:
+                aval = a.get(metric_key, 0)
+                bval = b.get(metric_key, 0)
+                diff = pct_diff(aval, bval)
+                print(f"{cls:<14} {label:<16} {seed:>6} {aval:>16.2f} {bval:>16.2f} {diff:>+9.1f}%")
+            print()
+
+
+def analyze_per_request(a_json_files, b_json_files):
+    """Analyze per-request data to understand scheduling effect by SLO class."""
+    slo_classes = ["realtime", "interactive", "batch"]
+
+    # --- TTFT comparison ---
+    print(f"Per-Request Analysis: TTFT by SLO Class (mean across requests, ms)")
+    print("-" * 95)
+    print(f"{'SLO Class':<14} {'Seed':>6} {CONFIG_A+' TTFT':>16} {CONFIG_B+' TTFT':>16} {'Diff%':>10} {'N':>6}")
+    print("-" * 95)
+
+    # Collect for cross-seed average
+    ttft_by_class_a = {cls: [] for cls in slo_classes}
+    ttft_by_class_b = {cls: [] for cls in slo_classes}
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        for slo_class in slo_classes:
+            a_ttfts = [r["ttft_ms"] for r in a_reqs if r.get("slo_class") == slo_class and r["ttft_ms"] > 0]
+            b_ttfts = [r["ttft_ms"] for r in b_reqs if r.get("slo_class") == slo_class and r["ttft_ms"] > 0]
+
+            a_mean = mean(a_ttfts)
+            b_mean = mean(b_ttfts)
+            diff = pct_diff(a_mean, b_mean)
+            n = len(a_ttfts)
+            print(f"{slo_class:<14} {seed:>6} {a_mean:>16.2f} {b_mean:>16.2f} {diff:>+9.1f}% {n:>6}")
+
+            ttft_by_class_a[slo_class].append(a_mean)
+            ttft_by_class_b[slo_class].append(b_mean)
+        print()
+
+    # Cross-seed average
+    print("  Cross-seed average:")
+    for cls in slo_classes:
+        a_avg = mean(ttft_by_class_a[cls])
+        b_avg = mean(ttft_by_class_b[cls])
+        diff = pct_diff(a_avg, b_avg)
+        print(f"  {cls:<14} {'avg':>6} {a_avg:>16.2f} {b_avg:>16.2f} {diff:>+9.1f}%")
+    print()
+
+    # --- P99 TTFT comparison ---
+    print(f"Per-Request Analysis: TTFT P99 by SLO Class (ms)")
+    print("-" * 90)
+    print(f"{'SLO Class':<14} {'Seed':>6} {CONFIG_A+' P99':>16} {CONFIG_B+' P99':>16} {'Diff%':>10}")
+    print("-" * 90)
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        for slo_class in slo_classes:
+            a_ttfts = [r["ttft_ms"] for r in a_reqs if r.get("slo_class") == slo_class and r["ttft_ms"] > 0]
+            b_ttfts = [r["ttft_ms"] for r in b_reqs if r.get("slo_class") == slo_class and r["ttft_ms"] > 0]
+
+            a_p99 = percentile(a_ttfts, 99)
+            b_p99 = percentile(b_ttfts, 99)
+            diff = pct_diff(a_p99, b_p99)
+            print(f"{slo_class:<14} {seed:>6} {a_p99:>16.2f} {b_p99:>16.2f} {diff:>+9.1f}%")
+        print()
+
+    # --- Scheduling delay comparison ---
+    print(f"Per-Request Analysis: Scheduling Delay by SLO Class (mean, in us)")
+    print("-" * 90)
+    print(f"{'SLO Class':<14} {'Seed':>6} {CONFIG_A+' Delay':>16} {CONFIG_B+' Delay':>16} {'Diff%':>10}")
+    print("-" * 90)
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        for slo_class in slo_classes:
+            # scheduling_delay_ms is actually in TICKS (microseconds)
+            a_delays = [r["scheduling_delay_ms"] for r in a_reqs if r.get("slo_class") == slo_class]
+            b_delays = [r["scheduling_delay_ms"] for r in b_reqs if r.get("slo_class") == slo_class]
+
+            a_mean_val = mean(a_delays)
+            b_mean_val = mean(b_delays)
+            diff = pct_diff(a_mean_val, b_mean_val)
+            print(f"{slo_class:<14} {seed:>6} {a_mean_val:>16.0f} {b_mean_val:>16.0f} {diff:>+9.1f}%")
+        print()
+
+    # --- E2E comparison ---
+    print(f"Per-Request Analysis: E2E by SLO Class (mean across requests, ms)")
+    print("-" * 90)
+    print(f"{'SLO Class':<14} {'Seed':>6} {CONFIG_A+' E2E':>16} {CONFIG_B+' E2E':>16} {'Diff%':>10}")
+    print("-" * 90)
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        for slo_class in slo_classes:
+            a_e2es = [r["e2e_ms"] for r in a_reqs if r.get("slo_class") == slo_class and r["e2e_ms"] > 0]
+            b_e2es = [r["e2e_ms"] for r in b_reqs if r.get("slo_class") == slo_class and r["e2e_ms"] > 0]
+
+            a_mean_val = mean(a_e2es)
+            b_mean_val = mean(b_e2es)
+            diff = pct_diff(a_mean_val, b_mean_val)
+            print(f"{slo_class:<14} {seed:>6} {a_mean_val:>16.2f} {b_mean_val:>16.2f} {diff:>+9.1f}%")
+        print()
+
+
+def analyze_priority(a_json_files, b_json_files):
+    """Analyze priority score distribution and ordering effects."""
+    slo_classes = ["realtime", "interactive", "batch"]
+
+    print("Priority Analysis: Scheduling Order Differences")
+    print("-" * 90)
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        print(f"\n  Seed {seed}: Request counts per SLO class")
+        for cls in slo_classes:
+            a_n = len([r for r in a_reqs if r.get("slo_class") == cls])
+            b_n = len([r for r in b_reqs if r.get("slo_class") == cls])
+            print(f"    {cls:<14} A: {a_n:>4}  B: {b_n:>4}")
+
+    # Compare arrival order vs completion order to detect reordering
+    print(f"\n\nScheduling Reordering Analysis:")
+    print("-" * 90)
+    print("  (Comparing request completion order between configs)")
+    print(f"  A request is 'reordered' if it completes in a different relative position.")
+    print()
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        # Build ID-to-rank maps by E2E completion time (arrival + e2e)
+        def completion_rank(reqs):
+            """Rank requests by completion time (arrived_at + e2e_ms)."""
+            completed = [(r["requestID"], r.get("arrived_at", 0) + r.get("e2e_ms", 0))
+                         for r in reqs if r.get("e2e_ms", 0) > 0]
+            completed.sort(key=lambda x: x[1])
+            return {rid: rank for rank, (rid, _) in enumerate(completed)}
+
+        a_ranks = completion_rank(a_reqs)
+        b_ranks = completion_rank(b_reqs)
+
+        # Count how many requests changed rank significantly
+        common_ids = set(a_ranks.keys()) & set(b_ranks.keys())
+        if not common_ids:
+            print(f"  Seed {seed}: no common completed requests")
+            continue
+
+        rank_diffs = []
+        for rid in common_ids:
+            rank_diffs.append(abs(a_ranks[rid] - b_ranks[rid]))
+
+        reordered = sum(1 for d in rank_diffs if d > 0)
+        significantly_reordered = sum(1 for d in rank_diffs if d > 10)
+        max_shift = max(rank_diffs) if rank_diffs else 0
+        mean_shift = mean(rank_diffs)
+
+        print(f"  Seed {seed}: {len(common_ids)} common requests")
+        print(f"    Reordered (any shift): {reordered} ({100*reordered/len(common_ids):.1f}%)")
+        print(f"    Significantly reordered (>10 positions): {significantly_reordered} ({100*significantly_reordered/len(common_ids):.1f}%)")
+        print(f"    Max rank shift: {max_shift}")
+        print(f"    Mean rank shift: {mean_shift:.1f}")
+
+    # Check if reordering benefits specific SLO classes
+    print(f"\n\nPer-SLO Completion Rank Shift (positive = completed earlier with Config B):")
+    print("-" * 90)
+    print(f"{'SLO Class':<14} {'Seed':>6} {'Mean Shift':>14} {'Positive%':>12} {'N':>6}")
+    print("-" * 90)
+
+    for i, seed in enumerate(SEEDS):
+        a_reqs = parse_per_request_json(a_json_files[i])
+        b_reqs = parse_per_request_json(b_json_files[i])
+
+        def completion_rank(reqs):
+            completed = [(r["requestID"], r.get("arrived_at", 0) + r.get("e2e_ms", 0))
+                         for r in reqs if r.get("e2e_ms", 0) > 0]
+            completed.sort(key=lambda x: x[1])
+            return {rid: rank for rank, (rid, _) in enumerate(completed)}
+
+        a_ranks = completion_rank(a_reqs)
+        b_ranks = completion_rank(b_reqs)
+        common_ids = set(a_ranks.keys()) & set(b_ranks.keys())
+
+        # Build ID -> SLO class map
+        slo_map = {}
+        for r in a_reqs:
+            slo_map[r["requestID"]] = r.get("slo_class", "")
+
+        for cls in slo_classes:
+            shifts = []
+            for rid in common_ids:
+                if slo_map.get(rid) == cls:
+                    # Positive shift = completed earlier with Config B (lower rank = earlier)
+                    shifts.append(a_ranks[rid] - b_ranks[rid])
+
+            if shifts:
+                mean_shift = mean(shifts)
+                positive_pct = 100 * sum(1 for s in shifts if s > 0) / len(shifts)
+                print(f"{cls:<14} {seed:>6} {mean_shift:>+14.1f} {positive_pct:>11.1f}% {len(shifts):>6}")
+        print()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: analyze.py <mode> <files...>", file=sys.stderr)
+        print("  Modes: aggregate, per_slo, per_request, priority", file=sys.stderr)
+        sys.exit(1)
+
+    mode = sys.argv[1]
+
+    if mode == "aggregate":
+        if len(sys.argv) != 8:
+            print("aggregate: need 3 Config A + 3 Config B stdout files", file=sys.stderr)
+            sys.exit(1)
+        a_files = sys.argv[2:5]
+        b_files = sys.argv[5:8]
+        analyze_aggregate(a_files, b_files)
+
+    elif mode == "per_slo":
+        if len(sys.argv) != 8:
+            print("per_slo: need 3 Config A + 3 Config B stdout files", file=sys.stderr)
+            sys.exit(1)
+        a_files = sys.argv[2:5]
+        b_files = sys.argv[5:8]
+        analyze_per_slo(a_files, b_files)
+
+    elif mode == "per_request":
+        if len(sys.argv) != 8:
+            print("per_request: need 3 Config A + 3 Config B JSON result files", file=sys.stderr)
+            sys.exit(1)
+        a_files = sys.argv[2:5]
+        b_files = sys.argv[5:8]
+        analyze_per_request(a_files, b_files)
+
+    elif mode == "priority":
+        if len(sys.argv) != 8:
+            print("priority: need 3 Config A + 3 Config B JSON result files", file=sys.stderr)
+            sys.exit(1)
+        a_files = sys.argv[2:5]
+        b_files = sys.argv[5:8]
+        analyze_priority(a_files, b_files)
+
+    else:
+        print(f"Unknown mode: {mode}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hypotheses/h2-priority-fcfs/mixed-slo-workload.yaml
+++ b/hypotheses/h2-priority-fcfs/mixed-slo-workload.yaml
@@ -1,0 +1,44 @@
+seed: 42
+aggregate_rate: 500
+num_requests: 500
+clients:
+  - id: realtime
+    slo_class: realtime
+    rate_fraction: 0.33
+    streaming: true
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 256
+    output_distribution:
+      type: constant
+      params:
+        value: 128
+  - id: interactive
+    slo_class: interactive
+    rate_fraction: 0.34
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 256
+    output_distribution:
+      type: constant
+      params:
+        value: 128
+  - id: batch
+    slo_class: batch
+    rate_fraction: 0.33
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 256
+    output_distribution:
+      type: constant
+      params:
+        value: 128

--- a/hypotheses/h2-priority-fcfs/run.sh
+++ b/hypotheses/h2-priority-fcfs/run.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# H2-Priority-FCFS: Priority-FCFS with SLO-based priority vs constant+FCFS
+#
+# Hypothesis: "Priority-FCFS with SLO-based priority should reduce realtime TTFT
+# at the cost of batch TTFT"
+#
+# Config A (baseline): --priority-policy constant --scheduler fcfs
+# Config B (prioritized): --priority-policy slo-based --scheduler priority-fcfs
+#
+# Family: Cross-policy comparative | Type: Statistical (Dominance)
+# VV&UQ: Validation | Tier: 5 (workload diversity)
+#
+# Usage: ./run.sh [--rebuild]
+#
+# Requires: Go 1.24+, Python 3
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$REPO_ROOT/simulation_worker"
+
+# Build if needed
+if [[ "${1:-}" == "--rebuild" ]] || [[ ! -x "$BINARY" ]]; then
+    echo "Building simulation_worker..."
+    (cd "$REPO_ROOT" && go build -o simulation_worker main.go)
+fi
+
+MODEL="meta-llama/llama-3.1-8b-instruct"
+WORKLOAD="$SCRIPT_DIR/mixed-slo-workload.yaml"
+
+run_sim() {
+    local priority="$1" sched="$2" seed="$3" results_file="$4"
+    "$BINARY" run \
+        --model "$MODEL" \
+        --num-instances 4 \
+        --workload-spec "$WORKLOAD" \
+        --priority-policy "$priority" \
+        --scheduler "$sched" \
+        --seed "$seed" \
+        --log error \
+        --results-path "$results_file" \
+        2>/dev/null
+}
+
+analyze() {
+    python3 "$SCRIPT_DIR/analyze.py" "$@"
+}
+
+echo "============================================================================"
+echo "  H2-Priority-FCFS: Constant+FCFS vs SLO-Based+Priority-FCFS"
+echo "  Family: Cross-policy comparative | Type: Statistical/Dominance"
+echo "============================================================================"
+echo ""
+
+RESULTS_DIR=$(mktemp -d)
+trap "rm -rf $RESULTS_DIR" EXIT
+
+# ── Experiment: Config A vs Config B across 3 seeds ──────────────────────────
+# Config A (baseline): --priority-policy constant --scheduler fcfs
+# Config B (prioritized): --priority-policy slo-based --scheduler priority-fcfs
+# Controlled: model, num-instances (4), workload, routing (round-robin default)
+# Seeds: 42, 123, 456
+
+echo "Experiment: Constant+FCFS vs SLO-Based+Priority-FCFS"
+echo "  Workload: Mixed SLO (33% realtime, 34% interactive, 33% batch)"
+echo "  All clients: 256 input tokens, 128 output tokens, poisson arrival"
+echo "  Rate: 500 req/s, 500 requests, 4 instances"
+echo "  Config A: --priority-policy constant --scheduler fcfs"
+echo "  Config B: --priority-policy slo-based --scheduler priority-fcfs"
+echo ""
+
+for SEED in 42 123 456; do
+    echo "  Running seed=$SEED..."
+    run_sim "constant" "fcfs" "$SEED" "$RESULTS_DIR/a_${SEED}.json" \
+        > "$RESULTS_DIR/a_${SEED}_stdout.txt"
+    run_sim "slo-based" "priority-fcfs" "$SEED" "$RESULTS_DIR/b_${SEED}.json" \
+        > "$RESULTS_DIR/b_${SEED}_stdout.txt"
+done
+
+echo ""
+echo "--- Aggregate Comparison (from stdout) ---"
+analyze aggregate \
+    "$RESULTS_DIR/a_42_stdout.txt" "$RESULTS_DIR/a_123_stdout.txt" "$RESULTS_DIR/a_456_stdout.txt" \
+    "$RESULTS_DIR/b_42_stdout.txt" "$RESULTS_DIR/b_123_stdout.txt" "$RESULTS_DIR/b_456_stdout.txt"
+
+echo ""
+echo "--- Per-SLO-Class Comparison (from stdout) ---"
+analyze per_slo \
+    "$RESULTS_DIR/a_42_stdout.txt" "$RESULTS_DIR/a_123_stdout.txt" "$RESULTS_DIR/a_456_stdout.txt" \
+    "$RESULTS_DIR/b_42_stdout.txt" "$RESULTS_DIR/b_123_stdout.txt" "$RESULTS_DIR/b_456_stdout.txt"
+
+echo ""
+echo "--- Per-Request Analysis (from JSON results) ---"
+analyze per_request \
+    "$RESULTS_DIR/a_42.json" "$RESULTS_DIR/a_123.json" "$RESULTS_DIR/a_456.json" \
+    "$RESULTS_DIR/b_42.json" "$RESULTS_DIR/b_123.json" "$RESULTS_DIR/b_456.json"
+
+echo ""
+echo "--- Priority Distribution Analysis ---"
+analyze priority \
+    "$RESULTS_DIR/a_42.json" "$RESULTS_DIR/a_123.json" "$RESULTS_DIR/a_456.json" \
+    "$RESULTS_DIR/b_42.json" "$RESULTS_DIR/b_123.json" "$RESULTS_DIR/b_456.json"
+
+echo ""
+echo "============================================================================"
+echo "  See FINDINGS.md for detailed analysis and root cause"
+echo "============================================================================"


### PR DESCRIPTION
## Summary
- **H2 Priority-FCFS** — Cross-policy/Statistical experiment
- **Status: Refuted — wrong mental model**
- `slo-based` priority + `priority-fcfs` produces **byte-identical output** to `constant` + `fcfs`
- **Root cause:** `SLOBasedPriority` computes `priority = BaseScore + AgeWeight * age` — a monotonic transform of arrival time, mathematically equivalent to FCFS. Does NOT use `Request.SLOClass` (documented at `sim/priority.go:26`)
- **Implication:** True SLO-class-aware scheduling requires a new priority policy; the `slo-based` name is misleading
- 3 seeds × 2 configs × 500 requests, 0.0% difference in every metric

## Test plan
- [x] `./hypotheses/h2-priority-fcfs/run.sh` passes with 0.0% difference across all metrics
- [x] External review (GPT-4o): "Strong" rating, converged Round 1
- [x] No new Go code — experiment artifacts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)