### PR TITLE
fix(skill): redesign convergence-review loop with two-phase execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ go.work.sum
 __pycache__/*
 */__pycache__/*
 
+# convergence review state files
+.claude/convergence-state/
+
 # data files
 *.json
 !testdata/goldendataset.json


### PR DESCRIPTION
## Summary

Fixes #430

The convergence-review skill relied on prose instructions to enforce a re-run loop after fixes, but LLMs reliably skipped the re-run once fixes felt "complete" (context window dilution, completion bias, ambiguous re-invocation instructions). This PR makes the loop structural rather than aspirational.

- **S7 — Two-phase protocol**: Phase A (review-only, produces one of three outcomes: converged / not-converged / stalled) and Phase B (fix-and-rerun, only exit is re-entering Phase A). Each phase is short enough that its exit instruction is never far from current context position.
- **S1 — Convergence state directory**: `.claude/convergence-state/` with JSON state files keyed by gate type + artifact identity. State-file-driven phase detection on invocation (no file → Phase A; `awaiting-rerun` → Phase B).
- **S4 — Remove re-invoke escape hatch**: The "After fixes / Re-invoke with same arguments" section that implied manual re-invocation is removed. The loop is now automatic and self-driven.
- **S8 — Round-boundary status banners**: Three banner formats (converged, not-converged, stalled) emitted after every Phase A verdict so the user sees round status.
- **Max rounds 10→5**: Updated canonical source (hypothesis.md) and pr-workflow.md. Stall protocol uses AskUserQuestion with three options (increase limit / accept / abort) instead of silently suspending.

## Test plan
- [ ] Invoke `/convergence-review pr-code` on a branch with known issues — verify Phase A dispatches, tallies, and transitions to Phase B
- [ ] After Phase B fixes, verify automatic re-entry into Phase A (Round 2) without manual re-invocation
- [ ] Verify state file created in `.claude/convergence-state/` with correct schema
- [ ] Verify convergence (0 CRITICAL + 0 IMPORTANT) produces converged banner and state file cleanup
- [ ] Verify `*.json` gitignore pattern covers state files
- [ ] Verify no stale "10 rounds" or "re-invoke" references remain