### PR TITLE
fix(docs): correct cross-model coefficient count from 4 to 7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,7 @@ Three modes, selected by `latency.NewLatencyModel()` factory (in `sim/latency/`)
    - **`--latency-model roofline`**: Auto-resolves both configs — checks `model_configs/` first, fetches from HuggingFace on miss (creating `model_configs/` and writing into it), and uses bundled `hardware_config.json`. Simplifies usage to: `./blis run --model <name> --latency-model roofline --hardware <GPU> --tp <N>`
 
 3. **Cross-model mode**: Physics-informed estimation via `sim/latency/crossmodel.go`
-   - Uses 4 globally-fitted coefficients (per-layer overhead, KV bandwidth, MoE dispatch, TP sync) from `crossmodel_defaults` in `defaults.yaml`
+   - Uses 7 globally-fitted coefficients — 4 beta (per-layer overhead, KV bandwidth, MoE dispatch, TP sync) + 3 alpha (pre-scheduling, per-token preprocessing, output processing) — from `crossmodel_defaults` in `defaults.yaml`
    - Derives architecture features from HuggingFace `config.json` (layer count, KV heads, head dimension, MoE expert count, TP degree)
    - MoE-aware: correctly models sparse activation patterns (unlike roofline which overestimates ~4x for MoE)
    - **`--latency-model crossmodel`**: Same auto-fetch chain as roofline. Usage: `./blis run --model <name> --latency-model crossmodel --hardware <GPU> --tp <N>`

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -93,7 +93,7 @@ Or let BLIS fetch it automatically with `--latency-model roofline`.
 
 ### Tensor Parallelism and Roofline
 
-The `--tp` flag divides FLOPs and memory bandwidth across TP ranks:
+The `--tp` flag divides FLOPs and memory traffic across TP ranks:
 
 - Higher TP reduces per-GPU step time (more parallelism)
 - Higher TP reduces KV blocks per GPU (memory split across ranks)
@@ -102,7 +102,7 @@ When choosing between TP and replication (more instances): TP reduces per-reques
 
 ## Cross-Model Mode (Physics-Informed)
 
-Cross-model mode estimates step time using 4 globally-fitted physics coefficients that work across model architectures. Unlike blackbox (per-model coefficients) or roofline (no MoE awareness), cross-model uses architecture features from `config.json` to scale a single coefficient set.
+Cross-model mode estimates step time using 7 globally-fitted coefficients (4 beta for step time + 3 alpha for CPU overhead) that work across model architectures. Unlike blackbox (per-model coefficients) or roofline (no MoE awareness), cross-model uses architecture features from `config.json` to scale a single coefficient set.
 
 ```bash
 ./blis run --model meta-llama/llama-3.1-8b-instruct \
@@ -122,7 +122,7 @@ Where `kvDimScaled = numLayers × numKVHeads × headDim / TP × 1e-6`, `isMoE = 
 
 **Pre-trained coefficients** from real vLLM measurements across 4 architectures (7B-70B dense + 8x7B MoE) are stored in `crossmodel_defaults` in `defaults.yaml`. No per-model calibration needed.
 
-**MoE support:** Cross-model correctly handles Mixture-of-Experts models. The `β₂` term captures the per-token routing and expert dispatch overhead. The `num_local_experts` and `num_experts_per_tok` fields are parsed directly from the HuggingFace config.json.
+**MoE support:** Cross-model correctly handles Mixture-of-Experts models. The `β₂` term captures the per-token routing and expert dispatch overhead, activated when `num_local_experts > 0` in the model's HuggingFace config.json. The MoE indicator is binary (MoE vs dense); the specific active expert count (`num_experts_per_tok`) is parsed for future refinement but not yet used in the formula.
 
 !!! warning "Dense model prefill limitation"
     For dense models (non-MoE), step time does not scale with prefill token count — prefill compute cost is absorbed into the per-layer overhead (β₀). A batch prefilling 1 token costs the same as 2048 tokens. This is a known approximation from the training methodology (prefill KV writes overlap with compute on H100). For prefill-heavy dense-model workloads, **blackbox mode with trained coefficients** provides more accurate estimates because its `β₁` term explicitly models per-prefill-token cost.
@@ -132,10 +132,10 @@ Where `kvDimScaled = numLayers × numKVHeads × headDim / TP × 1e-6`, `isMoE = 
 | Aspect | Blackbox (default) | Roofline | Cross-Model |
 |--------|-------------------|----------|-------------|
 | **When to use** | Model has per-model coefficients in `defaults.yaml` | Quick estimation, no training data | New model from config.json, MoE models |
-| **Data required** | `defaults.yaml` entry for model/GPU/TP | HuggingFace `config.json` + `hardware_config.json` | HuggingFace `config.json` (global coefficients bundled) |
-| **Accuracy** | Highest (trained on real per-model measurements) | Good mean (analytical FLOPs/bandwidth) | Good mean across architectures (4 global coefficients) |
-| **MoE support** | Yes (if trained coefficients exist) | No (~4x overestimate) | Yes (explicit MoE term) |
-| **Alpha overhead** | Full alpha modeling | Alpha from coefficients; step is analytical | Full alpha modeling (same as blackbox) |
+| **Data required** | `defaults.yaml` entry for model/GPU/TP | HuggingFace `config.json` + `--hardware` + `--tp` | HuggingFace `config.json` + `--hardware` + `--tp` (global coefficients bundled) |
+| **Accuracy** | Highest (trained on real per-model measurements) | Good mean (analytical FLOPs/bandwidth) | Good mean across architectures (7 global coefficients: 4 beta + 3 alpha) |
+| **MoE support** | Yes (if trained coefficients exist) | No (assumes dense transformers) | Yes (explicit MoE dispatch term via `num_local_experts`) |
+| **Alpha overhead** | Alpha from coefficients (queueing + output processing) | Alpha from coefficients (same as blackbox) | Alpha from coefficients (same as blackbox) |
 
 !!! tip "Choosing the right mode"
     **Blackbox** for models with trained coefficients (highest accuracy). **Cross-model** for new models or MoE models without per-model coefficients (global physics coefficients + config.json features). **Roofline** for quick analytical estimates of dense models when no coefficients are available at all.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -94,7 +94,7 @@ The latency model mode is selected based on available configuration:
 
 1. **Blackbox mode** (default): If coefficients are provided via CLI flags or loaded from `defaults.yaml`
 2. **Explicit roofline mode**: If `--latency-model roofline` is set with `--hardware` and `--tp`. Model config is auto-resolved: `model_configs/` (local) → HuggingFace fetch → error. Alpha coefficients and `total_kv_blocks` are loaded from `defaults.yaml` when available. Beta coefficients are replaced by analytical roofline computation. Note: `--latency-model blackbox` explicitly prevents implicit roofline detection (respecting user intent).
-3. **Explicit cross-model mode**: If `--latency-model crossmodel` is set with `--hardware` and `--tp`. Uses 4 globally-fitted physics coefficients from `crossmodel_defaults` in `defaults.yaml`. Architecture features derived from HuggingFace config.json. MoE-aware.
+3. **Explicit cross-model mode**: If `--latency-model crossmodel` is set with `--hardware` and `--tp`. Uses 7 globally-fitted coefficients (4 beta for step time + 3 alpha for CPU overhead) from `crossmodel_defaults` in `defaults.yaml`. Architecture features derived from HuggingFace config.json. MoE-aware.
 4. **Implicit roofline mode**: If all coefficients are zero and all four of `--model-config-folder`, `--hardware-config`, `--hardware`, and `--tp` are provided
 5. **Error**: If no coefficients can be resolved and roofline inputs are incomplete
 


### PR DESCRIPTION
## Summary

The cross-model backend documentation incorrectly states "4 globally-fitted coefficients" when it actually uses **7**: 4 beta (step time) + 3 alpha (CPU overhead). All 7 are model-independent and stored in `crossmodel_defaults` in `defaults.yaml`.

## Changes

- `docs/guide/latency-models.md`: "4 globally-fitted physics coefficients" → "7 globally-fitted coefficients (4 beta for step time + 3 alpha for CPU overhead)"
- `docs/reference/configuration.md`: same fix in mode selection description
- `CLAUDE.md`: expanded to list all 7 coefficient roles

## Context

The "4 coefficients" framing propagated from the issue design (#472) which focused on the StepTime formula (4 beta terms) and treated the alpha coefficients as a footnote. But from the user's perspective, all 7 come from `crossmodel_defaults` — they're all part of the cross-model prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)