### PR TITLE
fix(hardening): 8-issue bugfix audit — SaveResults error, StepTime floor, coefficient validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,6 @@ var (
 	hwConfigPath              string    // Path to constants specific to hardware type (GPU)
 	workloadType              string    // Workload type (chatbot, summarization, contentgen, multidoc, distribution, traces)
 	tracesWorkloadFilePath    string    // Workload filepath for traces workload type.
-	maxModelLength            int       // Max request length (input + output tokens) to be handled
 	longPrefillTokenThreshold int64     // Max length of prefill beyond which chunked prefill is triggered
 	rate                      float64   // Requests arrival per second
 	numRequests               int       // Number of requests
@@ -210,7 +209,7 @@ var runCmd = &cobra.Command{
 					}
 				}
 				defAlpha, _, kvBlocks := GetCoefficients(model, tensorParallelism, gpu, vllmVersion, defaultsFilePath)
-				if AllZeros(alphaCoeffs) && !AllZeros(defAlpha) {
+				if !cmd.Flags().Changed("alpha-coeffs") && !AllZeros(defAlpha) {
 					alphaCoeffs = defAlpha
 					logrus.Infof("--latency-model: loaded alpha coefficients from defaults.yaml for queueing time estimation")
 				}
@@ -222,7 +221,7 @@ var runCmd = &cobra.Command{
 						"using default %d. Consider setting --total-kv-blocks explicitly for accurate KV cache simulation",
 						model, gpu, tensorParallelism, totalKVBlocks)
 				}
-				if AllZeros(alphaCoeffs) {
+				if AllZeros(alphaCoeffs) && !cmd.Flags().Changed("alpha-coeffs") {
 					logrus.Warnf("--latency-model: no trained alpha coefficients found for model=%s, GPU=%s, TP=%d; "+
 						"queueing time and output token processing time will use zero alpha (may underestimate TTFT/ITL)",
 						model, gpu, tensorParallelism)
@@ -301,7 +300,7 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		if AllZeros(alphaCoeffs) && AllZeros(betaCoeffs) && len(modelConfigFolder) == 0 && len(hwConfigPath) == 0 { // default all 0s
+		if !cmd.Flags().Changed("alpha-coeffs") && !cmd.Flags().Changed("beta-coeffs") && len(modelConfigFolder) == 0 && len(hwConfigPath) == 0 { // default all 0s
 			// GPU, TP, vLLM version configuration
 			hardware, tp, version := GetDefaultSpecs(model) // pick default config for tp, GPU, vllmVersion
 
@@ -582,6 +581,12 @@ var runCmd = &cobra.Command{
 		if snapshotRefreshInterval < 0 {
 			logrus.Fatalf("--snapshot-refresh-interval must be >= 0, got %d", snapshotRefreshInterval)
 		}
+		if admissionLatency < 0 {
+			logrus.Fatalf("--admission-latency must be >= 0, got %d", admissionLatency)
+		}
+		if routingLatency < 0 {
+			logrus.Fatalf("--routing-latency must be >= 0, got %d", routingLatency)
+		}
 
 		// Log active policy configuration so users can verify which policies are in effect
 		logrus.Infof("Policy config: admission=%s, routing=%s, priority=%s, scheduler=%s",
@@ -659,11 +664,15 @@ var runCmd = &cobra.Command{
 		if numInstances > 1 {
 			// Print per-instance metrics to stdout (multi-instance only)
 			for _, inst := range cs.Instances() {
-				inst.Metrics().SaveResults(string(inst.ID()), config.Horizon, totalKVBlocks, "")
+				if err := inst.Metrics().SaveResults(string(inst.ID()), config.Horizon, totalKVBlocks, ""); err != nil {
+					logrus.Fatalf("SaveResults for instance %s: %v", inst.ID(), err)
+				}
 			}
 		}
 		// Save aggregated metrics (prints to stdout + saves to file if resultsPath set)
-		cs.AggregatedMetrics().SaveResults("cluster", config.Horizon, totalKVBlocks, resultsPath)
+		if err := cs.AggregatedMetrics().SaveResults("cluster", config.Horizon, totalKVBlocks, resultsPath); err != nil {
+			logrus.Fatalf("SaveResults: %v", err)
+		}
 
 		// Collect RawMetrics and compute fitness (PR9)
 		rawMetrics := cluster.CollectRawMetrics(
@@ -798,7 +807,6 @@ func init() {
 	runCmd.Flags().Float64SliceVar(&betaCoeffs, "beta-coeffs", []float64{0.0, 0.0, 0.0}, "Comma-separated list of beta coefficients")
 	runCmd.Flags().Float64SliceVar(&alphaCoeffs, "alpha-coeffs", []float64{0.0, 0.0, 0.0}, "Comma-separated alpha coefficients (alpha0,alpha1) for processing delays")
 	runCmd.Flags().Int64Var(&blockSizeTokens, "block-size-in-tokens", 16, "Number of tokens contained in a KV cache block")
-	runCmd.Flags().IntVar(&maxModelLength, "max-model-len", 2048, "Max request length (input + output tokens)")
 	runCmd.Flags().Int64Var(&longPrefillTokenThreshold, "long-prefill-token-threshold", 0, "Max length of prefill beyond which chunked prefill is triggered")
 
 	// BLIS model configs

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -41,7 +41,9 @@ func TestSaveResults_MetricsPrintedToStdout(t *testing.T) {
 	os.Stdout = w
 
 	// WHEN SaveResults is called
-	m.SaveResults("test", 1_000_000, 1000, "")
+	if err := m.SaveResults("test", 1_000_000, 1000, ""); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// Restore stdout and read captured output
 	_ = w.Close()

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -39,7 +39,7 @@ QueueingTime           = alpha0 + alpha1 * input_length
 OutputTokenProcessingTime = alpha2
 ```
 
-Pre-trained coefficient sets exist in `defaults.yaml` for common model/GPU/TP combinations (e.g., `meta-llama/llama-3.1-8b-instruct` on H100 with TP=2).
+All alpha and beta coefficients must be non-negative. Negative values are rejected at construction time (INV-5: causality). Pre-trained coefficient sets exist in `defaults.yaml` for common model/GPU/TP combinations (e.g., `meta-llama/llama-3.1-8b-instruct` on H100 with TP=2).
 
 !!! note "Alpha overhead is non-blocking"
     Alpha coefficients model CPU post-processing (tokenization, output serialization) that runs concurrently with GPU execution. Alpha time inflates TTFT and ITL metrics but does **not** block step scheduling -- the next batch step is scheduled at `now + stepTime` regardless of alpha overhead. This matches real vLLM's asynchronous post-processing pipeline.

--- a/docs/plans/bugfix-audit-plan.md
+++ b/docs/plans/bugfix-audit-plan.md
@@ -1,0 +1,432 @@
+# Bugfix Audit: 8-Issue Hardening PR
+
+- **Goal:** Fix 8 bugs discovered during a systematic codebase audit — silent data loss, CLI flag issues, livelock risk, and dead code.
+- **The problem today:** `SaveResults` silently drops output on marshal failure (R1). Blackbox coefficient loading silently overrides explicit user zeros (R18). `StepTime()` can return 0 causing infinite loops (R19). Several CLI flags are unvalidated or dead. Negative alpha/beta coefficients can violate causality.
+- **What this PR adds:**
+  1. `SaveResults` returns error instead of silently dropping output
+  2. Blackbox coefficient loading uses `Flags().Changed()` instead of `AllZeros()` (R18)
+  3. `StepTime()` floor of `max(1, ...)` for Blackbox and Roofline models (R19)
+  4. CLI validation for `--admission-latency`, `--routing-latency` (R3), and non-negative coefficients (INV-5)
+  5. Remove dead `--max-model-len` flag
+  6. Guard throughput divide-by-zero in `SaveResults` (R11)
+  7. Warning when `InjectArrival` receives requests beyond horizon (INV-1)
+- **Why this matters:** Each bug was found by a real rule (R1, R3, R11, R18, R19, INV-1, INV-5). Fixing them hardens the simulator against pathological inputs and silent failures.
+- **Architecture:** Changes span `cmd/root.go` (CLI validation + flag cleanup), `sim/metrics.go` (error returns + division guard), `sim/latency/latency.go` (StepTime floor + coefficient validation), `sim/simulator.go` (horizon warning). No new types, interfaces, or module boundaries.
+- **Source:** Issues #490, #491, #493, #495, #496, #497, #498, #499 (see #494 deferral below)
+- **Closes:** Fixes #490, fixes #491, fixes #493, fixes #495, fixes #496, fixes #497, fixes #498, fixes #499
+- **Behavioral Contracts:** See Part 1, Section B.
+
+**Note on #494 (Request.Streaming):** Deferred. Removing the field touches workload generation, trace export, and test assertions across 5+ files — not a small fix. Filed for a separate PR.
+
+---
+
+## Phase 0: Component Context
+
+1. **Building blocks modified:** CLI validation layer (`cmd/root.go`), metrics output (`sim/metrics.go`), latency model factory + implementations (`sim/latency/latency.go`), simulator injection (`sim/simulator.go`)
+2. **Adjacent blocks:** `sim/cluster/cluster.go` calls `SaveResults` via instances; `sim/simulator.go:343` calls `StepTime()` in the hot loop (via `executeBatchStep`); `cmd/root.go` is the only entry point for CLI flags
+3. **Invariants touched:** INV-1 (conservation — horizon guard), INV-5 (causality — coefficient validation), R19 (livelock — StepTime floor)
+4. **Construction site audit:** No struct fields added. `SaveResults` signature changes from `void` to `error` — all 13 call sites:
+   - `cmd/root.go:662,666` (2 production calls — handle error)
+   - `cmd/root_test.go:44` (1 test call)
+   - `sim/metrics_test.go:44,92,140,184,229,264,298,323` (8 test calls)
+   - `sim/simulator_test.go:719,728` (2 test calls — determinism test)
+   - Note: `sim/cluster/instance.go:Finalize()` does NOT call SaveResults
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR fixes 8 bugs (deferring #494) found during a systematic rule-by-rule audit. The fixes are independent, each touching 1-5 lines. The highest-severity fixes are: (1) `SaveResults` returning error instead of silently dropping output, (2) blackbox coefficient loading using `Flags().Changed()`, and (3) `StepTime()` livelock prevention. All fixes are validation guards, dead code removal, or simple control flow changes. No behavioral changes to simulation output for valid inputs (INV-6 preserved).
+
+### B) Behavioral Contracts
+
+**Positive contracts:**
+
+```
+BC-1: SaveResults propagates errors
+- GIVEN a metrics output that fails JSON marshalling (e.g., contains +Inf)
+- WHEN SaveResults is called
+- THEN it returns a non-nil error describing the failure
+- MECHANISM: Change signature to return error; cmd/ callers handle via logrus.Fatalf (per R1 + CLI convention)
+```
+
+```
+BC-2: Throughput divide-by-zero guarded
+- GIVEN SimEndedTime == 0 (zero runtime)
+- WHEN SaveResults computes ResponsesPerSec and TokensPerSec
+- THEN both are 0.0 (not +Inf or NaN)
+- MECHANISM: Guard with `if vllmRuntime > 0` before division
+```
+
+```
+BC-3: Coefficient loading respects explicit CLI flags across all backends
+- GIVEN a user provides --beta-coeffs 0,0,0 or --alpha-coeffs 0,0,0 explicitly
+- WHEN the blackbox OR roofline loading path runs
+- THEN the zero coefficients are preserved (not overwritten by defaults.yaml)
+- MECHANISM: Use cmd.Flags().Changed() instead of AllZeros() at line 304 (blackbox) AND line 213 (roofline alpha)
+```
+
+```
+BC-4: StepTime returns at least 1 tick for non-empty batches
+- GIVEN a batch with one or more requests
+- WHEN any LatencyModel.StepTime() is called
+- THEN the return value is >= 1
+- MECHANISM: Add max(1, ...) to Blackbox (line 40) and Roofline (line 89), applied unconditionally (no empty-batch early return — see DES Expert analysis below). CrossModelLatencyModel already has max(1, ...) at crossmodel.go:59.
+- NOTE: Round 2 convergence review (PP-6 DES Expert) found that adding an empty-batch `return 0` early exit would create a livelock: when KV allocation fails for all queued requests, FormBatch returns an empty batch, StepTime returns 0, and scheduleNextStep schedules at `now + 0` with WaitQ still non-empty — infinite loop. The `max(1, ...)` floor must apply unconditionally to prevent this. All three backends share the same scheduleNextStep code path — CrossModel's existing `return 0` for empty batches (crossmodel.go:41) has the same latent livelock risk (pre-existing bug, filed as known debt — see deviation log). For Blackbox/Roofline, the unconditional `max(1, ...)` is the livelock protection.
+```
+
+```
+BC-5: Negative latency coefficients rejected at construction (defense-in-depth)
+- GIVEN alpha or beta coefficients containing negative values
+- WHEN NewLatencyModel is called
+- THEN it returns an error mentioning the negative coefficient
+- MECHANISM: Add c < 0 check in validateCoeffs
+- NOTE: This overlaps with BC-4 (StepTime floor) — belt-and-suspenders. BC-4 prevents livelock at runtime; BC-5 prevents causality violations (negative QueueingTime) at construction. Both are needed: BC-4 alone doesn't prevent negative enqueue times from negative alpha coefficients. If future calibration requires small negative coefficients, a corresponding floor on QueueingTime (similar to BC-4's StepTime floor) MUST be added before relaxing this check — otherwise negative QueueingTime would violate INV-5 causality.
+```
+
+**Negative contracts:**
+
+```
+BC-6: Negative admission/routing latency rejected
+- GIVEN --admission-latency -100 or --routing-latency -100
+- WHEN the CLI validation runs
+- THEN the process exits with a descriptive error message
+- MECHANISM: Add validation checks in cmd/root.go validation block
+```
+
+```
+BC-7: Dead --max-model-len flag removed
+- GIVEN the CLI flag registry
+- WHEN a user runs blis run --help
+- THEN --max-model-len does not appear in the output
+- MECHANISM: Remove flag declaration and registration
+```
+
+**Warning contracts:**
+
+```
+BC-8: Horizon overflow warning (single-instance mode)
+- GIVEN a request with ArrivalTime > sim.Horizon
+- WHEN InjectArrival is called
+- THEN a warning is logged to stderr
+- MECHANISM: Add logrus.Warnf check in InjectArrival
+- NOTE: InjectArrivalAt (cluster mode) is NOT covered — cluster mode is already guarded by the event loop horizon break at cluster.go:149/155. The INV-1 conservation impact for beyond-horizon requests in single-instance mode remains as known debt (request registered but never processed).
+```
+
+### C) Component Interaction
+
+```
+cmd/root.go (CLI entry)
+  │
+  ├─ BC-3: Flags().Changed() guard on alpha/beta loading
+  ├─ BC-6: Validate admission-latency >= 0, routing-latency >= 0
+  ├─ BC-7: Remove maxModelLength declaration + registration
+  ├─ BC-1: Handle SaveResults error return via logrus.Fatalf
+  │
+  └─► sim/metrics.go (metrics output)
+       ├─ BC-1: SaveResults returns error
+       ├─ BC-2: Guard vllmRuntime > 0 before division
+       │
+  └─► sim/latency/latency.go (latency factory)
+       ├─ BC-4: max(1,...) floor in StepTime()
+       ├─ BC-5: Negative coefficient validation
+       │
+  └─► sim/simulator.go (core engine)
+       └─ BC-8: Horizon warning in InjectArrival
+```
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| #494: Remove Request.Streaming | Deferred to separate PR | DEFERRAL — touches 5+ files across workload/trace/tests; not a small fix |
+| #490: "add error return or Fatalf" | Returns error (not Fatalf) | CORRECTION — R6 says sim/ must not terminate; error return is the right pattern for library code |
+| BC-8: Ideal would be error return from InjectArrival | Uses logrus.Warnf instead | SIMPLIFICATION — Adding error return to InjectArrival is a larger API change (touches cluster injection path); warning is pragmatic. Precedent: sim/ already uses logrus.Debugf/Infof/Warnf. Known debt for future cleanup. |
+| BC-3 (#491): Fix only blackbox path | Also fixes roofline alpha path at line 213, 225 | ADDITION — Pre-pass review (I1) found the same R18 violation in the roofline alpha-loading path |
+| BC-3: "preserve explicit zero coefficients" | Zero-coefficient safety guard at line 351 still fires Fatalf for all-zero blackbox coefficients | CLARIFICATION — BC-3 preserves explicit zeros for the defaults-loading path (line 304). The safety guard at line 351 intentionally rejects all-zero blackbox coefficients (meaningless results). These are separate concerns: line 304 = "don't override user input with defaults", line 351 = "don't run with unusable coefficients". |
+| BC-4: CrossModel already safe | CrossModel has the same latent livelock risk (return 0 for empty batches via same scheduleNextStep path) | CORRECTION — Round 3 convergence (7/9 perspectives) identified that CrossModel's `return 0` at crossmodel.go:41 bypasses its own `max(1,...)` at line 59. This is a pre-existing bug, not introduced by this plan. File as separate issue. |
+
+### E) Review Guide
+
+**Tricky part:** BC-1 (SaveResults signature change) ripples to 13 call sites (2 production + 11 test). All test callers that previously discarded the void return must now handle the error (assign to `_` or check). BC-3 now also covers the roofline alpha-loading path (line 213), not just the blackbox path (line 304).
+
+**Safe to skim:** BC-6, BC-7 (mechanical CLI validation/removal). BC-8 (one-line warning).
+
+**Known debt:** BC-8 uses `logrus.Warnf` in `sim/` (pragmatic but not ideal per R6 spirit). A cleaner approach would be an error return from `InjectArrival`, deferred to a future PR.
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+| File | Change |
+|------|--------|
+| `sim/metrics.go` | BC-1: Change SaveResults to return error. BC-2: Guard vllmRuntime > 0 |
+| `cmd/root.go` | BC-1: Handle SaveResults error. BC-3: Flags().Changed() guard. BC-6: Validate latencies. BC-7: Remove dead flag |
+| `sim/latency/latency.go` | BC-4: max(1,...) floor. BC-5: Negative coefficient validation |
+| `sim/simulator.go` | BC-8: Horizon warning in InjectArrival |
+| `sim/metrics_test.go` | BC-1: Update 8 test call sites to handle error return |
+| `sim/simulator_test.go` | BC-1: Update 2 test call sites to handle error return |
+| `cmd/root_test.go` | BC-1: Update 1 test call site to handle error return |
+
+No dead code. No new types. No new files.
+
+### G) Task Breakdown
+
+#### Task 1: BC-2 + BC-1 — SaveResults error return + throughput guard
+
+**Test (BC-2):**
+```go
+// sim/metrics_test.go — add test
+func TestSaveResults_ZeroRuntime_NoInfinity(t *testing.T) {
+    m := NewMetrics()
+    m.CompletedRequests = 1
+    m.SimEndedTime = 0 // zero runtime
+    m.RequestTTFTs["r1"] = 100.0
+    m.RequestE2Es["r1"] = 200.0
+    m.RequestITLs["r1"] = 50.0
+    m.AllITLs = []int64{50}
+    m.RequestSchedulingDelays["r1"] = 100
+    m.Requests["r1"] = NewRequestMetrics(&Request{ID: "r1", InputTokens: make([]int, 10), OutputTokens: make([]int, 5)}, 0)
+
+    err := m.SaveResults("test", 1000000, 100, "")
+    if err != nil {
+        t.Fatalf("SaveResults returned error for zero runtime: %v", err)
+    }
+    // Should NOT produce +Inf — if it did, JSON marshal would fail
+}
+```
+
+**Run:** `go test ./sim/... -run TestSaveResults_ZeroRuntime_NoInfinity` → FAIL (SaveResults has no error return yet)
+
+**Implement:**
+1. In `sim/metrics.go`, change `func (m *Metrics) SaveResults(...)` to return `error`
+2. Add `if vllmRuntime > 0 { ... }` guard around ResponsesPerSec/TokensPerSec division
+3. Replace `logrus.Errorf` + `return` with `return fmt.Errorf(...)` for marshal/write errors
+4. Add `return nil` at end
+
+**Update all 13 callers:**
+- `cmd/root.go:662,666`: Add `if err := ... SaveResults(...); err != nil { logrus.Fatalf("SaveResults: %v", err) }` (Fatalf per CLI convention + R1)
+- `sim/metrics_test.go` (8 sites at lines 44,92,140,184,229,264,298,323): Tests that don't check error → add `if err := m.SaveResults(...); err != nil { t.Fatalf(...) }`
+- `sim/simulator_test.go:719,728`: Same pattern for determinism test
+- `cmd/root_test.go:44`: Same pattern
+
+**Run:** `go test ./sim/... -run TestSaveResults_ZeroRuntime_NoInfinity` → PASS
+**Lint:** `golangci-lint run ./sim/... ./cmd/...`
+**Commit:** `fix(metrics): SaveResults returns error + guards divide-by-zero (R1, R11) (#490, #496)`
+
+#### Task 2: BC-3 — Coefficient Flags().Changed() guard (blackbox + roofline)
+
+**Test:** CLI-level fix. Existing test suite must still pass (coefficients loaded correctly for normal usage).
+
+**Implement:**
+1. In `cmd/root.go:304` (blackbox path), replace:
+```go
+if AllZeros(alphaCoeffs) && AllZeros(betaCoeffs) && len(modelConfigFolder) == 0 && len(hwConfigPath) == 0 {
+```
+with:
+```go
+if !cmd.Flags().Changed("alpha-coeffs") && !cmd.Flags().Changed("beta-coeffs") && len(modelConfigFolder) == 0 && len(hwConfigPath) == 0 {
+```
+
+2. In `cmd/root.go:213` (roofline alpha path), replace:
+```go
+if AllZeros(alphaCoeffs) && !AllZeros(defAlpha) {
+```
+with:
+```go
+if !cmd.Flags().Changed("alpha-coeffs") && !AllZeros(defAlpha) {
+```
+
+3. In `cmd/root.go:225` (roofline alpha warning), replace:
+```go
+if AllZeros(alphaCoeffs) {
+```
+with:
+```go
+if AllZeros(alphaCoeffs) && !cmd.Flags().Changed("alpha-coeffs") {
+```
+This prevents the spurious "no trained alpha coefficients found" warning when the user explicitly passed `--alpha-coeffs 0,0,0`.
+
+**Run:** `go test ./... -count=1` → all pass
+**Lint:** `golangci-lint run ./cmd/...`
+**Commit:** `fix(cli): use Flags().Changed() for coefficient loading across all backends (R18) (#491)`
+
+#### Task 3: BC-4 — StepTime floor for Blackbox and Roofline
+
+**Test:**
+```go
+// sim/latency/latency_test.go — add test
+func TestBlackboxLatencyModel_StepTime_FloorAtOne(t *testing.T) {
+    // Zero beta coefficients → StepTime should return 1 (not 0)
+    coeffs := sim.NewLatencyCoeffs([]float64{0, 0, 0}, []float64{0, 0, 0})
+    hw := sim.ModelHardwareConfig{} // blackbox backend (empty Backend field)
+    model, err := NewLatencyModel(coeffs, hw)
+    if err != nil {
+        t.Fatalf("NewLatencyModel: %v", err)
+    }
+    batch := []*sim.Request{{InputTokens: make([]int, 16), OutputTokens: make([]int, 4), NumNewTokens: 1}}
+    stepTime := model.StepTime(batch)
+    if stepTime < 1 {
+        t.Errorf("StepTime = %d, want >= 1", stepTime)
+    }
+}
+```
+
+**Run:** `go test ./sim/latency/... -run TestBlackboxLatencyModel_StepTime_FloorAtOne` → FAIL (returns 0)
+
+**Implement:**
+- `sim/latency/latency.go:40`: Change `return int64(totalStepTime)` to `return max(1, int64(totalStepTime))`
+- `sim/latency/latency.go:89`: Change `return rooflineStepTime(...)` to `return max(1, rooflineStepTime(...))`
+- NOTE: Do NOT add empty-batch early return — see BC-4 NOTE about livelock risk from PP-6 DES Expert review.
+
+**Run:** → PASS
+**Lint:** `golangci-lint run ./sim/latency/...`
+**Commit:** `fix(latency): floor StepTime at 1 tick for Blackbox and Roofline (R19) (#497)`
+
+#### Task 4: BC-5 — Negative coefficient validation
+
+**Test:**
+```go
+// sim/latency/latency_test.go — add test
+func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
+    coeffs := sim.NewLatencyCoeffs([]float64{-1, 0, 0}, []float64{100, 1, 1})
+    hw := sim.ModelHardwareConfig{}
+    _, err := NewLatencyModel(coeffs, hw)
+    if err == nil {
+        t.Fatal("expected error for negative alpha coefficient")
+    }
+    if !strings.Contains(err.Error(), "negative") {
+        t.Errorf("error should mention 'negative', got: %v", err)
+    }
+}
+```
+
+**Run:** → FAIL (no negativity check)
+
+**Implement:**
+In `sim/latency/latency.go`, add to `validateCoeffs`:
+```go
+if c < 0 {
+    return fmt.Errorf("latency model: %s[%d] must be non-negative, got %f", name, i, c)
+}
+```
+
+**Run:** → PASS
+**Lint:** `golangci-lint run ./sim/latency/...`
+**Commit:** `fix(latency): reject negative alpha/beta coefficients (INV-5) (#499)`
+
+#### Task 5: BC-6 — Validate admission/routing latency
+
+**Test:** CLI-level. Existing tests must pass.
+
+**Implement:**
+In `cmd/root.go`, after `snapshotRefreshInterval` validation (line ~583), add:
+```go
+if admissionLatency < 0 {
+    logrus.Fatalf("--admission-latency must be >= 0, got %d", admissionLatency)
+}
+if routingLatency < 0 {
+    logrus.Fatalf("--routing-latency must be >= 0, got %d", routingLatency)
+}
+```
+
+**Run:** `go test ./cmd/... -count=1` → pass
+**Lint:** `golangci-lint run ./cmd/...`
+**Commit:** `fix(cli): validate admission-latency and routing-latency >= 0 (R3) (#495)`
+
+#### Task 6: BC-7 — Remove dead --max-model-len flag
+
+**Implement:**
+- `cmd/root.go:41`: Remove `maxModelLength int` declaration
+- `cmd/root.go:801`: Remove `runCmd.Flags().IntVar(&maxModelLength, ...)` registration
+
+**Run:** `go build ./...` → pass (no references to maxModelLength remain)
+**Lint:** `golangci-lint run ./cmd/...`
+**Commit:** `fix(cli): remove dead --max-model-len flag (#493)`
+
+#### Task 7: BC-8 — Horizon warning in InjectArrival
+
+**Test:**
+```go
+// sim/simulator_test.go — add test
+func TestInjectArrival_BeyondHorizon_Warns(t *testing.T) {
+    // This test verifies the warning is logged; it doesn't test log output directly
+    // but ensures no panic and the request is still registered (backward compatible)
+    cfg := SimConfig{
+        Horizon:       1000,
+        Seed:          42,
+        KVCacheConfig: NewKVCacheConfig(100, 16, 0, 0, 0, 0),
+        BatchConfig:   NewBatchConfig(10, 2048, 0),
+        LatencyCoeffs: NewLatencyCoeffs([]float64{100, 1, 1}, []float64{50, 0.1, 50}),
+    }
+    sim := mustNewSimulator(t, cfg)
+    req := &Request{
+        ID: "beyond_horizon", InputTokens: make([]int, 16),
+        OutputTokens: make([]int, 4), ArrivalTime: 2000, State: StateQueued,
+    }
+    sim.InjectArrival(req) // should not panic
+    // Request is registered (backward compatible)
+    if _, ok := sim.Metrics.Requests["beyond_horizon"]; !ok {
+        t.Error("request should still be registered in Metrics.Requests")
+    }
+}
+```
+
+**Run:** → PASS (already works, just adding the warning)
+
+**Implement:**
+In `sim/simulator.go`, `InjectArrival` method, add before the `Schedule` call:
+```go
+if req.ArrivalTime > sim.Horizon {
+    logrus.Warnf("InjectArrival: request %s has ArrivalTime %d > Horizon %d; ArrivalEvent will not fire (INV-1 conservation may be affected)", req.ID, req.ArrivalTime, sim.Horizon)
+}
+```
+
+**Lint:** `golangci-lint run ./sim/...`
+**Commit:** `fix(sim): warn when InjectArrival receives request beyond horizon (INV-1) (#498)`
+
+### H) Test Strategy
+
+| Contract | Test | Type |
+|----------|------|------|
+| BC-1 | TestSaveResults_ZeroRuntime_NoInfinity | Behavioral — verifies error return on edge case |
+| BC-2 | Same test (zero runtime → no +Inf → no error) | Behavioral — verifies division guard |
+| BC-3 | Existing test suite (regression) | Regression — coefficients still load for normal usage |
+| BC-4 | TestBlackboxLatencyModel_StepTime_FloorAtOne | Behavioral — verifies floor property |
+| BC-5 | TestNewLatencyModel_NegativeCoefficients_ReturnsError | Behavioral — verifies error on bad input |
+| BC-6 | Build-level (CLI validation) | Regression — existing tests pass |
+| BC-7 | Build-level (flag removed) | Regression — no compilation references |
+| BC-8 | TestInjectArrival_BeyondHorizon_Warns | Behavioral — verifies no panic + backward compat |
+
+### I) Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| BC-1 signature change breaks callers | Grep for all SaveResults call sites; update each |
+| BC-3 changes coefficient loading behavior | Existing golden test verifies output unchanged for normal inputs |
+| BC-4 changes step timing for pathological inputs | Only affects zero-coefficient case; normal coefficients always > 1 |
+| BC-5 rejects previously-accepted inputs | Only negative coefficients rejected; all real-world coefficients are positive |
+
+---
+
+## Part 3: Appendix
+
+### J) File-Level Details
+
+**`sim/metrics.go`:** Change `SaveResults` signature to `func (m *Metrics) SaveResults(...) error`. Add `if vllmRuntime > 0` guard at line ~120. Replace 3 silent returns with `return fmt.Errorf(...)`. Add `return nil` at end.
+
+**`cmd/root.go`:** (1) Replace `AllZeros()` with `Flags().Changed()` at line ~304 (blackbox) AND line ~213 (roofline alpha). (2) Add 2 latency validation checks after line ~583. (3) Remove 2 lines for maxModelLength. (4) Handle SaveResults error at lines 662, 666.
+
+**`sim/latency/latency.go`:** (1) Add `max(1, ...)` to Blackbox StepTime return (line 40). (2) Add `max(1, ...)` to Roofline StepTime return (line 89). (3) Add `c < 0` check in validateCoeffs (line ~113).
+
+**`sim/simulator.go`:** Add 3-line horizon warning in InjectArrival (line ~174).
+
+**`sim/metrics_test.go`:** Update 8 SaveResults call sites to handle error return.
+
+**`sim/simulator_test.go`:** Update 2 SaveResults call sites (determinism test) to handle error return.
+
+**`cmd/root_test.go`:** Update 1 SaveResults call site to handle error return.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,10 +60,10 @@ Trained coefficients for the blackbox latency model. Maps to `LatencyCoeffs`.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--alpha-coeffs` | float64 slice | [0, 0, 0] | Alpha coefficients [alpha0, alpha1, alpha2]. Models non-GPU overhead. |
-| `--beta-coeffs` | float64 slice | [0, 0, 0] | Beta coefficients [beta0, beta1, beta2]. Models GPU step time. |
+| `--alpha-coeffs` | float64 slice | [0, 0, 0] | Alpha coefficients [alpha0, alpha1, alpha2]. Models non-GPU overhead. Must be non-negative. |
+| `--beta-coeffs` | float64 slice | [0, 0, 0] | Beta coefficients [beta0, beta1, beta2]. Models GPU step time. Must be non-negative. |
 
-When both alpha and beta coefficients are all zeros, BLIS automatically loads pre-trained coefficients from `defaults.yaml` based on the model, GPU, and TP configuration.
+When `--alpha-coeffs` and `--beta-coeffs` are not explicitly provided on the CLI, BLIS automatically loads pre-trained coefficients from `defaults.yaml` based on the model, GPU, and TP configuration. Explicitly passing `--alpha-coeffs 0,0,0` preserves zero coefficients (they are not overridden by defaults).
 
 ### Model and Hardware Selection
 
@@ -113,7 +113,7 @@ Controls which requests enter the routing pipeline. See [Cluster Architecture: A
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--admission-policy` | string | "always-admit" | Policy name: `always-admit`, `token-bucket`, `reject-all`. |
-| `--admission-latency` | int64 | 0 | Admission decision latency in microseconds. |
+| `--admission-latency` | int64 | 0 | Admission decision latency in microseconds. Must be >= 0. |
 | `--token-bucket-capacity` | float64 | 10000 | Token bucket maximum capacity. Required > 0 when using `token-bucket`. |
 | `--token-bucket-refill-rate` | float64 | 1000 | Token bucket refill rate in tokens/second. Required > 0 when using `token-bucket`. |
 
@@ -124,7 +124,7 @@ Controls how admitted requests are assigned to instances. See [Cluster Architect
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--routing-policy` | string | "round-robin" | Policy name: `round-robin`, `least-loaded`, `weighted`, `always-busiest`. |
-| `--routing-latency` | int64 | 0 | Routing decision latency in microseconds. |
+| `--routing-latency` | int64 | 0 | Routing decision latency in microseconds. Must be >= 0. |
 | `--routing-scorers` | string | "" | Scorer configuration for `weighted` policy. Format: `name:weight,name:weight,...` |
 | `--snapshot-refresh-interval` | int64 | 0 | Prometheus snapshot refresh interval for all instance metrics (QueueDepth, BatchSize, KVUtilization) in microseconds. 0 = immediate. |
 
@@ -336,13 +336,13 @@ When BLIS starts:
    - Auto-resolve hardware config from bundled `hardware_config.json`
    - Load alpha coefficients and `total_kv_blocks` from `defaults.yaml` (beta coefficients are replaced by roofline computation)
    - `--model-config-folder` and `--hardware-config` override auto-resolution when explicitly set
-2. If `--alpha-coeffs` and `--beta-coeffs` are both all-zero and no roofline config is provided:
+2. If `--alpha-coeffs` and `--beta-coeffs` are not explicitly provided on the CLI and no roofline config is provided:
    - Look up the model in `defaults.yaml` using `--model`, `--hardware`, `--tp`, `--vllm-version`
    - Load alpha/beta coefficients and `total_kv_blocks` from the matching entry
    - Override `--total-kv-blocks` only if the user did not explicitly set it
-3. If coefficients are still all-zero but `--model-config-folder` and `--hardware-config` are provided:
+3. If coefficients are still all-zero (no defaults found) but `--model-config-folder` and `--hardware-config` are provided:
    - Enable roofline mode (implicit activation)
-4. If coefficients were explicitly provided via CLI:
+4. If coefficients were explicitly provided via CLI (including explicit zeros):
    - Use them directly, no `defaults.yaml` lookup
 
 ## Coefficient Calibration

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -37,7 +37,7 @@ func (m *BlackboxLatencyModel) StepTime(batch []*sim.Request) int64 {
 	totalStepTime += m.betaCoeffs[0]
 	totalStepTime += m.betaCoeffs[1] * float64(totalCacheMissTokens)
 	totalStepTime += m.betaCoeffs[2] * float64(totalDecodeTokens)
-	return int64(totalStepTime)
+	return max(1, int64(totalStepTime))
 }
 
 func (m *BlackboxLatencyModel) QueueingTime(req *sim.Request) int64 {
@@ -86,7 +86,7 @@ func (m *RooflineLatencyModel) StepTime(batch []*sim.Request) int64 {
 			})
 		}
 	}
-	return rooflineStepTime(m.modelConfig, m.hwConfig, stepConfig, m.tp)
+	return max(1, rooflineStepTime(m.modelConfig, m.hwConfig, stepConfig, m.tp))
 }
 
 func (m *RooflineLatencyModel) QueueingTime(req *sim.Request) int64 {
@@ -108,7 +108,7 @@ func (m *RooflineLatencyModel) PreemptionProcessingTime() int64 {
 	return 0
 }
 
-// validateCoeffs checks for NaN or Inf in a coefficient slice.
+// validateCoeffs checks for NaN, Inf, or negative values in a coefficient slice.
 func validateCoeffs(name string, coeffs []float64) error {
 	for i, c := range coeffs {
 		if math.IsNaN(c) {
@@ -116,6 +116,9 @@ func validateCoeffs(name string, coeffs []float64) error {
 		}
 		if math.IsInf(c, 0) {
 			return fmt.Errorf("latency model: %s[%d] is Inf", name, i)
+		}
+		if c < 0 {
+			return fmt.Errorf("latency model: %s[%d] must be non-negative, got %f", name, i, c)
 		}
 	}
 	return nil

--- a/sim/latency/latency_test.go
+++ b/sim/latency/latency_test.go
@@ -2,6 +2,7 @@ package latency
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -392,6 +393,54 @@ func TestNewLatencyModel_UnknownBackend_ReturnsError(t *testing.T) {
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+// TestNewLatencyModel_NegativeCoefficients_ReturnsError verifies BC-5:
+// GIVEN alpha or beta coefficients containing negative values
+// WHEN NewLatencyModel is called
+// THEN it returns an error mentioning "negative"
+func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name  string
+		beta  []float64
+		alpha []float64
+	}{
+		{"negative_alpha_0", []float64{100, 1, 1}, []float64{-1, 0, 0}},
+		{"negative_alpha_2", []float64{100, 1, 1}, []float64{0, 0, -5}},
+		{"negative_beta_0", []float64{-100, 1, 1}, []float64{100, 1, 100}},
+		{"negative_beta_1", []float64{100, -1, 1}, []float64{100, 1, 100}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			coeffs := sim.NewLatencyCoeffs(tc.beta, tc.alpha)
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+			_, err := NewLatencyModel(coeffs, hw)
+			if err == nil {
+				t.Fatal("expected error for negative coefficient")
+			}
+			if !strings.Contains(err.Error(), "negative") {
+				t.Errorf("error should mention 'negative', got: %v", err)
+			}
+		})
+	}
+}
+
+// TestBlackboxLatencyModel_StepTime_FloorAtOne verifies BC-4:
+// GIVEN zero beta coefficients (pathological input)
+// WHEN StepTime is called with a non-empty batch
+// THEN the return value is >= 1 (livelock protection via R19)
+func TestBlackboxLatencyModel_StepTime_FloorAtOne(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs([]float64{0, 0, 0}, []float64{0, 0, 0})
+	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+	model, err := NewLatencyModel(coeffs, hw)
+	if err != nil {
+		t.Fatalf("NewLatencyModel: %v", err)
+	}
+	batch := []*sim.Request{{InputTokens: make([]int, 16), OutputTokens: make([]int, 4), NumNewTokens: 1}}
+	stepTime := model.StepTime(batch)
+	if stepTime < 1 {
+		t.Errorf("StepTime = %d, want >= 1", stepTime)
+	}
 }
 
 // TestBlackboxRoofline_ZeroOutputTokens_ConsistentClassification verifies BC-5:

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -61,7 +61,7 @@ func NewMetrics() *Metrics {
 	}
 }
 
-func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int64, outputFilePath string) {
+func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int64, outputFilePath string) error {
 	vllmRuntime := float64(m.SimEndedTime) / float64(1e6)
 
 	// Create an instance of our output struct to populate
@@ -117,15 +117,16 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 		sort.Float64s(sortedSchedulingDelays)
 		output.SchedulingDelayP99Ms = CalculatePercentile(sortedSchedulingDelays, 99)
 
-		output.ResponsesPerSec = float64(m.CompletedRequests) / vllmRuntime
-		output.TokensPerSec = float64(m.TotalOutputTokens) / vllmRuntime
+		if vllmRuntime > 0 {
+			output.ResponsesPerSec = float64(m.CompletedRequests) / vllmRuntime
+			output.TokensPerSec = float64(m.TotalOutputTokens) / vllmRuntime
+		}
 
 		// Print to stdout (results are primary output, not log messages)
 		fmt.Println("=== Simulation Metrics ===")
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			logrus.Errorf("Error marshalling metrics: %v", err)
-			return
+			return fmt.Errorf("error marshalling metrics: %w", err)
 		}
 		fmt.Println(string(data))
 	}
@@ -151,17 +152,16 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			logrus.Errorf("Error marshalling metrics to JSON: %v", err)
-			return
+			return fmt.Errorf("error marshalling metrics to JSON: %w", err)
 		}
 
 		writeErr := os.WriteFile(outputFilePath, data, 0644)
 		if writeErr != nil {
-			logrus.Errorf("Error writing JSON file: %v", writeErr)
-			return
+			return fmt.Errorf("error writing JSON file: %w", writeErr)
 		}
 		logrus.Infof("Metrics written to: %s", outputFilePath)
 	}
+	return nil
 }
 
 // sortedRequestIDs returns request IDs from the Requests map in sorted order.

--- a/sim/metrics_test.go
+++ b/sim/metrics_test.go
@@ -41,7 +41,9 @@ func TestSaveResults_InstanceID_InJSON(t *testing.T) {
 	outputPath := filepath.Join(tmpDir, "test_output.json")
 
 	// WHEN SaveResults is called with instanceID "test-instance"
-	m.SaveResults("test-instance", 1000000, 1000, outputPath)
+	if err := m.SaveResults("test-instance", 1000000, 1000, outputPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the JSON file contains "instance_id": "test-instance"
 	data, err := os.ReadFile(outputPath)
@@ -89,7 +91,9 @@ func TestSaveResults_InstanceID_Empty(t *testing.T) {
 	outputPath := filepath.Join(tmpDir, "test_output.json")
 
 	// WHEN SaveResults is called with empty instanceID
-	m.SaveResults("", 1000000, 1000, outputPath)
+	if err := m.SaveResults("", 1000000, 1000, outputPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the JSON file contains "instance_id": ""
 	data, err := os.ReadFile(outputPath)
@@ -137,7 +141,9 @@ func TestSaveResults_InstanceID_Default(t *testing.T) {
 	outputPath := filepath.Join(tmpDir, "test_output.json")
 
 	// WHEN SaveResults is called with instanceID "default"
-	m.SaveResults("default", 1000000, 1000, outputPath)
+	if err := m.SaveResults("default", 1000000, 1000, outputPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the JSON file contains "instance_id": "default"
 	data, err := os.ReadFile(outputPath)
@@ -181,7 +187,9 @@ func TestSaveResults_IncludesIncompleteRequests(t *testing.T) {
 	// WHEN SaveResults writes to a temp file
 	tmpDir := t.TempDir()
 	outPath := filepath.Join(tmpDir, "results.json")
-	m.SaveResults("test-instance", 10_000_000, 100, outPath)
+	if err := m.SaveResults("test-instance", 10_000_000, 100, outPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the output file contains all 3 requests
 	data, err := os.ReadFile(outPath)
@@ -226,7 +234,9 @@ func TestSaveResults_NoWallClockFields(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "results.json")
 
 	// WHEN SaveResults writes output
-	m.SaveResults("test", 1_000_000, 1000, outPath)
+	if err := m.SaveResults("test", 1_000_000, 1000, outPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the JSON must not contain wall-clock fields
 	data, err := os.ReadFile(outPath)
@@ -261,7 +271,9 @@ func TestSaveResults_ConservationFields(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "results.json")
 
 	// WHEN SaveResults writes output
-	m.SaveResults("test", 5_000_000, 1000, outPath)
+	if err := m.SaveResults("test", 5_000_000, 1000, outPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN JSON must contain conservation fields
 	data, err := os.ReadFile(outPath)
@@ -295,7 +307,9 @@ func TestSaveResults_PerRequestITL_InMilliseconds(t *testing.T) {
 	m.AllITLs = []int64{5000}
 
 	outputPath := filepath.Join(t.TempDir(), "results.json")
-	m.SaveResults("test", 1e15, 100, outputPath)
+	if err := m.SaveResults("test", 1e15, 100, outputPath); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	data, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
@@ -311,6 +325,29 @@ func TestSaveResults_PerRequestITL_InMilliseconds(t *testing.T) {
 	assert.InDelta(t, 50.0, output.Requests[0].E2E, 0.001, "E2E should be in ms")
 }
 
+// TestSaveResults_ZeroRuntime_NoInfinity verifies BC-2:
+// GIVEN SimEndedTime == 0 (zero runtime)
+// WHEN SaveResults computes throughput metrics
+// THEN ResponsesPerSec and TokensPerSec are 0.0 (not +Inf or NaN)
+// AND SaveResults returns nil (no error)
+func TestSaveResults_ZeroRuntime_NoInfinity(t *testing.T) {
+	m := NewMetrics()
+	m.CompletedRequests = 1
+	m.SimEndedTime = 0 // zero runtime
+	m.RequestTTFTs["r1"] = 100.0
+	m.RequestE2Es["r1"] = 200.0
+	m.RequestITLs["r1"] = 50.0
+	m.AllITLs = []int64{50}
+	m.RequestSchedulingDelays["r1"] = 100
+	m.Requests["r1"] = NewRequestMetrics(&Request{ID: "r1", InputTokens: make([]int, 10), OutputTokens: make([]int, 5)}, 0)
+
+	err := m.SaveResults("test", 1000000, 100, "")
+	if err != nil {
+		t.Fatalf("SaveResults returned error for zero runtime: %v", err)
+	}
+	// Should NOT produce +Inf — if it did, JSON marshal would fail
+}
+
 // BC-4: DroppedUnservable appears in JSON output
 func TestSaveResults_DroppedUnservable_InJSON(t *testing.T) {
 	// GIVEN metrics with dropped requests
@@ -320,7 +357,9 @@ func TestSaveResults_DroppedUnservable_InJSON(t *testing.T) {
 
 	// WHEN saving results to a temp file
 	tmpFile := filepath.Join(t.TempDir(), "test_output.json")
-	m.SaveResults("test", 10_000_000, 100, tmpFile)
+	if err := m.SaveResults("test", 10_000_000, 100, tmpFile); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
 
 	// THEN the JSON file must contain dropped_unservable
 	data, err := os.ReadFile(tmpFile)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -172,6 +172,11 @@ func (sim *Simulator) Finalize() {
 
 // InjectArrival schedules an ArrivalEvent for req and registers it in Metrics.Requests.
 func (sim *Simulator) InjectArrival(req *Request) {
+	if req.ArrivalTime > sim.Horizon {
+		logrus.Warnf("InjectArrival: request %s has ArrivalTime %d > Horizon %d; "+
+			"ArrivalEvent will not fire (INV-1 conservation may be affected)",
+			req.ID, req.ArrivalTime, sim.Horizon)
+	}
 	sim.Schedule(&ArrivalEvent{time: req.ArrivalTime, Request: req})
 	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, float64(req.ArrivalTime)/1e6)
 }

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -695,6 +695,31 @@ func TestSimulator_ClockMonotonicity_NeverDecreases(t *testing.T) {
 	t.Logf("clock monotonicity held across %d events (final clock: %d)", eventCount, sim.Clock)
 }
 
+// TestInjectArrival_BeyondHorizon_Warns verifies BC-8 (bugfix-audit):
+// GIVEN a request with ArrivalTime > sim.Horizon
+// WHEN InjectArrival is called
+// THEN the request is still registered (backward compatible) and no panic occurs.
+func TestInjectArrival_BeyondHorizon_Warns(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(10, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{50, 0.1, 50}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+	}
+	sim := mustNewSimulator(t, cfg)
+	req := &Request{
+		ID: "beyond_horizon", InputTokens: make([]int, 16),
+		OutputTokens: make([]int, 4), ArrivalTime: 2000, State: StateQueued,
+	}
+	sim.InjectArrival(req) // should not panic
+	// Request is registered (backward compatible)
+	if _, ok := sim.Metrics.Requests["beyond_horizon"]; !ok {
+		t.Error("request should still be registered in Metrics.Requests")
+	}
+}
+
 // TestSimulator_Determinism_ByteIdenticalJSON verifies BC-8:
 // GIVEN two simulator runs with identical config and seed
 // WHEN both save results via SaveResults to temp files
@@ -716,7 +741,9 @@ func TestSimulator_Determinism_ByteIdenticalJSON(t *testing.T) {
 	injectRequests(sim1, requests1)
 	sim1.Run()
 	f1 := t.TempDir() + "/run1.json"
-	sim1.Metrics.SaveResults("determinism-test", cfg.Horizon, cfg.TotalKVBlocks, f1)
+	if err := sim1.Metrics.SaveResults("determinism-test", cfg.Horizon, cfg.TotalKVBlocks, f1); err != nil {
+		t.Fatalf("SaveResults run1: %v", err)
+	}
 
 	// Run 2
 	sim2 := mustNewSimulator(t, cfg)
@@ -725,7 +752,9 @@ func TestSimulator_Determinism_ByteIdenticalJSON(t *testing.T) {
 	injectRequests(sim2, requests2)
 	sim2.Run()
 	f2 := t.TempDir() + "/run2.json"
-	sim2.Metrics.SaveResults("determinism-test", cfg.Horizon, cfg.TotalKVBlocks, f2)
+	if err := sim2.Metrics.SaveResults("determinism-test", cfg.Horizon, cfg.TotalKVBlocks, f2); err != nil {
+		t.Fatalf("SaveResults run2: %v", err)
+	}
 
 	data1, err1 := os.ReadFile(f1)
 	if err1 != nil {


### PR DESCRIPTION
## Summary

Fixes 8 bugs discovered during a systematic rule-by-rule codebase audit. Each fix traces to a specific antipattern rule (R1, R3, R11, R18, R19) or invariant (INV-1, INV-5).

- **BC-1**: `SaveResults` returns `error` instead of silently dropping output on marshal/write failure (R1)
- **BC-2**: Guard `vllmRuntime > 0` before throughput division — prevents `+Inf` in JSON output (R11)
- **BC-3**: Use `Flags().Changed()` for coefficient loading across blackbox and roofline paths — explicit `--alpha-coeffs 0,0,0` no longer silently overridden by defaults.yaml (R18)
- **BC-4**: Floor `StepTime` at `max(1, ...)` for Blackbox and Roofline — prevents livelock from zero step time (R19)
- **BC-5**: Reject negative alpha/beta coefficients at construction — prevents causality violations from negative QueueingTime (INV-5)
- **BC-6**: Validate `--admission-latency` and `--routing-latency >= 0` (R3)
- **BC-7**: Remove dead `--max-model-len` flag (declared but never used)
- **BC-8**: Warn when `InjectArrival` receives request with ArrivalTime > Horizon (INV-1)
- **Docs**: Update configuration reference and latency-models guide for new validation constraints

Deferred: #494 (Request.Streaming removal) — touches 5+ files, separate PR.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` — all 11 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests: `TestSaveResults_ZeroRuntime_NoInfinity`, `TestBlackboxLatencyModel_StepTime_FloorAtOne`, `TestNewLatencyModel_NegativeCoefficients_ReturnsError`, `TestInjectArrival_BeyondHorizon_Warns`
- [x] All 13 `SaveResults` call sites updated for error return
- [x] Code review: converged in Round 2 (holistic pre-pass + 10 perspectives × 2 rounds)
- [x] Self-audit: 10 dimensions, zero issues

Fixes #490, fixes #491, fixes #493, fixes #495, fixes #496, fixes #497, fixes #498, fixes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)