### PR TITLE
feat(skills): add hypothesis-experiment and convergence-review Claude Code skills

### DIFF
--- a/.claude/skills/convergence-review/SKILL.md
+++ b/.claude/skills/convergence-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: convergence-review
+description: Dispatch parallel review perspectives and enforce convergence (zero CRITICAL + zero IMPORTANT). Supports 7 gate types — design doc (8), macro plan (8), PR plan (10), PR code (10), hypothesis design (5), hypothesis code (5), hypothesis FINDINGS (10).
+argument-hint: <gate-type> [artifact-path]
+---
+
+# Convergence Review Dispatcher
+
+Dispatch parallel review perspectives for gate **$0** and enforce convergence.
+
+## Gate Types
+
+| Gate | Perspectives | Artifact | Prompts Source |
+|------|-------------|----------|----------------|
+| `design` | 8 | Design doc at `$1` | [design-prompts.md](design-prompts.md) Section A |
+| `macro-plan` | 8 | Macro plan at `$1` | [design-prompts.md](design-prompts.md) Section B |
+| `pr-plan` | 10 | Micro plan at `$1` | [pr-prompts.md](pr-prompts.md) Section A |
+| `pr-code` | 10 | Current git diff | [pr-prompts.md](pr-prompts.md) Section B |
+| `h-design` | 5 | Design from conversation context | `.claude/skills/hypothesis-experiment/review-prompts.md` Section A |
+| `h-code` | 5 | `run.sh` + `analyze.py` at `$1` | `.claude/skills/hypothesis-experiment/review-prompts.md` Section B |
+| `h-findings` | 10 | FINDINGS.md at `$1` | `.claude/skills/hypothesis-experiment/review-prompts.md` Section C |
+
+---
+
+## Convergence Protocol (non-negotiable)
+
+> **Canonical source:** [docs/process/hypothesis.md — Universal Convergence Protocol](../../../docs/process/hypothesis.md#universal-convergence-protocol). The rules below are a self-contained copy for skill execution; hypothesis.md is authoritative if they diverge.
+
+These rules are identical across all gates. No exceptions. No shortcuts.
+
+### The Algorithm
+
+```
+round = 1
+while round <= 10:
+    1. Dispatch ALL perspectives in parallel (background Task agents, model=haiku)
+    2. Wait for all to complete (5 min timeout per agent)
+    3. Read each agent's output INDEPENDENTLY
+    4. Tally CRITICAL and IMPORTANT counts YOURSELF (do NOT trust agent totals)
+    5. Report round results to user
+
+    if total_critical == 0 AND total_important == 0:
+        CONVERGED — report success, proceed to next workflow step
+        break
+    else:
+        Report all findings with severity
+        Fix all CRITICAL and IMPORTANT items
+        round += 1
+        RE-RUN ENTIRE ROUND (go to step 1)
+
+if round > 10:
+    SUSPEND — document remaining issues as future work
+```
+
+### Hard Rules
+
+1. **Zero means zero.** One CRITICAL from one reviewer = not converged.
+2. **Re-run is mandatory.** After fixing issues, you MUST re-run the entire round. You may NOT skip, propose alternatives, or rationalize fixes were trivial.
+3. **SUGGESTION items do not block.** Only CRITICAL and IMPORTANT count.
+4. **Independent tallying.** Read each agent's output file. Count findings yourself. Agents have fabricated "0 CRITICAL, 0 IMPORTANT" when actual output contained 3 CRITICAL + 18 IMPORTANT (#390).
+5. **No partial re-runs.** Re-run ALL perspectives, not just the ones that found issues. Fixes can introduce new issues in other perspectives.
+6. **Agent timeout = 5 minutes.** If an agent exceeds this, check its output and restart. If it fails, perform that review directly.
+7. **Max 10 rounds per gate.** If still not converged, suspend the experiment/PR.
+
+### Severity Classification
+
+When reviewing agent output, verify severity assignments:
+
+| Severity | Definition | Blocks? |
+|----------|-----------|---------|
+| **CRITICAL** | Must fix. Missing control experiment, status contradicted by data, silent data loss, cross-document contradiction. | Yes |
+| **IMPORTANT** | Should fix. Fixing would change a conclusion, metric, or user guidance. Sub-threshold effect, stale text, undocumented confound. | Yes |
+| **SUGGESTION** | Cosmetic. Off-by-one line citation, style consistency, terminology nit. Fixing only improves readability. | No |
+
+**When in doubt:** If fixing it would change any conclusion → IMPORTANT. If only readability → SUGGESTION.
+
+---
+
+## Dispatch Instructions
+
+### Step 1: Load Perspective Prompts
+
+Based on gate type `$0`, load the correct prompts file:
+
+- **`design` or `macro-plan`**: Read [design-prompts.md](design-prompts.md) for the matching section
+- **`pr-plan` or `pr-code`**: Read [pr-prompts.md](pr-prompts.md) for the matching section
+- **`h-design`, `h-code`, or `h-findings`**: Read `.claude/skills/hypothesis-experiment/review-prompts.md` for the matching section
+
+### Step 2: Prepare Context
+
+Each perspective agent needs the artifact being reviewed:
+
+| Gate | What to include in each agent's prompt |
+|------|----------------------------------------|
+| `design` | The design document contents (read `$1`) |
+| `macro-plan` | The macro plan contents (read `$1`) |
+| `pr-plan` | The micro plan file contents (read `$1`) |
+| `pr-code` | The current `git diff` output |
+| `h-design` | The hypothesis sentence, classification, and experiment design (from conversation) |
+| `h-code` | The `run.sh` and `analyze.py` file contents |
+| `h-findings` | The `FINDINGS.md` file contents + `run.sh` path for cross-reference |
+
+### Step 3: Dispatch All Perspectives
+
+Launch all N perspectives simultaneously as background Task agents:
+
+```
+For each perspective P in the gate's perspective set:
+    Task(
+        subagent_type = "general-purpose",
+        model = "haiku",
+        run_in_background = True,
+        prompt = "<perspective prompt from prompts file>\n\n<artifact content>"
+    )
+```
+
+**Why haiku?** Fast (~2-3 min), thorough reviews with accurate severity classification. Haiku produces consistent CRITICAL/IMPORTANT/SUGGESTION output. Using opus/sonnet for 10 parallel reviewers is unnecessarily expensive.
+
+**Exception — Perspective 5 in PR plan reviews (Structural Validation):** Perform this check directly (no agent). It requires structural validation of the plan (task dependencies, template completeness) that benefits from your full conversation context.
+
+### Step 4: Collect and Tally
+
+After all agents complete:
+
+1. **Read each output file** using the Read tool or TaskOutput
+2. **For each agent**, extract:
+   - List of findings with severity
+   - Count of CRITICAL findings
+   - Count of IMPORTANT findings
+3. **Independently verify** the counts match the findings listed
+4. **Aggregate** across all perspectives
+
+### Step 5: Report
+
+Present results in this format:
+
+```
+## Round N Results — Gate: <gate-type>
+
+| Perspective | CRITICAL | IMPORTANT | SUGGESTION |
+|-------------|----------|-----------|------------|
+| P1: <name>  | 0        | 1         | 2          |
+| P2: <name>  | 0        | 0         | 1          |
+| ...         | ...      | ...       | ...        |
+| **TOTAL**   | **0**    | **1**     | **3**      |
+
+### Convergence: NOT CONVERGED (1 IMPORTANT remaining)
+
+### Findings requiring action:
+1. [IMPORTANT] P1: <finding description>
+```
+
+If converged:
+```
+### Convergence: CONVERGED in Round N
+
+All perspectives report 0 CRITICAL and 0 IMPORTANT findings.
+Proceed to the next workflow step.
+```
+
+---
+
+## Round Tracking
+
+Track rounds across invocations. If this is a re-run after fixes:
+
+```
+## Round History
+- Round 1: 2 CRITICAL, 5 IMPORTANT — fixed
+- Round 2: 0 CRITICAL, 1 IMPORTANT — fixed
+- Round 3: 0 CRITICAL, 0 IMPORTANT — CONVERGED
+```
+
+---
+
+## Integration with Other Skills
+
+### From design process
+Review a design document before macro/micro planning:
+```
+/convergence-review design docs/plans/archive/<design-doc>.md
+```
+
+### From macro planning process
+Review a macro plan before micro-planning any PR:
+```
+/convergence-review macro-plan docs/plans/<macro-plan>.md
+```
+
+### From PR workflow
+The PR workflow calls this skill at Steps 2.5 and 4.5:
+```
+/convergence-review pr-plan docs/plans/pr<N>-<name>-plan.md
+/convergence-review pr-code
+```
+
+### From hypothesis-experiment skill
+The hypothesis-experiment skill calls this skill at Steps 2, 5, and 8:
+```
+/convergence-review h-design
+/convergence-review h-code hypotheses/h-<name>/
+/convergence-review h-findings hypotheses/h-<name>/FINDINGS.md
+```
+
+### After fixes
+Re-invoke with the same arguments to start the next round:
+```
+/convergence-review pr-code  (Round 2 after fixes)
+```

--- a/.claude/skills/convergence-review/design-prompts.md
+++ b/.claude/skills/convergence-review/design-prompts.md
@@ -1,0 +1,381 @@
+# Design & Macro Plan Review Perspective Prompts
+
+Reference file for the convergence-review skill. Contains exact prompts for design document review (8 perspectives) and macro plan review (8 perspectives).
+
+**Note:** Unlike PR and hypothesis prompts (which have canonical sources in their process docs), these design and macro-plan perspective prompts are defined here as the primary source — `docs/process/design.md` and `docs/process/macro-plan.md` are lightweight stubs that reference this skill.
+
+**Related documents:**
+- Design doc process: `docs/process/design.md`
+- Design guidelines: `docs/templates/design-guidelines.md`
+- Macro plan process: `docs/process/macro-plan.md`
+- Macro plan template: `docs/templates/macro-plan.md`
+
+**Dispatch pattern:** Launch each perspective as a parallel Task agent:
+```
+Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+     prompt="<prompt from below>\n\n<artifact content>")
+```
+
+---
+
+## Section A: Design Document Review (8 perspectives) — `design` gate
+
+### DD-1: DES Foundations Compliance
+
+```
+You are reviewing a BLIS design document. BLIS is a discrete-event simulator for LLM inference serving systems.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: DES Foundations (design guidelines Section 2)
+Check the DES design review checklist (Section 2.6):
+- What analysis questions does this design help answer? (Model scoping 2.1)
+- What is modeled, simplified, and deliberately omitted? Is there a table?
+- Are new events minimal and atomic? Classified as exogenous or endogenous? (2.2)
+- Are new events assigned priority constants for (timestamp, priority, seqID) ordering?
+- Is state vs. statistics separation maintained? (2.3) Does any module mix state mutation and metric computation?
+- Is verification strategy specified (which invariants)? Is validation strategy specified (against what real data)? (2.4)
+- If new randomness is introduced, does it flow through PartitionedRNG with a named subsystem? (2.5)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-2: Module Architecture
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Module Architecture
+- Does each module have a complete behavioral contract? (observes / controls / owns / invariants / events / extension friction)
+- Does the design fit BLIS's two-layer architecture? (domain-agnostic kernel + domain-specific modules)
+- Is the extension type identified? (policy template, subsystem module, backend swap, tier composition)
+- Is the correct extension recipe followed? (design guidelines Section 5)
+- Does the design maintain separation of concerns? (sim/ is a library, cluster/ sees global state, instances see only local data)
+- Is extension friction assessed? How many files to add one more variant?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-3: Prohibited Content
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Prohibited Content (design guidelines Section 3.4)
+Design docs describe WHAT modules do and WHY, never HOW they're implemented. Check for:
+- Go struct definitions (prohibited — belongs in micro plans)
+- Method implementations (prohibited — belongs in micro plans)
+- file:line references to current code (prohibited — design docs should be durable)
+- Factory function code (prohibited)
+- Test code (prohibited)
+- Interface signatures for unmerged code (prohibited — describe behaviorally instead)
+
+The staleness test (Section 3.1): Would any content in this doc mislead if the implementation changes?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-4: Invariant & Contract Completeness
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Invariant and Contract Completeness
+- Are ALL system invariants that this design affects identified? Check against docs/standards/invariants.md (INV-1 through INV-8).
+- Are new invariants introduced? Are they precisely stated and verifiable?
+- Are behavioral contracts testable? Could someone write a GIVEN/WHEN/THEN test from the contract alone?
+- Are failure modes specified? What happens under overload, misconfiguration, degenerate inputs?
+- Does each non-obvious decision have alternatives listed with rationale?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-5: Modeling Decisions
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Modeling Decisions and Fidelity Trade-offs
+Apply the six scoping criteria (Banks et al., design guidelines Section 2.1):
+1. Will including this component significantly affect accuracy for target analysis questions?
+2. What accuracy level is actually required?
+3. Can data requirements be satisfied (alpha/beta coefficients, hardware specs, traces)?
+4. What is the cost of inclusion (complexity, maintenance, config surface)?
+5. What breaks if we omit it? (<5% impact → defer)
+6. What is the simplest version that answers the same questions?
+
+For each simplification: is the real-system behavior loss documented? Under what conditions would it matter?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-6: vLLM/SGLang Domain Fit
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: vLLM/SGLang Domain Fit
+- Does the design match real continuous-batching server behavior?
+- Are KV cache semantics consistent with vLLM's implementation?
+- Are scheduling and preemption policies realistic?
+- Is the real-system correspondence table present? Does each building block map to a real component?
+- Are there assumptions about LLM inference serving that this design gets wrong?
+- Does the design enable future validation against real vLLM/SGLang data?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-7: Distributed Platform Implications
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Distributed Platform Implications (llm-d, KServe, vLLM multi-node)
+- Are multi-instance coordination implications considered?
+- Does the design handle routing, load balancing, and instance heterogeneity?
+- Are stale snapshot propagation risks identified?
+- Is horizontal scaling behavior addressed?
+- Are admission control implications at cluster scale considered?
+- Does the design enable prefix-affinity routing across instances?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DD-8: Validation Strategy
+
+```
+You are reviewing a BLIS design document.
+
+DESIGN DOCUMENT:
+<paste design doc>
+
+YOUR FOCUS: Validation Strategy
+- How will correctness be verified? Which specific invariants will be tested?
+- How will fidelity be validated? Against what real-system data or analytical baselines?
+- Are hypothesis experiments planned to validate key design claims?
+- Are there measurable success criteria (not "looks correct" — quantitative thresholds)?
+- Is sensitivity analysis planned for key parameters?
+- What would falsify the design's assumptions? How would you detect it?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+---
+
+## Section B: Macro Plan Review (8 perspectives) — `macro-plan` gate
+
+### MP-1: PR Decomposition
+
+```
+You are reviewing a BLIS macro-level implementation plan (multi-PR feature).
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: PR Decomposition Quality
+- Is each PR independently mergeable? (No PR requires another PR's uncommitted code)
+- Is each PR exercisable immediately after merge? (Via CLI or tests demonstrating new behavior)
+- Is there speculative scaffolding? (Unused interfaces, flags, or types "for later")
+- Does each PR deliver one cohesive building block change?
+- Are PR scope boundaries clean? (No PR does too much or too little)
+- Does each PR identify its extension type? (policy template, subsystem module, backend swap, tier composition)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-2: Dependency DAG
+
+```
+You are reviewing a BLIS macro-level implementation plan.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Dependency DAG Correctness
+- Does the dependency graph have any cycles? (Must be a DAG)
+- Are parallelizable workstreams identified? Is safe parallelism maximized?
+- Is merge sequencing guidance clear?
+- Are validation gates placed correctly? (From risk register — before the PR that depends on the assumption)
+- Are interface freeze points marked? (Which PRs unlock parallel development?)
+- Are there implicit dependencies not shown in the DAG? (e.g., shared test helpers)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-3: Module Contracts
+
+```
+You are reviewing a BLIS macro-level implementation plan.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Module Contract Completeness
+For each building block / PR, verify the module contract is complete:
+- OBSERVES: What state does the module read? (Inputs)
+- CONTROLS: What decisions does the module make? (Outputs)
+- OWNS: What mutable state does it exclusively manage?
+- INVARIANTS: What must always hold for this module?
+- EVENTS: What events does it produce or consume? Classified as exogenous or endogenous?
+- EXTENSION FRICTION: How many files to add one more variant?
+
+Are behavioral guarantees (BC-1, BC-2, etc.) testable with mocks? (Enables parallel development)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-4: Abstraction Level
+
+```
+You are reviewing a BLIS macro-level implementation plan.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Abstraction Level Compliance
+The macro plan describes WHAT to build and in WHAT ORDER, not HOW. Check:
+- Does the plan contain Go struct definitions? (PROHIBITED — belongs in micro plans)
+- Does the plan contain method implementations? (PROHIBITED)
+- Does the plan contain pre-freeze interface signatures as Go code? (PROHIBITED — describe behaviorally)
+- Are frozen interfaces (already merged code) correctly distinguished from aspirational ones?
+
+THE TEST: Is content a FACT about merged code, or an ASPIRATION about code to be written?
+- Facts (frozen interfaces, merged code references): Go code allowed
+- Aspirations (planned interfaces, future modules): Must be behavioral descriptions only
+
+Check the concept model (<80 lines?). Does it use behavioral descriptions or implementation details?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-5: Risk Register
+
+```
+You are reviewing a BLIS macro-level implementation plan.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Risk Register Completeness
+For each entry in the architectural risk register, verify:
+- DECISION: Is the choice clearly stated?
+- ASSUMPTION: What must be true for this to work?
+- VALIDATION: How to test cheaply? (Mock study, prototype, analysis, spike)
+- COST IF WRONG: How many PRs of rework? (Count affected PRs)
+- GATE: When must validation complete? (Before which PR)
+
+MANDATORY VALIDATION RULE: If cost-of-being-wrong >= 3 PRs, validation is MANDATORY.
+- Is there a spike/validation PR or pre-PR validation step?
+- Are success criteria measurable (not "looks good")?
+- Is there an abort plan (what changes if validation fails)?
+
+Are there unidentified risks? (Missing entries for non-obvious architectural decisions)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-6: DES Expert
+
+```
+You are reviewing a BLIS macro-level implementation plan as a DES expert.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: DES Design Implications
+- Is model scoping justified? (Banks et al. criteria from design guidelines Section 2.1)
+- Are new events correctly classified (exogenous vs endogenous)?
+- Is state vs. statistics separation maintained across the PR series?
+- Are there event-ordering implications for the proposed architectural changes?
+- Does the concept model accurately describe the DES components and their interactions?
+- Are there DES-specific failure modes in the design bug prevention checklist?
+  - Type catalog trap (Go structs that diverge from implementation)
+  - Fidelity for its own sake (components that don't affect analysis questions)
+  - Golden tests without invariant tests
+  - Mixing exogenous and endogenous inputs
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-7: vLLM/SGLang Expert
+
+```
+You are reviewing a BLIS macro-level implementation plan as a vLLM/SGLang expert.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Real-System Accuracy
+- Is the real-system correspondence table present and accurate?
+- Does each building block map correctly to real inference system components?
+  (Check against: llm-d, vLLM, SGLang, and other systems listed)
+- Are batching, KV cache, scheduling, and routing semantics accurate?
+- Are there assumptions about LLM serving that the plan gets wrong?
+- For each "Simplified" modeling decision: is the lost real-system behavior documented?
+- Would the planned features enable meaningful comparison with real vLLM deployments?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### MP-8: Cross-Cutting Completeness
+
+```
+You are reviewing a BLIS macro-level implementation plan.
+
+MACRO PLAN:
+<paste macro plan>
+
+YOUR FOCUS: Cross-Cutting Infrastructure
+Verify Phase 5 (cross-cutting) is complete:
+1. Shared Test Infrastructure — which PR creates it? Which consume it? Are invariant tests planned?
+2. Documentation Maintenance — CLAUDE.md update triggers? README updates? Design guidelines updates?
+3. CI Pipeline — new test packages added? New linter rules? Performance benchmarks?
+4. Dependency Management — new external deps justified? Version pinning?
+5. Interface Freeze Schedule — which PR freezes which interface? What must be validated before freezing?
+
+Check that NO item is left as "address when needed." Every cross-cutting concern must be assigned to a specific PR.
+
+Also check the design bug prevention checklist (Phase 8):
+- Scaffolding creep prevention
+- Documentation drift prevention
+- Test infrastructure duplication prevention
+- Golden dataset staleness prevention
+- Interface over-specification prevention
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```

--- a/.claude/skills/convergence-review/pr-prompts.md
+++ b/.claude/skills/convergence-review/pr-prompts.md
@@ -1,0 +1,370 @@
+# PR Review Perspective Prompts
+
+Reference file for the convergence-review skill. Contains exact prompts for the 20 PR review perspectives across plan review and code review gates.
+
+**Canonical source:** `docs/process/pr-workflow.md` (v3.0). If prompts here diverge from pr-workflow.md, the process doc is authoritative.
+
+**Dispatch pattern:** Launch each perspective as a parallel Task agent:
+```
+Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+     prompt="<prompt from below>\n\n<artifact content>")
+```
+
+---
+
+## Section A: PR Plan Review (10 perspectives) — Step 2.5
+
+### PP-1: Substance & Design
+
+```
+Review this implementation plan for substance: Are the behavioral contracts logically sound? Are there mathematical errors, scale mismatches, or unit confusions? Could the design actually achieve what the contracts promise? Check formulas, thresholds, and edge cases from first principles — not just structural completeness.
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-2: Cross-Document Consistency
+
+```
+Does this micro plan's scope match the source document? Are file paths consistent with the actual codebase? Does the deviation log account for all differences between what the source says and what the micro plan does? Check for stale references to completed PRs or removed files.
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-3: Architecture Boundary Verification
+
+```
+Does this plan maintain architectural boundaries? Check:
+(1) Individual instances don't access cluster-level state
+(2) Types are in the right packages (sim/ vs sim/cluster/ vs cmd/)
+(3) No import cycles introduced
+(4) Does the plan introduce multiple construction sites for the same type?
+(5) Does adding one field to a new type require >3 files?
+(6) Does library code (sim/) call logrus.Fatalf anywhere in new code?
+(7) Dependency direction: cmd/ → sim/cluster/ → sim/ (never reversed)
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-4: Codebase Readiness
+
+```
+We're about to implement this PR. Review the codebase for readiness. Check each file the plan will modify for:
+- Stale comments ("planned for PR N" where N is completed)
+- Pre-existing bugs that would complicate implementation
+- Missing dependencies
+- Unclear insertion points
+- TODO/FIXME items in the modification zone
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-5: Structural Validation (perform directly, no agent)
+
+> **For Claude:** Perform these 4 checks directly. Do NOT dispatch an agent.
+
+**Check 1 — Task Dependencies:**
+For each task, verify it can actually start given what comes before it. Trace the dependency chain: what files does each task create/modify? Does any task require a file or type that hasn't been created yet?
+
+**Check 2 — Template Completeness:**
+Verify all sections from `docs/templates/micro-plan.md` are present and non-empty: Header, Part 1 (A-E), Part 2 (F-I), Part 3 (J), Appendix.
+
+**Check 3 — Executive Summary Clarity:**
+Read the executive summary as if you're a new team member. Is the scope clear without reading the rest?
+
+**Check 4 — Under-specified Tasks:**
+For each task, verify it has complete code. Flag any step an executing agent would need to figure out on its own.
+
+### PP-6: DES Expert
+
+```
+Review this plan as a discrete-event simulation expert. Check for:
+- Event ordering bugs in the proposed design
+- Clock monotonicity violations (INV-3)
+- Stale signal propagation between event types (INV-7)
+- Heap priority errors (cluster uses (timestamp, priority, seqID))
+- Event-driven race conditions
+- Work-conserving property violations (INV-8)
+- Incorrect assumptions about DES event processing semantics
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-7: vLLM/SGLang Expert
+
+```
+Review this plan as a vLLM/SGLang inference serving expert. Check for:
+- Batching semantics that don't match real continuous-batching servers
+- KV cache eviction policies that differ from vLLM's implementation
+- Chunked prefill behavior mismatches
+- Preemption policy differences from vLLM
+- Missing scheduling features that real servers have
+- Flag any assumption about LLM serving that this plan gets wrong
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-8: Distributed Inference Platform Expert
+
+```
+Review this plan as a distributed inference platform expert (llm-d, KServe, vLLM multi-node). Check for:
+- Multi-instance coordination bugs
+- Routing load imbalance under high request rates
+- Stale snapshot propagation between instances
+- Admission control edge cases at scale
+- Horizontal scaling assumption violations
+- Prefix-affinity routing correctness across instances
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-9: Performance & Scalability
+
+```
+Review this plan as a performance and scalability analyst. Check for:
+- Algorithmic complexity issues (O(n^2) where O(n) suffices)
+- Unnecessary allocations in hot paths (event loop, batch formation)
+- Map iteration in O(n) loops that could grow
+- Benchmark-sensitive changes
+- Memory growth patterns
+- Changes that would degrade performance at 1000+ requests or 10+ instances
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PP-10: Security & Robustness
+
+```
+Review this plan as a security and robustness reviewer. Check for:
+- Input validation completeness (all CLI flags, YAML fields, config values)
+- Panic paths reachable from user input (R3, R6)
+- Resource exhaustion vectors (unbounded loops, unlimited memory growth) (R19)
+- Degenerate input handling (empty, zero, negative, NaN, Inf) (R3, R20)
+- Configuration injection risks
+- Silent data loss paths (R1)
+
+PLAN CONTENTS:
+<paste plan file>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+---
+
+## Section B: PR Code Review (10 perspectives) — Step 4.5
+
+### PC-1: Substance & Design
+
+```
+Review this diff for substance: Are there logic bugs, design mismatches between contracts and implementation, mathematical errors, or silent regressions? Check from first principles — not just structural patterns. Does the implementation actually achieve what the behavioral contracts promise?
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-2: Code Quality + Antipattern Check
+
+```
+Review this diff for code quality. Check all of these:
+(1) Any new error paths that use `continue` or early `return` — do they clean up partial state? (R1, R5)
+(2) Any map iteration that accumulates floats — are keys sorted? (R2)
+(3) Any struct field added — are all construction sites updated? (R4)
+(4) Does library code (sim/) call logrus.Fatalf anywhere in new code? (R6)
+(5) Any exported mutable maps — should they be unexported with IsValid*() accessors? (R8)
+(6) Any YAML config fields using float64 instead of *float64 where zero is valid? (R9)
+(7) Any division where the denominator derives from runtime state without a zero guard? (R11)
+(8) Any new interface with methods only meaningful for one implementation? (R13)
+(9) Any method >50 lines spanning multiple concerns (scheduling + latency + metrics)? (R14)
+(10) Any changes to docs/standards/ files — are CLAUDE.md working copies updated? (DRY)
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-3: Test Behavioral Quality
+
+```
+Review the tests in this diff. For each test, rate as Behavioral, Mixed, or Structural:
+- Behavioral: tests observable behavior (GIVEN/WHEN/THEN), survives refactoring
+- Mixed: some behavioral assertions, some structural coupling
+- Structural: asserts internal structure (field access, type assertions), breaks on refactor
+
+Also check:
+- Are there golden dataset tests that lack companion invariant tests? (R7)
+- Do tests verify laws (conservation, monotonicity, causality) not just values?
+- Would each test still pass if the implementation were completely rewritten?
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-4: Getting-Started Experience
+
+```
+Review this diff for user and contributor experience. Simulate both journeys:
+(1) A user doing capacity planning with the CLI — would they find everything they need?
+(2) A contributor adding a new algorithm — would they know how to extend this?
+
+Check:
+- Missing example files or CLI documentation
+- Undocumented output metrics
+- Incomplete contributor guide updates
+- Unclear extension points
+- README not updated for new features
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-5: Automated Reviewer Simulation
+
+```
+The upstream community uses GitHub Copilot, Claude, and Codex to review PRs. Do a rigorous check so this will pass their review. Look for:
+- Exported mutable globals
+- User-controlled panic paths
+- YAML typo acceptance (should use KnownFields(true))
+- NaN/Inf validation gaps
+- Redundant or dead code
+- Style inconsistencies
+- Missing error returns
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-6: DES Expert
+
+```
+Review this diff as a discrete-event simulation expert. Check for:
+- Event ordering bugs in the implementation
+- Clock monotonicity violations (INV-3)
+- Stale signal propagation between event types (INV-7)
+- Heap priority errors
+- Work-conserving property violations (INV-8)
+- Event-driven race conditions
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-7: vLLM/SGLang Expert
+
+```
+Review this diff as a vLLM/SGLang inference serving expert. Check for:
+- Batching semantics that don't match real continuous-batching servers
+- KV cache eviction mismatches with vLLM
+- Chunked prefill behavior errors
+- Preemption policy differences
+- Missing scheduling features
+- Flag any assumption about LLM serving that this code gets wrong
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-8: Distributed Inference Platform Expert
+
+```
+Review this diff as a distributed inference platform expert (llm-d, KServe, vLLM multi-node). Check for:
+- Multi-instance coordination bugs
+- Routing load imbalance
+- Stale snapshot propagation
+- Admission control edge cases
+- Horizontal scaling assumption violations
+- Prefix-affinity routing correctness
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-9: Performance & Scalability
+
+```
+Review this diff as a performance and scalability analyst. Check for:
+- Algorithmic complexity regressions (O(n^2) where O(n) suffices)
+- Unnecessary allocations in hot paths
+- Map iteration in O(n) loops
+- Benchmark-sensitive changes
+- Memory growth patterns
+- Changes degrading performance at 1000+ requests or 10+ instances
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### PC-10: Security & Robustness
+
+```
+Review this diff as a security and robustness reviewer. Check for:
+- Input validation completeness (CLI flags, YAML fields, config values)
+- Panic paths reachable from user input
+- Resource exhaustion vectors (unbounded loops, unlimited memory growth)
+- Degenerate input handling (empty, zero, NaN, Inf)
+- Configuration injection risks
+- Silent data loss in error paths
+
+DIFF:
+<paste git diff output>
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```

--- a/.claude/skills/hypothesis-experiment/SKILL.md
+++ b/.claude/skills/hypothesis-experiment/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: hypothesis-experiment
+description: Run the full hypothesis experiment workflow (Steps 0-10) — worktree, classify, design review (5 perspectives), human gate, implement, code review (5 perspectives), run, analyze, FINDINGS review (10 perspectives), self-audit, commit + PR. Enforces convergence protocol and hard gates.
+argument-hint: <hypothesis-name>
+disable-model-invocation: true
+---
+
+# Hypothesis Experiment Workflow
+
+You are running the hypothesis experiment workflow for hypothesis **$ARGUMENTS**.
+
+**Canonical source:** `docs/process/hypothesis.md` (v2.0). Read it NOW before proceeding.
+**Standards:** `docs/standards/experiments.md` (ED-1–ED-6, RCV-1–RCV-6).
+**Template:** `docs/templates/hypothesis.md` (FINDINGS.md structure).
+**Review prompts:** See [review-prompts.md](review-prompts.md) for exact agent dispatch prompts.
+
+---
+
+## Hard Rules (non-negotiable)
+
+1. **Follow the steps in order.** Do not skip steps. Do not reorder.
+2. **Human gate at Step 3 is a STOP.** Present the design and WAIT. Do not say "I'll proceed unless you stop me."
+3. **Convergence = zero CRITICAL + zero IMPORTANT from ALL reviewers in a round.** Re-run the ENTIRE round after fixes. No exceptions. No shortcuts.
+4. **NEVER trust agent self-reported convergence.** Independently verify every finding count. Agents have fabricated "0 CRITICAL, 0 IMPORTANT" when actual review found 3 CRITICAL + 18 IMPORTANT (#390).
+5. **Code review BEFORE running experiments** (Step 5). Three of four major bugs in PR #310 would have been caught.
+6. **Max 10 rounds per gate.** If not converged by round 10, suspend the experiment.
+7. **Cross-gate regression:** If Code or FINDINGS Review finds a design flaw, loop back to Step 2. Max 2 regressions total.
+
+## Lessons Learned (encoded from MEMORY.md)
+
+- **`--stderr` must come BEFORE other flags** in `blis_run` calls — harness checks position 3 only
+- **CLI defaults vs workload-spec YAML**: `--rate` mode uses CLI defaults (512/512 tokens). Workload YAMLs define own distributions. Capacity estimates MUST match the actual workload.
+- **`--total-kv-blocks` default is context-dependent**: CLI default 1000000 but `defaults.yaml` overrides to 132139 for llama/H100/TP=2. Check defaults.yaml.
+- **Conservation formula**: Always 4-term INV-1: `injected == completed + queued + running + dropped_unservable`. `parse_blis_output` does NOT extract `dropped_unservable` — parse it separately.
+- **Analyzer verdict must match FINDINGS status**: If `analyze.py` produces a different verdict than FINDINGS.md, acknowledge the discrepancy explicitly.
+- **Think before coding calibration**: Compute parameters analytically from alpha/beta coefficients FIRST, then validate with a tiny run.
+- **Beta coefficients** (llama-3.1-8b, H100, TP=2): `[6910.42, 17.67, 2.84]` -> stepTime = beta0 + beta1*cacheMissTokens + beta2*decodeTokens
+- **Alpha coefficients**: `[1601.35, 3.51, 1805.54]` -> queueDelay = alpha0 + alpha1*inputLen; outputProcessing = alpha2
+- **WorkloadSpec YAML format**: `id:` not `client_id:`, `process:` not `type:` in arrival, `aggregate_rate:` top-level, `rate_fraction:` per client, distribution params under `params:` with `std_dev` not `stdev`
+
+---
+
+## Step 0: Create Worktree
+
+Create an isolated workspace FIRST, before any other work.
+
+```
+/superpowers:using-git-worktrees h-$ARGUMENTS
+```
+
+All subsequent steps happen in the worktree. Set your working directory there.
+
+---
+
+## Step 1: Select and Classify
+
+1. **Check coverage gaps**: Read `hypotheses/README.md` for the coverage table
+2. **Classify the hypothesis**:
+   - **Family**: Which of the 6 families? (See `docs/standards/experiments.md`)
+   - **VV&UQ**: Verification, Validation, or UQ?
+   - **Type**: Deterministic or Statistical? If statistical: dominance, monotonicity, equivalence, or Pareto?
+3. **Write the hypothesis sentence** using the family-specific pattern from experiments.md
+4. **Add diagnostic clause**: "If this fails, it would indicate..."
+
+**WARNING**: Pose the hypothesis WITHOUT reading the code first. Code-grounded hypotheses test implementation, not behavior.
+
+---
+
+## Step 2: Design + Design Review
+
+### 2a: Design the Experiment
+
+Follow ED-1 through ED-6 (see `docs/standards/experiments.md`):
+- ED-1: Controlled comparison (vary exactly ONE dimension)
+- ED-2: Rate awareness (run where effect expected AND where it should vanish)
+- ED-3: Precondition verification (in script, not just prose)
+- ED-4: Workload seed independence (3 seeds minimum for statistical: 42, 123, 456)
+- ED-5: Reproducibility (everything from `run.sh` alone)
+- ED-6: Config diff against referenced experiments
+
+**Compute parameters analytically** from alpha/beta coefficients. Do NOT guess.
+
+### 2b: Design Review (5 perspectives)
+
+Dispatch 5 parallel review agents using the convergence-review skill:
+
+```
+/convergence-review h-design
+```
+
+Alternatively, dispatch manually. See [review-prompts.md](review-prompts.md) Section A for exact prompts.
+
+**Perspectives**: (1) Hypothesis Quality, (2) ED Rigor, (3) Parameter Calibration, (4) Control Completeness, (5) DES/Domain Fit
+
+The convergence-review skill enforces the protocol automatically. If dispatching manually, apply the **convergence protocol**:
+1. Launch all 5 in parallel as background Task agents (subagent_type="general-purpose", model="haiku")
+2. Collect all findings classified as CRITICAL / IMPORTANT / SUGGESTION
+3. **Zero CRITICAL + zero IMPORTANT = converged** -> proceed to Step 3
+4. **Any CRITICAL or IMPORTANT** -> fix all, re-run ENTIRE round (not just failed perspectives)
+5. **Independently count findings yourself.** Do not trust agent summaries.
+
+---
+
+## Step 3: Human Approval Gate — STOP HERE
+
+**Present the experiment design to the user.** Include:
+- Hypothesis sentence + classification (family, VV&UQ, type)
+- Experiment design summary (configurations, controlled variables, seeds)
+- Parameter choices with analytical derivation
+- Planned controls (one per proposed mechanism)
+- Expected outcomes and diagnostic implications
+
+**This is a hard gate. WAIT for explicit human approval before proceeding.**
+
+Use the AskUserQuestion tool:
+```
+"Do you approve this experiment design?"
+Options: "Approve — proceed to implementation", "Revise — I have feedback"
+```
+
+---
+
+## Step 4: Implement
+
+Create `hypotheses/h-$ARGUMENTS/run.sh` and `hypotheses/h-$ARGUMENTS/analyze.py`.
+
+### Mandatory harness requirements
+
+**run.sh** MUST:
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib/harness.sh"
+setup_experiment "${1:-}"
+```
+- Use `blis_run` for EVERY simulation call (not `$BINARY run` directly)
+- Every `blis_run` needs a timeout tier: `$TIMEOUT_QUICK` (<100 req), `$TIMEOUT_STANDARD` (100-500), `$TIMEOUT_EXTENDED` (>500)
+- If using `--total-kv-blocks`, call `preflight_kv_check` first
+- Call `python3 "$SCRIPT_DIR/analyze.py" ...` at the end
+
+**analyze.py** MUST:
+```python
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from analyze_helpers import parse_blis_output, check_for_timeout
+```
+- Use `parse_blis_output()` for all metric extraction
+- Check `metrics["timed_out"]` before computing ratios
+- Print warnings to stderr, results to stdout
+- Verify INV-1 conservation (4-term formula) for every run
+
+---
+
+## Step 5: Code Review (5 perspectives) — BEFORE running
+
+**Every run.sh and analyze.py must be code-reviewed BEFORE running.**
+
+Dispatch 5 parallel review agents using the convergence-review skill:
+
+```
+/convergence-review h-code hypotheses/h-$ARGUMENTS/
+```
+
+Alternatively, dispatch manually. See [review-prompts.md](review-prompts.md) Section B for exact prompts.
+
+**Perspectives**: (1) Parser-Output Agreement, (2) CLI Flag Correctness, (3) YAML Field Validation, (4) Config Diff (ED-6), (5) Seed and Determinism
+
+Apply the convergence protocol (same rules as Step 2b).
+
+**Cross-gate regression**: If this review finds a design flaw, loop back to Step 2.
+
+---
+
+## Step 6: Run Experiments
+
+After Code Review converges:
+- **Deterministic**: Single seed sufficient
+- **Statistical**: Minimum 3 seeds (42, 123, 456) per configuration
+- Execute: `bash hypotheses/h-$ARGUMENTS/run.sh`
+- Verify reproducibility: running twice produces identical output
+
+---
+
+## Step 7: Analyze and Document
+
+1. **Review analyzer output** from Step 6
+2. **Trace every causal claim through code** (RCV-1: cite `file:line`)
+3. **Compute expected values from first principles** for any "surprises" (RCV-2)
+4. **Check mechanism AND direction** (RCV-3)
+5. **Write FINDINGS.md** using `docs/templates/hypothesis.md` — ALL sections must be non-empty
+6. **Update `hypotheses/README.md`** — add row to the validated hypotheses table
+
+---
+
+## Step 8: FINDINGS Review (10 perspectives)
+
+Dispatch 10 parallel review agents using the convergence-review skill:
+
+```
+/convergence-review h-findings hypotheses/h-$ARGUMENTS/FINDINGS.md
+```
+
+Alternatively, dispatch manually. See [review-prompts.md](review-prompts.md) Section C for exact prompts.
+
+**Perspectives**: (1) Code Verifier, (2) Experiment Designer, (3) Statistical Rigor, (4) Control Auditor, (5) Standards Compliance, (6) Substance/Logic, (7) DES Mechanism, (8) Reproducibility, (9) Cross-Experiment, (10) User Guidance
+
+Expected: 1-5 rounds (10 perspectives = higher quality bar).
+
+**CRITICAL**: Independently read every agent's output and count findings yourself. Do NOT rely on agent self-reported totals.
+
+**Cross-gate regression**: If design flaw found, loop back to Step 2. Max 2 regressions total.
+
+---
+
+## Step 9: Self-Audit (6 dimensions)
+
+**This is NOT an agent pass.** Stop. Think critically. Answer each question yourself.
+
+1. **Logic bugs in analyzer**: Trace through `analyze.py` mentally. Edge cases? Silent defaults to 0? Integer vs float?
+2. **Reproducibility**: Would `./run.sh` again produce identical output? Any non-deterministic dependencies?
+3. **FINDINGS.md consistency**: Does Status match Results data? Does Devil's Advocate actually argue against the conclusion?
+4. **Cross-experiment contradictions**: Do findings contradict prior experiments or MEMORY.md knowledge?
+5. **User guidance**: Would a BLIS user know what to do with these findings?
+6. **Issue filing completeness**: Every actionable finding has a planned issue?
+
+Fix all issues found. Then proceed to Step 10.
+
+---
+
+## Step 10: Verify + Commit + PR
+
+### If code fixes were discovered:
+```bash
+go build ./...
+go test ./... -count=1
+golangci-lint run ./...
+```
+All three must pass before committing.
+
+### Commit and PR:
+```
+/commit-commands:commit-push-pr
+```
+
+PR description must include:
+- Hypothesis sentence and status
+- Key findings (1-3 bullets)
+- `Fixes #NNN` for any issues addressed
+
+### Post-PR: File issues per the taxonomy
+- **Bug**: `--label bug` — code defects discovered
+- **Enhancement**: `--label enhancement` — improvements needed
+- **New hypothesis**: `--label hypothesis` — follow-up experiments (use `.github/ISSUE_TEMPLATE/hypothesis.md`)
+- **Design limitation**: `--label design` — documented limitations
+- **Standards update**: `--label standards` — new rules/invariants
+
+**Issue title format for hypotheses**: behavioral prediction ("X should Y"), NOT a task ("test X").
+
+---
+
+## Convergence Protocol Quick Reference
+
+| Rule | Detail |
+|------|--------|
+| **Converged** | Zero CRITICAL + zero IMPORTANT from ALL reviewers in current round |
+| **Not converged** | Fix all issues, re-run ENTIRE round |
+| **Max rounds** | 10 per gate (Design, Code, FINDINGS each independent) |
+| **SUGGESTION items** | Do not block convergence |
+| **Agent timeout** | 5 min per reviewer; if exceeded, check output and restart |
+| **Agent failure** | Fall back to performing that review directly |
+| **Severity doubtful?** | If fixing it would change a conclusion → IMPORTANT. If only readability → SUGGESTION |
+| **Model for reviewers** | Use haiku for speed (~2-3 min, thorough reviews) |

--- a/.claude/skills/hypothesis-experiment/review-prompts.md
+++ b/.claude/skills/hypothesis-experiment/review-prompts.md
@@ -1,0 +1,418 @@
+# Review Agent Dispatch Prompts
+
+Reference file for the hypothesis-experiment skill. Contains exact prompts for all 20 reviewer perspectives across the three review gates.
+
+**Canonical source:** `docs/process/hypothesis.md` (v2.0). If prompts here diverge from hypothesis.md, the process doc is authoritative.
+
+**Usage**: Launch each perspective as a parallel Task agent:
+```
+Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+     prompt="<prompt from below>")
+```
+
+**After all agents complete**: Read each output file independently. Count CRITICAL and IMPORTANT findings yourself. Do NOT trust agent-reported totals.
+
+---
+
+## Section A: Design Review (5 perspectives) — Step 2
+
+### DR-1: Hypothesis Quality
+
+```
+You are reviewing a hypothesis experiment design for the BLIS discrete-event simulator.
+
+HYPOTHESIS AND DESIGN:
+<paste hypothesis sentence, classification, experiment design>
+
+YOUR FOCUS: Hypothesis Quality
+- Is the hypothesis behavioral, testable, and diagnostic?
+- Does it follow the family-specific sentence pattern from docs/standards/experiments.md?
+- Is the diagnostic clause present ("If this fails, it would indicate...")?
+- Is it correctly classified (family, VV&UQ category, type)?
+- Is the hypothesis conceptual (not code-grounded)? It should NOT reference specific files/lines.
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DR-2: Experiment Design Rigor (ED-1–ED-6)
+
+```
+You are reviewing a hypothesis experiment design for the BLIS discrete-event simulator.
+
+HYPOTHESIS AND DESIGN:
+<paste hypothesis sentence, classification, experiment design>
+
+YOUR FOCUS: Experiment Design Rigor
+Check compliance with each standard:
+- ED-1: Is exactly ONE dimension varied between configurations? Everything else constant?
+- ED-2: Is there a rate where the effect should vanish, to confirm mechanism dependence?
+- ED-3: Are preconditions verified in the script (not just prose)?
+- ED-4: Is seed handling correct? (3+ seeds for statistical: 42, 123, 456)
+- ED-5: Is the experiment reproducible from run.sh alone?
+- ED-6: If reusing calibration from a prior experiment, is the config diff documented?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DR-3: Parameter Calibration
+
+```
+You are reviewing a hypothesis experiment design for the BLIS discrete-event simulator.
+
+HYPOTHESIS AND DESIGN:
+<paste hypothesis sentence, classification, experiment design>
+
+YOUR FOCUS: Parameter Calibration
+- Are parameters computed analytically from known coefficients, not guessed?
+  - Beta coefficients (llama-3.1-8b, H100, TP=2): [6910.42, 17.67, 2.84]
+    stepTime = 6910.42 + 17.67*cacheMissTokens + 2.84*decodeTokens (microseconds)
+  - Alpha coefficients: [1601.35, 3.51, 1805.54]
+    queueDelay = 1601.35 + 3.51*inputLen; outputProcessing = 1805.54 (microseconds)
+- Are capacity estimates matched to the actual workload mode?
+  - CLI mode (--rate): uses defaults prompt=512, output=512 -> step ~17.4ms, capacity ~57.4 req/s
+  - Workload-spec YAML: uses distributions defined in the YAML (compute step time from YAML params)
+- Is the operating point correct? (near saturation for queueing effects, sub-saturation for baseline)
+- Is --total-kv-blocks appropriate? (CLI default is overridden by defaults.yaml to 132139 for llama/H100/TP=2)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DR-4: Control Completeness
+
+```
+You are reviewing a hypothesis experiment design for the BLIS discrete-event simulator.
+
+HYPOTHESIS AND DESIGN:
+<paste hypothesis sentence, classification, experiment design>
+
+YOUR FOCUS: Control Completeness
+- Does every proposed mechanism have a planned control experiment? (RCV-4)
+- Does each control isolate exactly one variable?
+- Is the baseline configuration clearly defined?
+- Are there confounding variables that could explain results without the proposed mechanism?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### DR-5: DES and Domain Fit
+
+```
+You are reviewing a hypothesis experiment design for the BLIS discrete-event simulator.
+
+HYPOTHESIS AND DESIGN:
+<paste hypothesis sentence, classification, experiment design>
+
+YOUR FOCUS: DES and Domain Fit
+- Will the experiment create the conditions needed for the hypothesis to be testable?
+- Are there DES-specific subtleties that could confound results?
+  - Alpha overhead (~4.3ms/req) is non-blocking but inflates E2E metrics
+  - Step quantization: step time is per-batch, not per-request
+  - Clock granularity: microsecond ticks
+  - Event ordering: (timestamp, priority, seqID) at cluster level
+- Is the experiment duration sufficient? Request count adequate for the intended effect?
+- Is the warmup period adequate (or does the experiment need cold-start behavior)?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+---
+
+## Section B: Code Review (5 perspectives) — Step 5
+
+### CR-1: Parser–Output Format Agreement
+
+```
+You are code-reviewing a BLIS hypothesis experiment BEFORE it runs.
+
+FILES TO REVIEW:
+<paste or reference run.sh and analyze.py paths>
+
+YOUR FOCUS: Parser–Output Format Agreement
+For every regex or field extraction in analyze.py, verify the pattern matches actual output:
+- Read cmd/root.go — what text does the CLI print? (format strings for "Preemption Rate: %.4f", etc.)
+- Read sim/metrics_utils.go — what JSON fields exist in MetricsOutput?
+- Match every regex in analyze.py against the format string in the producer code
+- SILENT DEFAULTS: verify that when a regex matches nothing, analyze.py warns to stderr rather than silently defaulting to 0
+- Check parse_blis_output() from hypotheses/lib/analyze_helpers.py — does it extract what this experiment needs? (NOTE: it does NOT extract dropped_unservable)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### CR-2: CLI Flag Correctness
+
+```
+You are code-reviewing a BLIS hypothesis experiment BEFORE it runs.
+
+FILES TO REVIEW:
+<paste or reference run.sh path>
+
+YOUR FOCUS: CLI Flag Correctness
+For every flag in run.sh:
+- Verify the flag name exists in cmd/root.go
+- Verify the value type matches (string, int, float)
+- Check for typos that strict YAML parsing would reject
+- Verify --stderr comes BEFORE other flags in blis_run calls (harness checks position 3 only)
+- Cross-reference blis_run timeout tiers: TIMEOUT_QUICK (<100 req), TIMEOUT_STANDARD (100-500), TIMEOUT_EXTENDED (>500)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### CR-3: YAML Field Validation
+
+```
+You are code-reviewing a BLIS hypothesis experiment BEFORE it runs.
+
+FILES TO REVIEW:
+<paste or reference run.sh and any .yaml files>
+
+YOUR FOCUS: YAML Field Validation
+If the experiment uses workload-spec YAML files:
+- Verify field names against sim/workload/spec.go struct tags
+- Key gotchas: `id:` not `client_id:`, `process:` not `type:` in arrival, `aggregate_rate:` top-level, `rate_fraction:` per client, distribution params under `params:` with `std_dev` not `stdev`, `prefix_group`+`prefix_length` not `prefix_tokens`
+- KnownFields(true) will reject typos at runtime — catching them now saves a failed run
+- If YAML is generated inline in run.sh (heredoc), verify the heredoc syntax is correct
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### CR-4: Config Diff (ED-6)
+
+```
+You are code-reviewing a BLIS hypothesis experiment BEFORE it runs.
+
+FILES TO REVIEW:
+<paste or reference run.sh path>
+
+YOUR FOCUS: Config Diff (ED-6)
+- If the experiment reuses calibration from a prior experiment, diff every CLI flag and YAML field between the two
+- Explicitly list all differences
+- Verify the # Reference: comment in run.sh points to the correct file
+- Check: does any changed flag (routing policy, seed, rate, blocks) invalidate the calibration?
+- Evidence: H10 used --routing-policy least-loaded while H8 used round-robin, shifting the preemption cliff. Caught only in post-publication review.
+
+If no prior experiment is referenced, report "N/A — no referenced experiment" and move on.
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### CR-5: Seed and Determinism
+
+```
+You are code-reviewing a BLIS hypothesis experiment BEFORE it runs.
+
+FILES TO REVIEW:
+<paste or reference run.sh path>
+
+YOUR FOCUS: Seed and Determinism
+- Verify --seed is passed correctly in every blis_run call
+- Verify workload YAML seed: field doesn't conflict with --seed (CLI overrides YAML when explicit)
+- Verify seeds vary across runs as intended (ED-4)
+- Check that run.sh builds the binary (setup_experiment) and is fully self-contained (ED-5)
+- Verify run.sh sources hypotheses/lib/harness.sh
+- Verify every blis_run call has a timeout tier (no bare $BINARY run calls)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+---
+
+## Section C: FINDINGS Review (10 perspectives) — Step 8
+
+### FR-1: Code Verifier
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: Code Verification
+- READ the actual source files cited in FINDINGS.md. Verify every file:line citation.
+- Does the code at the cited location actually produce the claimed behavior?
+- Are there off-by-one errors in line citations? (Acceptable: +/-2 lines. Flag: >2 lines off.)
+- Does the mechanism explanation match what the code does, not just what it's named?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-2: Experiment Designer
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+RUN SCRIPT: <path to run.sh>
+
+YOUR FOCUS: Experiment Design Compliance
+- ED-1 through ED-6 compliance (controlled comparison, rate awareness, preconditions, seeds, reproducibility, config diff)
+- Are there missing control experiments or confound matrix cells?
+- Are parameters properly calibrated?
+- Cross-reference every CLI flag in run.sh against cmd/root.go flag definitions
+- Cross-reference every YAML field name against sim/workload/spec.go struct tags
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-3: Statistical Rigor
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: Statistical Rigor
+- Are "surprises" computed from first principles? (RCV-2)
+- Is the sample size adequate (seeds, operating points)?
+- Are claims properly scoped (not over-generalized)?
+- Is the evidence quality table complete and honest?
+- Effect size thresholds: >20% for dominance (ALL seeds), <5% for equivalence (ALL seeds), <10% in any seed = inconclusive
+- Is the status classification consistent with the data?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-4: Control Experiment Auditor
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+RUN SCRIPT: <path to run.sh>
+
+YOUR FOCUS: Control Experiment Audit
+- Does every proposed mechanism (RCV-3) have a control experiment (RCV-4)?
+- Were controls EXECUTED, not just proposed? Look for past tense with data vs conditional language ("could be confirmed by")
+- Does each control isolate exactly one variable? Diff CLI flags between treatment and control in run.sh
+- Do control results confirm or refute the proposed mechanism?
+- Do Evidence Quality table entries reflect the current round (not stale from prior rounds)?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-5: Standards Compliance
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: Standards Compliance
+- Are ALL FINDINGS.md sections present and non-empty? (per docs/templates/hypothesis.md)
+- Is the hypothesis correctly classified (family, VV&UQ, type)?
+- Does the Devil's Advocate section argue both directions convincingly? (RCV-5)
+- Are Scope and Limitations complete? (RCV-6) Operating point, dependencies, what was NOT tested, generalizability, UQ
+- Does the Standards Audit check against docs/standards/rules.md and docs/standards/invariants.md?
+- Are any new rules or invariants warranted?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-6: Substance and Logic
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: Substance and Logic
+- Are there logical errors in the conclusions?
+- Are there mathematical mistakes in effect size calculations or statistical claims?
+- Does the evidence actually support the claims? (Not just "the numbers are close enough")
+- Are alternative explanations adequately considered?
+- Does the analyzer verdict in analyze.py match the FINDINGS.md status? If not, is the discrepancy acknowledged?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-7: DES Mechanism Expert
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: DES Mechanism Analysis
+- Are there event-ordering subtleties that could explain results differently?
+- Are assumptions about DES timing correct?
+  - Alpha overhead (~4.3ms/req) is non-blocking (delays enqueue, not step advance)
+  - Step quantization: step time is per-batch
+  - Clock: microsecond ticks
+- Could the result be a simulation artifact rather than modeled system behavior?
+- Are routing snapshot freshness assumptions correct? (INV-7: PendingRequests = synchronous, KVUtilization = stale)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-8: Reproducibility and Robustness
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+RUN SCRIPT: <path to run.sh>
+
+YOUR FOCUS: Reproducibility and Robustness
+- Can run.sh reproduce results from scratch on a clean checkout?
+- Are results fragile to small parameter variations? (Would +/-10% on key params change the conclusion?)
+- Are all intermediate files generated by the script, not checked in as stale artifacts?
+- Does run.sh build the binary (setup_experiment call)?
+- Are there any non-deterministic dependencies (timestamps, system load, file ordering)?
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-9: Cross-Experiment Consistency
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: Cross-Experiment Consistency
+- Do findings contradict any prior experiment? If so, is the contradiction acknowledged and explained?
+- Check references to prior experiments — are specific claims accurate? (Read the referenced FINDINGS.md)
+- Are there stale references to prior review rounds that should have been updated?
+- Key prior findings to check against:
+  - H4: RR and LL mean-equivalent at low load; LL p99 worse from tie-breaking bias
+  - H7: Horizontal scaling is super-linear (7.4x TTFT p99 for 4->8 instances)
+  - H20: ParetoLogNormal produces FEWER preemptions than Gaussian (median drives KV pressure)
+  - H23: Uniform workloads eliminate policy differentiation even under overload
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```
+
+### FR-10: User Guidance and Actionability
+
+```
+You are reviewing a FINDINGS.md for a BLIS hypothesis experiment.
+
+FINDINGS FILE: <path to FINDINGS.md>
+
+YOUR FOCUS: User Guidance and Actionability
+- Are "Implications for Users" practical and specific enough to act on?
+- Are proposed issues (bugs, enhancements, follow-up hypotheses) well-scoped?
+- Would a BLIS user reading this understand what to do differently?
+- Are findings classified correctly in the Findings Classification table?
+- Is the promotion assessment complete? (Should any confirmed findings become Go tests or formal invariants?)
+
+Rate each finding as CRITICAL, IMPORTANT, or SUGGESTION.
+Report: (1) numbered list of findings with severity, (2) total CRITICAL count, (3) total IMPORTANT count.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,12 @@ Follow `docs/process/pr-workflow.md` for the complete PR lifecycle. The workflow
 1. **Create worktree** — isolate your work from the main branch
 2. **Write design doc** (if needed) — for new modules or architecture changes, write a design doc per the guidelines before planning. Four species: decision record, specification, problem analysis, system overview. Not needed for bug fixes or new policy templates behind existing interfaces.
 3. **Write implementation plan** — behavioral contracts + TDD tasks using `docs/templates/micro-plan.md`
-4. **Review plan** — 5 focused passes (external review, cross-doc, architecture, codebase, structural)
-5. **Implement** — test-first, one contract at a time
-6. **Review code** — 4 focused passes (quality, test quality, getting-started, automated reviewer)
-7. **Self-audit** — 9 dimensions of deliberate critical thinking (no automation)
-8. **Commit, push, PR**
+4. **Review plan** — two-stage: holistic `review-pr` pre-pass, then `convergence-review` with 10 targeted perspectives
+5. **Human review** — approve plan before implementation (hard gate)
+6. **Implement** — test-first, one contract at a time
+7. **Review code** — two-stage: holistic `review-pr` pre-pass, then `convergence-review` with 10 targeted perspectives
+8. **Self-audit** — 9 dimensions of deliberate critical thinking (no automation)
+9. **Commit, push, PR**
 
 ## Engineering Principles
 

--- a/docs/process/design.md
+++ b/docs/process/design.md
@@ -19,7 +19,8 @@ This document describes the process for writing a BLIS design document. For the 
 3. **Complete the DES checklist** (Section 2.6) — model scoping, event design, state/statistics, V&V, randomness
 4. **Write the design doc** per the template's required sections (Section 3.3): motivation, scope, modeling decisions, invariants, decisions with trade-offs, extension points, validation strategy
 5. **Apply the staleness test** (Section 3.1) — would this content mislead if the implementation changes?
-6. **Human review** — approve before macro/micro planning begins
+6. **Convergence review** — `/convergence-review design <design-doc-path>` dispatches 8 parallel perspectives and enforces convergence (see [hypothesis.md — Universal Convergence Protocol](hypothesis.md#universal-convergence-protocol)). Manual alternative: review against the quality gates below.
+7. **Human review** — approve before macro/micro planning begins
 
 ## Quality Gates
 
@@ -28,6 +29,12 @@ This document describes the process for writing a BLIS design document. For the 
 - [ ] No prohibited content (Section 3.4): no Go structs, no method implementations, no file:line references
 - [ ] Every non-obvious decision has alternatives listed with rationale
 - [ ] Validation strategy specified (which invariants? against what real-system data?)
+
+## Prerequisites
+
+| Skill | Purpose | Manual Alternative |
+|-------|---------|--------------------|
+| `convergence-review` | Dispatch parallel review perspectives (Step 6) | Review against quality gates manually |
 
 ## References
 

--- a/docs/process/macro-plan.md
+++ b/docs/process/macro-plan.md
@@ -20,7 +20,8 @@ This document describes the process for creating a macro-level implementation pl
 4. **Define module contracts per PR boundary** — what does each PR guarantee to the next?
 5. **Identify frozen interfaces** — which interfaces are stable (can be developed against in parallel)?
 6. **Identify flexible internals** — which implementation details may change during micro-planning?
-7. **Human review** — approve before micro-planning begins for any PR in the plan
+7. **Convergence review** — `/convergence-review macro-plan <plan-path>` dispatches 8 parallel perspectives and enforces convergence (see [hypothesis.md — Universal Convergence Protocol](hypothesis.md#universal-convergence-protocol)). Manual alternative: review against the quality gates below.
+8. **Human review** — approve before micro-planning begins for any PR in the plan
 
 ## Quality Gates
 
@@ -29,6 +30,12 @@ This document describes the process for creating a macro-level implementation pl
 - [ ] Module contracts are testable with mocks (parallel development enabled)
 - [ ] No Go struct definitions or method implementations (those belong in micro plans)
 - [ ] Extension friction assessed for each new module boundary
+
+## Prerequisites
+
+| Skill | Purpose | Manual Alternative |
+|-------|---------|--------------------|
+| `convergence-review` | Dispatch parallel review perspectives (Step 7) | Review against quality gates manually |
 
 ## References
 

--- a/docs/standards/principles.md
+++ b/docs/standards/principles.md
@@ -88,5 +88,5 @@ Every piece of documentation lives in exactly one canonical location. Other file
 | Hypothesis catalog and specifications | `docs/plans/research.md` | — |
 | Experiment status and coverage | `hypotheses/README.md` | — |
 | Experiment standards | `docs/standards/experiments.md` | — (note: review protocol subsection references `docs/process/hypothesis.md` as canonical) |
-| Hypothesis experiment workflow | `docs/process/hypothesis.md` | CONTRIBUTING.md (summary), hypotheses/README.md (step list) |
-| PR workflow | `docs/process/pr-workflow.md` | — |
+| Hypothesis experiment workflow | `docs/process/hypothesis.md` | CONTRIBUTING.md (summary), hypotheses/README.md (step list), `.claude/skills/hypothesis-experiment/SKILL.md` (workflow steps), `.claude/skills/hypothesis-experiment/review-prompts.md` (perspective prompts), `.claude/skills/convergence-review/SKILL.md` (convergence protocol copy) |
+| PR workflow | `docs/process/pr-workflow.md` | CONTRIBUTING.md (summary), `.claude/skills/convergence-review/pr-prompts.md` (perspective prompts) |


### PR DESCRIPTION
## Summary

- Add two Claude Code skills encoding project workflows:
  - `hypothesis-experiment`: Steps 0-10 of the hypothesis experiment process
  - `convergence-review`: 7 gate types (design, macro-plan, pr-plan, pr-code, h-design, h-code, h-findings) with parallel perspective dispatch and convergence enforcement
- Update all 4 process docs (`hypothesis.md`, `pr-workflow.md`, `design.md`, `macro-plan.md`) to reference the `convergence-review` skill as the primary mechanism for review gates, retaining inline perspective checklists as manual alternatives
- Replace the partial convergence protocol redefinition in `pr-workflow.md` with a reference to the canonical source in `hypothesis.md`
- Add formal convergence review steps to `design.md` (Step 6) and `macro-plan.md` (Step 7)

## Test plan

- [ ] Verify `convergence-review` skill appears in `/agents` listing
- [ ] Invoke `/convergence-review pr-plan docs/plans/<any-plan>.md` and confirm perspectives dispatch
- [ ] Invoke `/convergence-review design docs/plans/archive/<any-design-doc>.md` and confirm 8 perspectives dispatch
- [ ] Verify all internal links resolve (hypothesis.md anchor `#universal-convergence-protocol`)
- [ ] Grep for "convergence-review" in process docs confirms references added to all 4 files
- [ ] No Go code changes — no build/test/lint needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)