### PR TITLE
feat(hypotheses): H-Step-Quantum — alpha/beta service time split discovery (#329)

### DIFF
--- a/hypotheses/h-step-quantum/FINDINGS.md
+++ b/hypotheses/h-step-quantum/FINDINGS.md
@@ -1,0 +1,203 @@
+# H-Step-Quantum: Step-Time Quantum vs DES-to-M/M/1 Wait-Time Divergence
+
+**Status:** Refuted
+**Resolution:** Refuted -- wrong mental model. The DES-to-M/M/1 divergence is NOT primarily caused by discrete step-time quantization. Scaling beta coefficients down by 100x increases the percentage divergence from 47-78% to 98-99%, because the alpha model overhead (which does not block the server) increasingly dominates the calibrated service time. The root cause of the original divergence is the split between "server-blocking time" (step time only) and "request E2E time" (steps + alpha overhead), which makes the effective DES utilization lower than the nominal M/M/1 rho.
+**Family:** Structural model
+**VV&UQ:** Validation
+**Tier:** Tier 1 (grounds other experiments)
+**Type:** Statistical (Monotonicity)
+**Date:** 2026-02-23
+**Rounds:** 2
+
+## Hypothesis
+
+> Reducing the DES step-time quantum (by scaling beta coefficients) should proportionally reduce the DES-to-M/M/1 mean wait time divergence. Specifically: at rho=0.7, the W_q error (currently ~60% with ~6.9ms steps) should scale linearly with step_time / mean_service_time, approaching 0% as step time -> 0.
+
+## Experiment Design
+
+**Classification:** Statistical / Monotonicity
+
+**Configurations compared:**
+- A (baseline): beta=[6910.42, 17.67, 2.84], alpha=[1601.35, 3.51, 1805.54], step_time ~6913 us
+- B (10x smaller): beta=[691.042, 1.767, 0.284], alpha=[1601.35, 3.51, 1805.54], step_time ~691 us
+- C (100x smaller): beta=[69.104, 0.177, 0.028], alpha=[1601.35, 3.51, 1805.54], step_time ~69 us
+
+**All three configurations use identical:**
+- `--model meta-llama/llama-3.1-8b-instruct --num-instances 1 --max-num-running-reqs 1`
+- `--scheduler fcfs --admission-policy always-admit --total-kv-blocks 1000000`
+- Workload: Poisson arrivals, constant input=1, exponential output mean=128
+- Seeds: 42, 123, 456
+
+**Controlled variables:** Alpha coefficients, input/output token distribution, admission policy, scheduler, instances, KV blocks
+**Varied variable:** Beta coefficients (scaling factor: 1.0, 0.1, 0.01)
+**Seeds:** 42, 123, 456
+**Preconditions verified:**
+- Calibration at each scale: 10 requests, constant output=128, very low rate (0.01 req/s)
+- 1.0x: service_time=1126.2 ms, mu=0.888 req/s (matches H-MMK calibration)
+- 0.1x: service_time=323.6 ms, mu=3.090 req/s
+- 0.01x: service_time=243.3 ms, mu=4.109 req/s
+- Arrival rates correctly computed as lambda = rho * mu for each scale
+
+**Config diff against H-MMK (ED-6):**
+- Added: `--beta-coeffs` and `--alpha-coeffs` explicit flags (H-MMK used defaults, which produce the 1.0x values)
+- Removed: Sub-experiments 2 and 3 (cluster mode with routing)
+- Changed: Added rho=0.9 (H-MMK used 0.85)
+- Identical: All other flags, workload parameters, seed set
+
+## Results
+
+### Per-Scale W_q Comparison (3-seed average, 2000 requests/run)
+
+| Scale | Step (us) | Svc (ms) | rho=0.3 err | rho=0.5 err | rho=0.7 err | rho=0.9 err |
+|-------|-----------|----------|-------------|-------------|-------------|-------------|
+| 1.0x  | 6913      | 1126.2   | -47.2%      | -50.5%      | -59.6%      | -78.3%      |
+| 0.1x  | 691       | 323.6    | -93.6%      | -95.6%      | -97.2%      | -99.0%      |
+| 0.01x | 69        | 243.3    | -98.4%      | -99.3%      | -99.7%      | -99.9%      |
+
+**All errors are negative** (DES W_q < M/M/1 analytical). Error **increases** as beta decreases -- the opposite of the prediction.
+
+**Monotonicity check:** 0/4 utilization levels show decreasing error with decreasing step quantum. The hypothesis is refuted at all operating points.
+
+### Service Time Composition
+
+| Scale | Service (ms) | Step total (ms) | Alpha total (ms) | Step fraction |
+|-------|-------------|-----------------|-------------------|---------------|
+| 1.0x  | 1126.2      | 891.8           | 232.7             | 79.2%         |
+| 0.1x  | 323.6       | 89.2            | 232.7             | 27.6%         |
+| 0.01x | 243.3       | 8.9             | 232.7             | 3.7%          |
+
+As beta decreases, the alpha overhead (constant at 232.7 ms) increasingly dominates the calibrated service time. At 0.01x, 96.3% of the "service time" is alpha overhead.
+
+### Conservation: INV-1 OK across all 36 runs (3 scales x 4 rhos x 3 seeds)
+
+### Per-Seed Consistency
+
+| Scale | rho | seed 42 | seed 123 | seed 456 | CV |
+|-------|-----|---------|----------|----------|-----|
+| 1.0x  | 0.7 | 979.7   | 1037.3   | 1170.1   | 7.5% |
+| 0.1x  | 0.7 | 20.0    | 20.0     | 22.9     | 6.7% |
+| 0.01x | 0.7 | 1.8     | 1.8      | 1.9      | 1.9% |
+
+Results are consistent across seeds (CV < 11% for all configs).
+
+## Root Cause Analysis
+
+### The DES has two distinct "service time" concepts (RCV-1, RCV-3)
+
+The M/M/1 analytical model uses a single service time mu = 1/E[S] where E[S] is the calibrated E2E time at zero load. But the BLIS DES has **two different time components** that contribute to E2E:
+
+1. **Server-blocking time (step time):** Determined by `StepTime()` (`sim/latency_model.go:35-50`). This is the only component that advances the simulation clock and blocks the server from processing other requests. For a single request with output=128: step_total = prefill_step + 128 * decode_step.
+
+2. **Alpha overhead (non-blocking):** Two components:
+   - `QueueingTime()` (`sim/latency_model.go:53-57`): alpha0 + alpha1*inputLen = 1604.86 us. Applied as a delay between ArrivalEvent and QueuedEvent (`sim/event.go:31-35`). This delays enqueuing but does not block the server.
+   - `OutputTokenProcessingTime()` (`sim/latency_model.go:60-62`): alpha2 = 1805.54 us per token. Added to each decode step's ITL (`sim/simulator.go:560`) and to TTFT/E2E metrics, but does NOT advance the simulation clock or delay the next step (`sim/simulator.go:618`: next step at `now + currStepAdvance`, not `now + currStepAdvance + outputProcessingTime`).
+
+### Why reducing beta increases divergence (RCV-3)
+
+The M/M/1 analytical W_q depends on **total service time** (1126 ms at 1.0x). The DES W_q depends only on **server-blocking time** (892 ms at 1.0x, 8.9 ms at 0.01x). The effective DES utilization is:
+
+```
+rho_eff = lambda * step_total_s   (not lambda * calibrated_service_s)
+```
+
+At nominal rho=0.7:
+- 1.0x: rho_eff = 0.622 * 0.892 = 0.554 (server utilization)
+- 0.1x: rho_eff = 2.163 * 0.089 = 0.193
+- 0.01x: rho_eff = 2.877 * 0.009 = 0.026
+
+At 0.01x, the DES server is idle 97.4% of the time despite the nominal M/M/1 rho being 0.7. Requests find an empty queue on almost every arrival, so W_q approaches the minimum (alpha0 queueing delay of ~1.6 ms).
+
+Reducing beta shrinks step_total while leaving alpha_total constant. This **widens** the gap between nominal rho (calibrated from E2E) and effective rho (from step time only), making the DES look less loaded and the M/M/1 comparison worse.
+
+### The H-MMK 47-71% divergence explained (RCV-2)
+
+At the 1.0x baseline:
+- Step fraction = 79.2%, so the effective utilization is ~79.2% of nominal
+- At nominal rho=0.7: lambda = 0.622 req/s, mu_eff = 1/step_total = 1.121 req/s
+- rho_eff = lambda / mu_eff = 0.622 / 1.121 = 0.555
+- M/M/1 W_q at rho_eff=0.555 with mu_eff=1.121: rho_eff/(mu_eff*(1-rho_eff)) = 0.555/(1.121*0.445) = 1112 ms
+- DES W_q observed: 1062 ms → error vs corrected M/M/1: -4.5%
+
+This first-principles calculation shows that **most of the H-MMK divergence disappears** when using step_total as the service time. The alpha=0 control experiment confirms this: DES W_q at rho=0.7 is 2074 ms vs M/M/1 prediction 2081 ms (-0.3% error). The 47% minimum divergence at rho=0.3 in H-MMK is almost entirely from calibrating mu using E2E (which includes non-blocking alpha overhead) instead of step_total.
+
+### Control experiment: alpha=0 (RCV-4) -- Round 2
+
+To confirm the mechanism, a control experiment was run with alpha=[0, 0, 0] (no alpha overhead) while keeping beta at 1.0x. This eliminates the blocking/non-blocking split, making the calibrated service time equal to the step total (E2E = 891.8 ms = step_total, mu = 1.121 req/s).
+
+| rho | W_q M/M/1 (ms) | W_q DES alpha=0 (ms) | Error | Original error (alpha != 0) |
+|-----|----------------|----------------------|-------|---------------------------|
+| 0.3 | 382.20         | 356.89               | -6.6% | -47.2%                    |
+| 0.5 | 891.79         | 853.08               | -4.3% | -50.5%                    |
+| 0.7 | 2080.85        | 2074.04              | -0.3% | -59.6%                    |
+| 0.9 | 8026.13        | 6908.47              | -13.9%| -78.3%                    |
+
+**The control confirms the mechanism.** Removing alpha overhead reduces the divergence from 47-78% to 0.3-14%. At rho=0.5 and rho=0.7, the DES is within the 5% M/M/1 tolerance. The remaining residual divergence at rho=0.3 (6.6%) and rho=0.9 (13.9%) is consistent with the discrete step effect and exponential service time approximation (M/G/1 correction).
+
+**Interpretation:** The alpha overhead IS the dominant source of DES-to-M/M/1 divergence. With alpha=0, the DES closely matches M/M/1 across the utilization range, with residual error from discrete step quantization growing modestly at high rho. The original H-MMK "discrete step processing" mechanism was a secondary effect, not the primary one.
+
+## Devil's Advocate (RCV-5)
+
+**If this is "Refuted," argue why it might be Confirmed:**
+The original hypothesis claimed step-time quantum causes divergence. At the 1.0x scale, the step fraction is 79.2%, meaning step quantization IS the dominant contributor to the server-blocking time. The divergence at 1.0x (47-78%) is partly due to discrete steps -- the experiment just didn't isolate this effect properly because reducing beta also changes the alpha/beta ratio. A better test would hold the alpha/beta ratio constant (scale both equally).
+
+**Counter-argument (why Refuted is correct):**
+Even at 1.0x, the first-principles calculation shows that 20% of the service time is non-blocking alpha overhead, which alone accounts for most of the low-rho divergence (47%). The discrete step effect contributes a second-order correction. The hypothesis's prediction was clearly wrong: divergence increases 2x (from 47% to 98%) instead of decreasing to ~5%. The mental model was wrong about the primary mechanism.
+
+## Findings Classification
+
+| Finding | Type | Action |
+|---------|------|--------|
+| DES has split service time: server-blocking (beta/step) vs non-blocking (alpha overhead) | **Design limitation** | File `--label design` issue for documentation and potential DES calibration guidance |
+| Alpha overhead (output processing, queueing delay) does not advance simulation clock | **Confirmation** | Documented here -- this is by design, matching vLLM's architecture where post-processing is non-blocking |
+| H-MMK's 47-71% divergence is primarily explained by the alpha/beta split, not discrete step quantization | **Surprise** | Overturns the proposed mechanism in H-MMK FINDINGS.md. File update to H-MMK documentation. |
+| DES effective utilization = lambda * step_total, not lambda * E2E_total | **New insight** | Document as guidance for users comparing DES to analytical models |
+| Conservation (INV-1) holds across all 36 runs | **Confirmation** | Documented here |
+| Reducing step quantum increases M/M/1 divergence (opposite of prediction) | **Refutation** | Documented here -- the hypothesis is wrong |
+
+## Standards Audit
+
+Findings checked against docs/standards/:
+- [x] Any violations of existing rules? **No.** The alpha overhead design is intentional (models vLLM post-processing).
+- [x] Any new rules needed? **Yes.** Proposed: "When comparing DES to analytical queueing models, use step_total as the service time (not E2E), since alpha overhead does not block the server."
+- [x] Any new invariants needed? **No.**
+- [x] Any existing rules/invariants confirmed? **INV-1** (conservation) confirmed across all 36 runs.
+
+## Scope and Limitations (RCV-6)
+
+- **Operating point tested:** k=1, rho = {0.3, 0.5, 0.7, 0.9}, seeds = {42, 123, 456}, 2000 requests/run, beta scales = {1.0, 0.1, 0.01}, constant input=1, exponential output mean=128
+- **Parameters findings depend on:** `--max-num-running-reqs 1` (single-server-per-instance). With batch sizes > 1, the alpha/beta split has different dynamics -- multiple requests share the same step time.
+- **What was NOT tested:**
+  - Batch sizes > 1 (typical inference serving uses 32-256)
+  - Non-zero alpha scaling (what happens if we also scale alpha proportionally?)
+  - Roofline mode (different step time model)
+  - Different input/output token distributions
+  - Multi-instance (k > 1) configurations
+- **Generalizability:** The alpha/beta split finding generalizes to ALL BLIS configurations using the blackbox latency model, since the architecture (alpha overhead not advancing the clock) is fundamental. However, the quantitative impact varies with the alpha/beta ratio, which depends on input/output token counts and model coefficients.
+- **Uncertainty quantification:** The effect is robust across seeds (CV < 11%). The direction (reducing beta increases divergence) is consistent across all 12 (rho, scale) combinations. No UQ needed for the qualitative finding.
+
+## Evidence Quality
+
+| Metric | Value | Confidence |
+|--------|-------|------------|
+| Divergence direction (DES < M/M/1) | Consistent across all 36 runs | **High** -- same direction, growing with rho |
+| Divergence increases with decreasing beta | 0/4 rhos show decreasing error | **High** -- opposite of prediction in all cases |
+| Root cause: alpha/beta split | Step fraction ranges from 79.2% to 3.7% | **High** -- computed analytically AND confirmed by DES data |
+| First-principles rho_eff calculation | Matches DES behavior qualitatively and quantitatively | **High** -- confirmed by alpha=0 control (divergence drops from 47-78% to 0.3-14%) |
+| Conservation (INV-1) | Holds in all 36 runs | **High** |
+
+## Implications for Users
+
+1. **Do NOT calibrate M/M/1/M/M/k comparisons using E2E at zero load.** The calibrated E2E includes alpha overhead that does not block the DES server. Instead, compute the effective service time from beta coefficients directly: `step_total = (beta0 + beta1*input) + output_tokens * (beta0 + beta2)` for a single request.
+
+2. **The effective DES utilization is lower than you think.** For the default llama-3.1-8b coefficients with input=1, output=128: `rho_eff = 0.792 * rho_nominal`. At nominal rho=0.7, the DES server is only at 55.4% utilization.
+
+3. **The alpha overhead models post-processing and network delays** that in real vLLM are non-blocking (happen after the step completes and the server is ready for the next batch). This is architecturally correct -- the mismatch is with M/M/1, not with vLLM.
+
+4. **For analytical model comparison, use step_total as the service time.** This gives: mu_eff = 1000 / step_total_ms. For the H-MMK experiment at 1.0x: mu_eff = 1000/891.8 = 1.121 req/s (vs calibrated mu = 0.888 req/s).
+
+## Reproducing
+
+```
+cd hypotheses/h-step-quantum
+./run.sh
+```

--- a/hypotheses/h-step-quantum/analyze.py
+++ b/hypotheses/h-step-quantum/analyze.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Analysis script for H-Step-Quantum: Step-Time Quantum vs DES-M/M/1 Divergence.
+
+Compares DES wait times against M/M/1 analytical predictions at multiple beta
+coefficient scalings to test whether discrete step-time quantum causes the
+DES-to-M/M/1 divergence observed in H-MMK.
+
+BLIS output format (see cmd/root.go and sim/metrics_utils.go):
+  - Per-request JSON via --results-path
+  - scheduling_delay_ms in per-request JSON is in TICKS (microseconds), not ms
+    (known unit inconsistency — see sim/metrics_utils.go line 27)
+  - e2e_ms is in actual milliseconds
+  - Aggregate scheduling_delay_p99_ms IS in ms (goes through CalculatePercentile)
+
+M/M/1 analytical formulas:
+  rho = lambda / mu
+  W_q = rho / (mu * (1 - rho))  # mean wait time in queue (seconds)
+"""
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+
+# -- M/M/1 Analytical Model ------------------------------------------------
+
+def mm1_mean_wait_s(lam, mu):
+    """Mean wait time in queue (W_q) for M/M/1 in seconds."""
+    rho = lam / mu
+    if rho >= 1.0:
+        return float('inf')
+    return rho / (mu * (1.0 - rho))
+
+
+def mm1_mean_sojourn_s(lam, mu):
+    """Mean sojourn time (W = W_q + 1/mu) for M/M/1 in seconds."""
+    rho = lam / mu
+    if rho >= 1.0:
+        return float('inf')
+    return 1.0 / (mu * (1.0 - rho))
+
+
+# -- DES Output Parsing -----------------------------------------------------
+
+def parse_results_json(filepath):
+    """Parse BLIS --results-path JSON -> per-request data.
+
+    Returns dict with wait_times_ms, e2e_times_ms, service_times_ms lists
+    and conservation counts.
+
+    JSON fields verified against sim/metrics_utils.go:
+      - RequestMetrics.SchedulingDelay (json:"scheduling_delay_ms") → TICKS (us)
+      - RequestMetrics.E2E (json:"e2e_ms") → actual ms
+      - MetricsOutput.InjectedRequests (json:"injected_requests")
+      - MetricsOutput.CompletedRequests (json:"completed_requests")
+      - MetricsOutput.StillQueued (json:"still_queued")
+      - MetricsOutput.StillRunning (json:"still_running")
+    """
+    data = json.loads(Path(filepath).read_text())
+    completed = [r for r in data.get('requests', []) if r['e2e_ms'] > 0]
+
+    # scheduling_delay_ms is in TICKS (microseconds), convert to ms
+    wait_times_ms = [r['scheduling_delay_ms'] / 1000.0 for r in completed]
+    e2e_times_ms = [r['e2e_ms'] for r in completed]
+    service_times_ms = [
+        r['e2e_ms'] - r['scheduling_delay_ms'] / 1000.0
+        for r in completed
+    ]
+
+    return {
+        'completed': len(completed),
+        'injected': data.get('injected_requests', 0),
+        'still_queued': data.get('still_queued', 0),
+        'still_running': data.get('still_running', 0),
+        'wait_times_ms': wait_times_ms,
+        'e2e_times_ms': e2e_times_ms,
+        'service_times_ms': service_times_ms,
+    }
+
+
+# -- Little's Law -----------------------------------------------------------
+
+def verify_littles_law(data):
+    """Verify L = lambda * W from per-request data.
+
+    Uses e2e_times_ms for sojourn time W.
+    Lambda = completed / sim_duration.
+    """
+    e2e_times = data['e2e_times_ms']
+    if len(e2e_times) < 2:
+        return None
+
+    # Effective throughput from completion count / total time span
+    total_e2e_s = sum(e2e_times) / 1000.0
+    n = len(e2e_times)
+
+    # We use the standard approach: lambda_eff * W_mean
+    # For a stable system, lambda_eff ≈ arrival rate
+    # W = mean sojourn time
+    w_mean_s = sum(e2e_times) / n / 1000.0
+
+    return {
+        'W_mean_ms': w_mean_s * 1000.0,
+        'n_completed': n,
+    }
+
+
+# -- Analysis ---------------------------------------------------------------
+
+def analyze(results_dir, beta_scales, mu_values, service_ms_values,
+            step_us_values, num_requests):
+    """Main analysis: compare DES vs M/M/1 at each beta scaling."""
+    rhos = [0.3, 0.5, 0.7, 0.9]
+    seeds = [42, 123, 456]
+
+    print("Configuration:")
+    for i, scale in enumerate(beta_scales):
+        print(f"  Scale {scale}x: mu={mu_values[i]:.4f} req/s, "
+              f"service_time={service_ms_values[i]:.1f} ms, "
+              f"step_time={step_us_values[i]:.0f} us")
+    print(f"  Utilization levels: {rhos}")
+    print(f"  Seeds: {seeds}")
+    print(f"  Requests per run: {num_requests}")
+    print()
+
+    # Collect all results for cross-scale comparison
+    all_results = {}  # (scale, rho) -> {wq_ana_ms, wq_des_ms, pct_err, ...}
+
+    for i, scale in enumerate(beta_scales):
+        mu = mu_values[i]
+        svc_ms = service_ms_values[i]
+        step_us = step_us_values[i]
+
+        print(f"{'=' * 74}")
+        print(f"  Beta scale {scale}x: step_time={step_us:.0f} us, "
+              f"service_time={svc_ms:.1f} ms")
+        print(f"{'=' * 74}")
+        print()
+        print(f"  {'rho':<6} {'W_q Ana (ms)':>14} {'W_q DES (ms)':>14} "
+              f"{'Error':>8} {'Dir':>5} {'INV-1':>7} {'n':>6}")
+        print(f"  {'-' * 6} {'-' * 14} {'-' * 14} {'-' * 8} {'-' * 5} {'-' * 7} {'-' * 6}")
+
+        for rho in rhos:
+            lam = rho * mu
+            wq_ana_ms = mm1_mean_wait_s(lam, mu) * 1000.0
+
+            wait_times_all = []
+            conservation_ok = True
+            for seed in seeds:
+                fpath = os.path.join(results_dir, f"s{scale}_r{rho}_s{seed}.json")
+                if not os.path.exists(fpath):
+                    print(f"  WARNING: missing {fpath}", file=sys.stderr)
+                    continue
+                data = parse_results_json(fpath)
+                wait_times_all.extend(data['wait_times_ms'])
+                # Conservation check: injected == completed + queued + running
+                total = data['completed'] + data['still_queued'] + data['still_running']
+                if total != data['injected']:
+                    conservation_ok = False
+                    print(f"  WARNING: INV-1 FAIL for scale={scale} rho={rho} "
+                          f"seed={seed}: {total} != {data['injected']}",
+                          file=sys.stderr)
+
+            if not wait_times_all:
+                print(f"  {rho:<6} {'MISSING':>14} {'MISSING':>14} "
+                      f"{'N/A':>8} {'N/A':>5} {'N/A':>7} {'0':>6}")
+                continue
+
+            wq_des_ms = sum(wait_times_all) / len(wait_times_all)
+
+            if wq_ana_ms > 0:
+                # Signed error: negative means DES < analytical
+                signed_err = (wq_des_ms - wq_ana_ms) / wq_ana_ms * 100
+            else:
+                signed_err = 0.0
+
+            direction = "LOW" if signed_err < 0 else "HIGH"
+            inv1 = "OK" if conservation_ok else "FAIL"
+
+            print(f"  {rho:<6} {wq_ana_ms:>14.2f} {wq_des_ms:>14.2f} "
+                  f"{signed_err:>+7.1f}% {direction:>5} {inv1:>7} "
+                  f"{len(wait_times_all):>6}")
+
+            all_results[(scale, rho)] = {
+                'wq_ana_ms': wq_ana_ms,
+                'wq_des_ms': wq_des_ms,
+                'signed_err': signed_err,
+                'abs_err': abs(signed_err),
+                'step_us': step_us,
+                'svc_ms': svc_ms,
+                'n_samples': len(wait_times_all),
+            }
+
+        print()
+
+    # -- Cross-scale comparison table --
+    print(f"{'=' * 74}")
+    print("  Cross-Scale Comparison: |W_q error| vs step-time quantum")
+    print(f"{'=' * 74}")
+    print()
+    print(f"  {'rho':<6}", end="")
+    for scale in beta_scales:
+        label = f"|err| @{scale}x"
+        print(f" {label:>14}", end="")
+    print(f" {'Monotonic?':>12}")
+    print(f"  {'-' * 6}", end="")
+    for _ in beta_scales:
+        print(f" {'-' * 14}", end="")
+    print(f" {'-' * 12}")
+
+    monotonic_count = 0
+    total_rows = 0
+    for rho in rhos:
+        print(f"  {rho:<6}", end="")
+        errors = []
+        for scale in beta_scales:
+            key = (scale, rho)
+            if key in all_results:
+                err = all_results[key]['abs_err']
+                errors.append(err)
+                print(f" {err:>13.1f}%", end="")
+            else:
+                errors.append(None)
+                print(f" {'N/A':>14}", end="")
+
+        # Check monotonicity: error should decrease as scale decreases
+        valid_errors = [e for e in errors if e is not None]
+        if len(valid_errors) >= 2:
+            total_rows += 1
+            is_mono = all(valid_errors[j] >= valid_errors[j + 1]
+                          for j in range(len(valid_errors) - 1))
+            if is_mono:
+                monotonic_count += 1
+                print(f" {'YES':>12}")
+            else:
+                print(f" {'NO':>12}")
+        else:
+            print(f" {'N/A':>12}")
+
+    print()
+    if total_rows > 0:
+        print(f"  Monotonicity: {monotonic_count}/{total_rows} utilization levels")
+        print(f"  Hypothesis {'CONFIRMED' if monotonic_count == total_rows else 'NOT CONFIRMED'}: "
+              f"reducing step quantum {'monotonically' if monotonic_count == total_rows else 'does NOT monotonically'} "
+              f"reduces divergence")
+    print()
+
+    # -- Step-time ratio vs error ratio (linearity check) --
+    print(f"{'=' * 74}")
+    print("  Linearity Check: Does error scale proportionally with step time?")
+    print(f"{'=' * 74}")
+    print()
+    print(f"  For linear scaling: error_ratio ≈ step_time_ratio")
+    print(f"  step_time_ratio = step_time(scale) / step_time(baseline)")
+    print(f"  error_ratio = |error(scale)| / |error(baseline)|")
+    print()
+
+    baseline_scale = beta_scales[0]
+    baseline_step_us = step_us_values[0]
+
+    print(f"  {'rho':<6} {'scale':>6} {'step_ratio':>12} {'err_ratio':>12} "
+          f"{'linear?':>10}")
+    print(f"  {'-' * 6} {'-' * 6} {'-' * 12} {'-' * 12} {'-' * 10}")
+
+    for rho in rhos:
+        baseline_key = (baseline_scale, rho)
+        if baseline_key not in all_results:
+            continue
+        baseline_err = all_results[baseline_key]['abs_err']
+        if baseline_err < 0.1:
+            continue  # skip if baseline error is negligible
+
+        for j, scale in enumerate(beta_scales[1:], 1):
+            key = (scale, rho)
+            if key not in all_results:
+                continue
+            err = all_results[key]['abs_err']
+            step_ratio = step_us_values[j] / baseline_step_us
+            err_ratio = err / baseline_err if baseline_err > 0 else 0
+
+            # Linear if err_ratio ≈ step_ratio within 50% tolerance
+            if step_ratio > 0:
+                ratio_of_ratios = err_ratio / step_ratio
+                is_linear = 0.5 <= ratio_of_ratios <= 1.5
+            else:
+                is_linear = False
+
+            linear_str = "YES" if is_linear else "NO"
+            print(f"  {rho:<6} {scale:>6} {step_ratio:>12.3f} {err_ratio:>12.3f} "
+                  f"{linear_str:>10}")
+
+    print()
+
+    # -- Service time composition table --
+    print(f"{'=' * 74}")
+    print("  Service Time Composition: Step-time vs Alpha overhead")
+    print(f"{'=' * 74}")
+    print()
+    print(f"  As beta decreases, alpha overhead (constant) dominates service time.")
+    print(f"  step_fraction = total_step_time / total_service_time")
+    print()
+    print(f"  {'scale':>6} {'svc_ms':>10} {'step_total_ms':>14} {'alpha_ms':>10} "
+          f"{'step_frac':>10}")
+    print(f"  {'-' * 6} {'-' * 10} {'-' * 14} {'-' * 10} {'-' * 10}")
+
+    # For constant input=1, output=128:
+    # step_total = prefill_step + 128 * decode_step
+    # alpha_total = alpha0 + alpha1*1 + 128*alpha2 (queueing + output processing)
+    alpha0, alpha1, alpha2 = 1601.35, 3.51, 1805.54
+    for j, scale in enumerate(beta_scales):
+        svc_ms = service_ms_values[j]
+        # Compute step time in ms for constant output=128
+        prefill_step_us = 6910.42 * scale + 17.67 * scale * 1  # beta0 + beta1*input
+        decode_step_us = 6910.42 * scale + 2.84 * scale * 1    # beta0 + beta2*1
+        step_total_ms = (prefill_step_us + 128 * decode_step_us) / 1000.0
+        alpha_total_ms = (alpha0 + alpha1 * 1 + 128 * alpha2) / 1000.0
+        step_frac = step_total_ms / svc_ms if svc_ms > 0 else 0
+
+        print(f"  {scale:>6} {svc_ms:>10.1f} {step_total_ms:>14.1f} "
+              f"{alpha_total_ms:>10.1f} {step_frac:>9.1%}")
+
+    print()
+
+    # -- Per-seed consistency check --
+    print(f"{'=' * 74}")
+    print("  Per-Seed Consistency: W_q DES across seeds")
+    print(f"{'=' * 74}")
+    print()
+
+    for i, scale in enumerate(beta_scales):
+        mu = mu_values[i]
+        print(f"  Scale {scale}x:")
+        print(f"    {'rho':<6} {'seed 42':>12} {'seed 123':>12} {'seed 456':>12} "
+              f"{'CV':>8}")
+        print(f"    {'-' * 6} {'-' * 12} {'-' * 12} {'-' * 12} {'-' * 8}")
+
+        for rho in rhos:
+            per_seed_wq = []
+            for seed in seeds:
+                fpath = os.path.join(results_dir, f"s{scale}_r{rho}_s{seed}.json")
+                if not os.path.exists(fpath):
+                    per_seed_wq.append(None)
+                    continue
+                data = parse_results_json(fpath)
+                wq = sum(data['wait_times_ms']) / len(data['wait_times_ms']) \
+                    if data['wait_times_ms'] else 0
+                per_seed_wq.append(wq)
+
+            vals = [v for v in per_seed_wq if v is not None]
+            if len(vals) >= 2:
+                mean_v = sum(vals) / len(vals)
+                std_v = (sum((v - mean_v) ** 2 for v in vals) / len(vals)) ** 0.5
+                cv = std_v / mean_v if mean_v > 0 else 0
+            else:
+                cv = 0
+
+            parts = []
+            for v in per_seed_wq:
+                if v is not None:
+                    parts.append(f"{v:>12.1f}")
+                else:
+                    parts.append(f"{'N/A':>12}")
+
+            print(f"    {rho:<6} {parts[0]} {parts[1]} {parts[2]} {cv:>7.1%}")
+
+        print()
+
+    return all_results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="H-Step-Quantum: Step-Time Quantum Divergence Analyzer")
+    parser.add_argument("--results-dir", required=True,
+                        help="Directory with DES results")
+    parser.add_argument("--beta-scales", required=True,
+                        help="Comma-separated beta scale factors")
+    parser.add_argument("--mu-values", required=True,
+                        help="Comma-separated mu values (req/s) per scale")
+    parser.add_argument("--service-ms-values", required=True,
+                        help="Comma-separated service times (ms) per scale")
+    parser.add_argument("--step-us-values", required=True,
+                        help="Comma-separated step times (us) per scale")
+    parser.add_argument("--num-requests", type=int, required=True,
+                        help="Requests per run")
+    args = parser.parse_args()
+
+    beta_scales = [float(x) for x in args.beta_scales.split(",")]
+    mu_values = [float(x) for x in args.mu_values.split(",")]
+    service_ms_values = [float(x) for x in args.service_ms_values.split(",")]
+    step_us_values = [float(x) for x in args.step_us_values.split(",")]
+
+    if len(beta_scales) != len(mu_values):
+        print("ERROR: beta_scales and mu_values must have same length",
+              file=sys.stderr)
+        sys.exit(1)
+
+    analyze(args.results_dir, beta_scales, mu_values, service_ms_values,
+            step_us_values, args.num_requests)
+
+
+if __name__ == "__main__":
+    main()

--- a/hypotheses/h-step-quantum/run.sh
+++ b/hypotheses/h-step-quantum/run.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+# H-Step-Quantum: Does reducing step-time quantum shrink DES-to-M/M/1 wait-time divergence?
+#
+# Hypothesis: Reducing the DES step-time quantum (by scaling beta coefficients)
+# should proportionally reduce the DES-to-M/M/1 mean wait time divergence.
+# At rho=0.7, the W_q error (currently ~60% with ~6.9ms steps) should scale
+# linearly with step_time / mean_service_time, approaching 0% as step time -> 0.
+#
+# Classification: Statistical / Monotonicity
+# Family: Structural model
+# VV&UQ: Validation
+#
+# Design:
+#   - Three beta coefficient scalings: 1x (baseline), 0.1x, 0.01x
+#   - Alpha coefficients held constant (controls overhead, not step quantum)
+#   - Single instance (k=1, M/M/1 comparison — cleanest)
+#   - Utilization sweep: rho = {0.3, 0.5, 0.7, 0.9}
+#   - Each beta scaling requires re-calibration of mu (service rate)
+#   - Workload: Poisson arrivals, constant input=1, exponential output mean=128
+#   - Seeds: 42, 123, 456
+#
+# ED-1: Controlled comparison — only beta coefficients vary between configurations
+# ED-2: Rate calibrated per beta scaling from empirical service time
+# ED-3: Preconditions — stability (rho < 1), constant output for calibration
+# ED-5: Reproducible — builds binary, runs all variants, no manual steps
+# ED-6: Reference: hypotheses/h-mmk-validation/run.sh
+#   Config diff: beta-coeffs and alpha-coeffs now explicit (h-mmk used defaults);
+#   all other flags identical to h-mmk sub-experiment 1 (k=1, fcfs, always-admit)
+#
+# Reference: https://github.com/inference-sim/inference-sim/issues/329
+#
+# Usage: ./run.sh [--rebuild]
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$REPO_ROOT/simulation_worker"
+
+# Build if needed
+if [[ "${1:-}" == "--rebuild" ]] || [[ ! -x "$BINARY" ]]; then
+    echo "Building simulation_worker..."
+    (cd "$REPO_ROOT" && go build -o simulation_worker main.go)
+fi
+
+MODEL="meta-llama/llama-3.1-8b-instruct"
+SEEDS=(42 123 456)
+RHOS=(0.3 0.5 0.7 0.9)
+NUM_REQUESTS=2000
+OUTPUT_TOKEN_MEAN=128
+INPUT_TOKENS=1
+
+# Default alpha coefficients (held constant across all beta scalings)
+ALPHA_COEFFS="1601.35,3.51,1805.54"
+
+# Beta coefficient scalings to test
+# Baseline: [6910.42, 17.67, 2.84] → step_time ≈ 6913 us per decode step
+# 0.1x:    [691.042, 1.767, 0.284] → step_time ≈ 691 us per decode step
+# 0.01x:   [69.1042, 0.1767, 0.0284] → step_time ≈ 69 us per decode step
+BETA_SCALES=(1.0 0.1 0.01)
+BETA_BASE_0=6910.42
+BETA_BASE_1=17.67
+BETA_BASE_2=2.84
+
+RESULTS_DIR=$(mktemp -d)
+trap "rm -rf $RESULTS_DIR" EXIT
+
+# Generate workload YAML with a given rate
+make_workload() {
+    local rate=$1
+    local seed=$2
+    local outfile=$3
+
+    cat > "$outfile" << YAMLEOF
+version: "1"
+seed: $seed
+category: language
+aggregate_rate: $rate
+num_requests: $NUM_REQUESTS
+clients:
+  - id: "step-quantum-client"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: $INPUT_TOKENS
+    output_distribution:
+      type: exponential
+      params:
+        mean: $OUTPUT_TOKEN_MEAN
+YAMLEOF
+}
+
+echo "============================================================================"
+echo "  H-Step-Quantum: Step-Time Quantum vs DES-M/M/1 Divergence"
+echo "  Reference: issue #329, H-MMK findings (PR #325)"
+echo "  Type: Statistical / Monotonicity"
+echo "  Family: Structural model | VV&UQ: Validation"
+echo "============================================================================"
+echo ""
+
+# ── Step 0: Calibrate mean service time for each beta scaling ─────────────
+# Use constant output and very low load to measure service time precisely.
+
+echo "Step 0: Calibrating service times for each beta scaling..."
+echo ""
+
+# Store calibration results in files (avoid bash 4+ associative arrays)
+CAL_DIR="$RESULTS_DIR/calibration"
+mkdir -p "$CAL_DIR"
+
+for scale in "${BETA_SCALES[@]}"; do
+    BETA_0=$(python3 -c "print(f'{$BETA_BASE_0 * $scale:.4f}')")
+    BETA_1=$(python3 -c "print(f'{$BETA_BASE_1 * $scale:.4f}')")
+    BETA_2=$(python3 -c "print(f'{$BETA_BASE_2 * $scale:.4f}')")
+    BETA_COEFFS="$BETA_0,$BETA_1,$BETA_2"
+
+    # Compute expected step time per decode step (single request)
+    STEP_US=$(python3 -c "print(f'{$BETA_BASE_0 * $scale + $BETA_BASE_2 * $scale:.2f}')")
+
+    echo "  Beta scale ${scale}x: beta=[$BETA_COEFFS], expected step_time=${STEP_US} us"
+
+    cat > "$RESULTS_DIR/cal_wl_${scale}.yaml" << YAMLEOF
+version: "1"
+seed: 42
+category: language
+aggregate_rate: 0.01
+num_requests: 10
+clients:
+  - id: "calibrate"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: $INPUT_TOKENS
+    output_distribution:
+      type: constant
+      params:
+        value: $OUTPUT_TOKEN_MEAN
+YAMLEOF
+
+    timeout 120 "$BINARY" run \
+        --model "$MODEL" \
+        --num-instances 1 \
+        --max-num-running-reqs 1 \
+        --workload-spec "$RESULTS_DIR/cal_wl_${scale}.yaml" \
+        --seed 42 \
+        --scheduler fcfs \
+        --admission-policy always-admit \
+        --total-kv-blocks 1000000 \
+        --beta-coeffs "$BETA_COEFFS" \
+        --alpha-coeffs "$ALPHA_COEFFS" \
+        --log error \
+        --results-path "$RESULTS_DIR/cal_${scale}.json" \
+        2>/dev/null \
+        > "$RESULTS_DIR/cal_${scale}_stdout.txt"
+
+    MEAN_SERVICE_MS=$(python3 -c "
+import json
+data = json.load(open('$RESULTS_DIR/cal_${scale}.json'))
+reqs = [r for r in data['requests'] if r['e2e_ms'] > 0]
+mean_e2e = sum(r['e2e_ms'] for r in reqs) / len(reqs)
+print(f'{mean_e2e:.3f}')
+")
+    MU=$(python3 -c "print(f'{1000.0 / $MEAN_SERVICE_MS:.6f}')")
+
+    echo "    Mean service time: ${MEAN_SERVICE_MS} ms, mu = ${MU} req/s"
+
+    # Store calibration results in files
+    echo "$MU" > "$CAL_DIR/mu_${scale}"
+    echo "$MEAN_SERVICE_MS" > "$CAL_DIR/svc_${scale}"
+    echo "$STEP_US" > "$CAL_DIR/step_${scale}"
+done
+
+echo ""
+
+# ── Main experiment: M/M/1 comparison at each beta scaling ────────────────
+
+for scale in "${BETA_SCALES[@]}"; do
+    BETA_0=$(python3 -c "print(f'{$BETA_BASE_0 * $scale:.4f}')")
+    BETA_1=$(python3 -c "print(f'{$BETA_BASE_1 * $scale:.4f}')")
+    BETA_2=$(python3 -c "print(f'{$BETA_BASE_2 * $scale:.4f}')")
+    BETA_COEFFS="$BETA_0,$BETA_1,$BETA_2"
+    MU=$(cat "$CAL_DIR/mu_${scale}")
+    SVC_MS=$(cat "$CAL_DIR/svc_${scale}")
+    STEP_US=$(cat "$CAL_DIR/step_${scale}")
+
+    echo "============================================================================"
+    echo "  Beta scale ${scale}x: step_time=${STEP_US} us"
+    echo "    mu=${MU} req/s, service_time=${SVC_MS} ms"
+    echo "    beta=[$BETA_COEFFS], alpha=[$ALPHA_COEFFS]"
+    echo "============================================================================"
+    echo ""
+
+    for rho in "${RHOS[@]}"; do
+        RATE=$(python3 -c "print(f'{$rho * $MU:.6f}')")
+        for seed in "${SEEDS[@]}"; do
+            echo "  Running: scale=${scale} rho=$rho rate=$RATE seed=$seed ..."
+            make_workload "$RATE" "$seed" "$RESULTS_DIR/wl_s${scale}_r${rho}_s${seed}.yaml"
+            timeout 300 "$BINARY" run \
+                --model "$MODEL" \
+                --num-instances 1 \
+                --max-num-running-reqs 1 \
+                --workload-spec "$RESULTS_DIR/wl_s${scale}_r${rho}_s${seed}.yaml" \
+                --seed "$seed" \
+                --scheduler fcfs \
+                --admission-policy always-admit \
+                --total-kv-blocks 1000000 \
+                --beta-coeffs "$BETA_COEFFS" \
+                --alpha-coeffs "$ALPHA_COEFFS" \
+                --log error \
+                --results-path "$RESULTS_DIR/s${scale}_r${rho}_s${seed}.json" \
+                2>/dev/null \
+                > "$RESULTS_DIR/s${scale}_r${rho}_s${seed}_stdout.txt" \
+                || echo "    WARNING: timeout or error for scale=$scale rho=$rho seed=$seed"
+        done
+    done
+
+    echo ""
+done
+
+echo "============================================================================"
+echo "  Analysis"
+echo "============================================================================"
+echo ""
+
+# Read calibration data from files
+MU_1=$(cat "$CAL_DIR/mu_1.0")
+MU_01=$(cat "$CAL_DIR/mu_0.1")
+MU_001=$(cat "$CAL_DIR/mu_0.01")
+SVC_1=$(cat "$CAL_DIR/svc_1.0")
+SVC_01=$(cat "$CAL_DIR/svc_0.1")
+SVC_001=$(cat "$CAL_DIR/svc_0.01")
+STEP_1=$(cat "$CAL_DIR/step_1.0")
+STEP_01=$(cat "$CAL_DIR/step_0.1")
+STEP_001=$(cat "$CAL_DIR/step_0.01")
+
+# Pass calibration data to analyzer
+python3 "$SCRIPT_DIR/analyze.py" \
+    --results-dir "$RESULTS_DIR" \
+    --beta-scales "1.0,0.1,0.01" \
+    --mu-values "${MU_1},${MU_01},${MU_001}" \
+    --service-ms-values "${SVC_1},${SVC_01},${SVC_001}" \
+    --step-us-values "${STEP_1},${STEP_01},${STEP_001}" \
+    --num-requests "$NUM_REQUESTS"
+
+echo ""
+
+# ── Control experiment: alpha=0 (Round 2, RCV-4) ──────────────────────────
+# Disables alpha overhead to confirm it is the root cause of divergence.
+# With alpha=0, E2E = step_total, so M/M/1 comparison uses the correct mu.
+
+echo "============================================================================"
+echo "  Control Experiment: alpha=[0,0,0] with beta at 1.0x"
+echo "  Purpose: confirm alpha/beta split as root cause of divergence"
+echo "============================================================================"
+echo ""
+
+# Calibrate with alpha=0
+ALPHA_ZERO="0,0,0"
+BETA_BASELINE="$BETA_BASE_0,$BETA_BASE_1,$BETA_BASE_2"
+
+cat > "$RESULTS_DIR/cal_wl_a0.yaml" << YAMLEOF
+version: "1"
+seed: 42
+category: language
+aggregate_rate: 0.01
+num_requests: 10
+clients:
+  - id: "calibrate"
+    tenant_id: "default"
+    slo_class: "batch"
+    rate_fraction: 1.0
+    streaming: false
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: $INPUT_TOKENS
+    output_distribution:
+      type: constant
+      params:
+        value: $OUTPUT_TOKEN_MEAN
+YAMLEOF
+
+timeout 120 "$BINARY" run \
+    --model "$MODEL" \
+    --num-instances 1 \
+    --max-num-running-reqs 1 \
+    --workload-spec "$RESULTS_DIR/cal_wl_a0.yaml" \
+    --seed 42 \
+    --scheduler fcfs \
+    --admission-policy always-admit \
+    --total-kv-blocks 1000000 \
+    --beta-coeffs "$BETA_BASELINE" \
+    --alpha-coeffs "$ALPHA_ZERO" \
+    --log error \
+    --results-path "$RESULTS_DIR/cal_a0.json" \
+    2>/dev/null \
+    > "$RESULTS_DIR/cal_a0_stdout.txt"
+
+MU_A0=$(python3 -c "
+import json
+data = json.load(open('$RESULTS_DIR/cal_a0.json'))
+reqs = [r for r in data['requests'] if r['e2e_ms'] > 0]
+mean_e2e = sum(r['e2e_ms'] for r in reqs) / len(reqs)
+print(f'{1000.0 / mean_e2e:.6f}')
+")
+SVC_A0=$(python3 -c "
+import json
+data = json.load(open('$RESULTS_DIR/cal_a0.json'))
+reqs = [r for r in data['requests'] if r['e2e_ms'] > 0]
+mean_e2e = sum(r['e2e_ms'] for r in reqs) / len(reqs)
+print(f'{mean_e2e:.3f}')
+")
+echo "  Alpha=0 calibration: service_time=${SVC_A0} ms, mu=${MU_A0} req/s"
+echo ""
+
+for rho in "${RHOS[@]}"; do
+    RATE=$(python3 -c "print(f'{$rho * $MU_A0:.6f}')")
+    for seed in "${SEEDS[@]}"; do
+        echo "  Running: alpha=0 rho=$rho rate=$RATE seed=$seed ..."
+        make_workload "$RATE" "$seed" "$RESULTS_DIR/wl_a0_r${rho}_s${seed}.yaml"
+        timeout 300 "$BINARY" run \
+            --model "$MODEL" \
+            --num-instances 1 \
+            --max-num-running-reqs 1 \
+            --workload-spec "$RESULTS_DIR/wl_a0_r${rho}_s${seed}.yaml" \
+            --seed "$seed" \
+            --scheduler fcfs \
+            --admission-policy always-admit \
+            --total-kv-blocks 1000000 \
+            --beta-coeffs "$BETA_BASELINE" \
+            --alpha-coeffs "$ALPHA_ZERO" \
+            --log error \
+            --results-path "$RESULTS_DIR/a0_r${rho}_s${seed}.json" \
+            2>/dev/null \
+            > "$RESULTS_DIR/a0_r${rho}_s${seed}_stdout.txt" \
+            || echo "    WARNING: timeout or error for alpha=0 rho=$rho seed=$seed"
+    done
+done
+
+echo ""
+echo "  Alpha=0 control results:"
+python3 -c "
+import json, os
+
+mu = $MU_A0
+rhos = [0.3, 0.5, 0.7, 0.9]
+seeds = [42, 123, 456]
+
+def mm1_wq(lam, mu):
+    rho = lam / mu
+    if rho >= 1: return float('inf')
+    return rho / (mu * (1 - rho))
+
+print(f'  {\"rho\":<8} {\"W_q Ana (ms)\":>14} {\"W_q DES (ms)\":>14} {\"Error\":>10}')
+print(f'  {\"-\"*8} {\"-\"*14} {\"-\"*14} {\"-\"*10}')
+
+for rho in rhos:
+    lam = rho * mu
+    wq_ana = mm1_wq(lam, mu) * 1000
+    waits = []
+    for seed in seeds:
+        fpath = os.path.join('$RESULTS_DIR', f'a0_r{rho}_s{seed}.json')
+        if not os.path.exists(fpath):
+            continue
+        data = json.load(open(fpath))
+        completed = [r for r in data['requests'] if r['e2e_ms'] > 0]
+        waits.extend([r['scheduling_delay_ms'] / 1000.0 for r in completed])
+    if waits:
+        wq_des = sum(waits) / len(waits)
+        err = (wq_des - wq_ana) / wq_ana * 100 if wq_ana > 0 else 0
+        print(f'  {rho:<8} {wq_ana:>14.2f} {wq_des:>14.2f} {err:>+9.1f}%')
+"
+
+echo ""
+echo "============================================================================"
+echo "  See FINDINGS.md for detailed analysis"
+echo "============================================================================"


### PR DESCRIPTION
## Summary
- **Refuted**: Reducing step-time quantum INCREASES DES-to-M/M/1 divergence (opposite of prediction)
- Root cause: alpha overhead (queueing delay + output processing) inflates E2E but does NOT advance the sim clock
- Effective utilization = lambda × step_total, not lambda × E2E_total
- Alpha=0 control (Round 2): divergence drops from 47-78% to 0.3-14%, confirming mechanism
- Overturns H-MMK's proposed mechanism — the primary cause of divergence is the alpha/beta split, not discrete step quantization
- Family: Structural model | Converged: Round 2 (alpha=0 control per RCV-4) | 48 simulations

**Closes #329**

## Artifacts
- `hypotheses/h-step-quantum/FINDINGS.md` — full analysis with Round 2 control experiment
- `hypotheses/h-step-quantum/run.sh` — reproducible experiment (3 beta scales + alpha=0 control)
- `hypotheses/h-step-quantum/analyze.py` — cross-scale comparison and composition analysis

## Test plan
- [ ] `./hypotheses/h-step-quantum/run.sh` reproduces results
- [ ] FINDINGS.md has all required sections including Round 2 control
- [ ] File design issue: document DES service time split for analytical model comparisons
- [ ] File enhancement: update H-MMK FINDINGS with correct root cause
- [ ] File standards issue: proposed rule for analytical model calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)