### PR TITLE
feat(hypotheses): H26 Admission Latency — event pipeline causal ordering verification

### DIFF
--- a/hypotheses/h26-admission-latency/FINDINGS.md
+++ b/hypotheses/h26-admission-latency/FINDINGS.md
@@ -1,0 +1,142 @@
+# H26: Admission Latency Causal Ordering — FINDINGS
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Hypothesis** | Adding admission latency should delay E2E by exactly that amount under low load |
+| **Family** | Structural model |
+| **VV&UQ** | Verification (deterministic) |
+| **Type** | Deterministic |
+| **Result** | **Confirmed** |
+| **Round** | 1 |
+
+## Hypothesis Statement
+
+Under low load (no queuing), configuring `--admission-latency L` should increase both TTFT and E2E by exactly `L` microseconds. This validates the cluster event pipeline's causal ordering: Arrival -> Admission (+latency) -> Routing -> Queue -> Batch -> Step.
+
+## Precondition Analysis
+
+**Q: Is TTFT measured from request arrival or from queue entry?**
+
+Both TTFT and E2E are measured from `req.ArrivalTime`, which is set at workload generation time (before the admission pipeline). This means both metrics include admission latency.
+
+Code trace:
+- `sim/cluster/workload.go:54`: `ArrivalTime: currentTime` — set at generation
+- `sim/cluster/cluster.go:120`: `ClusterArrivalEvent{time: req.ArrivalTime}` — arrival event at original time
+- `sim/cluster/cluster_event.go:89`: `time: e.time + cs.admissionLatency` — admission delays by L
+- `sim/cluster/cluster_event.go:130`: `time: e.time + cs.routingLatency` — routing delays further
+- `sim/cluster/cluster_event.go:186`: `inst.InjectRequestOnline(e.request, e.time)` — injects at delayed time
+- `sim/simulator.go:564`: `FirstTokenTime = now + currStepAdvance + OutputTokenProcessingTime() - req.ArrivalTime` — TTFT from original ArrivalTime
+- `sim/simulator.go:499-500`: `lat = req.FirstTokenTime + itlSum` — E2E = TTFT + decode time
+- `sim/simulator.go:460`: `SchedulingDelay = now + scheduledDelay - req.ArrivalTime` — also from original ArrivalTime
+
+**Conclusion**: `ArrivalTime` is never modified after generation. All metrics (TTFT, E2E, SchedulingDelay) are computed relative to the original arrival time. Admission latency creates a gap between arrival and instance injection that is captured in all three metrics.
+
+## Experiment Design
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Rate | 10 req/s | Low load, avoids queuing confounds |
+| Requests | 50 | Sufficient for mean comparison |
+| Instances | 4 | Multi-instance cluster mode |
+| Input tokens | 128 (constant) | Eliminates variance |
+| Output tokens | 32 (constant) | Eliminates variance |
+| Routing | least-loaded | Balanced distribution |
+| Seed | 42 | Deterministic |
+| Arrival | Poisson | Standard arrival process |
+
+**Configs:**
+- A: `--admission-latency 0` (baseline)
+- B: `--admission-latency 10000` (10ms)
+- C: `--admission-latency 50000` (50ms, linearity check)
+
+**Control variable**: Only `--admission-latency` differs. All other parameters identical.
+
+## Results
+
+### Aggregate Metrics
+
+| Config | TTFT mean (ms) | E2E mean (ms) | Completed |
+|--------|----------------|---------------|-----------|
+| A (latency=0) | 13.3742 | 292.5819 | 50 |
+| B (latency=10ms) | 23.3742 | 302.5819 | 50 |
+| C (latency=50ms) | 63.3742 | 342.5819 | 50 |
+
+### Deltas
+
+| Config | TTFT delta (ms) | E2E delta (ms) | Expected (ms) | TTFT match | E2E match |
+|--------|-----------------|----------------|---------------|------------|-----------|
+| B (10ms) | 10.0000 | 10.0000 | 10.0000 | PASS | PASS |
+| C (50ms) | 50.0000 | 50.0000 | 50.0000 | PASS | PASS |
+
+### Scheduling Delay (per-request mean, in ticks/us)
+
+| Config | Mean sched delay (us) | Delta (us) | Expected (us) | Match |
+|--------|----------------------|------------|----------------|-------|
+| A | 2396.9 | — | — | — |
+| B | 12396.9 | 10000.0 | 10000 | PASS |
+| C | 52396.9 | 50000.0 | 50000 | PASS |
+
+### Linearity Check
+
+E2E delta ratio C/B = 50.0000 / 10.0000 = **5.0000** (expected: 5.0). PASS.
+
+## Root Cause Analysis
+
+The admission latency is injected as a timestamp offset in the cluster event pipeline:
+
+1. `ClusterArrivalEvent.Execute()` (`cluster_event.go:85-93`): Creates `AdmissionDecisionEvent` with `time = arrival_time + admissionLatency`
+2. `AdmissionDecisionEvent.Execute()` (`cluster_event.go:109-135`): If admitted, creates `RoutingDecisionEvent` with `time = admission_time + routingLatency`
+3. `RoutingDecisionEvent.Execute()` (`cluster_event.go:148-193`): Calls `InjectRequestOnline(req, e.time)` — request enters instance at `arrival_time + admissionLatency + routingLatency`
+
+Since `req.ArrivalTime` is set at generation time and never modified, the time gap between arrival and instance injection is exactly `admissionLatency + routingLatency`. All metrics (TTFT, E2E, SchedulingDelay) subtract `ArrivalTime` from the measurement timestamp, so the admission latency appears as an exact additive offset.
+
+**Why exact (not approximate)?** Under low load with constant token lengths:
+- No queuing interference (requests are processed immediately)
+- Constant service time (same tokens for every request)
+- Deterministic seed ensures identical arrival patterns
+- Only the admission latency offset varies between configs
+
+## Standards Audit
+
+| Standard | Status |
+|----------|--------|
+| ED-1 (clear hypothesis) | Met — behavioral prediction with metric and direction |
+| ED-2 (control variable) | Met — only admission-latency varies |
+| ED-3 (parameter calibration) | Met — low rate avoids queuing |
+| ED-4 (family classification) | Met — structural model |
+| ED-5 (reproducibility) | Met — deterministic with seed=42 |
+| ED-6 (config diff) | N/A — no reference experiment |
+| RCV-1 (code citation) | Met — all causal claims cite file:line |
+| RCV-2 (first principles) | Met — expected delta = admission latency exactly |
+| RCV-3 (mechanism + direction) | Met — timestamp offset mechanism explains additive delta |
+| RCV-4 (control experiment) | Met — Config A (latency=0) is the control |
+
+## Findings Classification
+
+| Finding | Type | Resolution |
+|---------|------|------------|
+| Admission latency adds exact offset to TTFT, E2E, and SchedulingDelay | Confirmation | Clean confirmation — event pipeline causal ordering works as designed |
+| Both TTFT and E2E include admission delay (measured from ArrivalTime, not queue entry) | Confirmation | Validates measurement point: ArrivalTime = original generation time |
+| Linearity holds (50ms/10ms ratio = 5.0) | Confirmation | Linear relationship: no overhead or interaction effects |
+
+## Evidence Quality
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Precision | Exact | Delta matches to 4+ decimal places |
+| Sample size | 50 per config | Sufficient for deterministic verification |
+| Controls | 3 configs | Baseline + 2 treatment levels + linearity check |
+| Confounds | None identified | Low load, constant tokens, deterministic seed |
+| Reproducibility | Deterministic | `./run.sh` reproduces exactly |
+
+## Promotion Assessment
+
+This is a deterministic hypothesis with exact verification. Suitable for promotion to Go test suite:
+- Test: run cluster sim with admission-latency=0 and admission-latency=L, verify E2E delta = L/1000 ms
+- Would provide regression protection for the event pipeline's causal ordering
+
+## Issues to File
+
+None required. This is a clean confirmation with no bugs, design limitations, or surprises discovered.

--- a/hypotheses/h26-admission-latency/analyze.py
+++ b/hypotheses/h26-admission-latency/analyze.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""H26: Admission Latency Causal Ordering — Analysis
+
+Compares three configurations:
+  A: admission-latency=0 (baseline)
+  B: admission-latency=10000 (10ms)
+  C: admission-latency=50000 (50ms)
+
+Expected: TTFT and E2E mean increase by exactly the admission latency.
+Verification: per-request scheduling_delay should also shift by the admission latency.
+
+Output format cross-reference:
+  - Aggregate JSON: sim/metrics_utils.go MetricsOutput struct
+    - "e2e_mean_ms", "ttft_mean_ms" (in ms)
+  - Per-request JSON: sim/metrics_utils.go RequestMetrics struct
+    - "ttft_ms" (in ms, divided by 1e3 at sim/metrics.go:138)
+    - "e2e_ms" (in ms, divided by 1e3 at sim/metrics.go:139)
+    - "scheduling_delay_ms" (in TICKS/us despite name, sim/metrics.go:141)
+"""
+
+import json
+import os
+import sys
+
+
+def load_results(results_dir, label):
+    """Load aggregate and per-request JSON results."""
+    agg_path = os.path.join(results_dir, f"results_{label}.json")
+    if not os.path.exists(agg_path):
+        print(f"ERROR: {agg_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    with open(agg_path) as f:
+        data = json.load(f)
+
+    return data
+
+
+def extract_aggregate(data):
+    """Extract aggregate metrics from JSON."""
+    return {
+        "e2e_mean_ms": data.get("e2e_mean_ms", 0.0),
+        "ttft_mean_ms": data.get("ttft_mean_ms", 0.0),
+        "e2e_p99_ms": data.get("e2e_p99_ms", 0.0),
+        "ttft_p99_ms": data.get("ttft_p99_ms", 0.0),
+        "completed": data.get("completed_requests", 0),
+        "scheduling_delay_p99_ms": data.get("scheduling_delay_p99_ms", 0.0),
+    }
+
+
+def extract_per_request(data):
+    """Extract per-request metrics."""
+    requests = data.get("requests", [])
+    if not requests:
+        print("WARNING: no per-request data found", file=sys.stderr)
+        return []
+    return requests
+
+
+def compute_per_request_stats(requests):
+    """Compute mean TTFT, E2E, and scheduling_delay from per-request data."""
+    if not requests:
+        return {"ttft_ms": 0, "e2e_ms": 0, "sched_delay_us": 0, "count": 0}
+
+    ttfts = [r["ttft_ms"] for r in requests if r.get("ttft_ms", 0) > 0]
+    e2es = [r["e2e_ms"] for r in requests if r.get("e2e_ms", 0) > 0]
+    # scheduling_delay_ms is actually in ticks (us) — see MEMORY.md
+    sched_delays = [r["scheduling_delay_ms"] for r in requests if r.get("scheduling_delay_ms", 0) > 0]
+
+    return {
+        "ttft_ms": sum(ttfts) / len(ttfts) if ttfts else 0,
+        "e2e_ms": sum(e2es) / len(e2es) if e2es else 0,
+        "sched_delay_us": sum(sched_delays) / len(sched_delays) if sched_delays else 0,
+        "count": len(e2es),
+    }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: analyze.py <results_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    results_dir = sys.argv[1]
+
+    configs = {
+        "A (latency=0)": {"label": "a", "latency_us": 0},
+        "B (latency=10ms)": {"label": "b", "latency_us": 10000},
+        "C (latency=50ms)": {"label": "c", "latency_us": 50000},
+    }
+
+    results = {}
+    for name, info in configs.items():
+        data = load_results(results_dir, info["label"])
+        agg = extract_aggregate(data)
+        per_req = extract_per_request(data)
+        per_req_stats = compute_per_request_stats(per_req)
+        results[name] = {
+            "agg": agg,
+            "per_req": per_req_stats,
+            "latency_us": info["latency_us"],
+        }
+
+    # --- Print aggregate comparison ---
+    print("=" * 70)
+    print("H26: Admission Latency Causal Ordering — Results")
+    print("=" * 70)
+    print()
+
+    print("--- Aggregate Metrics (from JSON output) ---")
+    print(f"{'Config':<25} {'TTFT mean (ms)':<18} {'E2E mean (ms)':<18} {'Completed':<12}")
+    print("-" * 70)
+    for name, r in results.items():
+        agg = r["agg"]
+        print(f"{name:<25} {agg['ttft_mean_ms']:<18.4f} {agg['e2e_mean_ms']:<18.4f} {agg['completed']:<12}")
+
+    print()
+
+    # --- Compute deltas ---
+    baseline = results["A (latency=0)"]
+
+    print("--- Deltas vs Baseline (Config A) ---")
+    print(f"{'Config':<25} {'TTFT delta (ms)':<18} {'E2E delta (ms)':<18} {'Expected (ms)':<18} {'TTFT match?':<14} {'E2E match?':<14}")
+    print("-" * 105)
+
+    all_pass = True
+    for name, r in results.items():
+        if r["latency_us"] == 0:
+            continue
+        expected_ms = r["latency_us"] / 1000.0
+        ttft_delta = r["agg"]["ttft_mean_ms"] - baseline["agg"]["ttft_mean_ms"]
+        e2e_delta = r["agg"]["e2e_mean_ms"] - baseline["agg"]["e2e_mean_ms"]
+
+        # Tolerance: 0.1ms (100 us) — rounding precision
+        ttft_ok = abs(ttft_delta - expected_ms) < 0.1
+        e2e_ok = abs(e2e_delta - expected_ms) < 0.1
+        if not ttft_ok or not e2e_ok:
+            all_pass = False
+
+        print(f"{name:<25} {ttft_delta:<18.4f} {e2e_delta:<18.4f} {expected_ms:<18.4f} {'PASS' if ttft_ok else 'FAIL':<14} {'PASS' if e2e_ok else 'FAIL':<14}")
+
+    print()
+
+    # --- Per-request analysis ---
+    print("--- Per-Request Statistics ---")
+    print(f"{'Config':<25} {'Mean TTFT (ms)':<18} {'Mean E2E (ms)':<18} {'Mean SchedDelay (us)':<22} {'Count':<8}")
+    print("-" * 90)
+    for name, r in results.items():
+        pr = r["per_req"]
+        print(f"{name:<25} {pr['ttft_ms']:<18.4f} {pr['e2e_ms']:<18.4f} {pr['sched_delay_us']:<22.1f} {pr['count']:<8}")
+
+    print()
+
+    # --- Scheduling delay deltas ---
+    print("--- Scheduling Delay Deltas (per-request) ---")
+    print("Note: scheduling_delay_ms field is in TICKS (us), not ms")
+    print(f"{'Config':<25} {'SchedDelay delta (us)':<24} {'Expected delta (us)':<22} {'Match?':<10}")
+    print("-" * 80)
+
+    baseline_sched = baseline["per_req"]["sched_delay_us"]
+    for name, r in results.items():
+        if r["latency_us"] == 0:
+            continue
+        expected_us = r["latency_us"]
+        actual_delta_us = r["per_req"]["sched_delay_us"] - baseline_sched
+        # Tolerance: 100 us
+        ok = abs(actual_delta_us - expected_us) < 100
+        if not ok:
+            all_pass = False
+        print(f"{name:<25} {actual_delta_us:<24.1f} {expected_us:<22.1f} {'PASS' if ok else 'FAIL':<10}")
+
+    print()
+
+    # --- Linearity check ---
+    print("--- Linearity Check ---")
+    b_delta = results["B (latency=10ms)"]["agg"]["e2e_mean_ms"] - baseline["agg"]["e2e_mean_ms"]
+    c_delta = results["C (latency=50ms)"]["agg"]["e2e_mean_ms"] - baseline["agg"]["e2e_mean_ms"]
+    if b_delta > 0:
+        ratio = c_delta / b_delta
+        expected_ratio = 5.0  # 50ms / 10ms
+        print(f"E2E delta ratio C/B: {ratio:.4f} (expected: {expected_ratio:.1f})")
+        linear_ok = abs(ratio - expected_ratio) < 0.1
+        print(f"Linearity: {'PASS' if linear_ok else 'FAIL'}")
+        if not linear_ok:
+            all_pass = False
+    else:
+        print("Cannot compute linearity (B delta is 0)")
+        all_pass = False
+
+    print()
+
+    # --- Verdict ---
+    print("=" * 70)
+    if all_pass:
+        print("VERDICT: H26 CONFIRMED")
+        print("Admission latency delays TTFT and E2E by exactly the configured amount.")
+        print("Causal ordering: Arrival -> Admission (+latency) -> Routing -> Queue -> Batch -> Step")
+    else:
+        print("VERDICT: H26 REFUTED or PARTIAL")
+        print("Some deltas did not match expected values. Investigate event pipeline.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/hypotheses/h26-admission-latency/run.sh
+++ b/hypotheses/h26-admission-latency/run.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# H26: Admission latency causal ordering
+# Tests whether adding admission latency delays E2E by exactly that amount under low load.
+#
+# Family: Structural model
+# VV&UQ: Verification (deterministic)
+# Reference: None (first experiment in this area)
+#
+# Design:
+#   - 3 configurations: admission-latency=0, 10000 (10ms), 50000 (50ms) in ticks/us
+#   - Low rate (10 req/s) → no queuing confound
+#   - CONSTANT distributions for input/output → minimal noise
+#   - 4 instances, 50 requests, seed=42
+#   - Both TTFT and E2E measured from original ArrivalTime (verified in sim/simulator.go:564)
+#   - Expected: TTFT and E2E mean both increase by exactly 10ms with admission latency
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$WORKTREE_DIR/simulation_worker"
+RESULTS_DIR="$SCRIPT_DIR/results"
+
+mkdir -p "$RESULTS_DIR"
+
+MODEL="meta-llama/llama-3.1-8b-instruct"
+NUM_INSTANCES=4
+NUM_REQUESTS=50
+SEED=42
+HORIZON=60000000  # 60s in ticks (us) — plenty for 50 requests at 10 req/s
+
+# Workload: CONSTANT input=128, CONSTANT output=32, rate=10
+# Low rate avoids queuing; constant distributions eliminate variance.
+# Field names verified against sim/workload/spec.go struct tags.
+make_workload() {
+    local outfile=$1
+    cat > "$outfile" << YAMLEOF
+version: "1"
+seed: 42
+category: language
+aggregate_rate: 10.0
+num_requests: 50
+clients:
+  - id: "h26-client"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 128
+    output_distribution:
+      type: constant
+      params:
+        value: 32
+YAMLEOF
+}
+
+echo "=== H26: Admission Latency Causal Ordering ==="
+echo ""
+
+# --- Config A: No admission latency (baseline) ---
+echo "--- Config A: admission-latency=0 (baseline) ---"
+WORKLOAD_FILE_A="$RESULTS_DIR/workload_a.yaml"
+make_workload "$WORKLOAD_FILE_A"
+
+"$BINARY" run \
+  --model "$MODEL" \
+  --num-instances "$NUM_INSTANCES" \
+  --seed "$SEED" \
+  --horizon "$HORIZON" \
+  --admission-latency 0 \
+  --routing-latency 0 \
+  --routing-policy least-loaded \
+  --workload-spec "$WORKLOAD_FILE_A" \
+  --results-path "$RESULTS_DIR/results_a.json" \
+  > "$RESULTS_DIR/stdout_a.txt" 2>"$RESULTS_DIR/stderr_a.txt"
+
+echo "Config A done."
+
+# --- Config B: 10ms admission latency ---
+echo "--- Config B: admission-latency=10000 (10ms) ---"
+WORKLOAD_FILE_B="$RESULTS_DIR/workload_b.yaml"
+make_workload "$WORKLOAD_FILE_B"
+
+"$BINARY" run \
+  --model "$MODEL" \
+  --num-instances "$NUM_INSTANCES" \
+  --seed "$SEED" \
+  --horizon "$HORIZON" \
+  --admission-latency 10000 \
+  --routing-latency 0 \
+  --routing-policy least-loaded \
+  --workload-spec "$WORKLOAD_FILE_B" \
+  --results-path "$RESULTS_DIR/results_b.json" \
+  > "$RESULTS_DIR/stdout_b.txt" 2>"$RESULTS_DIR/stderr_b.txt"
+
+echo "Config B done."
+
+# --- Config C: 50ms admission latency (linearity check) ---
+echo "--- Config C: admission-latency=50000 (50ms) ---"
+WORKLOAD_FILE_C="$RESULTS_DIR/workload_c.yaml"
+make_workload "$WORKLOAD_FILE_C"
+
+"$BINARY" run \
+  --model "$MODEL" \
+  --num-instances "$NUM_INSTANCES" \
+  --seed "$SEED" \
+  --horizon "$HORIZON" \
+  --admission-latency 50000 \
+  --routing-latency 0 \
+  --routing-policy least-loaded \
+  --workload-spec "$WORKLOAD_FILE_C" \
+  --results-path "$RESULTS_DIR/results_c.json" \
+  > "$RESULTS_DIR/stdout_c.txt" 2>"$RESULTS_DIR/stderr_c.txt"
+
+echo "Config C done."
+
+echo ""
+echo "=== Running analysis ==="
+python3 "$SCRIPT_DIR/analyze.py" "$RESULTS_DIR"


### PR DESCRIPTION
## Summary
- **Confirmed**: `--admission-latency L` adds exact additive offset to TTFT, E2E, and scheduling delay
- Deltas match to 4+ decimal places at 10ms and 50ms; linearity ratio = 5.0000
- Validates the cluster event pipeline causal ordering: Arrival → Admission (+L) → Routing → Queue → Batch → Step
- Family: Structural model | Converged: Round 1

## Artifacts
- `hypotheses/h26-admission-latency/FINDINGS.md` — full analysis
- `hypotheses/h26-admission-latency/run.sh` — reproducible experiment
- `hypotheses/h26-admission-latency/analyze.py` — delta and linearity analysis

## Test plan
- [ ] `./hypotheses/h26-admission-latency/run.sh` reproduces results
- [ ] FINDINGS.md has all required sections (standards audit, evidence quality, scope)
- [ ] Promotion candidate: deterministic Go test for event pipeline causal ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)