### PR TITLE
docs: fix Strategy Evolution methodology page issues

### DIFF
--- a/docs/methodology/index.md
+++ b/docs/methodology/index.md
@@ -7,7 +7,7 @@ Reusable research methodologies developed and validated through BLIS experiments
 | Page | Description |
 |------|-------------|
 | [Strategy Evolution](strategy-evolution.md) | Iterative policy discovery through simulation: 5-phase methodology with multi-judge review, Bayesian parameter optimization, and cumulative principle extraction |
-| [Discovered Principles](principles.md) | Catalog of 30 principles discovered across 30 iterations and 1000+ experiments, with source iteration and experimental evidence for each |
+| Discovered Principles *(coming soon)* | Catalog of principles discovered across strategy evolution experiments, with source iteration and experimental evidence for each. Pending simulator stabilization. |
 
 ## When to Use Strategy Evolution
 

--- a/docs/methodology/strategy-evolution.md
+++ b/docs/methodology/strategy-evolution.md
@@ -11,13 +11,13 @@ In systems with multiple interacting policy layers — routing, scheduling, memo
 Strategy Evolution discovers optimal configurations through disciplined experimentation: human-guided mechanism design combined with machine-guided parameter optimization, organized into iterative cycles with rigorous measurement and cumulative principle extraction.
 
 ```mermaid
-flowchart LR
-    P1[Phase 1\nProblem\nFraming] --> P2[Phase 2\nMulti-Judge\nResearch]
-    P2 --> P3[Phase 3\nImplement &\nMeasure]
-    P3 --> P4[Phase 4\nBayesian\nOptimization]
-    P4 --> P5[Phase 5\nAblation &\nPrinciples]
+flowchart TD
+    P1["Phase 1<br/>Problem Framing"] --> P2["Phase 2<br/>Multi-Judge Research"]
+    P2 --> P3["Phase 3<br/>Implement & Measure"]
+    P3 --> P4["Phase 4<br/>Bayesian Optimization"]
+    P4 --> P5["Phase 5<br/>Ablation & Principles"]
     P5 -->|Iterate| P2
-    P5 -->|Converged| Done[Definitive\nStrategy +\nPrinciples]
+    P5 -->|Converged| Done["Definitive Strategy<br/>+ Principles"]
 ```
 
 ---
@@ -105,15 +105,15 @@ Once a mechanism proves directionally correct, optimize its parameters:
 
 ```mermaid
 flowchart TD
-    A[Define parameter ranges\nin strategy YAML] --> B[Bayesian optimizer\nselects next point]
-    B --> C[Run simulator\n3 seeds × N params]
-    C --> D{Constraint\nviolation?}
-    D -->|Yes| E[Add penalty\nto objective]
-    D -->|No| F[Record metric]
-    E --> G[Update GP\nsurrogate model]
+    A["Define parameter ranges<br/>in strategy YAML"] --> B["Bayesian optimizer<br/>selects next point"]
+    B --> C["Run simulator<br/>3 seeds x N params"]
+    C --> D{"Constraint<br/>violation?"}
+    D -->|Yes| E["Add penalty<br/>to objective"]
+    D -->|No| F["Record metric"]
+    E --> G["Update GP<br/>surrogate model"]
     F --> G
     G -->|Budget remaining| B
-    G -->|Budget exhausted| H[Extract best\nparameters]
+    G -->|Budget exhausted| H["Extract best<br/>parameters"]
 ```
 
 This separates **mechanism design** (human creativity) from **parameter tuning** (machine search). Every strategy gets the benefit of optimization, so comparisons are fair.
@@ -161,7 +161,7 @@ Stress-test winning strategies:
 
 Every few iterations, distill findings into **numbered principles** — concise, falsifiable statements grounded in experimental evidence. These constrain future iterations and prevent re-learning the same lessons.
 
-See [Discovered Principles](principles.md) for the full catalog.
+A principles catalog documenting findings from the BLIS strategy evolution experiments is planned for a future release.
 
 ---
 
@@ -176,13 +176,21 @@ The following Claude Code skills were used throughout the process:
 | `/convergence-review` (design gate) | 2 | Multi-perspective design review (5 judges) |
 | `/convergence-review` (h-findings gate) | 5 | Multi-perspective findings review (10 judges) |
 | `/review-plan` | 2, 3 | Send plans to external LLMs for technical review |
-| `/hypothesis-test` | 3 | Structured experiment: scaffold → run → analyze → findings |
+| `/hypothesis-experiment` | 3 | Structured experiment: scaffold → run → analyze → findings |
 | `/test-driven-development` | 3 | TDD for new policy implementations |
 | `/executing-plans` | 3 | Step-by-step implementation with review gates |
 | `/verification-before-completion` | 3, 5 | Confirm results before claiming success |
 | `/code-review` | 5 | Post-implementation quality audit |
 | `/commit-push-pr` | 5 | Clean git integration after validation |
 | `/dispatching-parallel-agents` | 3 | Parallel hypothesis execution across tracks |
+
+!!! info "Where to Get These Skills"
+    These skills are [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins. To install them:
+
+    - **`/brainstorming`, `/test-driven-development`, `/executing-plans`, `/verification-before-completion`, `/dispatching-parallel-agents`, `/code-review`, `/commit-push-pr`**: Install the [superpowers](https://github.com/anthropics/claude-code-plugins) plugin — `claude plugins add superpowers`
+    - **`/convergence-review`, `/hypothesis-experiment`**: Project-local skills defined in this repository's `.claude/skills/` directory. Available automatically when Claude Code is run from the repo root.
+    - **`/research-ideas`, `/review-plan`**: Install the [research-ideas](https://github.com/anthropics/claude-code-plugins) plugin — `claude plugins add research-ideas`
+    - **`/pr-review-toolkit:review-pr`**: Install the [pr-review-toolkit](https://github.com/anthropics/claude-code-plugins) plugin — `claude plugins add pr-review-toolkit`
 
 **Non-skill tools:**
 
@@ -245,4 +253,4 @@ gantt
 ```
 
 !!! note "Experimental Configurations"
-    The winning strategies described above were discovered during Strategy Evolution experiments using custom configurations. Some components (SLO-gated admission, SLO-tiered priority as compound strategies) are not yet available as standard BLIS policy templates. The current BLIS default (`pa:3,qd:2,kv:2`) is maintained for llm-d parity. See RP-7 in the [principles catalog](principles.md) for the regime-dependent recommendation.
+    The winning strategies described above were discovered during Strategy Evolution experiments using custom configurations. Some components (SLO-gated admission, SLO-tiered priority as compound strategies) are not yet available as standard BLIS policy templates. The current BLIS default (`pa:3,qd:2,kv:2`) is maintained for llm-d parity. The regime-dependent recommendation (normal KV: `pa:3,qd:2,kv:2`; under pressure: `pa:3,qd:2`; high load with admission: `pa:4,qd:3`) will be documented in the forthcoming principles catalog.

--- a/docs/plans/fix-methodology-456-plan.md
+++ b/docs/plans/fix-methodology-456-plan.md
@@ -1,0 +1,83 @@
+# Fix Strategy Evolution Methodology Page Issues — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix four post-merge issues in the Strategy Evolution methodology documentation: premature principles page, broken Mermaid line breaks, compressed overview diagram, and missing skills provenance.
+
+**The problem today:** PR #455 shipped with `\n` literals in Mermaid nodes (should be `<br/>`), a horizontal overview diagram that compresses fonts, the principles catalog exposed before the simulator stabilizes, and no information about where to get the referenced Claude Code skills.
+
+**What this PR adds:**
+1. Removes principles from nav (keeps file as draft)
+2. Fixes Mermaid `\n` → `<br/>` across all diagrams
+3. Switches overview to top-down layout
+4. Adds skills provenance section
+
+**Architecture:** Edits to 3 existing files: `mkdocs.yml`, `docs/methodology/strategy-evolution.md`, `docs/methodology/index.md`. No new files.
+
+**Source:** GitHub issue #456
+
+**Closes:** Fixes #456
+
+---
+
+## Behavioral Contracts
+
+BC-1: Mermaid Line Breaks Render Correctly
+- GIVEN a Mermaid flowchart node with multi-line text
+- WHEN the site is built and viewed
+- THEN the text MUST display on separate lines (not as literal `\n`)
+- MECHANISM: Use `<br/>` instead of `\n` in Mermaid node labels
+
+BC-2: Overview Diagram Readable
+- GIVEN the Phase 1-5 overview flowchart
+- WHEN rendered in a browser
+- THEN all node text MUST be readable without zooming
+- MECHANISM: `flowchart TD` (top-down) instead of `flowchart LR` (left-right)
+
+BC-3: Principles Not in Nav
+- GIVEN the MkDocs site navigation
+- WHEN a user browses the Methodology section
+- THEN they MUST see only "Strategy Evolution" (not "Discovered Principles")
+
+BC-4: Skills Provenance
+- GIVEN a reader who wants to use the skills referenced in the inventory
+- WHEN they read the Skills and Tools Inventory section
+- THEN they MUST find information about where to install/obtain the skills
+
+---
+
+## Task Breakdown
+
+### Task 1: Fix Mermaid line breaks and overview layout
+
+**Files:** `docs/methodology/strategy-evolution.md`
+
+**Step 1:** Replace all `\n` with `<br/>` in Mermaid node labels. Change overview from `flowchart LR` to `flowchart TD`.
+
+**Step 2:** Verify `mkdocs build --strict` passes.
+
+**Step 3:** Commit.
+
+### Task 2: Remove principles from nav, update index
+
+**Files:** `mkdocs.yml`, `docs/methodology/index.md`
+
+**Step 1:** Remove `Discovered Principles: methodology/principles.md` from mkdocs.yml nav.
+
+**Step 2:** Update index.md to mark principles as "coming soon."
+
+**Step 3:** Update the cross-reference in strategy-evolution.md Phase 5 section (currently links to principles.md).
+
+**Step 4:** Commit.
+
+### Task 3: Add skills provenance section
+
+**Files:** `docs/methodology/strategy-evolution.md`
+
+**Step 1:** Add a provenance note below the skills inventory table explaining where the skills come from.
+
+**Step 2:** Commit.
+
+### Task 4: Final verification
+
+Verify build, nav structure, cross-refs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,6 @@ nav:
   - Methodology:
       - methodology/index.md
       - Strategy Evolution: methodology/strategy-evolution.md
-      - Discovered Principles: methodology/principles.md
   - Contributing:
       - contributing/index.md
       - Extension Recipes: contributing/extension-recipes.md


### PR DESCRIPTION
## Summary

Fixes four post-merge issues from #455:

- **Mermaid line breaks**: `\n` → `<br/>` in all node labels (was rendering as literal text)
- **Overview diagram**: `flowchart LR` → `flowchart TD` (horizontal was compressing fonts)
- **Principles catalog**: Removed from nav (premature — simulator still stabilizing). File kept as draft, index shows "coming soon"
- **Skills provenance**: Added "Where to Get These Skills" admonition with plugin names and install commands
- **Skill name fix**: `/hypothesis-test` → `/hypothesis-experiment` (matching actual skill name)

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `go build ./...` passes
- [x] `go test ./...` all pass
- [x] `golangci-lint run ./...` 0 issues
- [x] No broken cross-references (principles.md links replaced with inline text)

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)