### PR TITLE
fix(test): update conservation tests to four-term INV-1 formula

### DIFF
--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -205,11 +205,11 @@ func TestInstanceSimulator_GoldenDataset_Invariants(t *testing.T) {
 			m := instance.Metrics()
 
 			// INV-1: Request conservation
-			// completed + still_queued + still_running == injected
-			total := m.CompletedRequests + m.StillQueued + m.StillRunning
+			// completed + still_queued + still_running + dropped == injected
+			total := m.CompletedRequests + m.StillQueued + m.StillRunning + m.DroppedUnservable
 			if total != tc.NumRequests {
-				t.Errorf("INV-1 request conservation: completed(%d) + queued(%d) + running(%d) = %d, want %d (NumRequests)",
-					m.CompletedRequests, m.StillQueued, m.StillRunning, total, tc.NumRequests)
+				t.Errorf("INV-1 request conservation: completed(%d) + queued(%d) + running(%d) + dropped(%d) = %d, want %d (NumRequests)",
+					m.CompletedRequests, m.StillQueued, m.StillRunning, m.DroppedUnservable, total, tc.NumRequests)
 			}
 
 			// INV-5: Causality — for every completed request, TTFT >= 0 and E2E >= TTFT

--- a/sim/metrics_test.go
+++ b/sim/metrics_test.go
@@ -273,8 +273,8 @@ func TestSaveResults_ConservationFields(t *testing.T) {
 	assert.Equal(t, 1, output.StillQueued)
 	assert.Equal(t, 1, output.StillRunning)
 	assert.Equal(t, 10, output.InjectedRequests)
-	// Conservation identity: injected = completed + queued + running
-	assert.Equal(t, output.InjectedRequests, output.CompletedRequests+output.StillQueued+output.StillRunning)
+	// Conservation identity: injected = completed + queued + running + dropped (INV-1)
+	assert.Equal(t, output.InjectedRequests, output.CompletedRequests+output.StillQueued+output.StillRunning+output.DroppedUnservable)
 }
 
 // TestSaveResults_PerRequestITL_InMilliseconds verifies BC-14:


### PR DESCRIPTION
## Summary

- Update all existing conservation test assertions from three-term (`completed + queued + running`) to four-term (`completed + queued + running + dropped`) to match the INV-1 formula change from PR #386
- Update stale comments: "three-term conservation" → "four-term conservation"
- Affected tests: `TestSaveResults_Conservation`, `TestClusterSimulator_Conservation_PolicyMatrix`, `TestClusterSimulator_Conservation_Overload`, `TestInstanceSimulator_GoldenDataset_Invariants`

## Why this matters

The old assertions passed silently because `DroppedUnservable=0` in all existing test scenarios. But a contributor copying this pattern to write a new conservation test would encode the wrong invariant — missing the `dropped_unservable` term introduced in PR #386.

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)