### PR TITLE
refactor(sim): remove PreemptionProcessingTime from LatencyModel interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,10 +218,10 @@ inference-sim/
 │   ├── prefix_cache_index.go  # PrefixCacheIndex: per-instance LRU of hierarchical block hashes
 │   ├── priority.go            # PriorityPolicy interface with ConstantPriority, SLOBasedPriority, and InvertedSLO templates, NewPriorityPolicy factory
 │   ├── scheduler.go           # InstanceScheduler interface with FCFSScheduler, PriorityFCFSScheduler, SJFScheduler, and ReversePriority templates, NewScheduler factory
-│   ├── latency_model.go       # LatencyModel interface (5 methods), NewLatencyModelFunc registration variable, MustNewLatencyModel nil-guarded wrapper
+│   ├── latency_model.go       # LatencyModel interface (4 methods), NewLatencyModelFunc registration variable, MustNewLatencyModel nil-guarded wrapper
 │   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
 │   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
-│   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, Preemption, RequestLeft)
+│   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft)
 │   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted), Request lifecycle and state machine, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.)
 │   ├── kv_store.go            # KVStore interface (11 methods: +SetClock, +ConsumePendingTransferLatency), NewKVStoreFromConfig registration variable, MustNewKVCacheState/MustNewKVStoreFromConfig nil-guarded wrappers
 │   ├── batch.go               # Batch struct

--- a/docs/concepts/core-engine.md
+++ b/docs/concepts/core-engine.md
@@ -27,7 +27,6 @@ The event queue is a min-heap ordered by event timestamp. Events represent state
 | `QueuedEvent` | Request enters wait queue | Adds request to wait queue; if no `StepEvent` exists, schedules one (work-conserving) |
 | `StepEvent` | Batch ready for execution | Runs the 4-phase Step() cycle (see below) |
 | `ScheduledEvent` | Request moves to running batch | Timeline marker for tracing (scheduling delay recorded in `scheduleBatch`) |
-| `PreemptionEvent` | KV cache eviction | Timeline marker for tracing (preemption count recorded in `scheduleBatch`) |
 | `RequestLeftEvent` | Request completes | Timeline marker for tracing (E2E metrics recorded in `processCompletions`) |
 
 **Clock monotonicity (INV-3):** The simulation clock never decreases. Events are processed in strictly non-decreasing timestamp order.
@@ -71,7 +70,7 @@ flowchart TD
 1. Assign priority scores to all queued requests via the priority policy
 2. Reorder the wait queue via the scheduling policy (e.g., FCFS, SJF, priority-based)
 3. Invoke batch formation to select which requests enter the running batch
-4. Schedule `PreemptionEvent` for any evicted requests
+4. Record preemption metrics for any evicted requests
 5. Schedule `ScheduledEvent` for any newly admitted requests
 
 ### Phase 2: Execute Batch Step (`executeBatchStep`)
@@ -164,7 +163,7 @@ When KV cache pressure forces eviction, running requests are preempted:
 1. Request is removed from the running batch (tail-first eviction)
 2. Its KV blocks are freed
 3. It is re-enqueued at the front of the wait queue (not the back)
-4. A `PreemptionEvent` is recorded for tracing
+4. A debug log is emitted and `PreemptionCount` is incremented
 
 Preempted requests reset to the beginning of prefill (ProgressIndex = 0) and their KV blocks are freed. However, the freed blocks' prefix hashes are preserved in the KV cache's free list — when the request is re-scheduled, prefix caching may find these blocks (if not yet evicted by LRU), reducing recomputation. This matches vLLM's "recompute" preemption mode.
 

--- a/docs/contributing/extension-recipes.md
+++ b/docs/contributing/extension-recipes.md
@@ -84,12 +84,11 @@ Examples:
 
 To add a new latency estimation backend (e.g., SGLang RadixAttention, TensorRT-LLM, neural surrogate):
 
-1. **Implement the `LatencyModel` interface** in `sim/latency/latency.go` (or a new file in `sim/latency/` for complex models) — 5 methods:
+1. **Implement the `LatencyModel` interface** in `sim/latency/latency.go` (or a new file in `sim/latency/` for complex models) — 4 methods:
    - `StepTime(batch []*Request) int64` — estimate batch step duration from request states
    - `QueueingTime(req *Request) int64` — estimate arrival-to-queue delay
    - `OutputTokenProcessingTime() int64` — per-token post-processing overhead
    - `SchedulingProcessingTime() int64` — scheduling overhead per request
-   - `PreemptionProcessingTime() int64` — preemption overhead per eviction
 2. **Register in `NewLatencyModel` factory** in `sim/latency/latency.go`: add a `case` branch in the `switch hw.Backend` block. The backend string (e.g., `"crossmodel"`) is set by the `--latency-model` CLI flag and stored in `ModelHardwareConfig.Backend`. The factory signature is `NewLatencyModel(LatencyCoeffs, ModelHardwareConfig)`.
 3. **Add behavioral tests** in `sim/latency/` — monotonicity (more tokens → longer step time), positive output, boundary cases (empty batch)
 4. Extension friction: **2 touch points** (implementation + factory branch)

--- a/docs/contributing/templates/design-guidelines.md
+++ b/docs/contributing/templates/design-guidelines.md
@@ -240,7 +240,7 @@ flowchart TD
 | **Priority** | Compute request priority for scheduler | `PriorityPolicy` (single method) | Implemented, frozen |
 | **KV Cache Manager** | Allocate/release/cache KV blocks | `KVStore` (11 methods) | Implemented |
 | **AutoScaler** | Add/remove instances based on load signals | `AutoScalePolicy` (planned) | Target — PR11 |
-| **Latency Model** | Estimate step execution time | `LatencyModel` (5 methods) | Implemented — `NewLatencyModel` factory |
+| **Latency Model** | Estimate step execution time | `LatencyModel` (4 methods) | Implemented — `NewLatencyModel` factory |
 | **Batch Formation** | Select requests from queue for next step | `BatchFormation` (1 method: `FormBatch`) | Implemented — `NewBatchFormation` factory |
 | **Workload Generator** | Produce request streams from specs/traces | `GenerateRequests()` function | Implemented |
 | **Trace Recorder** | Record decisions for analysis | `SimulationTrace` | Implemented |

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -148,7 +148,7 @@ Where `kvDimScaled = numLayers × numKVHeads × headDim / TP × 1e-6`, `isMoE = 
 
 ## Pluggable Architecture
 
-The `LatencyModel` interface (defined in `sim/latency_model.go`) has five methods:
+The `LatencyModel` interface (defined in `sim/latency_model.go`) has four methods:
 
 | Method | Purpose |
 |--------|---------|
@@ -156,11 +156,10 @@ The `LatencyModel` interface (defined in `sim/latency_model.go`) has five method
 | `QueueingTime(req)` | Arrival-to-queue delay for a request |
 | `OutputTokenProcessingTime()` | Per-token post-processing time |
 | `SchedulingProcessingTime()` | Scheduling overhead per request |
-| `PreemptionProcessingTime()` | Preemption overhead per eviction |
 
 All time estimates are in microseconds (ticks).
 
-New backends register via the `NewLatencyModelFunc` variable in `sim/latency_model.go`. The `sim/latency/register.go` file uses `init()` to wire the factory, breaking the import cycle between `sim/` (interface owner) and `sim/latency/` (implementation). To add a custom backend, implement the five methods and register your factory via `init()` in a sub-package. See [Extension Recipes](../contributing/extension-recipes.md) for a step-by-step guide.
+New backends register via the `NewLatencyModelFunc` variable in `sim/latency_model.go`. The `sim/latency/register.go` file uses `init()` to wire the factory, breaking the import cycle between `sim/` (interface owner) and `sim/latency/` (implementation). To add a custom backend, implement the four methods and register your factory via `init()` in a sub-package. See [Extension Recipes](../contributing/extension-recipes.md) for a step-by-step guide.
 
 ## Further Reading
 

--- a/docs/plans/pr554-remove-preemption-processing-time-plan.md
+++ b/docs/plans/pr554-remove-preemption-processing-time-plan.md
@@ -1,0 +1,444 @@
+# PR #554: Remove PreemptionProcessingTime from LatencyModel Interface
+
+- **Goal:** Remove the dead `PreemptionProcessingTime()` method from the `LatencyModel` interface and the dead `PreemptionEvent` type, simplifying the latency model contract.
+- **The problem today:** `PreemptionProcessingTime()` is a method on the `LatencyModel` interface that all three backends implement as `return 0`. The `PreemptionEvent` type's `Execute()` method does nothing but log a debug message. Together, they add boilerplate to every latency backend and create the false impression that preemption overhead is a tunable parameter, when the actual cost of preemption (re-prefill) is already correctly modeled by the existing `ProgressIndex = 0` reset in batch formation.
+- **What this PR adds:**
+  1. Removes `PreemptionProcessingTime() int64` from the `LatencyModel` interface — one fewer method every backend must implement
+  2. Removes the dead `PreemptionEvent` type — simplifies event.go
+  3. Removes the `PreemptionDelay` field from `PreemptedRequest` — simpler batch result type
+  4. Replaces `PreemptionEvent` scheduling with an inline `logrus.Debugf` call — preserves debug observability
+- **Why this matters:** Reducing interface surface area lowers the cost of adding new latency backends (4 methods instead of 5) and eliminates a misleading extension point.
+- **Architecture:** Pure removal from `sim/latency_model.go` (interface), `sim/event.go` (event type), `sim/batch_formation.go` (field + call), `sim/simulator.go` (event scheduling), `sim/latency/latency.go` and `sim/latency/crossmodel.go` (implementations), plus documentation updates.
+- **Source:** [GitHub issue #554](https://github.com/inference-sim/inference-sim/issues/554)
+- **Closes:** Fixes #554
+- **Behavioral Contracts:** See Part 1, Section B.
+
+---
+
+## Phase 0: Component Context
+
+1. **Building block:** LatencyModel interface (`sim/latency_model.go`) — defines the contract for all latency estimation backends.
+2. **Adjacent blocks:** BatchFormation (`sim/batch_formation.go`) calls `PreemptionProcessingTime()` during preemption. Simulator (`sim/simulator.go`) schedules `PreemptionEvent` using the delay. Three backends in `sim/latency/` implement the method.
+3. **Invariants touched:** None directly. INV-1 (request conservation) is unaffected because `PreemptionCount++` is retained. INV-8 (work-conserving) is unaffected because preemption logic is unchanged — only the delay and event are removed.
+4. **Construction Site Audit:**
+   - `PreemptedRequest` struct: constructed at `sim/batch_formation.go:177`. One site. Removing `PreemptionDelay` field.
+   - `PreemptionEvent` struct: constructed at `sim/simulator.go:333`. One site. Being deleted entirely.
+   - No struct fields are being added.
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR removes dead code from the latency model interface and event system. `PreemptionProcessingTime()` always returns 0 in all three backends and has never been configurable. `PreemptionEvent` is a no-op event type whose only effect is a debug log. The preemption counter (`PreemptionCount++`) and all preemption logic (KV release, state reset, re-enqueue) are preserved — only the delay calculation and the no-op event scheduling are removed. Debug observability is preserved by replacing the event with an inline `logrus.Debugf` at the preemption site.
+
+### B) Behavioral Contracts
+
+**Positive contracts:**
+
+```
+BC-1: Interface Simplification
+- GIVEN the LatencyModel interface
+- WHEN a new backend is implemented
+- THEN it needs to implement only 4 methods (StepTime, QueueingTime, OutputTokenProcessingTime, SchedulingProcessingTime)
+- MECHANISM: PreemptionProcessingTime() removed from the interface definition
+```
+
+```
+BC-2: Preemption Metrics Preserved
+- GIVEN a simulation with KV cache pressure that triggers preemptions
+- WHEN preemption occurs during batch formation
+- THEN PreemptionCount is still incremented for each evicted request
+- MECHANISM: PreemptionCount++ remains in scheduleBatch, unchanged
+```
+
+```
+BC-3: Preemption Behavior Preserved
+- GIVEN a running request that is preempted
+- WHEN batch formation evicts it
+- THEN the request is re-enqueued at queue front with ProgressIndex=0 and KV blocks released
+- MECHANISM: preemptForTokens logic is unchanged except removal of the delay computation
+```
+
+```
+BC-4: Debug Observability Preserved
+- GIVEN a simulation with preemptions and debug logging enabled
+- WHEN preemption occurs
+- THEN a debug log message is emitted for each preempted request
+- MECHANISM: logrus.Debugf in scheduleBatch replaces the PreemptionEvent.Execute() debug log
+```
+
+**Negative contracts:**
+
+```
+BC-5: No Golden Dataset Impact
+- GIVEN the golden dataset
+- WHEN tests run after this change
+- THEN all golden dataset tests pass unchanged
+- MECHANISM: PreemptionProcessingTime was 0 in all backends; PreemptionEvent.Execute was a no-op
+```
+
+```
+BC-6: No Behavioral Change
+- GIVEN any simulation configuration
+- WHEN run before and after this change with the same seed
+- THEN the output is byte-identical (INV-6)
+- MECHANISM: removed code had zero observable effect (0 delay, no-op execute)
+```
+
+### C) Component Interaction
+
+```
+LatencyModel interface (sim/latency_model.go)
+  - BEFORE: 5 methods including PreemptionProcessingTime()
+  - AFTER:  4 methods
+  |
+  +-- BlackboxLatencyModel (sim/latency/latency.go)
+  |     BEFORE: implements PreemptionProcessingTime() { return 0 }
+  |     AFTER:  method removed
+  |
+  +-- RooflineLatencyModel (sim/latency/latency.go)
+  |     BEFORE: implements PreemptionProcessingTime() { return 0 }
+  |     AFTER:  method removed
+  |
+  +-- CrossModelLatencyModel (sim/latency/crossmodel.go)
+        BEFORE: implements PreemptionProcessingTime() { return 0 }
+        AFTER:  method removed
+
+BatchFormation (sim/batch_formation.go)
+  - preemptForTokens()
+    BEFORE: calls v.latencyModel.PreemptionProcessingTime(), stores in PreemptionDelay
+    AFTER:  no delay computation
+  - PreemptedRequest struct
+    BEFORE: has PreemptionDelay field
+    AFTER:  field removed
+
+Simulator (sim/simulator.go)
+  - scheduleBatch()
+    BEFORE: schedules PreemptionEvent for each preempted request using p.PreemptionDelay
+    AFTER:  emits logrus.Debugf for each preempted request; PreemptionCount++ preserved
+
+Event types (sim/event.go)
+  - BEFORE: PreemptionEvent type with Timestamp() and Execute() methods
+  - AFTER:  type removed entirely
+```
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| Issue says "Update `problem.md` Section 2a" | Updates the PreemptionProcessingTime row | ALIGNED |
+| Issue says "Remove `PreemptionEvent` scheduling in `scheduleBatch`" | Replaces with inline `logrus.Debugf` | ADDITION: preserves debug observability that the event provided |
+| Issue does not mention documentation updates beyond problem.md | Also updates `docs/concepts/core-engine.md`, `docs/guide/latency-models.md`, `docs/contributing/extension-recipes.md`, `training/research.md`, `CLAUDE.md`, `docs/contributing/templates/design-guidelines.md`, and additional `training/problem.md` references | ADDITION: documentation DRY — all working copies of the interface description must be updated |
+| Hypothesis FINDINGS reference PreemptionEvent in mechanism explanation | `hypotheses/h-overload-kv/FINDINGS.md` line 90 — add footnote noting removal in #554 | ADDITION: historical accuracy for future readers |
+| Archived/active plan docs reference PreemptionProcessingTime | NOT updated — `docs/plans/` files are historical snapshots | EXCLUSION: plan documents are frozen records of their time |
+| `training/problem.md` and `training/research.md` reference interface | NOT updated in this PR — files are untracked (never committed) and absent from worktree | EXCLUSION: untracked files cannot be modified in a worktree-based PR. Updates deferred to when these files are committed. |
+
+### E) Review Guide
+
+**The tricky part:** Ensuring that the `PreemptionEvent` removal doesn't break the event queue's ordering properties. Since `PreemptionEvent.Execute()` was a no-op (only debug log), and the preemption delay was always 0, removing it cannot change event ordering or simulation behavior.
+
+**What to scrutinize:** The `scheduleBatch` change — verify that `PreemptionCount++` is preserved and the debug log replacement covers the same information. Verify no other code references `PreemptionEvent` or `PreemptionDelay`.
+
+**What's safe to skim:** Documentation updates (straightforward removals from tables). The latency backend changes (mechanical deletion of `return 0` methods).
+
+**Known debt:** `SchedulingProcessingTime()` is also always 0 across all backends — but unlike `PreemptionProcessingTime()`, its return value feeds into `ScheduledEvent` timing which is consumed by `RequestSchedulingDelays` at `simulator.go:346`. It is a dormant-but-wired extension point, not dead code. A future issue could track its removal if the wiring is never activated. Out of scope for this PR.
+
+**Debug log interleaving change:** The replacement `logrus.Debugf` runs synchronously during `scheduleBatch`, whereas the original `PreemptionEvent.Execute()` ran when the event was popped from the queue. Since both fire at the same simulation clock value (`now + 0 = now`), the content is identical, but debug log ordering in stderr changes (preemption messages now appear grouped during batch formation rather than interleaved with other events). No structured log parsing exists, so this is cosmetic.
+
+**Verification notes:** Confirmed via grep that `PreemptionDelay` is consumed at exactly one site (`simulator.go:334`). Confirmed `PreemptionEvent` is not referenced in `sim/trace/` or `sim/cluster/`. No test files type-assert on `PreemptionEvent`.
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+Files to modify:
+- `sim/latency_model.go` — remove `PreemptionProcessingTime()` from interface (2 lines)
+- `sim/event.go` — remove `PreemptionEvent` type (15 lines)
+- `sim/batch_formation.go` — remove `PreemptionDelay` field, simplify `preemptForTokens`
+- `sim/simulator.go` — replace `PreemptionEvent` scheduling with debug log
+- `sim/latency/latency.go` — remove method from BlackboxLatencyModel and RooflineLatencyModel
+- `sim/latency/crossmodel.go` — remove method from CrossModelLatencyModel
+- `sim/latency/latency_test.go` — update `TestBlackboxLatencyModel_PlaceholderOverheads`
+- `CLAUDE.md` — update "5 methods" → "4 methods" (line 221), remove "Preemption" from event types (line 224)
+- `sim/doc.go` — remove "preemption/" from LatencyModel overhead list (line 26)
+- `docs/concepts/core-engine.md` — remove PreemptionEvent from event table, update Phase 1 description, update preemption section
+- `docs/guide/latency-models.md` — update interface method table, "five methods" → "four methods"
+- `docs/contributing/extension-recipes.md` — update latency backend recipe, "5 methods" → "4 methods"
+- `docs/contributing/templates/design-guidelines.md` — update "5 methods" → "4 methods" (line 243)
+- `hypotheses/h-overload-kv/FINDINGS.md` — add footnote about PreemptionEvent removal (line 90)
+
+No dead code introduced. No new files. No new abstractions.
+
+### G) Task Breakdown
+
+#### Task 1: Remove PreemptionProcessingTime, PreemptionEvent, and PreemptionDelay (BC-1, BC-3, BC-4)
+
+**Contracts:** BC-1, BC-3, BC-4
+
+**Note:** All code changes must be applied atomically because removing `PreemptionProcessingTime()` from the interface causes a compile failure in `batch_formation.go` (which calls the method). The interface removal, backend removals, caller removal, event type removal, and struct field removal are all done in one step.
+
+**Test update:**
+
+Modify `sim/latency/latency_test.go` — remove the `PreemptionProcessingTime` assertion from `TestBlackboxLatencyModel_PlaceholderOverheads`:
+
+```go
+// TestBlackboxLatencyModel_PlaceholderOverheads verifies placeholders return 0.
+func TestBlackboxLatencyModel_PlaceholderOverheads(t *testing.T) {
+	model := &BlackboxLatencyModel{
+		betaCoeffs:  []float64{1000, 10, 5},
+		alphaCoeffs: []float64{100, 1, 100},
+	}
+
+	if model.SchedulingProcessingTime() != 0 {
+		t.Errorf("SchedulingProcessingTime = %d, want 0", model.SchedulingProcessingTime())
+	}
+}
+```
+
+**Implementation:**
+
+1. `sim/latency_model.go`: Remove lines 21-22 (`PreemptionProcessingTime` from interface)
+2. `sim/latency/latency.go`: Remove `BlackboxLatencyModel.PreemptionProcessingTime()` (lines 58-60) and `RooflineLatencyModel.PreemptionProcessingTime()` (lines 107-109)
+3. `sim/latency/crossmodel.go`: Remove `CrossModelLatencyModel.PreemptionProcessingTime()` (lines 77-79)
+4. `sim/event.go`: Remove lines 82-96 (`PreemptionEvent` type, `Timestamp()`, `Execute()`)
+5. `sim/batch_formation.go`:
+   - Remove `PreemptionDelay` field from `PreemptedRequest` struct (line 44)
+   - In `preemptForTokens`, remove the `preemptionDelay` variable and simplify `PreemptedRequest` construction:
+     ```go
+     result.Preempted = append(result.Preempted, PreemptedRequest{
+         Request: preemptedRequest,
+     })
+     ```
+6. `sim/simulator.go` — in `scheduleBatch`, replace the PreemptionEvent scheduling loop (lines 332-338) with:
+   ```go
+   // Record preemption metrics and emit debug log for each preempted request
+   for _, p := range batchResult.Preempted {
+       logrus.Debugf("<< Preemption: %s at %d ticks", p.Request.ID, now)
+       sim.Metrics.PreemptionCount++
+   }
+   ```
+
+**Note:** Do NOT remove the `latencyModel` field from `VLLMBatchFormation` — it is still needed for `SchedulingProcessingTime()` at `batch_formation.go:143`.
+
+**Verify:**
+```bash
+cd .worktrees/pr554-remove-preemption-processing-time && go build ./... && go test ./... -count=1
+```
+
+**Lint:**
+```bash
+cd .worktrees/pr554-remove-preemption-processing-time && golangci-lint run ./...
+```
+
+#### Task 2: Update documentation (BC-1 doc updates)
+
+**Contracts:** Documentation accuracy
+
+**Files:**
+
+1. `CLAUDE.md`:
+   - Line 221: Update "5 methods" → "4 methods" in `latency_model.go` comment
+   - Line 224: Remove "Preemption" from `event.go` event type list
+2. `sim/doc.go`:
+   - Line 26: Remove "preemption/" from LatencyModel overhead list → `scheduling/output processing overheads`
+3. `docs/concepts/core-engine.md`:
+   - Line 30: Remove `PreemptionEvent` row from event table
+   - Line 74: Remove "Schedule `PreemptionEvent` for any evicted requests" from Phase 1 steps
+   - Line 167: Replace "A `PreemptionEvent` is recorded for tracing" with "A debug log is emitted"
+5. `docs/guide/latency-models.md`:
+   - Line 159: Remove `PreemptionProcessingTime()` row from interface method table
+   - Lines 151, 163: Update "five methods" → "four methods"
+6. `docs/contributing/extension-recipes.md`:
+   - Line 87: Update "5 methods" → "4 methods"
+   - Line 92: Remove `PreemptionProcessingTime()` from method list
+7. `docs/contributing/templates/design-guidelines.md`:
+   - Line 243: Update "5 methods" → "4 methods"
+8. `hypotheses/h-overload-kv/FINDINGS.md`:
+   - Line 90: Add footnote: "(Note: `PreemptionEvent` removed in #554; preemptions now emit debug log only, reducing event count per preemption cycle from 3 to 2)"
+
+**Verify:**
+```bash
+cd .worktrees/pr554-remove-preemption-processing-time && go build ./... && go test ./... -count=1
+```
+
+### H) Test Strategy
+
+| Contract | Task | Test Type | Test Name |
+|----------|------|-----------|-----------|
+| BC-1 | Task 1 | Unit (negative) | Compile-time: backends without PreemptionProcessingTime satisfy LatencyModel |
+| BC-1 | Task 1 | Unit (update) | TestBlackboxLatencyModel_PlaceholderOverheads — updated |
+| BC-2 | Task 1 | Integration | Existing preemption tests verify PreemptionCount is still tracked |
+| BC-3 | Task 1 | Integration | Existing preemption tests verify preemption behavior unchanged |
+| BC-5 | Task 1 | Regression | Existing golden dataset tests pass unchanged |
+| BC-6 | Task 1 | Determinism | Existing determinism tests pass unchanged |
+
+**Key insight:** This is a pure removal of dead code (always-zero return values and no-op execution). Existing tests verify the properties we care about (preemption counting, request conservation, KV cache conservation). No new tests are needed because no new behavior is introduced.
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation | Task |
+|------|-----------|--------|------------|------|
+| External code implements LatencyModel | Low | Medium | This is an internal interface; no known external implementors. Issue scope explicitly states all three backends. | Task 1 |
+| Debug log format change breaks log parsing | Low | Low | The format string is consistent with other event debug logs. No structured log parsing exists. | Task 2 |
+| Documentation references missed | Low | Low | grep for all references completed in Phase 0 analysis | Task 2 |
+
+---
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+**Plan-specific checks:**
+- [x] No unnecessary abstractions
+- [x] No feature creep beyond PR scope
+- [x] No unexercised flags or interfaces
+- [x] No partial implementations
+- [x] No breaking changes without explicit contract updates
+- [x] No hidden global state impact
+- [x] All new code will pass golangci-lint (only removals + one debug log)
+- [x] Shared test helpers used from existing shared test package (N/A)
+- [x] CLAUDE.md updated: interface method count in extension recipes reference
+- [x] No stale references left in CLAUDE.md
+- [x] Documentation DRY: all working copies of interface method list updated
+- [x] Deviation log reviewed — no unresolved deviations
+- [x] Each task produces working, testable code
+- [x] Task dependencies correctly ordered (Task 1 atomic code change, Task 2 docs)
+- [x] All contracts mapped to specific tasks
+- [x] Golden dataset regeneration: NOT needed (zero behavioral change)
+- [x] Construction site audit completed: PreemptedRequest (1 site), PreemptionEvent (1 site, deleted)
+
+**Antipattern rules:**
+- [x] R1: No silent data loss (no new error paths)
+- [x] R2: No new map iteration
+- [x] R3: No new numeric parameters
+- [x] R4: PreemptedRequest field removed; single construction site updated
+- [x] R5: No new resource allocation loops
+- [x] R6: No logrus.Fatalf in sim/
+- [x] R7: No new golden tests
+- [x] R8-R23: N/A (pure removal, no new code beyond a debug log)
+
+---
+
+## Appendix: File-Level Implementation Details
+
+### File: `sim/latency_model.go`
+
+Remove lines 21-22:
+```go
+// Before:
+	// PreemptionProcessingTime estimates preemption overhead per eviction.
+	PreemptionProcessingTime() int64
+
+// After: (lines deleted)
+```
+
+### File: `sim/event.go`
+
+Remove lines 82-96 (entire `PreemptionEvent` type):
+```go
+// DELETED:
+// PreemptionEvent represents the pre-emption of an inference request in the system.
+type PreemptionEvent struct { ... }
+func (e *PreemptionEvent) Timestamp() int64 { ... }
+func (e *PreemptionEvent) Execute(sim *Simulator) { ... }
+```
+
+### File: `sim/batch_formation.go`
+
+1. Remove `PreemptionDelay` from `PreemptedRequest`:
+```go
+// Before:
+type PreemptedRequest struct {
+	Request         *Request
+	PreemptionDelay int64
+}
+
+// After:
+type PreemptedRequest struct {
+	Request *Request
+}
+```
+
+2. Simplify `preemptForTokens`:
+```go
+// Before:
+			preemptionDelay := v.latencyModel.PreemptionProcessingTime()
+			...
+			result.Preempted = append(result.Preempted, PreemptedRequest{
+				Request:         preemptedRequest,
+				PreemptionDelay: preemptionDelay,
+			})
+
+// After:
+			...
+			result.Preempted = append(result.Preempted, PreemptedRequest{
+				Request: preemptedRequest,
+			})
+```
+
+3. Remove `latencyModel` dependency from `VLLMBatchFormation` if it's only used for `PreemptionProcessingTime`. CHECK: `SchedulingProcessingTime()` is also called — `latencyModel` is still needed (line 143).
+
+### File: `sim/simulator.go`
+
+Replace PreemptionEvent scheduling in `scheduleBatch`:
+```go
+// Before (lines 332-338):
+	for _, p := range batchResult.Preempted {
+		sim.Schedule(&PreemptionEvent{
+			time:    now + p.PreemptionDelay,
+			Request: p.Request,
+		})
+		sim.Metrics.PreemptionCount++
+	}
+
+// After:
+	for _, p := range batchResult.Preempted {
+		logrus.Debugf("<< Preemption: %s at %d ticks", p.Request.ID, now)
+		sim.Metrics.PreemptionCount++
+	}
+```
+
+### File: `sim/latency/latency.go`
+
+Remove two methods:
+```go
+// DELETED from BlackboxLatencyModel:
+func (m *BlackboxLatencyModel) PreemptionProcessingTime() int64 {
+	return 0
+}
+
+// DELETED from RooflineLatencyModel:
+func (m *RooflineLatencyModel) PreemptionProcessingTime() int64 {
+	return 0
+}
+```
+
+### File: `sim/latency/crossmodel.go`
+
+Remove one method:
+```go
+// DELETED from CrossModelLatencyModel:
+func (m *CrossModelLatencyModel) PreemptionProcessingTime() int64 {
+	return 0
+}
+```
+
+### File: `sim/latency/latency_test.go`
+
+Update `TestBlackboxLatencyModel_PlaceholderOverheads` — remove PreemptionProcessingTime assertion:
+```go
+func TestBlackboxLatencyModel_PlaceholderOverheads(t *testing.T) {
+	model := &BlackboxLatencyModel{
+		betaCoeffs:  []float64{1000, 10, 5},
+		alphaCoeffs: []float64{100, 1, 100},
+	}
+
+	if model.SchedulingProcessingTime() != 0 {
+		t.Errorf("SchedulingProcessingTime = %d, want 0", model.SchedulingProcessingTime())
+	}
+}
+```

--- a/hypotheses/h-overload-kv/FINDINGS.md
+++ b/hypotheses/h-overload-kv/FINDINGS.md
@@ -87,7 +87,7 @@ Conservation invariant INV-1 (`sim/simulator.go:310-318`) is verified at simulat
 
 The finding from Round 1 reveals a sharp cliff in simulation tractability:
 
-- **500 blocks/4 instances = 125/instance**: At ~5 concurrent requests per instance, virtually every arriving request triggers a preemption. Each preemption generates a `PreemptionEvent` + re-`QueuedEvent` + new `StepEvent`, tripling the event count per cycle. Under 2x+ overload, this creates exponential event cascade that exceeds the 180s timeout.
+- **500 blocks/4 instances = 125/instance**: At ~5 concurrent requests per instance, virtually every arriving request triggers a preemption. Each preemption generates a `PreemptionEvent` + re-`QueuedEvent` + new `StepEvent`, tripling the event count per cycle. Under 2x+ overload, this creates exponential event cascade that exceeds the 180s timeout. (Note: `PreemptionEvent` removed in #554 — preemptions now emit a debug log only, reducing per-preemption event overhead.)
 - **2000 blocks/4 instances = 500/instance**: At ~20 concurrent requests per instance, the batch (max 256 requests) easily fits within the block budget. Zero preemptions.
 
 This cliff was also observed in H8 (KV-pressure): the preemption transition is abrupt, occurring between 2000-2300 blocks (`hypotheses/h8-kv-pressure/FINDINGS.md`). Below the cliff, preemption cascades dominate; above it, the system is pressure-free.

--- a/sim/batch_formation.go
+++ b/sim/batch_formation.go
@@ -40,8 +40,7 @@ type ScheduledRequest struct {
 
 // PreemptedRequest carries metadata about a preempted request.
 type PreemptedRequest struct {
-	Request         *Request
-	PreemptionDelay int64
+	Request *Request
 }
 
 // BatchResult describes the outcome of batch formation.
@@ -169,14 +168,12 @@ func (v *VLLMBatchFormation) preemptForTokens(req *Request, numNewTokens int64, 
 			}
 
 			result.PreemptionHappened = true
-			preemptionDelay := v.latencyModel.PreemptionProcessingTime()
 			preemptedRequest := result.RunningBatch.Requests[len(result.RunningBatch.Requests)-1]
 			logrus.Warnf("[tick %07d] preemption: evicting %s to make room", ctx.Now, preemptedRequest.ID)
 			result.RunningBatch.Requests = result.RunningBatch.Requests[:len(result.RunningBatch.Requests)-1]
 
 			result.Preempted = append(result.Preempted, PreemptedRequest{
-				Request:         preemptedRequest,
-				PreemptionDelay: preemptionDelay,
+				Request: preemptedRequest,
 			})
 
 			// Defensive: restore token budget if preempted request was already

--- a/sim/doc.go
+++ b/sim/doc.go
@@ -23,7 +23,7 @@
 // # Key Interfaces
 //
 // The extension points are single-method or small interfaces:
-//   - LatencyModel: step time, queueing time, scheduling/preemption/output processing overheads
+//   - LatencyModel: step time, queueing time, scheduling/output processing overheads
 //   - KVStore: block allocation, eviction, prefix caching, capacity queries
 //   - RoutingPolicy: select target instance given cluster snapshots
 //   - AdmissionPolicy: accept or reject incoming requests

--- a/sim/event.go
+++ b/sim/event.go
@@ -79,22 +79,6 @@ func (e *ScheduledEvent) Execute(sim *Simulator) {
 	logrus.Debugf("<< Schedule: %s at %d ticks", e.Request.ID, e.time)
 }
 
-// PreemptionEvent represents the pre-emption of an inference request in the system.
-type PreemptionEvent struct {
-	time    int64    // Simulation time of PreemptionEvent (in ticks)
-	Request *Request // The incoming request associated with this event
-}
-
-// Timestamp returns the time of the PreemptionEvent.
-func (e *PreemptionEvent) Timestamp() int64 {
-	return e.time
-}
-
-// Execute does nothing
-func (e *PreemptionEvent) Execute(sim *Simulator) {
-	logrus.Debugf("<< Preemption: %s at %d ticks", e.Request.ID, e.time)
-}
-
 // RequestLeftEvent represents the leaving of an inference request from the system.
 type RequestLeftEvent struct {
 	time    int64    // Simulation time of RequestLeftEvent (in ticks)

--- a/sim/latency/crossmodel.go
+++ b/sim/latency/crossmodel.go
@@ -73,7 +73,3 @@ func (m *CrossModelLatencyModel) OutputTokenProcessingTime() int64 {
 func (m *CrossModelLatencyModel) SchedulingProcessingTime() int64 {
 	return 0
 }
-
-func (m *CrossModelLatencyModel) PreemptionProcessingTime() int64 {
-	return 0
-}

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -55,10 +55,6 @@ func (m *BlackboxLatencyModel) SchedulingProcessingTime() int64 {
 	return 0
 }
 
-func (m *BlackboxLatencyModel) PreemptionProcessingTime() int64 {
-	return 0
-}
-
 // RooflineLatencyModel estimates latency using analytical FLOPs/bandwidth roofline model.
 // Step time is computed via rooflineStepTime(); overhead estimates use alpha coefficients.
 type RooflineLatencyModel struct {
@@ -101,10 +97,6 @@ func (m *RooflineLatencyModel) OutputTokenProcessingTime() int64 {
 }
 
 func (m *RooflineLatencyModel) SchedulingProcessingTime() int64 {
-	return 0
-}
-
-func (m *RooflineLatencyModel) PreemptionProcessingTime() int64 {
 	return 0
 }
 

--- a/sim/latency/latency_test.go
+++ b/sim/latency/latency_test.go
@@ -109,9 +109,6 @@ func TestBlackboxLatencyModel_PlaceholderOverheads(t *testing.T) {
 	if model.SchedulingProcessingTime() != 0 {
 		t.Errorf("SchedulingProcessingTime = %d, want 0", model.SchedulingProcessingTime())
 	}
-	if model.PreemptionProcessingTime() != 0 {
-		t.Errorf("PreemptionProcessingTime = %d, want 0", model.PreemptionProcessingTime())
-	}
 }
 
 // TestBlackboxLatencyModel_StepTime_Monotonic verifies BC-1 invariant:

--- a/sim/latency_model.go
+++ b/sim/latency_model.go
@@ -17,9 +17,6 @@ type LatencyModel interface {
 
 	// SchedulingProcessingTime estimates scheduling overhead per request.
 	SchedulingProcessingTime() int64
-
-	// PreemptionProcessingTime estimates preemption overhead per eviction.
-	PreemptionProcessingTime() int64
 }
 
 // NewLatencyModelFunc is a factory function for creating LatencyModel implementations.

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -328,12 +328,9 @@ func (sim *Simulator) scheduleBatch(now int64) {
 	// Apply result: update running batch
 	sim.RunningBatch = batchResult.RunningBatch
 
-	// Schedule events for preempted requests and record preemption metrics
+	// Record preemption metrics and emit debug log for each preempted request
 	for _, p := range batchResult.Preempted {
-		sim.Schedule(&PreemptionEvent{
-			time:    now + p.PreemptionDelay,
-			Request: p.Request,
-		})
+		logrus.Debugf("<< Preemption: %s at %d ticks", p.Request.ID, now)
 		sim.Metrics.PreemptionCount++
 	}
 


### PR DESCRIPTION
## Summary

- Remove `PreemptionProcessingTime()` from the `LatencyModel` interface (5→4 methods) — all three backends returned 0
- Remove `PreemptionEvent` type — its `Execute()` was a no-op (debug log only)
- Remove `PreemptionDelay` field from `PreemptedRequest` — always carried value 0
- Replace `PreemptionEvent` scheduling with inline `logrus.Debugf` — preserves debug observability
- Preserve `PreemptionCount++` and all preemption mechanics (KV release, ProgressIndex reset, front-of-queue re-enqueue)

## Behavioral Contracts

```
BC-1: Interface Simplification
GIVEN the LatencyModel interface
WHEN a new backend is implemented
THEN it needs to implement only 4 methods

BC-2: Preemption Metrics Preserved
GIVEN a simulation with KV cache pressure
WHEN preemption occurs
THEN PreemptionCount is still incremented

BC-3: Preemption Behavior Preserved
GIVEN a running request that is preempted
WHEN batch formation evicts it
THEN request is re-enqueued at queue front with ProgressIndex=0 and KV blocks released

BC-6: No Behavioral Change
GIVEN any simulation configuration
WHEN run before and after this change with the same seed
THEN the output is byte-identical (INV-6)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all 11 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Golden dataset tests pass unchanged (BC-5)
- [x] Grep confirms zero remaining references in Go source

Fixes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)