### PR TITLE
feat(hypotheses): H-Reasoning-KV — reasoning workload KV pressure + prefix caching

### DIFF
--- a/hypotheses/h-reasoning-kv/FINDINGS.md
+++ b/hypotheses/h-reasoning-kv/FINDINGS.md
@@ -1,0 +1,225 @@
+# H-Reasoning-KV: Reasoning Context Accumulation Under KV Pressure
+
+**Status:** Refuted (primary), Confirmed (supporting)
+**Resolution:** Refuted — wrong mental model. Demand heterogeneity does NOT shift the preemption cliff because the cliff is driven by peak *concurrent* block demand, not per-request peak demand. The mean demand per request (72 blocks) is identical for both workloads, so concurrency-driven pressure is the same. However, context accumulation produces 63.8% prefix cache hits — a major positive finding for capacity planning.
+**Family:** Performance-regime (scaling laws)
+**VV&UQ:** Validation (cliff comparison) + Verification (#386, INV-1)
+**Tier:** New (not in original research.md tiers)
+**Type:** Statistical (Monotonicity) + Deterministic (invariant checks)
+**Date:** 2026-02-23
+**Rounds:** 1
+
+## Hypothesis
+
+> Under constrained KV capacity, multi-turn reasoning workloads with context accumulation trigger the preemption cliff at a block count proportional to their peak per-request demand (120 blocks for round 4), while standard workloads with uniform per-request demand (72 blocks) trigger it at a proportionally lower block count. The cliff shift ratio should be approximately 1.1-1.3x.
+
+## Experiment Design
+
+**Classification:** Statistical/Monotonicity (preemption rate vs block count)
+
+**Configurations compared:**
+- Workload A (reasoning): 2 sessions/s, 5 rounds with context accumulation, constant input=128, output=256
+- Workload B (standard-throughput-matched): 10 req/s, constant input=896, output=256. Matches ~10 req/s effective rate of reasoning.
+- Workload C (standard-session-matched): 2 req/s, constant input=896, output=256. Matches session arrival rate.
+
+All workloads: `--model meta-llama/llama-3.1-8b-instruct --num-instances 1 --max-num-running-reqs 32 --max-num-scheduled-tokens 2048 --block-size-in-tokens 16 --horizon 100000000`
+
+**KV sweep:** 5000, 3000, 2000, 1500, 1200, 1000, 800, 600, 400, 100 blocks
+**Seeds:** 42, 123, 456
+**Total runs:** 90 (10 blocks × 3 seeds × 3 workloads)
+**Preconditions verified:** Context accumulation produces expected token pattern [128, 512, 896, 1280, 1664] — PASS. 123 sessions detected.
+
+**Config diff (ED-6):** Novel experiment — no prior reference. Reasoning workload YAML is new. Standard workloads use constant distributions for isolation.
+
+## Results
+
+### 1. Preemption Cliff Detection (primary metric)
+
+5% preemption rate threshold crossing (3-seed average):
+
+| Workload | Cliff (blocks) | Per-seed cliffs |
+|----------|----------------|-----------------|
+| Reasoning | 2651 | [2541, 2805, 2606] |
+| Std (throughput-matched) | 2482 | [2554, 2932, 1961] |
+| Std (session-matched) | 710 | [549, 780, 800] |
+
+**Cliff shift ratio (reasoning / std-throughput):** 1.09x
+**Per-seed ratios:** [0.99, 0.96, 1.33]
+**Detection criterion (pre-committed):** "Cliff shift detected" requires >=20% difference in ALL 3 seeds. Result: NOT DETECTED (two seeds show <10%).
+
+**Statistical power caveat:** With 3 seeds and per-seed ratio SD ≈ 0.21, the 95% CI for the mean ratio is [0.74, 1.44] — the experiment cannot distinguish "no effect" from "moderate effect." The "not detected" conclusion rests primarily on the analytical argument (identical mean demand → identical cliff), not on experimental power alone. A 10-seed replication with finer block granularity (every 100 blocks near the cliff) would be needed for definitive statistical confirmation.
+
+**Cliff characterization note:** The 5% preemption rate threshold is a heuristic. The data shows a gradual onset region (~1500-3000 blocks for reasoning/throughput-matched) rather than a sharp cliff. Compare H8's finer granularity (100-block steps) at a different operating point (4 instances, rate=2000).
+
+### 2. Per-Round TTFT (blocks=5000, reasoning workload)
+
+| Round | Input tokens | TTFT mean (ms) | Growth from Round 0 |
+|-------|-------------|----------------|---------------------|
+| 0 | 128 | 16.63 | — |
+| 1 | 512 | 17.77 | +6.8% |
+| 2 | 896 | 19.36 | +16.4% |
+| 3 | 1280 | 21.12 | +27.0% |
+| 4 | 1664 | 21.89 | +31.6% |
+
+**Spearman rho(round, TTFT):** +1.000 for all 3 seeds (perfect monotonicity).
+
+**Predicted vs actual:** Predicted 3.6x growth (from alpha0 + alpha1 × inputLen). Actual: 1.32x (31.6%). The 63.8% cache hit rate means round-4 requests with 1664 input tokens have ~1060 tokens cached, so effective new tokens ≈ 604 — explaining the attenuated TTFT growth.
+
+### 3. Prefix Cache Hit Rate (blocks=5000)
+
+| Workload | Cache Hit Rate |
+|----------|---------------|
+| Reasoning | **0.6384** |
+| Std (throughput-matched) | 0.0000 |
+| Std (session-matched) | 0.0000 |
+
+Consistent across all 3 seeds (0.6379, 0.6369, 0.6405).
+
+### 4. #386 Verification (blocks=100)
+
+| Workload | Avg dropped | Per-seed |
+|----------|------------|----------|
+| Reasoning | **76.0** | [75, 74, 79] |
+| Std (throughput-matched) | 0.0 | [0, 0, 0] |
+| Std (session-matched) | 0.0 | [0, 0, 0] |
+
+Reasoning drops rounds 3-4 (1280 and 1664 tokens need 80 and 104 blocks > 100 total). Standard requests (896 tokens = 56 blocks) fit in 100 blocks. #386 fix works as designed.
+
+### 5. Conservation Invariant (INV-1)
+
+**90/90 checks PASS.** `injected == completed + queued + running + dropped_unservable` holds for all configurations including blocks=100 with drops.
+
+### 6. Preemption Dynamics (observation)
+
+The standard-throughput-matched workload exhibits extreme non-monotonic preemption behavior:
+
+| Blocks | Reasoning preemption rate | Std-throughput preemption rate |
+|--------|--------------------------|-------------------------------|
+| 2000 | 0.164 | 0.284 |
+| 1500 | 0.257 | **160.5** |
+| 1000 | **170.7** | **217.4** |
+| 400 | 88.4 | **4602.3** |
+
+Rates >1.0 indicate cascading preemptions — each completed request was preempted multiple times on average. At blocks=400 for standard-throughput-matched, 4602 preemptions per completed request indicates severe thrashing. This is the cascading preemption phenomenon from #349.
+
+**Monotonicity (Spearman rho for blocks → preemption rate):**
+- Session-matched: rho=-0.952 (near-perfect negative monotonicity — well-behaved)
+- Reasoning: rho=-0.838 (good monotonicity despite cascade onset)
+- Throughput-matched: rho=-0.483 (poor — cascading preemptions create non-monotonic behavior)
+
+## Root Cause Analysis
+
+### Why the cliff shift is negligible (RCV-1, RCV-3)
+
+The hypothesis assumed per-request peak demand (120 blocks for round 4) would shift the cliff. But the cliff is driven by **concurrent** block demand, not individual request demand.
+
+At steady state with rate=2 sessions/s:
+- ~17.7 concurrent requests (Little's law, see research.md)
+- Mean block demand per request: (24+48+72+96+120)/5 = 72 blocks (reasoning) = 72 blocks (standard)
+- Total concurrent demand: 17.7 × 72 ≈ 1274 blocks for BOTH workloads
+
+The mean demand is identical by design (we matched total token throughput). The variance creates only a ~100-block fluctuation when multiple round-4 requests coincide, which is <10% of the cliff point (~2500 blocks). This matches the observed 1.09x ratio.
+
+**Code path (RCV-1):** Preemption occurs in `sim/batch_formation.go` `VLLMBatchFormation.FormBatch()` when `AllocateKVBlocks` fails. The allocation path in `sim/kvcache.go:AllocateKVBlocks` (line ~130-180) checks `freeBlocks >= blocksNeeded`. The cliff occurs when concurrent requests' total block demand exceeds total capacity — this depends on concurrent count × mean demand, not max single-request demand.
+
+### Why prefix cache hits are 63.8% (RCV-1)
+
+Context accumulation in `sim/workload/reasoning.go:54-58` creates round N's input by prepending all prior rounds' input + output tokens. These are exact token ID copies (line 55: `inputTokens = append(append([]int{}, contextPrefix...), newInputTokens...)`).
+
+When the KV cache processes round N, `AllocateKVBlocks` in `sim/kvcache.go` hashes each block of 16 tokens. If the prior round's blocks are still in the LRU cache, the hash lookup succeeds (cache hit). With think_time=5s between rounds and rate=2 sessions/s, only ~10 other requests arrive between rounds, churning ~720 blocks out of 5000 total (14.4%). The LRU retains most prior-round blocks.
+
+First-principles cache hit estimate (including round-0 dilution):
+- Total tokens across all 5 rounds: 128+512+896+1280+1664 = 4480
+- Cacheable tokens (if all prior-round blocks survive LRU): 0+384+768+1152+1536 = 3840
+- Expected token-level hit rate: 3840/4480 = 85.7%
+- LRU eviction correction: ~14.4% block churn between rounds → expected rate ≈ 85.7% × (1-0.144) = 73.3%
+- Observed block-level rate: 63.8%
+
+The residual gap (73.3% predicted vs 63.8% observed) is an **open question**. Possible causes: multi-session LRU contention patterns under interleaved arrivals, block-vs-token-level metric differences, or batch formation ordering effects. The cross-seed stability (0.6369-0.6405, σ=0.002) confirms this is a systematic effect, not noise. No control experiment disabling prefix matching was run (token-hash collision is theoretically impossible, making this unnecessary).
+
+### Why TTFT growth is 32% not 360% (RCV-2)
+
+TTFT has three components with different caching sensitivity:
+
+1. **QueueingTime (alpha model)** — `latency_model.go:58-59`: uses `len(req.InputTokens)` (FULL input, NOT reduced by caching). Round 0: 1601+3.51×128=2050 μs. Round 4: 1601+3.51×1664=7442 μs. **3.63x growth — caching has NO effect here.**
+
+2. **StepTime (beta model)** — `latency_model.go:42-43`: uses `NumNewTokens` (reduced by caching via `batch_formation.go:109-110`). Round 0: 6910+17.67×128=9172 μs. Round 4 with caching (602 new tokens): 6910+17.67×602=17,543 μs. **1.91x growth — significantly attenuated from the 3.96x without caching** (6910+17.67×1664=36,323 μs).
+
+3. **OutputTokenProcessingTime + scheduling overhead** — constant 1806 μs. **1.0x growth.**
+
+The composite TTFT growth is an average of these three channels, weighted by their contribution. The constant alpha0 (1601 μs) and constant OutputTokenProcessingTime (1806 μs) dilute the proportional growth. The observed 1.32x is consistent with the beta-channel attenuation being the primary mechanism, diluted by the two constant-overhead channels.
+
+## Devil's Advocate (RCV-5)
+
+**Argue why the cliff shift might actually be real:**
+The 1.33x ratio in seed 456 suggests the effect exists but is masked by noise in the other seeds. With only 3 seeds and a wide cliff detection range (2541-2805 for reasoning), the signal-to-noise ratio is too low. Running with 10 seeds or using a finer block granularity (every 50 blocks near the cliff) might reveal a consistent 10-15% shift.
+
+**Argue why the 63.8% cache hit rate might be misleading:**
+The cache hit rate is inflated by the generous KV capacity (5000 blocks). At constrained block counts (800-1000), LRU eviction between rounds would destroy cached blocks, and the cache hit rate would drop to near zero. The practical benefit of reasoning prefix caching only exists when KV is over-provisioned — exactly the regime where it matters least.
+
+## Findings Classification
+
+| Finding | Type | Action |
+|---------|------|--------|
+| Cliff shift not detected (1.09x, below threshold) | Refuted — wrong mental model | Documented here. Capacity planning: mean demand drives cliff, not per-request peak. |
+| TTFT monotonicity confirmed (rho=+1.000) | Confirmation | Documented here. Context accumulation correctly increases TTFT across rounds. |
+| 63.8% prefix cache hit rate for reasoning workloads | **Surprise** | Document as user guidance. Reasoning workloads benefit significantly from prefix caching when KV is adequate. |
+| #386 correctly drops oversized reasoning requests | Confirmation | Validates #386 fix under reasoning workload (first test of this path). |
+| INV-1 holds across all 90 configurations | Confirmation | Extends INV-1 validation to reasoning workloads + dropped_unservable. |
+| Cascading preemptions (rate >100x) at constrained KV | Known phenomenon | Reproduces #349 at new operating points. No new issue needed. |
+| `sim/workload/reasoning.go` generates correct token accumulation | Confirmation | First end-to-end validation of reasoning workload generation. |
+
+## Standards Audit
+
+Findings checked against docs/standards/:
+- [x] Any violations of existing rules? **None found.** R19 livelock protection verified via #386.
+- [x] Any new rules needed? **No.** Existing rules cover all observed behavior.
+- [x] Any new invariants needed? **No.** INV-1 updated formula (with dropped_unservable) holds.
+- [x] Any existing rules/invariants confirmed? **INV-1** confirmed under reasoning workload + drops. **R19** confirmed via #386 verification.
+
+## Scope and Limitations (RCV-6)
+
+- **Operating point tested:** rate=2 sessions/s, 5 rounds, constant input=128/output=256, single instance, blocks 100-5000
+- **Parameters findings depend on:** think_time=5s (affects cache hit rate via LRU churn), constant distributions (eliminates variance confound)
+- **Known confounds:**
+  - Arrival pattern differs between reasoning (bursty: 5 rounds/session with 5s gaps) and throughput-matched (uniform Poisson). This confound strengthens the refutation: bursty arrivals should create MORE demand spikes, yet no cliff shift was detected.
+  - `num_requests: 500` produces ~123 sessions with session truncation (some sessions incomplete). Round distribution is not uniform: 123 round-0, 75 round-4. This does not affect cliff analysis but is relevant for per-round TTFT interpretation.
+  - Session-matched comparison (rate=2 req/s) isolates *throughput* as the dominant cliff driver. Reasoning-vs-throughput-matched comparison tests demand heterogeneity *with* the arrival pattern confound.
+- **What was NOT tested:**
+  - Variable input/output distributions (real workloads have variance)
+  - Multi-instance cluster (routing interaction with reasoning workload)
+  - Tiered KV cache (CPU offload interaction)
+  - Roofline latency mode
+  - High utilization (rate > 10 sessions/s)
+  - Mixed reasoning + non-reasoning clients
+  - Different think_time values (5s is generous for LRU retention)
+  - Deconfounded heterogeneity test (Poisson at 10 req/s with randomized per-request sizes from [24,48,72,96,120] blocks)
+- **Generalizability:** The 63.8% cache hit rate is specific to this think_time, rate, and KV capacity (5000 blocks). Higher rates, shorter think_times, or constrained KV would increase LRU churn and reduce cache hits. The cliff non-shift finding likely generalizes: any workload with the same mean per-request block demand will have the same cliff location regardless of per-request variance.
+- **Uncertainty quantification:** Cliff location has wide seed-to-seed variance (±200 blocks). Cache hit rate is stable (±0.002 across seeds). More seeds or finer block granularity needed for UQ on cliff location.
+
+## Evidence Quality
+
+| Metric | Value | Confidence |
+|--------|-------|------------|
+| Cliff shift ratio | 1.09x | Medium — wide variance across seeds (0.96-1.33) |
+| TTFT monotonicity | rho=+1.000 | High — perfect monotonicity across all seeds |
+| Cache hit rate | 0.6384 | High — stable across seeds (±0.002) |
+| #386 dropped count | 76 avg | High — consistent mechanism (rounds 3-4 exceed capacity) |
+| Conservation | 90/90 | High — deterministic check |
+
+## Implications for Users
+
+1. **Capacity planning for reasoning workloads:** Provision KV blocks based on **mean** per-request demand × expected concurrency, not peak per-request demand. The quadratic growth in per-request demand does NOT create a cliff shift versus standard workloads with equivalent throughput.
+
+2. **Prefix caching is highly effective for reasoning/multi-turn** (at adequate KV capacity): 63.8% cache hit rate at 5000 blocks with rate=2 sessions/s and 5s think time. This reduces effective prefill tokens by ~2/3, significantly improving TTFT for later rounds. Cache hit rate will decrease with higher rates, shorter think times, or constrained KV capacity.
+
+3. **TTFT growth is modest with caching** (at this operating point): Despite 13x input growth (128→1664 tokens), TTFT grows only 32% thanks to prefix caching. Under constrained KV (where cache eviction is high), growth could approach the analytical 3.6x prediction.
+
+4. **#386 protects against oversized reasoning requests:** Late-round requests in very constrained KV will be cleanly dropped rather than causing livelock. Monitor `dropped_unservable` in production.
+
+## Reproducing
+
+```
+cd hypotheses/h-reasoning-kv
+./run.sh
+```

--- a/hypotheses/h-reasoning-kv/analyze.py
+++ b/hypotheses/h-reasoning-kv/analyze.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Analysis script for H-Reasoning-KV.
+
+Parses BLIS output and produces:
+1. Precondition check: verifies reasoning workload token accumulation pattern
+2. KV pressure sweep: preemption cliff detection, monotonicity, conservation
+3. Per-round TTFT analysis (at generous KV)
+4. Cache hit comparison
+5. #386 DroppedUnservable verification
+
+BLIS output format (see cmd/root.go and sim/metrics_utils.go):
+- Per-instance and cluster JSON blocks, each preceded by "=== Simulation Metrics ==="
+- Cluster block has "instance_id": "cluster"
+- KV cache summary lines: "Preemption Rate: 0.1750", "Cache Hit Rate: 0.0452"
+- Per-request data in results-path JSON: num_prefill_tokens, ttft_ms, e2e_ms
+"""
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def parse_stdout(filepath):
+    """Parse BLIS stdout -> cluster metrics + KV summary."""
+    content = Path(filepath).read_text()
+
+    cluster = None
+    for match in re.finditer(
+        r"=== Simulation Metrics ===\s*\n(\{[^}]+\})", content, re.DOTALL
+    ):
+        block = json.loads(match.group(1))
+        if block.get("instance_id") == "cluster":
+            cluster = block
+
+    preemption_rate = 0.0
+    m = re.search(r"Preemption Rate: ([0-9.]+)", content)
+    if m:
+        preemption_rate = float(m.group(1))
+
+    cache_hit_rate = 0.0
+    m = re.search(r"Cache Hit Rate: ([0-9.]+)", content)
+    if m:
+        cache_hit_rate = float(m.group(1))
+
+    return cluster, preemption_rate, cache_hit_rate
+
+
+def parse_json_results(filepath):
+    """Parse per-request JSON results file."""
+    if not os.path.exists(filepath):
+        return None
+    with open(filepath) as f:
+        return json.load(f)
+
+
+def check_conservation(cluster):
+    """Verify INV-1: injected == completed + queued + running + dropped."""
+    if not cluster:
+        return False, "no cluster data"
+    injected = cluster.get("injected_requests", 0)
+    completed = cluster.get("completed_requests", 0)
+    queued = cluster.get("still_queued", 0)
+    running = cluster.get("still_running", 0)
+    dropped = cluster.get("dropped_unservable", 0)
+    total = completed + queued + running + dropped
+    ok = injected == total
+    if not ok:
+        return False, f"injected={injected} != completed({completed})+queued({queued})+running({running})+dropped({dropped})={total}"
+    return True, f"PASS ({injected}=={total})"
+
+
+def precondition_check(json_path):
+    """Verify reasoning workload generates expected token accumulation pattern."""
+    data = parse_json_results(json_path)
+    if not data:
+        print("  FAIL: No results JSON found")
+        return False
+
+    requests = data.get("requests", [])
+    if not requests:
+        print("  FAIL: No per-request data in JSON")
+        return False
+
+    # Expected prefill tokens for constant input=128, output=256, 5 rounds with accumulate:
+    # Round 0: 128, Round 1: 128+256+128=512, Round 2: 512+256+128=896, etc.
+    expected_sizes = {128: 0, 512: 1, 896: 2, 1280: 3, 1664: 4}
+    prefill_tokens = [r.get("num_prefill_tokens", 0) for r in requests]
+
+    from collections import Counter
+    counts = Counter(prefill_tokens)
+
+    print(f"  Total requests: {len(requests)}")
+    print(f"  Prefill token distribution:")
+    match = True
+    for size in sorted(expected_sizes.keys()):
+        round_idx = expected_sizes[size]
+        count = counts.get(size, 0)
+        print(f"    Round {round_idx} ({size:>5} tokens): {count} requests")
+        if count == 0:
+            print(f"    FAIL: No requests with {size} tokens (expected for round {round_idx})")
+            match = False
+
+    if match:
+        print("  PASS: All 5 round types present — context accumulation working correctly")
+
+    n_sessions = counts.get(128, 0)
+    print(f"  Sessions detected: {n_sessions} (based on round-0 count)")
+    return match
+
+
+def spearman_rho(x, y):
+    """Compute Spearman rank correlation coefficient."""
+    n = len(x)
+    if n < 3:
+        return 0.0, 1.0
+
+    def rank(vals):
+        indexed = sorted(range(n), key=lambda i: vals[i])
+        ranks = [0.0] * n
+        for r, i in enumerate(indexed):
+            ranks[i] = r + 1
+        return ranks
+
+    rx = rank(x)
+    ry = rank(y)
+    d_sq = sum((rx[i] - ry[i]) ** 2 for i in range(n))
+    rho = 1 - (6 * d_sq) / (n * (n * n - 1))
+    # Approximate p-value using t-distribution (large-sample)
+    if abs(rho) >= 1.0:
+        p = 0.0
+    else:
+        t = rho * math.sqrt((n - 2) / (1 - rho * rho))
+        # Simple approximation: p ~ 2 * e^(-0.717 * t^2 / n) for large n
+        p = min(1.0, 2.0 * math.exp(-0.5 * t * t / max(1, n - 2)) * max(1, n - 2))
+    return rho, p
+
+
+def find_cliff(blocks_list, preemption_rates, threshold=0.05):
+    """Find block count where preemption rate first exceeds threshold.
+
+    Returns interpolated block count, or None if threshold never reached.
+    """
+    # Sort by blocks descending (generous -> constrained)
+    pairs = sorted(zip(blocks_list, preemption_rates), reverse=True)
+    for i in range(1, len(pairs)):
+        b_prev, p_prev = pairs[i - 1]
+        b_curr, p_curr = pairs[i]
+        if p_prev <= threshold and p_curr > threshold:
+            # Linear interpolation
+            if p_curr == p_prev:
+                return b_curr
+            frac = (threshold - p_prev) / (p_curr - p_prev)
+            return b_prev + frac * (b_curr - b_prev)
+    # Check if last point exceeds threshold
+    if pairs and pairs[-1][1] > threshold:
+        return pairs[-1][0]
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--precondition", help="Run precondition check on JSON results file")
+    parser.add_argument("--results-dir", help="Directory with all results")
+    parser.add_argument("--block-levels", nargs="+", type=int, help="Block levels tested")
+    parser.add_argument("--seeds", nargs="+", type=int, help="Seeds tested")
+    args = parser.parse_args()
+
+    if args.precondition:
+        print("--- Precondition: Token Accumulation Pattern ---")
+        ok = precondition_check(args.precondition)
+        if not ok:
+            print("\nPrecondition FAILED. Fix workload before proceeding.")
+            sys.exit(1)
+        print("")
+        return
+
+    if not args.results_dir:
+        print("Usage: analyze.py --precondition <json> OR --results-dir <dir> --block-levels ... --seeds ...")
+        sys.exit(1)
+
+    results_dir = args.results_dir
+    blocks_list = args.block_levels
+    seeds = args.seeds
+    workloads = ["reasoning", "standard_matched_throughput", "standard_matched_sessions"]
+    workload_labels = {
+        "reasoning": "Reasoning",
+        "standard_matched_throughput": "Std (throughput-matched)",
+        "standard_matched_sessions": "Std (session-matched)",
+    }
+
+    # ---- 1. Collect all metrics ----
+    data = {}  # data[workload][blocks][seed] = {preemption_rate, completed, ...}
+    conservation_violations = []
+
+    for wl in workloads:
+        data[wl] = {}
+        for bl in blocks_list:
+            data[wl][bl] = {}
+            for seed in seeds:
+                stdout_file = os.path.join(results_dir, f"{wl}_{bl}_{seed}.txt")
+                json_file = os.path.join(results_dir, f"{wl}_{bl}_{seed}.json")
+
+                cluster, preemption_rate, cache_hit_rate = parse_stdout(stdout_file)
+
+                json_data = parse_json_results(json_file)
+                dropped = 0
+                ttft_mean = 0
+                throughput = 0
+                completed = 0
+                if cluster:
+                    dropped = cluster.get("dropped_unservable", 0)
+                    ttft_mean = cluster.get("ttft_mean_ms", 0)
+                    throughput = cluster.get("responses_per_sec", 0)
+                    completed = cluster.get("completed_requests", 0)
+
+                    ok, msg = check_conservation(cluster)
+                    if not ok:
+                        conservation_violations.append(f"{wl} blocks={bl} seed={seed}: {msg}")
+
+                data[wl][bl][seed] = {
+                    "preemption_rate": preemption_rate,
+                    "cache_hit_rate": cache_hit_rate,
+                    "dropped": dropped,
+                    "ttft_mean": ttft_mean,
+                    "throughput": throughput,
+                    "completed": completed,
+                    "json_data": json_data,
+                }
+
+    # ---- 2. Preemption Rate Table ----
+    print("=" * 80)
+    print("1. PREEMPTION RATE BY BLOCK COUNT (3-seed average)")
+    print("=" * 80)
+    header = f"{'Blocks':>8}"
+    for wl in workloads:
+        header += f"  {workload_labels[wl]:>26}"
+    print(header)
+    print("-" * 80)
+
+    for bl in sorted(blocks_list, reverse=True):
+        row = f"{bl:>8}"
+        for wl in workloads:
+            rates = [data[wl][bl][s]["preemption_rate"] for s in seeds]
+            avg = sum(rates) / len(rates)
+            row += f"  {avg:>26.4f}"
+        print(row)
+    print("")
+
+    # ---- 3. Cliff Detection ----
+    print("=" * 80)
+    print("2. PREEMPTION CLIFF DETECTION (5% threshold)")
+    print("=" * 80)
+
+    cliffs = {}  # cliffs[workload] = [cliff_per_seed]
+    for wl in workloads:
+        cliffs[wl] = []
+        for seed in seeds:
+            bls = sorted(blocks_list, reverse=True)
+            prs = [data[wl][bl][seed]["preemption_rate"] for bl in bls]
+            cliff = find_cliff(bls, prs, threshold=0.05)
+            cliffs[wl].append(cliff)
+        cliff_vals = [c for c in cliffs[wl] if c is not None]
+        if cliff_vals:
+            avg_cliff = sum(cliff_vals) / len(cliff_vals)
+            print(f"  {workload_labels[wl]:>30}: {avg_cliff:>8.0f} blocks (seeds: {cliffs[wl]})")
+        else:
+            print(f"  {workload_labels[wl]:>30}: No cliff detected (preemption rate < 5% at all levels)")
+
+    # Cliff shift ratio
+    r_cliffs = [c for c in cliffs["reasoning"] if c is not None]
+    t_cliffs = [c for c in cliffs["standard_matched_throughput"] if c is not None]
+    if r_cliffs and t_cliffs:
+        ratios = []
+        for rc, tc in zip(r_cliffs, t_cliffs):
+            if tc and tc > 0:
+                ratios.append(rc / tc)
+        if ratios:
+            avg_ratio = sum(ratios) / len(ratios)
+            print(f"\n  Cliff shift ratio (reasoning / std-throughput): {avg_ratio:.2f}x")
+            print(f"  Per-seed ratios: {[f'{r:.2f}' for r in ratios]}")
+            if all(r >= 1.20 for r in ratios):
+                print("  --> CLIFF SHIFT DETECTED (>=20% in all seeds)")
+            elif any(r < 1.10 for r in ratios):
+                print("  --> CLIFF SHIFT NOT DETECTED (<10% in at least one seed)")
+            else:
+                print("  --> INCONCLUSIVE (10-20% range)")
+    print("")
+
+    # ---- 4. Monotonicity (Spearman) ----
+    print("=" * 80)
+    print("3. MONOTONICITY: Spearman rho(blocks, -preemption_rate)")
+    print("=" * 80)
+
+    for wl in workloads:
+        rhos = []
+        for seed in seeds:
+            bls = sorted(blocks_list)
+            prs = [data[wl][bl][seed]["preemption_rate"] for bl in bls]
+            neg_prs = [-p for p in prs]
+            rho, p = spearman_rho(bls, neg_prs)
+            rhos.append(rho)
+        avg_rho = sum(rhos) / len(rhos)
+        print(f"  {workload_labels[wl]:>30}: rho={avg_rho:+.3f} (per-seed: {[f'{r:+.3f}' for r in rhos]})")
+    print("")
+
+    # ---- 5. Cache Hit Rate Comparison (at generous KV) ----
+    generous_bl = max(blocks_list)
+    print("=" * 80)
+    print(f"4. CACHE HIT RATE (blocks={generous_bl}, 3-seed average)")
+    print("=" * 80)
+
+    for wl in workloads:
+        rates = [data[wl][generous_bl][s]["cache_hit_rate"] for s in seeds]
+        avg = sum(rates) / len(rates)
+        print(f"  {workload_labels[wl]:>30}: {avg:.4f} ({[f'{r:.4f}' for r in rates]})")
+    print("")
+
+    # ---- 6. Per-Round TTFT (reasoning at generous KV) ----
+    print("=" * 80)
+    print(f"5. PER-ROUND TTFT (reasoning, blocks={generous_bl})")
+    print("=" * 80)
+
+    expected_prefill = {128: 0, 512: 1, 896: 2, 1280: 3, 1664: 4}
+    for seed in seeds:
+        jd = data["reasoning"][generous_bl][seed]["json_data"]
+        if not jd or "requests" not in jd:
+            print(f"  Seed {seed}: No per-request data")
+            continue
+        round_ttfts = {i: [] for i in range(5)}
+        for req in jd["requests"]:
+            npt = req.get("num_prefill_tokens", 0)
+            ttft = req.get("ttft_ms", 0)
+            if npt in expected_prefill:
+                round_ttfts[expected_prefill[npt]].append(ttft)
+
+        print(f"  Seed {seed}:")
+        rounds = []
+        means = []
+        for r in range(5):
+            if round_ttfts[r]:
+                avg = sum(round_ttfts[r]) / len(round_ttfts[r])
+                rounds.append(r)
+                means.append(avg)
+                print(f"    Round {r} (input={[128,512,896,1280,1664][r]:>5}): TTFT mean={avg:>10.2f} ms (n={len(round_ttfts[r])})")
+            else:
+                print(f"    Round {r}: no data")
+
+        if len(rounds) >= 3:
+            rho, p = spearman_rho(rounds, means)
+            print(f"    Spearman rho(round, TTFT) = {rho:+.3f}")
+    print("")
+
+    # ---- 7. #386 Verification (blocks=100) ----
+    if 100 in blocks_list:
+        print("=" * 80)
+        print("6. #386 VERIFICATION: DroppedUnservable at blocks=100")
+        print("=" * 80)
+
+        for wl in workloads:
+            drops = [data[wl][100][s]["dropped"] for s in seeds]
+            avg = sum(drops) / len(drops)
+            print(f"  {workload_labels[wl]:>30}: avg dropped={avg:.1f} (per-seed: {drops})")
+
+        r_drops = [data["reasoning"][100][s]["dropped"] for s in seeds]
+        t_drops = [data["standard_matched_throughput"][100][s]["dropped"] for s in seeds]
+        if all(d > 0 for d in r_drops) and all(d == 0 for d in t_drops):
+            print("\n  --> #386 VERIFIED: Reasoning drops oversized requests; standard does not")
+        elif all(d > 0 for d in r_drops):
+            print("\n  --> Reasoning drops as expected; standard also drops (unexpected for 72-block requests)")
+        else:
+            print("\n  --> UNEXPECTED: Check block demand calculations")
+        print("")
+
+    # ---- 8. Conservation ----
+    print("=" * 80)
+    print("7. CONSERVATION INVARIANT (INV-1)")
+    print("=" * 80)
+
+    if conservation_violations:
+        for v in conservation_violations:
+            print(f"  FAIL: {v}")
+    else:
+        total_checks = len(workloads) * len(blocks_list) * len(seeds)
+        print(f"  PASS: {total_checks}/{total_checks} checks passed")
+    print("")
+
+    # ---- 9. Dropped + Throughput Table ----
+    print("=" * 80)
+    print("8. THROUGHPUT & DROPPED (3-seed average)")
+    print("=" * 80)
+    print(f"{'Blocks':>8}  {'Reasoning':>12} {'tput':>8}  {'Std-tput':>12} {'tput':>8}  {'Std-sess':>12} {'tput':>8}")
+    print(f"{'':>8}  {'dropped':>12} {'req/s':>8}  {'dropped':>12} {'req/s':>8}  {'dropped':>12} {'req/s':>8}")
+    print("-" * 90)
+    for bl in sorted(blocks_list, reverse=True):
+        parts = [f"{bl:>8}"]
+        for wl in workloads:
+            drops = [data[wl][bl][s]["dropped"] for s in seeds]
+            tputs = [data[wl][bl][s]["throughput"] for s in seeds]
+            avg_d = sum(drops) / len(drops)
+            avg_t = sum(tputs) / len(tputs)
+            parts.append(f"  {avg_d:>12.1f} {avg_t:>8.1f}")
+        print("".join(parts))
+
+
+if __name__ == "__main__":
+    main()

--- a/hypotheses/h-reasoning-kv/reasoning_workload.yaml
+++ b/hypotheses/h-reasoning-kv/reasoning_workload.yaml
@@ -1,0 +1,29 @@
+version: "1.0"
+seed: 42
+category: reasoning
+aggregate_rate: 2.0
+num_requests: 500
+clients:
+  - id: reasoning-client
+    tenant_id: default
+    slo_class: interactive
+    rate_fraction: 1.0
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 128
+    output_distribution:
+      type: constant
+      params:
+        value: 256
+    reasoning:
+      reason_ratio_distribution:
+        type: constant
+        params:
+          value: 50
+      multi_turn:
+        max_rounds: 5
+        think_time_us: 5000000
+        context_growth: accumulate

--- a/hypotheses/h-reasoning-kv/run.sh
+++ b/hypotheses/h-reasoning-kv/run.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# H-Reasoning-KV: Reasoning Context Accumulation Shifts KV Pressure Cliff
+# Tests whether multi-turn reasoning workloads trigger the preemption cliff
+# at higher block counts than standard workloads due to demand heterogeneity.
+# Also validates #386 fix (DroppedUnservable) at extreme low block counts.
+# Usage: ./run.sh [--rebuild]
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="$REPO_ROOT/simulation_worker"
+
+# Build if needed
+if [[ "${1:-}" == "--rebuild" ]] || [[ ! -x "$BINARY" ]]; then
+    echo "Building simulation_worker..."
+    (cd "$REPO_ROOT" && go build -o simulation_worker main.go)
+fi
+
+MODEL="meta-llama/llama-3.1-8b-instruct"
+HORIZON=100000000  # 100s, sufficient for all requests to complete
+RESULTS_DIR=$(mktemp -d)
+trap "rm -rf $RESULTS_DIR" EXIT
+
+run_sim() {
+    local workload_name="$1"
+    local workload_yaml="$SCRIPT_DIR/${workload_name}_workload.yaml"
+    local blocks="$2"
+    local seed="$3"
+    local outfile="$RESULTS_DIR/${workload_name}_${blocks}_${seed}.txt"
+
+    "$BINARY" run --model "$MODEL" \
+        --seed "$seed" \
+        --workload-spec "$workload_yaml" \
+        --total-kv-blocks "$blocks" \
+        --block-size-in-tokens 16 \
+        --max-num-running-reqs 32 \
+        --max-num-scheduled-tokens 2048 \
+        --num-instances 1 \
+        --horizon "$HORIZON" \
+        --results-path "$RESULTS_DIR/${workload_name}_${blocks}_${seed}.json" \
+        --log warn \
+        2>/dev/null > "$outfile" || true
+
+    echo "$outfile"
+}
+
+echo "============================================================"
+echo "H-Reasoning-KV: KV Pressure Cliff with Reasoning Workloads"
+echo "============================================================"
+echo ""
+
+# -- Precondition check (ED-3) -----------------------------------------------
+echo "=== Precondition Check ==="
+echo "Verifying reasoning workload generates expected token patterns..."
+
+PRECOND_OUT=$(run_sim "reasoning" 100000 42)
+python3 "$SCRIPT_DIR/analyze.py" --precondition "$RESULTS_DIR/reasoning_100000_42.json"
+
+echo ""
+
+# -- Main sweep ---------------------------------------------------------------
+echo "=== KV Pressure Sweep ==="
+
+BLOCK_LEVELS="5000 3000 2000 1500 1200 1000 800 600 400 100"
+SEEDS="42 123 456"
+WORKLOADS="reasoning standard_matched_throughput standard_matched_sessions"
+
+total_runs=$(echo "$BLOCK_LEVELS" | wc -w)
+total_runs=$((total_runs * 3 * 3))
+current=0
+
+for BLOCKS in $BLOCK_LEVELS; do
+    for SEED in $SEEDS; do
+        for WORKLOAD in $WORKLOADS; do
+            current=$((current + 1))
+            printf "\r  [%d/%d] %s blocks=%s seed=%s" "$current" "$total_runs" "$WORKLOAD" "$BLOCKS" "$SEED"
+            run_sim "$WORKLOAD" "$BLOCKS" "$SEED" > /dev/null
+        done
+    done
+done
+echo ""
+echo ""
+
+# -- Analysis -----------------------------------------------------------------
+echo "=== Analysis ==="
+python3 "$SCRIPT_DIR/analyze.py" \
+    --results-dir "$RESULTS_DIR" \
+    --block-levels $BLOCK_LEVELS \
+    --seeds $SEEDS

--- a/hypotheses/h-reasoning-kv/standard_matched_sessions_workload.yaml
+++ b/hypotheses/h-reasoning-kv/standard_matched_sessions_workload.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+seed: 42
+category: language
+aggregate_rate: 2.0
+num_requests: 500
+clients:
+  - id: standard-client
+    tenant_id: default
+    slo_class: interactive
+    rate_fraction: 1.0
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 896
+    output_distribution:
+      type: constant
+      params:
+        value: 256

--- a/hypotheses/h-reasoning-kv/standard_matched_throughput_workload.yaml
+++ b/hypotheses/h-reasoning-kv/standard_matched_throughput_workload.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+seed: 42
+category: language
+aggregate_rate: 10.0
+num_requests: 500
+clients:
+  - id: standard-client
+    tenant_id: default
+    slo_class: interactive
+    rate_fraction: 1.0
+    arrival:
+      process: poisson
+    input_distribution:
+      type: constant
+      params:
+        value: 896
+    output_distribution:
+      type: constant
+      params:
+        value: 256


### PR DESCRIPTION
## Summary

- First hypothesis experiment exercising `sim/workload/reasoning.go` (zero prior coverage)
- Tests whether multi-turn reasoning workloads with context accumulation shift the KV preemption cliff versus standard workloads
- 90 simulation runs across 10 block levels × 3 seeds × 3 workloads
- Converged in Round 1 (3 reviewers, all documentation-level fixes applied)

### Key findings

| Finding | Status | Significance |
|---------|--------|-------------|
| KV cliff shift (reasoning vs standard) | **Refuted** (1.09x ratio) | Mean demand drives cliff, not per-request peak |
| Prefix cache hit rate for reasoning | **63.8%** (surprise) | Context accumulation creates substantial inter-round prefix reuse |
| TTFT monotonicity across rounds | **Confirmed** (ρ=+1.000) | Only 32% TTFT growth despite 13× input growth |
| #386 DroppedUnservable verification | **Confirmed** | First test of livelock fix under reasoning workload |
| INV-1 conservation | **Confirmed** (90/90) | Includes `dropped_unservable` term |

### User guidance produced

1. Provision KV blocks based on mean per-request demand × concurrency, not peak per-request demand
2. Prefix caching is highly effective for reasoning/multi-turn workloads (63.8% hit rate at adequate KV)
3. TTFT growth is modest with caching despite quadratic input growth
4. `dropped_unservable` metric correctly protects against oversized reasoning requests (#386)

## Test plan

- [x] `go test ./...` passes
- [x] `run.sh` executes 90 runs successfully
- [x] Precondition check verifies token accumulation pattern [128, 512, 896, 1280, 1664]
- [x] Conservation INV-1 holds across all 90 configurations
- [x] 3-reviewer convergence protocol completed (Round 1)
- [ ] Verify `./hypotheses/h-reasoning-kv/run.sh` reproduces results on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)