### PR TITLE
skill(convergence-review): configurable reviewer model

### DIFF
--- a/.claude/skills/convergence-review/design-prompts.md
+++ b/.claude/skills/convergence-review/design-prompts.md
@@ -12,9 +12,10 @@ Reference file for the convergence-review skill. Contains exact prompts for desi
 
 **Dispatch pattern:** Launch each perspective as a parallel Task agent:
 ```
-Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+Task(subagent_type="general-purpose", model=REVIEW_MODEL, run_in_background=True,
      prompt="<prompt from below>\n\n<artifact content>")
 ```
+Model selection is controlled by the `--model` flag in the convergence-review skill (default: `haiku`).
 
 ---
 

--- a/.claude/skills/convergence-review/pr-prompts.md
+++ b/.claude/skills/convergence-review/pr-prompts.md
@@ -6,9 +6,10 @@ Reference file for the convergence-review skill. Contains exact prompts for the 
 
 **Dispatch pattern:** Launch each perspective as a parallel Task agent:
 ```
-Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+Task(subagent_type="general-purpose", model=REVIEW_MODEL, run_in_background=True,
      prompt="<prompt from below>\n\n<artifact content>")
 ```
+Model selection is controlled by the `--model` flag in the convergence-review skill (default: `haiku`).
 
 ---
 

--- a/.claude/skills/hypothesis-experiment/SKILL.md
+++ b/.claude/skills/hypothesis-experiment/SKILL.md
@@ -93,7 +93,7 @@ Alternatively, dispatch manually. See [review-prompts.md](review-prompts.md) Sec
 **Perspectives**: (1) Hypothesis Quality, (2) ED Rigor, (3) Parameter Calibration, (4) Control Completeness, (5) DES/Domain Fit
 
 The convergence-review skill enforces the protocol automatically. If dispatching manually, apply the **convergence protocol**:
-1. Launch all 5 in parallel as background Task agents (subagent_type="general-purpose", model="haiku")
+1. Launch all 5 in parallel as background Task agents (subagent_type="general-purpose", model=REVIEW_MODEL from `--model` flag, default "haiku")
 2. Collect all findings classified as CRITICAL / IMPORTANT / SUGGESTION
 3. **Zero CRITICAL + zero IMPORTANT = converged** -> proceed to Step 3
 4. **Any CRITICAL or IMPORTANT** -> fix all, re-run ENTIRE round (not just failed perspectives)
@@ -272,4 +272,4 @@ PR description must include:
 | **Agent timeout** | 5 min per reviewer; if exceeded, check output and restart |
 | **Agent failure** | Fall back to performing that review directly |
 | **Severity doubtful?** | If fixing it would change a conclusion → IMPORTANT. If only readability → SUGGESTION |
-| **Model for reviewers** | Use haiku for speed (~2-3 min, thorough reviews) |
+| **Model for reviewers** | Default: haiku (~2-3 min, thorough reviews). Override via `/convergence-review <gate> --model sonnet\|opus` |

--- a/.claude/skills/hypothesis-experiment/review-prompts.md
+++ b/.claude/skills/hypothesis-experiment/review-prompts.md
@@ -6,9 +6,10 @@ Reference file for the hypothesis-experiment skill. Contains exact prompts for a
 
 **Usage**: Launch each perspective as a parallel Task agent:
 ```
-Task(subagent_type="general-purpose", model="haiku", run_in_background=True,
+Task(subagent_type="general-purpose", model=REVIEW_MODEL, run_in_background=True,
      prompt="<prompt from below>")
 ```
+Model selection is controlled by the `--model` flag in the convergence-review skill (default: `haiku`).
 
 **After all agents complete**: Read each output file independently. Count CRITICAL and IMPORTANT findings yourself. Do NOT trust agent-reported totals.
 

--- a/docs/process/hypothesis.md
+++ b/docs/process/hypothesis.md
@@ -448,7 +448,7 @@ The PR description should include:
 
 All three review gates (Design Review, Code Review, FINDINGS Review) use this same protocol. It is defined here once and referenced from each gate.
 
-> **Executable implementation:** The `convergence-review` skill automates this protocol — dispatching perspectives, tallying findings independently, and enforcing the re-run gate. Invoke with `/convergence-review <gate-type> [artifact-path]`.
+> **Executable implementation:** The `convergence-review` skill automates this protocol — dispatching perspectives, tallying findings independently, and enforcing the re-run gate. Invoke with `/convergence-review <gate-type> [artifact-path] [--model opus|sonnet|haiku]` (default: `haiku`).
 
 ### The Protocol
 

--- a/docs/process/pr-workflow.md
+++ b/docs/process/pr-workflow.md
@@ -165,7 +165,7 @@ If skills are unavailable, you can implement each step manually:
 
 # Step 2.5: Review plan (two-stage)
 /pr-review-toolkit:review-pr
-/convergence-review pr-plan docs/plans/pr8-routing-state-and-policy-bundle-plan.md
+/convergence-review pr-plan docs/plans/pr8-routing-state-and-policy-bundle-plan.md  # [--model opus|sonnet|haiku]
 
 # Step 3: Human review
 # [Read plan, verify contracts and tasks, approve to proceed]
@@ -175,7 +175,7 @@ If skills are unavailable, you can implement each step manually:
 
 # Step 4.5: Review code (two-stage)
 /pr-review-toolkit:review-pr
-/convergence-review pr-code
+/convergence-review pr-code  # [--model opus|sonnet|haiku]
 
 # Step 5: Commit, push, and create PR
 /commit-commands:commit-push-pr


### PR DESCRIPTION
## Summary
- Add `--model opus|sonnet|haiku` flag to convergence-review skill (default: `haiku`)
- Previously hardcoded to `haiku` for all perspective agents with no override
- Updated algorithm pseudocode, dispatch instructions, argument-hint, and all prompt files
- Added validation, parsing order spec, and model-ID resolution docs

Closes #438

## Test plan
- [x] Run `/convergence-review pr-code` — THEN the Task tool calls include `model = "haiku"` (default)
- [x] Run `/convergence-review pr-code --model opus` — THEN the Task tool calls include `model = "opus"`
- [x] Run `/convergence-review pr-code --model sonnet` — THEN the Task tool calls include `model = "sonnet"`
- [x] Run `/convergence-review pr-code --model gpt4` — THEN an error is reported and review stops
- [x] Run `/convergence-review h-findings FINDINGS.md --model haiku` — THEN `--model` is stripped before positional parsing and `$0` = `h-findings`, `$1` = `FINDINGS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)