### PR TITLE
perf(kv): O(K) hierarchical block hashing in GetCachedBlocks and AllocateKVBlocks

### DIFF
--- a/sim/kv/cache.go
+++ b/sim/kv/cache.go
@@ -125,16 +125,24 @@ func (kvc *KVCacheState) removeFromFreeList(block *KVBlock) {
 // It returns block IDs for the longest contiguous cached prefix.
 // This is a pure query — it does not modify any state.
 // CacheHits are counted by AllocateKVBlocks when cached blocks are committed.
+//
+// Uses hierarchical block hashing: each block's hash chains the previous
+// block's hash, so each iteration hashes only blockSize tokens plus a
+// fixed-length prev hash (O(K * blockSize) total, down from O(K^2 * blockSize)
+// with flat-prefix hashing). Breaks on first miss.
 func (kvc *KVCacheState) GetCachedBlocks(tokens []int) (blockIDs []int64) {
 	n := util.Len64(tokens) / kvc.BlockSizeTokens
+	prevHash := ""
 	for i := int64(0); i < n; i++ {
-		chunk := tokens[:(i+1)*kvc.BlockSizeTokens]
-		h := hash.HashTokens(chunk)
+		start := i * kvc.BlockSizeTokens
+		end := start + kvc.BlockSizeTokens
+		h := hash.HashBlock(prevHash, tokens[start:end])
 		blockId, ok := kvc.HashToBlock[h]
 		if !ok {
 			break
 		}
 		blockIDs = append(blockIDs, blockId)
+		prevHash = h
 	}
 	return
 }
@@ -218,12 +226,13 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 			newTokenProgressIndex += util.Len64(toksToAppend)
 			logrus.Debugf("Appending to latest blk: req: %s, newTokenProgressIndex = %d, appended=%d tokens", req.ID, newTokenProgressIndex, util.Len64(toksToAppend))
 			if util.Len64(latestBlk.Tokens) == kvc.BlockSizeTokens {
-				// latesBlk is full
-				fullTokens := []int{}
-				for _, blockId := range ids {
-					fullTokens = append(fullTokens, kvc.Blocks[blockId].Tokens...)
+				// latestBlk is full — compute its hierarchical hash.
+				// Chain from the previous block's hash (or "" if first block).
+				prevHash := ""
+				if len(ids) >= 2 {
+					prevHash = kvc.Blocks[ids[len(ids)-2]].Hash
 				}
-				h := hash.HashTokens(fullTokens)
+				h := hash.HashBlock(prevHash, latestBlk.Tokens)
 				latestBlk.Hash = h
 				kvc.HashToBlock[h] = latestBlk.ID
 			}
@@ -236,6 +245,14 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 				break
 			}
 			numNewBlocks = (remainingTokens + kvc.BlockSizeTokens - 1) / kvc.BlockSizeTokens
+
+			// Initialize prevHash for hierarchical block hashing.
+			// Chain from the last existing block for this request (if any).
+			prevHash := ""
+			if existingIDs, has := kvc.RequestMap[reqID]; has && len(existingIDs) > 0 {
+				prevHash = kvc.Blocks[existingIDs[len(existingIDs)-1]].Hash
+			}
+
 			for i := int64(0); i < numNewBlocks; i++ {
 				// Save the original prefix hash before popFreeBlock clears it.
 				// This allows rollback to restore cached prefix hashes.
@@ -264,13 +281,12 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 
 				if util.Len64(blk.Tokens) == kvc.BlockSizeTokens && req.ProgressIndex < util.Len64(req.InputTokens) {
 					// Only compute prefix hash during prefill (not decode).
-					// During decode, startIndex >= len(InputTokens) and absoluteEnd
-					// would be out of range for req.InputTokens.
-					absoluteEnd := startIndex + end
-					fullPrefix := req.InputTokens[:absoluteEnd]
-					h := hash.HashTokens(fullPrefix)
+					// During decode, blocks hold output tokens that should not
+					// participate in prefix caching (input sequences only).
+					h := hash.HashBlock(prevHash, blk.Tokens)
 					blk.Hash = h
 					kvc.HashToBlock[h] = blk.ID
+					prevHash = h
 				}
 				newlyAllocated = append(newlyAllocated, newBlockMutation{block: blk, originalHash: originalHash})
 				// allocated is the block IDs allocated for this request
@@ -388,16 +404,10 @@ func (kvc *KVCacheState) ReleaseKVBlocks(req *sim.Request) {
 	ids := kvc.RequestMap[req.ID]
 	delete(kvc.RequestMap, req.ID)
 	// From https://docs.vllm.ai/en/v0.8.5/design/v1/prefix_caching.html
-	/*
-		When a request is finished, we free all its blocks if no other
-		requests are using them (reference count = 0).
-		In this example, we free request 1 and block 2, 3, 4, 8
-		associated with it. We can see that the freed blocks are added
-		to the tail of the free queue in the reverse order.
-		This is because the last block of a request must hash more tokens
-		and is less likely to be reused by other requests.
-		As a result, it should be evicted first.
-	*/
+	// Freed blocks are added to the tail of the free queue in reverse order.
+	// Later blocks can only be reused if all preceding blocks also match
+	// (hierarchical hashing), so evicting them first preserves the more
+	// broadly reusable earlier blocks.
 	for i := len(ids) - 1; i >= 0; i-- {
 		blockId := ids[i]
 		blk := kvc.Blocks[blockId]

--- a/sim/kv/cache_test.go
+++ b/sim/kv/cache_test.go
@@ -47,6 +47,9 @@ func TestAllocateKVBlocks_PartialBlockFill_AdvancesByActualTokenCount(t *testing
 	if len(blk.Tokens) != 2 {
 		t.Fatalf("expected partial block with 2 tokens, got %d", len(blk.Tokens))
 	}
+	if blk.Hash != "" {
+		t.Errorf("partial block should not have hash before fill, got %s", blk.Hash)
+	}
 
 	// WHEN we allocate 2 more tokens that should fill the partial block
 	req.ProgressIndex = 2
@@ -65,9 +68,119 @@ func TestAllocateKVBlocks_PartialBlockFill_AdvancesByActualTokenCount(t *testing
 	if len(finalIDs) != 1 {
 		t.Errorf("expected 1 block total (partial filled), got %d", len(finalIDs))
 	}
+
+	// THEN the filled block's hash equals HashBlock("", [10,20,30,40]) and is findable
+	// via GetCachedBlocks (partial-fill path with len(ids)==1 → prevHash="")
+	expectedHash := hash.HashBlock("", []int{10, 20, 30, 40})
+	if blk.Hash != expectedHash {
+		t.Errorf("partial-fill block hash mismatch:\n  got  %s\n  want %s", blk.Hash, expectedHash)
+	}
+	kvc.ReleaseKVBlocks(req)
+	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40})
+	if len(cached) != 1 {
+		t.Errorf("expected 1 cached block after partial-fill + release, got %d", len(cached))
+	}
 }
 
-func TestAllocateKVBlocks_ChunkedPrefill_PrefixHashUsesAbsoluteOffset(t *testing.T) {
+func TestAllocateKVBlocks_PartialBlockFill_MultiBlock_ChainsFromPreviousBlock(t *testing.T) {
+	// Exercises the len(ids) >= 2 branch of the partial-fill hash path:
+	// block 0 is full, block 1 is partial, then block 1 gets filled and
+	// its hash must chain from block 0's hash (not "").
+	kvc := NewKVCacheState(10, 4) // blockSize=4
+	req := &sim.Request{
+		ID:          "r1",
+		InputTokens: []int{10, 20, 30, 40, 50, 60, 70, 80},
+	}
+
+	// Allocate 5 tokens: block 0 full [10,20,30,40], block 1 partial [50]
+	ok := kvc.AllocateKVBlocks(req, 0, 5, []int64{})
+	if !ok {
+		t.Fatal("first allocation should succeed")
+	}
+	ids := kvc.RequestMap["r1"]
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 blocks (1 full + 1 partial), got %d", len(ids))
+	}
+
+	// WHEN we allocate tokens 5-8, filling partial block 1
+	req.ProgressIndex = 5
+	ok = kvc.AllocateKVBlocks(req, 5, 8, []int64{})
+	if !ok {
+		t.Fatal("second allocation should succeed")
+	}
+
+	// THEN block 1's hash chains from block 0's hash (len(ids)>=2 branch)
+	block0Hash := hash.HashBlock("", []int{10, 20, 30, 40})
+	expectedBlock1Hash := hash.HashBlock(block0Hash, []int{50, 60, 70, 80})
+	blk1 := kvc.Blocks[kvc.RequestMap["r1"][1]]
+	if blk1.Hash != expectedBlock1Hash {
+		t.Errorf("block 1 hash should chain from block 0:\n  got  %s\n  want %s", blk1.Hash, expectedBlock1Hash)
+	}
+
+	// BC-3 consistency: both hashes match ComputeBlockHashes
+	expected := hash.ComputeBlockHashes(4, []int{10, 20, 30, 40, 50, 60, 70, 80})
+	if len(expected) != 2 {
+		t.Fatalf("expected 2 hashes from ComputeBlockHashes, got %d", len(expected))
+	}
+	blk0 := kvc.Blocks[kvc.RequestMap["r1"][0]]
+	if blk0.Hash != expected[0] {
+		t.Errorf("block 0 hash mismatch with ComputeBlockHashes:\n  got  %s\n  want %s", blk0.Hash, expected[0])
+	}
+	if blk1.Hash != expected[1] {
+		t.Errorf("block 1 hash mismatch with ComputeBlockHashes:\n  got  %s\n  want %s", blk1.Hash, expected[1])
+	}
+
+	// Behavioral: round-trip via GetCachedBlocks
+	kvc.ReleaseKVBlocks(req)
+	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40, 50, 60, 70, 80})
+	if len(cached) != 2 {
+		t.Errorf("expected 2 cached blocks after multi-block partial-fill round-trip, got %d", len(cached))
+	}
+}
+
+func TestAllocateKVBlocks_CachedPrefixToNewBlocks_HashChainingRoundTrip(t *testing.T) {
+	// Verifies that new blocks allocated after a cached prefix correctly chain
+	// their hashes from the last cached block, and the full extended prefix is
+	// findable by GetCachedBlocks after release.
+	kvc := NewKVCacheState(8, 2) // 8 blocks, blockSize=2
+
+	// Step 1: Allocate [1,2,3,4] (2 blocks), then release to populate cache
+	req1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
+	kvc.ReleaseKVBlocks(req1)
+
+	// Step 2: Allocate [1,2,3,4,5,6,7,8] — 2 cached blocks + 2 new blocks
+	req2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	cached := kvc.GetCachedBlocks(req2.InputTokens)
+	if len(cached) != 2 {
+		t.Fatalf("expected 2 cached blocks, got %d", len(cached))
+	}
+	ok := kvc.AllocateKVBlocks(req2, 4, 8, cached)
+	if !ok {
+		t.Fatal("allocation should succeed")
+	}
+
+	// Step 3: Release and verify full 4-block prefix is findable
+	kvc.ReleaseKVBlocks(req2)
+	fullCached := kvc.GetCachedBlocks([]int{1, 2, 3, 4, 5, 6, 7, 8})
+	if len(fullCached) != 4 {
+		t.Errorf("expected 4 cached blocks after cached-prefix + new-block round-trip, got %d", len(fullCached))
+	}
+
+	// Verify hashes match ComputeBlockHashes (BC-3)
+	expected := hash.ComputeBlockHashes(2, []int{1, 2, 3, 4, 5, 6, 7, 8})
+	if len(expected) != 4 {
+		t.Fatalf("expected 4 hashes from ComputeBlockHashes, got %d", len(expected))
+	}
+	for i, blockID := range fullCached {
+		blk := kvc.Blocks[blockID]
+		if blk.Hash != expected[i] {
+			t.Errorf("block %d hash mismatch:\n  got  %s\n  want %s", i, blk.Hash, expected[i])
+		}
+	}
+}
+
+func TestAllocateKVBlocks_ChunkedPrefill_HierarchicalHashChaining(t *testing.T) {
 	// GIVEN a request with 8 tokens and BlockSize=4
 	kvc := NewKVCacheState(10, 4)
 	req := &sim.Request{
@@ -81,8 +194,8 @@ func TestAllocateKVBlocks_ChunkedPrefill_PrefixHashUsesAbsoluteOffset(t *testing
 		t.Fatal("first chunk allocation should succeed")
 	}
 
-	// Verify first block has correct hash
-	expectedHash1 := hash.HashTokens([]int{10, 20, 30, 40})
+	// Verify first block has correct hierarchical hash (chained from "")
+	expectedHash1 := hash.HashBlock("", []int{10, 20, 30, 40})
 	ids1 := kvc.RequestMap["r1"]
 	blk1 := kvc.Blocks[ids1[0]]
 	if blk1.Hash != expectedHash1 {
@@ -96,19 +209,33 @@ func TestAllocateKVBlocks_ChunkedPrefill_PrefixHashUsesAbsoluteOffset(t *testing
 		t.Fatal("second chunk allocation should succeed")
 	}
 
-	// THEN second block has hash of InputTokens[:8] (absolute), not InputTokens[:4] (relative)
+	// THEN second block has hierarchical hash chained from block 1's hash
 	ids2 := kvc.RequestMap["r1"]
 	if len(ids2) < 2 {
 		t.Fatalf("expected at least 2 blocks, got %d", len(ids2))
 	}
 	blk2 := kvc.Blocks[ids2[1]]
-	expectedHash2 := hash.HashTokens([]int{10, 20, 30, 40, 50, 60, 70, 80})
-	wrongHash := hash.HashTokens([]int{10, 20, 30, 40}) // This is what the buggy code produces
-	if blk2.Hash == wrongHash {
-		t.Errorf("second block has WRONG hash (newTokens-relative instead of absolute)")
-	}
+	expectedHash2 := hash.HashBlock(expectedHash1, []int{50, 60, 70, 80})
 	if blk2.Hash != expectedHash2 {
 		t.Errorf("second block hash mismatch:\n  got  %s\n  want %s", blk2.Hash, expectedHash2)
+	}
+	// Verify the two hashes match what ComputeBlockHashes produces (BC-3 consistency)
+	allHashes := hash.ComputeBlockHashes(4, []int{10, 20, 30, 40, 50, 60, 70, 80})
+	if len(allHashes) != 2 {
+		t.Fatalf("expected 2 block hashes from ComputeBlockHashes, got %d", len(allHashes))
+	}
+	if blk1.Hash != allHashes[0] {
+		t.Errorf("block 1 hash does not match ComputeBlockHashes[0]:\n  got  %s\n  want %s", blk1.Hash, allHashes[0])
+	}
+	if blk2.Hash != allHashes[1] {
+		t.Errorf("block 2 hash does not match ComputeBlockHashes[1]:\n  got  %s\n  want %s", blk2.Hash, allHashes[1])
+	}
+
+	// Behavioral assertion: release and verify full prefix is findable via GetCachedBlocks
+	kvc.ReleaseKVBlocks(req)
+	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40, 50, 60, 70, 80})
+	if len(cached) != 2 {
+		t.Errorf("expected 2 cached blocks after chunked-prefill + release round-trip, got %d", len(cached))
 	}
 }
 


### PR DESCRIPTION
## Summary

- **O(K²) → O(K) hashing**: Replace flat-prefix `hash.HashTokens(tokens[:end])` with hierarchical `hash.HashBlock(prevHash, blockTokens)` in `GetCachedBlocks` and `AllocateKVBlocks`
- **BC-3 consistency**: KV cache now uses the same hierarchical scheme as the router-side `PrefixCacheIndex` (both use `hash.HashBlock`)
- **4 new/updated tests**: partial-fill (single + multi-block), cached-prefix-to-new-blocks round-trip, chunked prefill chaining — all with structural + behavioral + BC-3 assertions

## Problem

`GetCachedBlocks` and `AllocateKVBlocks` called `hash.HashTokens(tokens[:end])` for each block, re-hashing the entire prefix from the start. For a request with K blocks, total work = `blockSize × K×(K+1)/2 = O(K² × blockSize)`. For reasoning workloads with accumulated context (20K+ tokens), this made the simulation impractically slow — the "happy path" (long cache hits) triggered worst-case O(K²).

## Fix

Switch all three hash call sites to `hash.HashBlock(prevHash, blockTokens)`, which hashes only `blockSize` tokens per block. Total work: `O(K × blockSize)`.

| Call site | Before | After |
|-----------|--------|-------|
| `GetCachedBlocks` | `HashTokens(tokens[:(i+1)*blockSize])` | `HashBlock(prevHash, tokens[start:end])` |
| `AllocateKVBlocks` partial-fill | `HashTokens(allBlockTokens)` | `HashBlock(prevBlockHash, latestBlk.Tokens)` |
| `AllocateKVBlocks` new-block | `HashTokens(fullPrefix)` | `HashBlock(prevHash, blk.Tokens)` |

## Test plan

- [x] `go test ./...` — all 11 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Golden dataset equivalence + invariant tests pass (INV-1 through INV-8)
- [x] 4 hash-specific tests with behavioral round-trips (`GetCachedBlocks` after release)
- [x] BC-3 consistency verified (`AllocateKVBlocks` hashes == `ComputeBlockHashes` output)
- [x] Convergence review: 3 rounds, 10 perspectives each, converged with 0 CRITICAL + 0 IMPORTANT

Fixes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)