### PR TITLE
fix(sim): random tie-breaking for routing + H29 erratum

### DIFF
--- a/docs/plans/research.md
+++ b/docs/plans/research.md
@@ -621,7 +621,7 @@ This prevents the scenario where an experiment runs but the measurement doesn't 
    - H19: Consider adding explicit `--latency-mode roofline` flag independent of alpha coefficients (CLI design coupling)
 8. **Promote confirmed hypotheses to Go tests:** H26 (event pipeline), H25 (full-stack conservation), H24 (anomaly detection completeness)
 9. **Act on new findings:**
-   - H4: LL tie-breaking positional bias (instance 0 preference) — consider random tie-breaking option
+   - ~~H4: LL tie-breaking positional bias (instance 0 preference)~~ — **Fixed** in #565: random tie-breaking for LeastLoaded and WeightedScoring
    - H6: Counterfactual regret is structurally zero for weighted policies — document limitation; regret only meaningful for non-score-based policies
    - H7: Super-linear scaling is a general queueing property — document for capacity planning guidance
    - H20: Distribution median (not mean/tail) drives KV pressure — document for workload configuration guidance

--- a/docs/plans/tiebreak-erratum-plan.md
+++ b/docs/plans/tiebreak-erratum-plan.md
@@ -1,0 +1,636 @@
+# Micro Plan: Random Tie-Breaking + H29 Erratum
+
+- **Goal:** Eliminate deterministic positional bias in routing tie-breaking and correct stale H29 documentation.
+- **The problem today:** `WeightedScoring.Route()` and `LeastLoaded.Route()` both use strict `>` / `<` comparison for argmax/argmin selection. When multiple instances have equal scores/loads, the lowest-index instance always wins. This deterministic bias seeds a prefix-affinity cold-start feedback loop (#565) and causes 12-21% worse TTFT P99 for LeastLoaded at low utilization (H4). Separately, H29's FINDINGS.md documents stale snapshot behavior that PR #467 invalidated (#566).
+- **What this PR adds:**
+  1. Random uniform tie-breaking in `WeightedScoring.Route()` using `PartitionedRNG`'s `SubsystemRouter` partition
+  2. Random uniform tie-breaking in `LeastLoaded.Route()` using the same RNG partition
+  3. Erratum in H29 FINDINGS.md documenting that PR #467 changed all signals to Periodic when `--snapshot-refresh-interval > 0`
+- **Why this matters:** The positional bias is the most actionable root cause of the extreme latency variance across seeds reported in #562. The H29 erratum prevents users from relying on stale guidance.
+- **Architecture:** `NewRoutingPolicy` factory gains a `*rand.Rand` parameter. `LeastLoaded` and `WeightedScoring` structs store the RNG. `ClusterSimulator` passes `rng.ForSubsystem(SubsystemRouter)`. Tests pass `nil` for backward compat (positional tie-breaking when rng is nil).
+- **Source:** Issues #565, #566
+- **Closes:** Fixes #565, fixes #566
+- **Behavioral Contracts:** See Part 1, Section B
+
+---
+
+## Phase 0: Component Context
+
+1. **Building block:** Routing policy layer (`sim/routing.go`)
+2. **Adjacent blocks:** `ClusterSimulator` (caller via `RoutingDecisionEvent.Execute`), `PartitionedRNG` (RNG source), scoring pipeline (`routing_scorers.go`, `routing_prefix_scorer.go`)
+3. **Invariants touched:** INV-6 (determinism — preserved via PartitionedRNG), INV-7 (signal freshness — H29 erratum updates documentation only)
+4. **Construction Site Audit:**
+   - `LeastLoaded{}` — constructed in `NewRoutingPolicy` (`routing.go:241`) only
+   - `WeightedScoring{scorers, weights, observers}` — constructed in `NewRoutingPolicy` (`routing.go:257`) only
+   - `NewRoutingPolicy(...)` — called in `cluster.go:78` (production) + ~40 test call sites
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR adds random tie-breaking to `WeightedScoring.Route()` and `LeastLoaded.Route()`. When multiple instances have equal composite scores (or equal effective load), the router selects uniformly at random among tied candidates using the `SubsystemRouter` RNG partition, preserving INV-6 determinism. The `NewRoutingPolicy` factory gains a `*rand.Rand` parameter; `nil` preserves positional tie-breaking for backward compatibility in tests. Separately, an erratum is added to `hypotheses/h29-snapshot-staleness/FINDINGS.md` noting that PR #467 changed the snapshot staleness model.
+
+### B) Behavioral Contracts
+
+**Positive contracts:**
+
+```
+BC-1: Random Tie-Breaking (WeightedScoring)
+- GIVEN WeightedScoring with a non-nil RNG and N >= 2 instances with equal composite scores
+- WHEN Route() is called repeatedly
+- THEN each tied instance is selected with approximately equal frequency (uniform distribution)
+- MECHANISM: Collect tied indices, pick rng.Intn(len(tied))
+```
+
+```
+BC-2: Random Tie-Breaking (LeastLoaded)
+- GIVEN LeastLoaded with a non-nil RNG and N >= 2 instances with equal EffectiveLoad
+- WHEN Route() is called repeatedly
+- THEN each tied instance is selected with approximately equal frequency (uniform distribution)
+- MECHANISM: Collect tied indices, pick rng.Intn(len(tied))
+```
+
+```
+BC-3: Determinism Preserved (INV-6)
+- GIVEN the same seed and configuration
+- WHEN the simulation is run twice
+- THEN routing decisions are identical across runs
+- MECHANISM: SubsystemRouter partition of PartitionedRNG produces identical sequence per seed
+```
+
+```
+BC-4: Non-Tie Behavior Unchanged
+- GIVEN instances with distinct scores/loads and a non-nil RNG
+- WHEN Route() is called and then a tie-scenario Route() is called
+- THEN the unique best instance is selected AND the subsequent tie-scenario produces the same sequence as if only the tie calls had been made (RNG state not advanced by non-tie calls)
+```
+
+```
+BC-5: Nil RNG Backward Compatibility
+- GIVEN a routing policy created with rng=nil
+- WHEN Route() encounters a tie
+- THEN the first occurrence (lowest index) wins (existing positional behavior)
+- MECHANISM: nil guard in tie-breaking code
+```
+
+**Documentation contract:**
+
+```
+BC-6: H29 Erratum
+- GIVEN H29 FINDINGS.md
+- WHEN a user reads the document
+- THEN they see a clear erratum noting PR #467 changed snapshot behavior
+- MECHANISM: New "Erratum" section with explanation of what changed
+```
+
+### C) Component Interaction
+
+```
+ClusterSimulator
+  │ creates PartitionedRNG(seed)
+  │ calls rng.ForSubsystem(SubsystemRouter)
+  │ passes *rand.Rand to NewRoutingPolicy(...)
+  │
+  ▼
+NewRoutingPolicy(name, scorers, blockSize, rng)
+  │ stores rng in LeastLoaded{rng} or WeightedScoring{..., rng}
+  │
+  ▼
+RoutingDecisionEvent.Execute()
+  │ calls routingPolicy.Route(req, state)
+  │
+  ▼
+WeightedScoring.Route() / LeastLoaded.Route()
+  │ computes scores/loads
+  │ collects tied candidates
+  │ if len(tied) > 1 && rng != nil: rng.Intn(len(tied))
+  │ else: first occurrence
+  │
+  ▼
+RoutingDecision (returned to cluster)
+```
+
+State ownership: `*rand.Rand` owned by the routing policy struct. No new state crosses boundaries.
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| #565 proposes fix for WeightedScoring and LeastLoaded | Also applies nil-guard for backward compat | ADDITION — minimizes test churn |
+| #566 proposes erratum in FINDINGS.md | Also updates the stale code snippet in Critical Design Note section | ADDITION — the code snippet is the most misleading part |
+
+### E) Review Guide
+
+**Tricky part:** The RNG must only be consumed when there's an actual tie (>1 candidate), so non-tie scenarios don't shift the RNG state. This preserves existing behavior for differentiated workloads while fixing the equal-score case.
+
+**Scrutinize:** BC-3 determinism test — ensure same seed produces identical decisions. The tie-breaking rewrite in existing tests that assert positional behavior.
+
+**Safe to skim:** The ~40 mechanical `nil` additions to test call sites. The H29 erratum text.
+
+**Known debt:** `AlwaysBusiest` also has positional tie-breaking but is a pathological test template — intentionally not fixed.
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+| File | Action |
+|------|--------|
+| `sim/routing.go` | Modify: add `rng` field to `LeastLoaded` and `WeightedScoring`, update `NewRoutingPolicy` factory signature, implement random tie-breaking |
+| `sim/routing_test.go` | Modify: update call sites with `nil` RNG, rewrite tie-breaking tests for random behavior, add BC-1 through BC-5 tests |
+| `sim/cluster/cluster.go` | Modify: pass `rng.ForSubsystem(SubsystemRouter)` to `NewRoutingPolicy` |
+| `sim/routing_scorers_test.go` | Modify: update `NewRoutingPolicy` call sites with `nil` |
+| `sim/routing_prefix_scorer_test.go` | Modify: update `NewRoutingPolicy` call sites with `nil` |
+| `sim/examples_test.go` | Modify: update `NewRoutingPolicy` call sites with `nil` |
+| `hypotheses/h29-snapshot-staleness/FINDINGS.md` | Modify: add erratum section, update stale code snippet |
+
+No new files created. No golden dataset regeneration needed (golden tests are single-instance, no routing policies involved).
+
+### G) Task Breakdown
+
+#### Task 1: Update `NewRoutingPolicy` factory and routing structs (BC-4, BC-5)
+
+**TDD deviation note:** This task implements the factory signature change and tie-breaking logic before tests (Task 2) because changing the factory signature breaks all ~45 existing test call sites at compile time. Task 1 updates all call sites to restore compilation; Task 2 adds new behavioral tests for the tie-breaking behavior.
+
+**Files:** `sim/routing.go`
+
+**Step 1 — Implement factory change and tie-breaking logic:**
+
+In `sim/routing.go`:
+
+1. Add `import "math/rand"` to imports
+2. Add `rng *rand.Rand` field to `LeastLoaded` struct
+3. Add `rng *rand.Rand` field to `WeightedScoring` struct
+4. Update `NewRoutingPolicy` signature to accept `rng *rand.Rand`
+5. Pass `rng` to `LeastLoaded` and `WeightedScoring` construction
+6. Rewrite `LeastLoaded.Route()` tie-breaking:
+   ```go
+   // Collect all indices with minimum load
+   minLoad := snapshots[0].EffectiveLoad()
+   for i := 1; i < len(snapshots); i++ {
+       if load := snapshots[i].EffectiveLoad(); load < minLoad {
+           minLoad = load
+       }
+   }
+   var tied []int
+   for i, snap := range snapshots {
+       if snap.EffectiveLoad() == minLoad {
+           tied = append(tied, i)
+       }
+   }
+   idx := tied[0]
+   if len(tied) > 1 && ll.rng != nil {
+       idx = tied[ll.rng.Intn(len(tied))]
+   }
+   target := snapshots[idx]
+   ```
+7. Rewrite `WeightedScoring.Route()` tie-breaking:
+   ```go
+   bestScore := -1.0
+   for _, snap := range snapshots {
+       if scores[snap.ID] > bestScore {
+           bestScore = scores[snap.ID]
+       }
+   }
+   var tied []int
+   for i, snap := range snapshots {
+       if scores[snap.ID] == bestScore {
+           tied = append(tied, i)
+       }
+   }
+   bestIdx := tied[0]
+   if len(tied) > 1 && ws.rng != nil {
+       bestIdx = tied[ws.rng.Intn(len(tied))]
+   }
+   ```
+8. Update doc comments:
+   - `LeastLoaded`: change "Ties are broken by first occurrence in snapshot order (lowest index)." to "Ties are broken randomly when rng is non-nil; by first occurrence (lowest index) when rng is nil."
+   - `WeightedScoring`: change "Higher scores are preferred. Ties broken by first occurrence in snapshot order." to "Higher scores are preferred. Ties broken randomly when rng is non-nil; by first occurrence (lowest index) when rng is nil."
+   - `NewRoutingPolicy` godoc: add "The rng parameter enables random tie-breaking for least-loaded and weighted policies; nil preserves positional tie-breaking. Ignored by round-robin and always-busiest."
+
+**Step 2 — Update all test call sites:**
+
+Add `nil` as the last argument to every `NewRoutingPolicy(...)` call in:
+- `sim/routing_test.go` (~25 sites)
+- `sim/routing_scorers_test.go` (~2 sites)
+- `sim/routing_prefix_scorer_test.go` (~10 sites)
+- `sim/examples_test.go` (~6 sites)
+
+**Step 3 — Update cluster.go production call site:**
+
+In `sim/cluster/cluster.go`, change:
+```go
+routingPolicy: sim.NewRoutingPolicy(config.RoutingPolicy, config.RoutingScorerConfigs, config.BlockSizeTokens),
+```
+to:
+```go
+routingPolicy: sim.NewRoutingPolicy(config.RoutingPolicy, config.RoutingScorerConfigs, config.BlockSizeTokens, sim.NewPartitionedRNG(sim.NewSimulationKey(config.Seed)).ForSubsystem(sim.SubsystemRouter)),
+```
+
+Note: the `rng` PartitionedRNG is already created at `cluster.go:71` and assigned to `cs.rng`. Since we're inside the struct literal, we can't reference `cs.rng` yet. Extract the PartitionedRNG creation before the struct literal so both the struct field and the routing policy share the same instance:
+
+```go
+rng := sim.NewPartitionedRNG(sim.NewSimulationKey(config.Seed))
+// ... in struct literal:
+rng: rng,  // same object, moved out of literal
+routingPolicy: sim.NewRoutingPolicy(config.RoutingPolicy, config.RoutingScorerConfigs, config.BlockSizeTokens, rng.ForSubsystem(sim.SubsystemRouter)),
+```
+
+**Step 4 — Build and run existing tests:**
+
+```bash
+cd .worktrees/pr-tiebreak-erratum
+go build ./...
+go test ./sim/... -count=1
+```
+
+Expected: build passes, all tests pass (existing tie-breaking tests now pass `nil` RNG from Step 2, preserving positional behavior per BC-5).
+
+**Commit:** `refactor(sim): add RNG parameter to NewRoutingPolicy for tie-breaking`
+
+#### Task 2: Write tie-breaking behavioral tests (BC-1, BC-2, BC-3, BC-4, BC-5)
+
+**Files:** `sim/routing_test.go`
+
+**Step 1 — Rewrite existing tie-breaking tests:**
+
+Replace `TestLeastLoaded_LoadBasedSelection` subcase "tie broken by first occurrence (lowest index)" and "all instances equal load" with:
+
+```go
+// TestLeastLoaded_TieBreaking_Random verifies BC-2: random uniform tie-breaking.
+func TestLeastLoaded_TieBreaking_Random(t *testing.T) {
+    rng := rand.New(rand.NewSource(42))
+    policy := NewRoutingPolicy("least-loaded", nil, 16, rng)
+    snapshots := []RoutingSnapshot{
+        {ID: "instance_0", QueueDepth: 5, BatchSize: 5},
+        {ID: "instance_1", QueueDepth: 5, BatchSize: 5},
+        {ID: "instance_2", QueueDepth: 5, BatchSize: 5},
+    }
+
+    counts := map[string]int{}
+    N := 300
+    for i := 0; i < N; i++ {
+        req := &Request{ID: fmt.Sprintf("req%d", i)}
+        decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+        counts[decision.TargetInstance]++
+    }
+
+    // Each instance should get roughly N/3 = 100 requests.
+    // With 3 instances and 300 trials, expected = 100 per instance.
+    // Allow ±50% tolerance (50-150 range) for random variation.
+    for _, id := range []string{"instance_0", "instance_1", "instance_2"} {
+        if counts[id] < 50 || counts[id] > 150 {
+            t.Errorf("instance %s got %d/%d requests, expected ~100 (uniform)", id, counts[id], N)
+        }
+    }
+}
+```
+
+Similar test for `WeightedScoring`:
+
+```go
+// TestWeightedScoring_TieBreaking_Random verifies BC-1: random uniform tie-breaking.
+func TestWeightedScoring_TieBreaking_Random(t *testing.T) {
+    rng := rand.New(rand.NewSource(42))
+    policy := NewRoutingPolicy("weighted", []ScorerConfig{
+        {Name: "queue-depth", Weight: 1.0},
+    }, 16, rng)
+    // All instances idle → queue-depth scores all 1.0 → tie
+    snapshots := []RoutingSnapshot{
+        {ID: "instance_0", QueueDepth: 0},
+        {ID: "instance_1", QueueDepth: 0},
+        {ID: "instance_2", QueueDepth: 0},
+    }
+
+    counts := map[string]int{}
+    N := 300
+    for i := 0; i < N; i++ {
+        req := &Request{ID: fmt.Sprintf("req%d", i)}
+        decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+        counts[decision.TargetInstance]++
+    }
+
+    for _, id := range []string{"instance_0", "instance_1", "instance_2"} {
+        if counts[id] < 50 || counts[id] > 150 {
+            t.Errorf("instance %s got %d/%d requests, expected ~100 (uniform)", id, counts[id], N)
+        }
+    }
+}
+```
+
+**Step 2 — Add BC-3 determinism test:**
+
+```go
+// TestTieBreaking_Determinism verifies BC-3: same seed → same decisions.
+func TestTieBreaking_Determinism(t *testing.T) {
+    snapshots := []RoutingSnapshot{
+        {ID: "a", QueueDepth: 0},
+        {ID: "b", QueueDepth: 0},
+    }
+
+    for _, policyName := range []string{"least-loaded", "weighted"} {
+        t.Run(policyName, func(t *testing.T) {
+            // Two policies with same seed
+            rng1 := rand.New(rand.NewSource(99))
+            rng2 := rand.New(rand.NewSource(99))
+            p1 := NewRoutingPolicy(policyName, nil, 16, rng1)
+            p2 := NewRoutingPolicy(policyName, nil, 16, rng2)
+
+            for i := 0; i < 50; i++ {
+                req := &Request{ID: fmt.Sprintf("req%d", i)}
+                d1 := p1.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+                d2 := p2.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+                if d1.TargetInstance != d2.TargetInstance {
+                    t.Errorf("request %d: different decisions with same seed: %s vs %s",
+                        i, d1.TargetInstance, d2.TargetInstance)
+                }
+            }
+        })
+    }
+}
+```
+
+**Step 3 — Add BC-4 non-tie test (verifies RNG state not consumed):**
+
+```go
+// TestTieBreaking_NoTie_PreservesRNGState verifies BC-4: distinct scores → unique winner,
+// RNG state not advanced (non-tie calls must not shift the RNG stream).
+func TestTieBreaking_NoTie_PreservesRNGState(t *testing.T) {
+    // Two RNGs with the same seed
+    rng1 := rand.New(rand.NewSource(42))
+    rng2 := rand.New(rand.NewSource(42))
+
+    policy := NewRoutingPolicy("least-loaded", nil, 16, rng1)
+
+    // Non-tie snapshots (unique minimum at instance_1)
+    nonTieSnaps := []RoutingSnapshot{
+        {ID: "instance_0", QueueDepth: 10},
+        {ID: "instance_1", QueueDepth: 1},
+        {ID: "instance_2", QueueDepth: 5},
+    }
+
+    // Make 50 non-tie routing calls — should NOT consume RNG
+    for i := 0; i < 50; i++ {
+        req := &Request{ID: fmt.Sprintf("req%d", i)}
+        decision := policy.Route(req, &RouterState{Snapshots: nonTieSnaps, Clock: 1000})
+        if decision.TargetInstance != "instance_1" {
+            t.Fatalf("request %d: expected instance_1 (unique min), got %q", i, decision.TargetInstance)
+        }
+    }
+
+    // Now verify rng1 and rng2 are in the same state:
+    // draw from both and compare — if rng1 was consumed by non-tie calls, they'll differ
+    val1 := rng1.Intn(1000)
+    val2 := rng2.Intn(1000)
+    if val1 != val2 {
+        t.Errorf("RNG state diverged after non-tie calls: rng1=%d, rng2=%d (RNG consumed on non-tie)", val1, val2)
+    }
+}
+```
+
+**Step 4 — Add BC-5 nil RNG test:**
+
+```go
+// TestTieBreaking_NilRNG_Positional verifies BC-5: nil RNG → positional tie-breaking.
+func TestTieBreaking_NilRNG_Positional(t *testing.T) {
+    policy := NewRoutingPolicy("least-loaded", nil, 16, nil)
+    snapshots := []RoutingSnapshot{
+        {ID: "instance_0", QueueDepth: 5},
+        {ID: "instance_1", QueueDepth: 5},
+    }
+
+    for i := 0; i < 10; i++ {
+        req := &Request{ID: fmt.Sprintf("req%d", i)}
+        decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+        if decision.TargetInstance != "instance_0" {
+            t.Errorf("nil RNG should use positional (first), got %q", decision.TargetInstance)
+        }
+    }
+}
+```
+
+**Step 5 — Update existing tests that assert positional tie-breaking:**
+
+In `TestLeastLoaded_LoadBasedSelection`, remove the subcases that test tie-breaking positional behavior (they're replaced by the new tests above). Keep the subcase "instance 1 has lowest load" (non-tie case).
+
+In `TestWeightedScoring_AllIdle_NoDivisionByZero`, change the assertion from:
+```go
+if decision.TargetInstance != "instance_0" {
+```
+to verify that the decision is valid (any instance) and scores are finite:
+```go
+// All idle with nil RNG: positional tie-breaking → instance_0
+```
+(This test already passes nil RNG from Task 1.)
+
+**Step 6 — Run tests:**
+
+```bash
+go test ./sim/... -count=1 -run "TieBreak|Routing|WeightedScoring|LeastLoaded"
+```
+
+Expected: all pass.
+
+**Commit:** `test(sim): add behavioral tests for random tie-breaking (BC-1 through BC-5)`
+
+#### Task 3: H29 Erratum (BC-6)
+
+**Files:** `hypotheses/h29-snapshot-staleness/FINDINGS.md`
+
+**Step 1 — Add erratum section after Metadata table:**
+
+Insert after line 15 (after the Metadata table):
+
+```markdown
+## Erratum (2026-03-09)
+
+**PR #467** (commit `9a603bc`) changed `sim/cluster/snapshot.go` so that when
+`--snapshot-refresh-interval > 0`, **all three signals** (QueueDepth, BatchSize,
+KVUtilization) use Periodic mode — not just KVUtilization. This invalidates the
+key design note and several conclusions in the original findings:
+
+- **"QueueDepth is always Immediate"** — no longer true when interval > 0. Only
+  `InFlightRequests` (injected synchronously by `buildRouterState()`) remains
+  unconditionally fresh.
+- **"queue-depth scorer is NOT affected"** — partially invalidated. Queue-depth
+  uses `EffectiveLoad() = QueueDepth + BatchSize + InFlightRequests`. When
+  interval > 0, both `QueueDepth` and `BatchSize` are stale; only
+  `InFlightRequests` remains fresh. The composite scorer resilience finding
+  (+3.8% mean) may no longer hold at non-zero intervals.
+- **"the default composite scorer is inherently resilient"** — this conclusion
+  now applies **only to the default `--snapshot-refresh-interval 0`
+  configuration**, where all signals are Immediate.
+
+The experiment results themselves remain valid — they were run before #467 and
+accurately describe the behavior at the time. INV-7 in
+`docs/contributing/standards/invariants.md` was updated in PR #467 to reflect
+the current behavior.
+
+**Experiment 2 (negative control) invalidated:** H29's queue-depth:1 negative
+control showed 0.0% change between fresh and stale configurations — but that
+result depended on QueueDepth being Immediate. Post-#467, queue-depth:1 with
+`--snapshot-refresh-interval > 0` would also exhibit staleness-driven
+degradation, since both QueueDepth and BatchSize (which feed `EffectiveLoad()`)
+are now Periodic.
+```
+
+**Step 2 — Update the stale code snippet in "Critical Design Note" section:**
+
+Replace the code block starting at line 27 with the current `newObservabilityConfig` implementation:
+
+```go
+func newObservabilityConfig(refreshInterval int64) ObservabilityConfig {
+    if refreshInterval <= 0 {
+        return DefaultObservabilityConfig()  // all Immediate
+    }
+    periodic := FieldConfig{Mode: Periodic, Interval: refreshInterval}
+    return ObservabilityConfig{
+        QueueDepth:    periodic,    // Periodic when interval > 0 (changed in PR #467)
+        BatchSize:     periodic,    // Periodic when interval > 0 (changed in PR #467)
+        KVUtilization: periodic,
+    }
+}
+```
+
+And update the surrounding explanation to note:
+
+```
+When `--snapshot-refresh-interval > 0`, all three Prometheus-sourced signals become Periodic.
+Only `InFlightRequests` (gateway-local counter) remains synchronous.
+```
+
+**Step 3 — Run lint:**
+
+```bash
+# No Go files changed in this task, so no lint needed
+```
+
+**Commit:** `docs: add erratum to H29 FINDINGS.md for PR #467 snapshot staleness change`
+
+#### Task 4: Full verification gate
+
+**Step 1 — Build:**
+```bash
+go build ./...
+```
+
+**Step 2 — Run all tests:**
+```bash
+go test ./... -count=1
+```
+
+**Step 3 — Lint:**
+```bash
+golangci-lint run ./...
+```
+
+**Step 4 — Git status:**
+```bash
+git status
+```
+
+Expected: all pass, working tree shows planned modifications only.
+
+### H) Test Strategy
+
+| Contract | Task | Test Type | Test Name |
+|----------|------|-----------|-----------|
+| BC-1 | Task 2 | Behavioral | `TestWeightedScoring_TieBreaking_Random` |
+| BC-2 | Task 2 | Behavioral | `TestLeastLoaded_TieBreaking_Random` |
+| BC-3 | Task 2 | Invariant | `TestTieBreaking_Determinism` |
+| BC-4 | Task 2 | Invariant | `TestTieBreaking_NoTie_PreservesRNGState` |
+| BC-5 | Task 2 | Behavioral | `TestTieBreaking_NilRNG_Positional` |
+| BC-6 | Task 3 | Manual | Read erratum in FINDINGS.md |
+
+Key invariants:
+- **INV-6 (Determinism):** BC-3 test verifies same seed → same decisions
+- **INV-1 (Conservation):** Existing cluster conservation tests pass (routing change doesn't affect request accounting)
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation | Task |
+|------|-----------|--------|-----------|------|
+| RNG consumed on non-tie changes output determinism | Low | High | Guard: only consume RNG when len(tied) > 1 | Task 1, BC-4 test |
+| Floating-point equality comparison misses near-ties | Low | Medium | Scores are computed identically for all instances with equal state; exact float equality is correct here | Task 1 |
+| Test randomness makes tests flaky | Low | Low | 300 trials with ±50% tolerance; seed is fixed | Task 2 |
+| H29 erratum text inaccurate | Low | Low | Cross-reference with current snapshot.go code | Task 3 |
+
+---
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+**Plan-specific checks:**
+- [x] No unnecessary abstractions
+- [x] No feature creep beyond PR scope (AlwaysBusiest intentionally not fixed — pathological template)
+- [x] No unexercised flags or interfaces
+- [x] No partial implementations
+- [x] No breaking changes without explicit contract updates
+- [x] No hidden global state impact
+- [x] All new code will pass golangci-lint
+- [x] Shared test helpers: uses standard `math/rand` and existing test patterns
+- [x] CLAUDE.md update: N/A — CLAUDE.md doesn't describe tie-breaking behavior; doc comments on structs are updated in Task 1
+- [x] No stale references left in CLAUDE.md
+- [x] Documentation DRY: INV-7 already updated; H29 erratum is the stale working copy
+- [x] Deviation log reviewed
+- [x] Each task produces working, testable code
+- [x] Task dependencies correctly ordered (Task 1 before Task 2)
+- [x] All contracts mapped to specific tasks
+- [x] Golden dataset regeneration not needed (single-instance only)
+- [x] Construction site audit: `NewRoutingPolicy` is the sole construction site for both structs
+
+**Antipattern rules:**
+- [x] R1: No silent data loss
+- [x] R2: No map iteration ordering issues
+- [x] R3: No new numeric parameters
+- [x] R4: Construction site audit — `NewRoutingPolicy` is sole constructor, updated
+- [x] R5: N/A (no resource allocation)
+- [x] R6: No Fatalf in sim/
+- [x] R7: BC-3 invariant test alongside behavioral tests
+- [x] R8: No exported maps
+- [x] R9-R10: N/A (no YAML changes)
+- [x] R11: N/A (no division)
+- [x] R12: Golden dataset unaffected
+- [x] R13-R23: N/A or checked
+
+---
+
+## Appendix: File-Level Implementation Details
+
+### File: `sim/routing.go`
+
+**Purpose:** Add RNG-based random tie-breaking to `LeastLoaded` and `WeightedScoring`.
+
+**Changes:**
+1. Add `"math/rand"` import
+2. `LeastLoaded` struct: add `rng *rand.Rand` field
+3. `LeastLoaded.Route()`: two-pass (find min, collect tied, random pick)
+4. `LeastLoaded` doc comment: update tie-breaking description
+5. `WeightedScoring` struct: add `rng *rand.Rand` field
+6. `WeightedScoring.Route()`: two-pass (find max, collect tied, random pick)
+7. `WeightedScoring` doc comment: update tie-breaking description
+8. `NewRoutingPolicy`: add `rng *rand.Rand` parameter, pass to LeastLoaded{rng: rng} and WeightedScoring{..., rng: rng}
+
+**RNG usage:** `SubsystemRouter` from `PartitionedRNG`. Consumed only on ties (len(tied) > 1).
+
+### File: `sim/cluster/cluster.go`
+
+**Purpose:** Pass router RNG to `NewRoutingPolicy`.
+
+**Changes:** Extract `rng` creation before struct literal, pass `rng.ForSubsystem(sim.SubsystemRouter)` to factory.
+
+### File: `sim/routing_test.go`
+
+**Purpose:** Update all `NewRoutingPolicy` call sites with `nil` RNG; add BC-1 through BC-5 tests.
+
+### File: `sim/routing_scorers_test.go`, `sim/routing_prefix_scorer_test.go`, `sim/examples_test.go`
+
+**Purpose:** Update `NewRoutingPolicy` call sites with `nil` RNG parameter.
+
+### File: `hypotheses/h29-snapshot-staleness/FINDINGS.md`
+
+**Purpose:** Add erratum section, update stale code snippet and explanation.

--- a/hypotheses/h29-snapshot-staleness/FINDINGS.md
+++ b/hypotheses/h29-snapshot-staleness/FINDINGS.md
@@ -14,6 +14,37 @@
 | **Date** | 2026-02-25 |
 | **Rounds** | 1 |
 
+## Erratum (2026-03-09)
+
+**PR #467** (commit `9a603bc`) changed `sim/cluster/snapshot.go` so that when
+`--snapshot-refresh-interval > 0`, **all three signals** (QueueDepth, BatchSize,
+KVUtilization) use Periodic mode — not just KVUtilization. This invalidates the
+key design note and several conclusions in the original findings:
+
+- **"QueueDepth is always Immediate"** — no longer true when interval > 0. Only
+  `InFlightRequests` (injected synchronously by `buildRouterState()`) remains
+  unconditionally fresh.
+- **"queue-depth scorer is NOT affected"** — partially invalidated. Queue-depth
+  uses `EffectiveLoad() = QueueDepth + BatchSize + InFlightRequests`. When
+  interval > 0, both `QueueDepth` and `BatchSize` are stale; only
+  `InFlightRequests` remains fresh. The composite scorer resilience finding
+  (+3.8% mean) may no longer hold at non-zero intervals.
+- **"the default composite scorer is inherently resilient"** — this conclusion
+  now applies **only to the default `--snapshot-refresh-interval 0`
+  configuration**, where all signals are Immediate.
+
+The experiment results themselves remain valid — they were run before #467 and
+accurately describe the behavior at the time. INV-7 in
+`docs/contributing/standards/invariants.md` was updated in PR #467 to reflect
+the current behavior.
+
+**Experiment 2 (negative control) invalidated:** H29's queue-depth:1 negative
+control showed 0.0% change between fresh and stale configurations — but that
+result depended on QueueDepth being Immediate. Post-#467, queue-depth:1 with
+`--snapshot-refresh-interval > 0` would also exhibit staleness-driven
+degradation, since both QueueDepth and BatchSize (which feed `EffectiveLoad()`)
+are now Periodic.
+
 ## Hypothesis Statement
 
 Increasing the snapshot refresh interval from 1ms to 100ms degrades TTFT p99 by at least 20% for weighted routing (kv-utilization scorer) at high request rates (>80% saturation, 4 instances), because stale load signals cause the router to repeatedly select already-loaded instances, creating transient load imbalance.
@@ -22,7 +53,9 @@ Increasing the snapshot refresh interval from 1ms to 100ms degrades TTFT p99 by 
 
 ## Critical Design Note
 
-The `--snapshot-refresh-interval` flag (defined in `cmd/root.go:667`) only controls **KVUtilization** staleness. From `sim/cluster/snapshot.go:39-48`:
+**[Updated 2026-03-09 — see Erratum above]**
+
+When this experiment was run, `--snapshot-refresh-interval` only controlled **KVUtilization** staleness. The code at that time was:
 
 ```go
 func newObservabilityConfig(refreshInterval int64) ObservabilityConfig {
@@ -30,18 +63,36 @@ func newObservabilityConfig(refreshInterval int64) ObservabilityConfig {
         return DefaultObservabilityConfig()  // all Immediate
     }
     return ObservabilityConfig{
-        QueueDepth:    FieldConfig{Mode: Immediate},      // ALWAYS fresh
-        BatchSize:     FieldConfig{Mode: Immediate},      // ALWAYS fresh
-        KVUtilization: FieldConfig{Mode: Periodic, Interval: refreshInterval}, // AFFECTED
+        QueueDepth:    FieldConfig{Mode: Immediate},      // was Immediate pre-#467
+        BatchSize:     FieldConfig{Mode: Immediate},      // was Immediate pre-#467
+        KVUtilization: FieldConfig{Mode: Periodic, Interval: refreshInterval},
     }
 }
 ```
 
-Therefore:
-- `kv-utilization` scorer IS affected (reads `KVUtilization` directly)
-- `queue-depth` scorer is NOT affected (reads `EffectiveLoad() = QueueDepth + BatchSize + PendingRequests`, all Immediate/synchronous)
+Post-PR #467, when `--snapshot-refresh-interval > 0`, all three Prometheus-sourced signals become Periodic. Only `InFlightRequests` (gateway-local counter) remains synchronous. The current code is:
 
-The original hypothesis text mentions "queue-depth scorer" but the mechanism only applies to `kv-utilization`. The experiment tests both scorers to confirm this architectural distinction.
+```go
+func newObservabilityConfig(refreshInterval int64) ObservabilityConfig {
+    if refreshInterval <= 0 {
+        return DefaultObservabilityConfig()  // all Immediate
+    }
+    periodic := FieldConfig{Mode: Periodic, Interval: refreshInterval}
+    return ObservabilityConfig{
+        QueueDepth:    periodic,    // Periodic when interval > 0 (changed in PR #467)
+        BatchSize:     periodic,    // Periodic when interval > 0 (changed in PR #467)
+        KVUtilization: periodic,
+    }
+}
+```
+
+At the time of this experiment:
+- `kv-utilization` scorer was affected (reads `KVUtilization` directly)
+- `queue-depth` scorer was NOT affected (reads `EffectiveLoad() = QueueDepth + BatchSize + InFlightRequests`, all Immediate/synchronous)
+
+**[Note: see Erratum]** Post-#467, queue-depth is also affected when interval > 0.
+
+The experiment tested both scorers to confirm the architectural distinction that existed at the time.
 
 ## Experiment Design
 
@@ -157,7 +208,7 @@ H3 (`hypotheses/h3-signal-freshness/FINDINGS.md`) showed 200x worse distribution
 
 ### Key insight for INV-7 (Signal Freshness)
 
-The experiment validates INV-7's design: the tiered freshness architecture (QueueDepth=Immediate, KVUtilization=Periodic) means that routing quality degrades gracefully when snapshot refresh is slow, as long as at least one Immediate signal is included in the scoring pipeline. The default profile (`prefix-affinity:3,queue-depth:2,kv-utilization:2`) achieves this by construction.
+**[See Erratum]** The experiment validates INV-7's design *as it existed pre-#467*: the tiered freshness architecture (QueueDepth=Immediate, KVUtilization=Periodic) means that routing quality degrades gracefully when snapshot refresh is slow, as long as at least one Immediate signal is included in the scoring pipeline. The default profile (`prefix-affinity:3,queue-depth:2,kv-utilization:2`) achieves this by construction. Post-#467, all three Prometheus-sourced signals share the same scrape interval; only `InFlightRequests` remains unconditionally fresh.
 
 ## Conservation Check (INV-1)
 
@@ -260,7 +311,7 @@ The herding effect could be an artifact of constant-token workloads where all re
 
 ## Implications for Users
 
-- The default scoring profile (`prefix-affinity:3,queue-depth:2,kv-utilization:2`) is inherently resilient to KV staleness because queue-depth provides a real-time corrective signal
+- **[See Erratum]** The default scoring profile (`prefix-affinity:3,queue-depth:2,kv-utilization:2`) is inherently resilient to KV staleness when `--snapshot-refresh-interval` is 0 (the default). Post-#467, non-zero intervals make all Prometheus-sourced signals stale; only `InFlightRequests` remains fresh
 - Users who configure kv-utilization as the sole scorer should keep snapshot refresh intervals below 5ms (< 1 step time) to avoid measurable degradation
 - The 10ms threshold (14% degradation) provides a useful "warning zone" for monitoring systems
 - At intervals exceeding 50ms, degradation becomes severe (>250%) due to herding feedback loop

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -65,17 +65,22 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request) *Clus
 		})
 	}
 
+	// Extract PartitionedRNG before struct literal so routing policy can use SubsystemRouter.
+	// The routing policy exclusively owns the SubsystemRouter partition — do not reuse
+	// cs.rng.ForSubsystem(SubsystemRouter) elsewhere to avoid interleaving RNG draws.
+	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(config.Seed))
+
 	cs := &ClusterSimulator{
 		config:               config,
 		instances:            instances,
-		rng:                  sim.NewPartitionedRNG(sim.NewSimulationKey(config.Seed)),
+		rng:                  rng,
 		preGeneratedRequests: requests,
 		clusterEvents:        make(ClusterEventQueue, 0),
 		admissionLatency:     config.AdmissionLatency,
 		routingLatency:       config.RoutingLatency,
 		admissionPolicy:      sim.NewAdmissionPolicy(config.AdmissionPolicy, config.TokenBucketCapacity, config.TokenBucketRefillRate),
 		snapshotProvider:     NewCachedSnapshotProvider(instanceMap, newObservabilityConfig(config.SnapshotRefreshInterval)),
-		routingPolicy:        sim.NewRoutingPolicy(config.RoutingPolicy, config.RoutingScorerConfigs, config.BlockSizeTokens),
+		routingPolicy:        sim.NewRoutingPolicy(config.RoutingPolicy, config.RoutingScorerConfigs, config.BlockSizeTokens, rng.ForSubsystem(sim.SubsystemRouter)),
 		trace:                simTrace,
 		inFlightRequests:     make(map[string]int, config.NumInstances),
 	}

--- a/sim/examples_test.go
+++ b/sim/examples_test.go
@@ -84,7 +84,7 @@ func TestExampleConfigs_EPPEstimatePrefix_RoutingBehavior(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN creating a routing policy from the config
-	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16)
+	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16, nil)
 
 	// GIVEN instances with different loads
 	snapshots := []RoutingSnapshot{
@@ -120,7 +120,7 @@ func TestExampleConfigs_EPPPrecisePrefix_RoutingBehavior(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN creating a routing policy from the config
-	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16)
+	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16, nil)
 
 	// GIVEN instances with different loads and utilizations
 	snapshots := []RoutingSnapshot{
@@ -156,7 +156,7 @@ func TestExampleConfigs_EPPPrecisePrefix_WeightRatioEffect(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN creating a routing policy from the config
-	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16)
+	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16, nil)
 
 	// GIVEN instances where prefix-affinity and load-balancing disagree:
 	// - First, route a request to build prefix cache
@@ -215,7 +215,7 @@ func TestExampleConfigs_EPPEstimatePrefix_LoadBalanceMonotonicity(t *testing.T) 
 	assert.True(t, hasLoadBalance, "load-balance scorer should be present")
 
 	// WHEN routing through the policy with instances of varying load
-	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16)
+	policy := NewRoutingPolicy(bundle.Routing.Policy, bundle.Routing.Scorers, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "low", QueueDepth: 0, BatchSize: 0},   // lowest load
 		{ID: "mid", QueueDepth: 5, BatchSize: 0},   // medium load
@@ -255,7 +255,7 @@ func TestExampleConfigs_EPPPrecisePrefix_QueueDepthMonotonicity(t *testing.T) {
 	assert.True(t, hasQueueDepth, "queue-depth scorer should be present")
 
 	// WHEN routing through a queue-depth-only policy with instances of varying load
-	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "queue-depth", Weight: 1.0}}, 16)
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "queue-depth", Weight: 1.0}}, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "empty", QueueDepth: 0, BatchSize: 0},   // lowest load
 		{ID: "half", QueueDepth: 5, BatchSize: 0},    // medium load
@@ -295,7 +295,7 @@ func TestExampleConfigs_EPPPrecisePrefix_KVUtilizationMonotonicity(t *testing.T)
 	assert.True(t, hasKVUtil, "kv-utilization scorer should be present")
 
 	// WHEN routing through a kv-utilization-only policy with instances of varying utilization
-	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "kv-utilization", Weight: 1.0}}, 16)
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "kv-utilization", Weight: 1.0}}, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "empty", KVUtilization: 0.0},  // lowest utilization
 		{ID: "half", KVUtilization: 0.5},   // medium utilization

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -2,6 +2,7 @@ package sim
 
 import (
 	"fmt"
+	"math/rand"
 )
 
 // RoutingSnapshot is a lightweight view of instance state for policy decisions.
@@ -103,8 +104,10 @@ func (rr *RoundRobin) Route(req *Request, state *RouterState) RoutingDecision {
 // LeastLoaded routes requests to the instance with minimum (QueueDepth + BatchSize + InFlightRequests).
 // InFlightRequests prevents pile-on at high request rates where multiple routing decisions
 // occur at the same timestamp before instance events process (#175).
-// Ties are broken by first occurrence in snapshot order (lowest index).
-type LeastLoaded struct{}
+// Ties are broken randomly when rng is non-nil; by first occurrence (lowest index) when rng is nil.
+type LeastLoaded struct {
+	rng *rand.Rand
+}
 
 // Route implements RoutingPolicy for LeastLoaded.
 func (ll *LeastLoaded) Route(req *Request, state *RouterState) RoutingDecision {
@@ -113,18 +116,29 @@ func (ll *LeastLoaded) Route(req *Request, state *RouterState) RoutingDecision {
 		panic("LeastLoaded.Route: empty snapshots")
 	}
 
+	// Pass 1: find minimum load
 	minLoad := snapshots[0].EffectiveLoad()
-	target := snapshots[0]
-
 	for i := 1; i < len(snapshots); i++ {
-		load := snapshots[i].EffectiveLoad()
-		if load < minLoad {
+		if load := snapshots[i].EffectiveLoad(); load < minLoad {
 			minLoad = load
-			target = snapshots[i]
 		}
 	}
 
-	return NewRoutingDecision(target.ID, fmt.Sprintf("least-loaded (load=%d)", minLoad))
+	// Pass 2: collect all instances tied at minimum load
+	var tied []int
+	for i, snap := range snapshots {
+		if snap.EffectiveLoad() == minLoad {
+			tied = append(tied, i)
+		}
+	}
+
+	// Random tie-breaking when rng is non-nil; positional (first) when nil.
+	idx := tied[0]
+	if len(tied) > 1 && ll.rng != nil {
+		idx = tied[ll.rng.Intn(len(tied))]
+	}
+
+	return NewRoutingDecision(snapshots[idx].ID, fmt.Sprintf("least-loaded (load=%d)", minLoad))
 }
 
 // observerFunc is called after each routing decision to update stateful scorer state.
@@ -144,11 +158,13 @@ type observerFunc func(req *Request, targetInstance string)
 // Stateful scorers (prefix-affinity) register observers that update internal
 // state after each routing decision. Observers are called after argmax selection.
 //
-// Higher scores are preferred. Ties broken by first occurrence in snapshot order.
+// Higher scores are preferred. Ties broken randomly when rng is non-nil;
+// by first occurrence (lowest index) when rng is nil.
 type WeightedScoring struct {
 	scorers   []scorerFunc
 	weights   []float64 // normalized to sum to 1.0
 	observers []observerFunc
+	rng       *rand.Rand
 }
 
 // Route implements RoutingPolicy for WeightedScoring.
@@ -176,17 +192,32 @@ func (ws *WeightedScoring) Route(req *Request, state *RouterState) RoutingDecisi
 	}
 
 	// Argmax: select instance with highest composite score.
-	// Ties broken by first occurrence in snapshot order (strict >).
+	// Pass 1: find maximum score.
 	bestScore := -1.0
-	bestIdx := 0
-	for i, snap := range snapshots {
+	for _, snap := range snapshots {
 		if scores[snap.ID] > bestScore {
 			bestScore = scores[snap.ID]
-			bestIdx = i
 		}
 	}
 
-	// Notify observers of routing decision (stateful scorers update their state)
+	// Pass 2: collect all instances tied at maximum score.
+	// Exact float equality is correct here because identical instance states produce
+	// bitwise-identical scores (same accumulation order on same data per IEEE 754).
+	var tied []int
+	for i, snap := range snapshots {
+		if scores[snap.ID] == bestScore {
+			tied = append(tied, i)
+		}
+	}
+
+	// Random tie-breaking when rng is non-nil; positional (first) when nil.
+	bestIdx := tied[0]
+	if len(tied) > 1 && ws.rng != nil {
+		bestIdx = tied[ws.rng.Intn(len(tied))]
+	}
+
+	// Notify observers of routing decision (stateful scorers update their state).
+	// Uses post-tie-breaking bestIdx so prefix-affinity records the actual target.
 	for _, obs := range ws.observers {
 		obs(req, snapshots[bestIdx].ID)
 	}
@@ -230,8 +261,10 @@ func (ab *AlwaysBusiest) Route(_ *Request, state *RouterState) RoutingDecision {
 // For weighted scoring, scorerConfigs configures the scorer pipeline.
 // If scorerConfigs is nil/empty for "weighted", DefaultScorerConfigs() is used.
 // Non-weighted policies ignore scorerConfigs.
+// The rng parameter enables random tie-breaking for least-loaded and weighted policies;
+// nil preserves positional tie-breaking. Ignored by round-robin and always-busiest.
 // Panics on unrecognized names.
-func NewRoutingPolicy(name string, scorerConfigs []ScorerConfig, blockSize int64) RoutingPolicy {
+func NewRoutingPolicy(name string, scorerConfigs []ScorerConfig, blockSize int64, rng *rand.Rand) RoutingPolicy {
 	if !IsValidRoutingPolicy(name) {
 		panic(fmt.Sprintf("unknown routing policy %q", name))
 	}
@@ -239,7 +272,7 @@ func NewRoutingPolicy(name string, scorerConfigs []ScorerConfig, blockSize int64
 	case "", "round-robin":
 		return &RoundRobin{}
 	case "least-loaded":
-		return &LeastLoaded{}
+		return &LeastLoaded{rng: rng}
 	case "weighted":
 		if len(scorerConfigs) == 0 {
 			scorerConfigs = DefaultScorerConfigs()
@@ -254,7 +287,7 @@ func NewRoutingPolicy(name string, scorerConfigs []ScorerConfig, blockSize int64
 			}
 		}
 		weights := normalizeScorerWeights(scorerConfigs)
-		return &WeightedScoring{scorers: scorers, weights: weights, observers: observers}
+		return &WeightedScoring{scorers: scorers, weights: weights, observers: observers, rng: rng}
 	case "always-busiest":
 		return &AlwaysBusiest{}
 	default:

--- a/sim/routing_prefix_scorer_test.go
+++ b/sim/routing_prefix_scorer_test.go
@@ -23,7 +23,7 @@ func TestPrefixAffinityScorer_NoHistory_ZeroScores(t *testing.T) {
 	// GIVEN a weighted policy with prefix-affinity scorer (no prior routing)
 	policy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 
 	snapshots := []RoutingSnapshot{
 		{ID: "inst_0", QueueDepth: 0},
@@ -46,7 +46,7 @@ func TestPrefixAffinityScorer_NoHistory_ZeroScores(t *testing.T) {
 func TestPrefixAffinityScorer_ObserverBuildsAffinity(t *testing.T) {
 	policy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 
 	snapshots := []RoutingSnapshot{
 		{ID: "inst_0", QueueDepth: 0},
@@ -73,7 +73,7 @@ func TestPrefixAffinityScorer_ObserverBuildsAffinity(t *testing.T) {
 func TestPrefixAffinityScorer_ProportionalScoring(t *testing.T) {
 	policy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 
 	// Set up: 4 blocks per request at block_size=16
 	snapshots := []RoutingSnapshot{
@@ -114,7 +114,7 @@ func TestPrefixAffinityScorer_ProportionalScoring(t *testing.T) {
 func TestPrefixAffinityScorer_ShortPrefix_ZeroScore(t *testing.T) {
 	policy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 
 	snapshots := []RoutingSnapshot{{ID: "inst_0"}, {ID: "inst_1"}}
 
@@ -165,11 +165,11 @@ func TestPrefixAffinityScorer_Deterministic(t *testing.T) {
 	policy1 := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 3.0},
 		{Name: "queue-depth", Weight: 2.0},
-	}, 16)
+	}, 16, nil)
 	policy2 := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 3.0},
 		{Name: "queue-depth", Weight: 2.0},
-	}, 16)
+	}, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "inst_0", QueueDepth: 0},
 		{ID: "inst_1", QueueDepth: 0},
@@ -220,7 +220,7 @@ func TestPrefixAffinityScorer_WeightSensitivity_ConcentratesRouting(t *testing.T
 	affinityPolicy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 5.0},
 		{Name: "load-balance", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 	affinityCounts := make(map[string]int)
 	for _, req := range buildWorkload() {
 		d := affinityPolicy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
@@ -230,7 +230,7 @@ func TestPrefixAffinityScorer_WeightSensitivity_ConcentratesRouting(t *testing.T
 	// Run with load-only weights (no prefix awareness)
 	loadPolicy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "load-balance", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 	loadCounts := make(map[string]int)
 	for _, req := range buildWorkload() {
 		d := loadPolicy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
@@ -278,7 +278,7 @@ func TestPrefixAffinityScorer_INV1_INV2_Conformance(t *testing.T) {
 	policy := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "prefix-affinity", Weight: 3.0},
 		{Name: "queue-depth", Weight: 2.0},
-	}, 16)
+	}, 16, nil)
 
 	snapshots := []RoutingSnapshot{
 		{ID: "inst_0", QueueDepth: 2},
@@ -345,7 +345,7 @@ func TestPrefixAffinityScorer_NonWeightedPolicies_Unchanged(t *testing.T) {
 
 	for _, name := range policies {
 		t.Run(name, func(t *testing.T) {
-			policy := NewRoutingPolicy(name, nil, 16)
+			policy := NewRoutingPolicy(name, nil, 16, nil)
 			req := &Request{ID: "r1", InputTokens: []int{1, 2, 3}}
 			d := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 			// Just verify it doesn't panic and returns valid target

--- a/sim/routing_scorers_test.go
+++ b/sim/routing_scorers_test.go
@@ -111,8 +111,8 @@ func TestParseScorerConfigs_SingleScorer(t *testing.T) {
 // weighted with load-balance:1 must select the same instance as least-loaded
 // for every request, because argmax(1/(1+load)) = argmin(load).
 func TestLoadBalanceOnly_EquivalentToLeastLoaded(t *testing.T) {
-	loadBalanceOnly := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16)
-	leastLoaded := NewRoutingPolicy("least-loaded", nil, 16)
+	loadBalanceOnly := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16, nil)
+	leastLoaded := NewRoutingPolicy("least-loaded", nil, 16, nil)
 
 	testCases := [][]RoutingSnapshot{
 		{

--- a/sim/routing_test.go
+++ b/sim/routing_test.go
@@ -3,13 +3,14 @@ package sim
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 )
 
 // TestRoutingPolicy_Interface_Contract verifies the RoutingPolicy interface contract (BC-1).
 func TestRoutingPolicy_Interface_Contract(t *testing.T) {
 	// GIVEN a RoutingPolicy implementation (RoundRobin)
-	policy := NewRoutingPolicy("round-robin", nil, 16)
+	policy := NewRoutingPolicy("round-robin", nil, 16, nil)
 
 	// WHEN Route() is called with valid inputs
 	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
@@ -40,7 +41,7 @@ func TestRoutingPolicy_Interface_Contract(t *testing.T) {
 // TestRoundRobin_DeterministicOrdering verifies BC-2.
 func TestRoundRobin_DeterministicOrdering(t *testing.T) {
 	// GIVEN RoundRobin policy
-	policy := NewRoutingPolicy("round-robin", nil, 16)
+	policy := NewRoutingPolicy("round-robin", nil, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0"},
 		{ID: "instance_1"},
@@ -72,7 +73,7 @@ func TestRoundRobin_EmptySnapshots_Panics(t *testing.T) {
 		}
 	}()
 
-	policy := NewRoutingPolicy("round-robin", nil, 16)
+	policy := NewRoutingPolicy("round-robin", nil, 16, nil)
 	req := &Request{ID: "req1"}
 	policy.Route(req, &RouterState{Snapshots: []RoutingSnapshot{}, Clock: 1000})
 }
@@ -85,12 +86,12 @@ func TestNewRoutingPolicy_UnknownName_Panics(t *testing.T) {
 		}
 	}()
 
-	NewRoutingPolicy("invalid-policy", nil, 16)
+	NewRoutingPolicy("invalid-policy", nil, 16, nil)
 }
 
 // TestNewRoutingPolicy_DefaultName verifies empty string defaults to round-robin behavior.
 func TestNewRoutingPolicy_DefaultName(t *testing.T) {
-	policy := NewRoutingPolicy("", nil, 16)
+	policy := NewRoutingPolicy("", nil, 16, nil)
 	if policy == nil {
 		t.Fatal("Expected non-nil policy for empty string, got nil")
 	}
@@ -106,7 +107,7 @@ func TestNewRoutingPolicy_DefaultName(t *testing.T) {
 
 // TestLeastLoaded_LoadBasedSelection verifies BC-3.
 func TestLeastLoaded_LoadBasedSelection(t *testing.T) {
-	policy := NewRoutingPolicy("least-loaded", nil, 16)
+	policy := NewRoutingPolicy("least-loaded", nil, 16, nil)
 
 	tests := []struct {
 		name      string
@@ -121,23 +122,6 @@ func TestLeastLoaded_LoadBasedSelection(t *testing.T) {
 				{ID: "instance_2", QueueDepth: 7, BatchSize: 8},
 			},
 			expected: "instance_1",
-		},
-		{
-			name: "tie broken by first occurrence (lowest index)",
-			snapshots: []RoutingSnapshot{
-				{ID: "instance_0", QueueDepth: 5, BatchSize: 5},
-				{ID: "instance_1", QueueDepth: 8, BatchSize: 2},
-				{ID: "instance_2", QueueDepth: 3, BatchSize: 12},
-			},
-			expected: "instance_0",
-		},
-		{
-			name: "all instances equal load",
-			snapshots: []RoutingSnapshot{
-				{ID: "instance_0", QueueDepth: 5, BatchSize: 5},
-				{ID: "instance_1", QueueDepth: 5, BatchSize: 5},
-			},
-			expected: "instance_0",
 		},
 	}
 
@@ -171,7 +155,7 @@ func TestRoutingSnapshot_EffectiveLoad_IncludesInFlightRequests(t *testing.T) {
 // TestLeastLoaded_InFlightRequests_BreaksTie verifies that InFlightRequests is included
 // in load calculation, preventing pile-on at high request rates (#175).
 func TestLeastLoaded_InFlightRequests_BreaksTie(t *testing.T) {
-	policy := NewRoutingPolicy("least-loaded", nil, 16)
+	policy := NewRoutingPolicy("least-loaded", nil, 16, nil)
 
 	// GIVEN two instances with equal QueueDepth+BatchSize but different InFlightRequests
 	snapshots := []RoutingSnapshot{
@@ -197,7 +181,7 @@ func TestLeastLoaded_EmptySnapshots_Panics(t *testing.T) {
 		}
 	}()
 
-	policy := NewRoutingPolicy("least-loaded", nil, 16)
+	policy := NewRoutingPolicy("least-loaded", nil, 16, nil)
 	req := &Request{ID: "req1"}
 	policy.Route(req, &RouterState{Snapshots: []RoutingSnapshot{}, Clock: 1000})
 }
@@ -207,7 +191,7 @@ func TestLeastLoaded_EmptySnapshots_Panics(t *testing.T) {
 // TestWeightedScoring_DefaultScorers_RoutesToBestComposite verifies BC-17-6 (argmax).
 func TestWeightedScoring_DefaultScorers_RoutesToBestComposite(t *testing.T) {
 	// GIVEN weighted policy with default scorers and instances with varying load/utilization
-	policy := NewRoutingPolicy("weighted", nil, 16)
+	policy := NewRoutingPolicy("weighted", nil, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 10, BatchSize: 0, KVUtilization: 0.8},
 		{ID: "instance_1", QueueDepth: 2, BatchSize: 0, KVUtilization: 0.2},
@@ -230,7 +214,7 @@ func TestWeightedScoring_DefaultScorers_RoutesToBestComposite(t *testing.T) {
 
 // TestWeightedScoring_HighestScoreWins verifies BC-17-6: target has the highest score.
 func TestWeightedScoring_HighestScoreWins(t *testing.T) {
-	policy := NewRoutingPolicy("weighted", nil, 16)
+	policy := NewRoutingPolicy("weighted", nil, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 5, KVUtilization: 0.5},
 		{ID: "instance_1", QueueDepth: 1, KVUtilization: 0.1},
@@ -265,12 +249,12 @@ func TestWeightedScoring_WeightsNormalized(t *testing.T) {
 		{Name: "queue-depth", Weight: 3.0},
 		{Name: "kv-utilization", Weight: 2.0},
 		{Name: "load-balance", Weight: 2.0},
-	}, 16)
+	}, 16, nil)
 	scaled := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "queue-depth", Weight: 6.0},
 		{Name: "kv-utilization", Weight: 4.0},
 		{Name: "load-balance", Weight: 4.0},
-	}, 16)
+	}, 16, nil)
 
 	d1 := unnormalized.Route(&Request{ID: "r1"}, &RouterState{Snapshots: snapshots, Clock: 1000})
 	d2 := scaled.Route(&Request{ID: "r2"}, &RouterState{Snapshots: snapshots, Clock: 1000})
@@ -284,7 +268,7 @@ func TestWeightedScoring_WeightsNormalized(t *testing.T) {
 
 // TestWeightedScoring_SingleScorer_LoadBalance verifies single-scorer configuration.
 func TestWeightedScoring_SingleScorer_LoadBalance(t *testing.T) {
-	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16)
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 10},
 		{ID: "instance_1", QueueDepth: 2},
@@ -312,14 +296,14 @@ func TestWeightedScoring_DifferentScorerWeights_FlipDecision(t *testing.T) {
 	qdDominant := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "queue-depth", Weight: 9.0},
 		{Name: "kv-utilization", Weight: 1.0},
-	}, 16)
+	}, 16, nil)
 	d1 := qdDominant.Route(&Request{ID: "r1"}, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// WHEN using kv-utilization-dominant weights
 	kvDominant := NewRoutingPolicy("weighted", []ScorerConfig{
 		{Name: "queue-depth", Weight: 1.0},
 		{Name: "kv-utilization", Weight: 9.0},
-	}, 16)
+	}, 16, nil)
 	d2 := kvDominant.Route(&Request{ID: "r2"}, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN different weights produce different decisions
@@ -330,7 +314,7 @@ func TestWeightedScoring_DifferentScorerWeights_FlipDecision(t *testing.T) {
 
 // TestWeightedScoring_AllIdle_NoDivisionByZero verifies BC-17-9 (no NaN/Inf).
 func TestWeightedScoring_AllIdle_NoDivisionByZero(t *testing.T) {
-	policy := NewRoutingPolicy("weighted", nil, 16)
+	policy := NewRoutingPolicy("weighted", nil, 16, nil)
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 0, BatchSize: 0, KVUtilization: 0.0},
 		{ID: "instance_1", QueueDepth: 0, BatchSize: 0, KVUtilization: 0.0},
@@ -359,14 +343,14 @@ func TestWeightedScoring_EmptySnapshots_Panics(t *testing.T) {
 		}
 	}()
 
-	policy := NewRoutingPolicy("weighted", nil, 16)
+	policy := NewRoutingPolicy("weighted", nil, 16, nil)
 	policy.Route(&Request{ID: "req1"}, &RouterState{Snapshots: []RoutingSnapshot{}, Clock: 1000})
 }
 
 // TestWeightedScoring_NilConfigs_UsesDefaults verifies default scorer configuration.
 func TestWeightedScoring_NilConfigs_UsesDefaults(t *testing.T) {
 	// GIVEN nil scorerConfigs
-	policy := NewRoutingPolicy("weighted", nil, 16)
+	policy := NewRoutingPolicy("weighted", nil, 16, nil)
 
 	// WHEN routing a request with differentiated snapshots
 	snapshots := []RoutingSnapshot{
@@ -387,7 +371,7 @@ func TestWeightedScoring_NilConfigs_UsesDefaults(t *testing.T) {
 // TestWeightedScoring_InFlightRequests_AffectsScorers verifies that InFlightRequests
 // affects queue-depth and load-balance scorers.
 func TestWeightedScoring_InFlightRequests_AffectsScorers(t *testing.T) {
-	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16)
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{{Name: "load-balance", Weight: 1.0}}, 16, nil)
 
 	// GIVEN two instances with equal QueueDepth but different InFlightRequests
 	snapshots := []RoutingSnapshot{
@@ -406,7 +390,7 @@ func TestWeightedScoring_InFlightRequests_AffectsScorers(t *testing.T) {
 
 // TestWeightedScoring_EmptyConfigs_UsesDefaults verifies that empty scorer slice falls back to defaults.
 func TestWeightedScoring_EmptyConfigs_UsesDefaults(t *testing.T) {
-	policy := NewRoutingPolicy("weighted", []ScorerConfig{}, 16)
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{}, 16, nil)
 	snapshots := []RoutingSnapshot{{ID: "a", QueueDepth: 1}}
 	decision := policy.Route(&Request{ID: "r1"}, &RouterState{Snapshots: snapshots, Clock: 1000})
 	if decision.TargetInstance != "a" {
@@ -420,7 +404,7 @@ func TestRoutingDecision_PriorityHint_DefaultZero(t *testing.T) {
 
 	for _, name := range policyNames {
 		t.Run(name, func(t *testing.T) {
-			policy := NewRoutingPolicy(name, nil, 16)
+			policy := NewRoutingPolicy(name, nil, 16, nil)
 			state := &RouterState{
 				Snapshots: []RoutingSnapshot{{ID: "instance_0", QueueDepth: 1}},
 				Clock:     1000,
@@ -439,7 +423,7 @@ func TestRoutingDecision_PriorityHint_DefaultZero(t *testing.T) {
 
 // TestAlwaysBusiest_RouteToHighestLoad verifies BC-6.
 func TestAlwaysBusiest_RouteToHighestLoad(t *testing.T) {
-	policy := NewRoutingPolicy("always-busiest", nil, 16)
+	policy := NewRoutingPolicy("always-busiest", nil, 16, nil)
 	req := &Request{ID: "r1", InputTokens: []int{1, 2}}
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 2, BatchSize: 1},
@@ -457,7 +441,7 @@ func TestAlwaysBusiest_RouteToHighestLoad(t *testing.T) {
 // TestAlwaysBusiest_InFlightRequests_IncludedInLoad verifies that InFlightRequests
 // is included in AlwaysBusiest load calculation (#175).
 func TestAlwaysBusiest_InFlightRequests_IncludedInLoad(t *testing.T) {
-	policy := NewRoutingPolicy("always-busiest", nil, 16)
+	policy := NewRoutingPolicy("always-busiest", nil, 16, nil)
 
 	// GIVEN two instances with equal QueueDepth+BatchSize but different InFlightRequests
 	snapshots := []RoutingSnapshot{
@@ -481,6 +465,197 @@ func TestAlwaysBusiest_EmptySnapshots_Panics(t *testing.T) {
 			t.Error("expected panic on empty snapshots")
 		}
 	}()
-	policy := NewRoutingPolicy("always-busiest", nil, 16)
+	policy := NewRoutingPolicy("always-busiest", nil, 16, nil)
 	policy.Route(&Request{ID: "r1"}, &RouterState{Snapshots: []RoutingSnapshot{}, Clock: 0})
+}
+
+// === Random Tie-Breaking Tests (#565) ===
+
+// TestLeastLoaded_TieBreaking_Random verifies BC-2: random uniform tie-breaking.
+// GIVEN LeastLoaded with a non-nil RNG and 3 instances with equal EffectiveLoad
+// WHEN Route() is called 300 times
+// THEN each tied instance is selected with approximately equal frequency.
+func TestLeastLoaded_TieBreaking_Random(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	policy := NewRoutingPolicy("least-loaded", nil, 16, rng)
+	snapshots := []RoutingSnapshot{
+		{ID: "instance_0", QueueDepth: 5, BatchSize: 5},
+		{ID: "instance_1", QueueDepth: 5, BatchSize: 5},
+		{ID: "instance_2", QueueDepth: 5, BatchSize: 5},
+	}
+
+	counts := map[string]int{}
+	N := 300
+	for i := 0; i < N; i++ {
+		req := &Request{ID: fmt.Sprintf("req%d", i)}
+		decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+		counts[decision.TargetInstance]++
+	}
+
+	// Each instance should get roughly N/3 = 100 requests.
+	// Allow ±50% tolerance (50-150 range) for random variation — 6.1 sigma.
+	for _, id := range []string{"instance_0", "instance_1", "instance_2"} {
+		if counts[id] < 50 || counts[id] > 150 {
+			t.Errorf("instance %s got %d/%d requests, expected ~100 (uniform)", id, counts[id], N)
+		}
+	}
+}
+
+// TestWeightedScoring_TieBreaking_Random verifies BC-1: random uniform tie-breaking.
+// GIVEN WeightedScoring with a non-nil RNG and 3 instances with equal composite scores
+// WHEN Route() is called 300 times
+// THEN each tied instance is selected with approximately equal frequency.
+func TestWeightedScoring_TieBreaking_Random(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	// Single queue-depth scorer: all idle → all score 1.0 → tie.
+	policy := NewRoutingPolicy("weighted", []ScorerConfig{
+		{Name: "queue-depth", Weight: 1.0},
+	}, 16, rng)
+	snapshots := []RoutingSnapshot{
+		{ID: "instance_0", QueueDepth: 0},
+		{ID: "instance_1", QueueDepth: 0},
+		{ID: "instance_2", QueueDepth: 0},
+	}
+
+	counts := map[string]int{}
+	N := 300
+	for i := 0; i < N; i++ {
+		req := &Request{ID: fmt.Sprintf("req%d", i)}
+		decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+		counts[decision.TargetInstance]++
+	}
+
+	for _, id := range []string{"instance_0", "instance_1", "instance_2"} {
+		if counts[id] < 50 || counts[id] > 150 {
+			t.Errorf("instance %s got %d/%d requests, expected ~100 (uniform)", id, counts[id], N)
+		}
+	}
+}
+
+// TestTieBreaking_Determinism verifies BC-3: same seed → same decisions.
+// Tests both all-tied and partial-tie scenarios.
+func TestTieBreaking_Determinism(t *testing.T) {
+	cases := []struct {
+		name      string
+		snapshots []RoutingSnapshot
+	}{
+		{
+			name: "all-tied",
+			snapshots: []RoutingSnapshot{
+				{ID: "a", QueueDepth: 0},
+				{ID: "b", QueueDepth: 0},
+				{ID: "c", QueueDepth: 0},
+			},
+		},
+		{
+			name: "partial-tie",
+			snapshots: []RoutingSnapshot{
+				{ID: "a", QueueDepth: 0},
+				{ID: "b", QueueDepth: 0},
+				{ID: "c", QueueDepth: 5},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, policyName := range []string{"least-loaded", "weighted"} {
+			t.Run(tc.name+"/"+policyName, func(t *testing.T) {
+				rng1 := rand.New(rand.NewSource(99))
+				rng2 := rand.New(rand.NewSource(99))
+				var scorers []ScorerConfig
+				if policyName == "weighted" {
+					scorers = []ScorerConfig{{Name: "queue-depth", Weight: 1.0}}
+				}
+				p1 := NewRoutingPolicy(policyName, scorers, 16, rng1)
+				p2 := NewRoutingPolicy(policyName, scorers, 16, rng2)
+
+				for i := 0; i < 50; i++ {
+					req := &Request{ID: fmt.Sprintf("req%d", i)}
+					d1 := p1.Route(req, &RouterState{Snapshots: tc.snapshots, Clock: 1000})
+					d2 := p2.Route(req, &RouterState{Snapshots: tc.snapshots, Clock: 1000})
+					if d1.TargetInstance != d2.TargetInstance {
+						t.Errorf("request %d: different decisions with same seed: %s vs %s",
+							i, d1.TargetInstance, d2.TargetInstance)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestTieBreaking_NoTie_PreservesRNGState verifies BC-4: distinct scores → unique winner,
+// RNG state not advanced (non-tie calls must not shift the RNG stream).
+// Tests both LeastLoaded and WeightedScoring to ensure neither consumes RNG on non-ties.
+func TestTieBreaking_NoTie_PreservesRNGState(t *testing.T) {
+	nonTieSnaps := []RoutingSnapshot{
+		{ID: "instance_0", QueueDepth: 10, KVUtilization: 0.8},
+		{ID: "instance_1", QueueDepth: 1, KVUtilization: 0.1},
+		{ID: "instance_2", QueueDepth: 5, KVUtilization: 0.5},
+	}
+
+	tests := []struct {
+		name    string
+		policy  string
+		scorers []ScorerConfig
+		winner  string
+	}{
+		{"least-loaded", "least-loaded", nil, "instance_1"},
+		{"weighted/queue-depth", "weighted", []ScorerConfig{{Name: "queue-depth", Weight: 1.0}}, "instance_1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rng1 := rand.New(rand.NewSource(42))
+			rng2 := rand.New(rand.NewSource(42))
+
+			policy := NewRoutingPolicy(tc.policy, tc.scorers, 16, rng1)
+
+			// Make 50 non-tie routing calls — should NOT consume RNG
+			for i := 0; i < 50; i++ {
+				req := &Request{ID: fmt.Sprintf("req%d", i)}
+				decision := policy.Route(req, &RouterState{Snapshots: nonTieSnaps, Clock: 1000})
+				if decision.TargetInstance != tc.winner {
+					t.Fatalf("request %d: expected %s (unique winner), got %q", i, tc.winner, decision.TargetInstance)
+				}
+			}
+
+			// Verify rng1 and rng2 are in the same state
+			val1 := rng1.Intn(1000)
+			val2 := rng2.Intn(1000)
+			if val1 != val2 {
+				t.Errorf("RNG state diverged after non-tie calls: rng1=%d, rng2=%d (RNG consumed on non-tie)", val1, val2)
+			}
+		})
+	}
+}
+
+// TestTieBreaking_NilRNG_Positional verifies BC-5: nil RNG → positional tie-breaking.
+// Tests both LeastLoaded and WeightedScoring to ensure parity (R23).
+func TestTieBreaking_NilRNG_Positional(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		scorers []ScorerConfig
+	}{
+		{"least-loaded", "least-loaded", nil},
+		{"weighted/queue-depth", "weighted", []ScorerConfig{{Name: "queue-depth", Weight: 1.0}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := NewRoutingPolicy(tc.policy, tc.scorers, 16, nil)
+			snapshots := []RoutingSnapshot{
+				{ID: "instance_0", QueueDepth: 5},
+				{ID: "instance_1", QueueDepth: 5},
+			}
+
+			for i := 0; i < 10; i++ {
+				req := &Request{ID: fmt.Sprintf("req%d", i)}
+				decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
+				if decision.TargetInstance != "instance_0" {
+					t.Errorf("nil RNG should use positional (first), got %q", decision.TargetInstance)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- **Random tie-breaking** for `WeightedScoring.Route()` and `LeastLoaded.Route()`: when multiple instances have equal scores/loads, select uniformly at random using `SubsystemRouter` RNG partition instead of always picking the lowest-index instance
- **H29 erratum**: documents that PR #467 changed all Prometheus-sourced snapshot signals to Periodic when `--snapshot-refresh-interval > 0`, invalidating the queue-depth negative control and qualifying composite scorer resilience to interval=0 only
- **research.md**: marks H4 tie-breaking action item as resolved

## Behavioral Contracts

| Contract | Description | Test |
|----------|-------------|------|
| BC-1 | WeightedScoring random uniform tie-breaking | `TestWeightedScoring_TieBreaking_Random` |
| BC-2 | LeastLoaded random uniform tie-breaking | `TestLeastLoaded_TieBreaking_Random` |
| BC-3 | Same seed → same decisions (INV-6) | `TestTieBreaking_Determinism` |
| BC-4 | Non-tie calls don't consume RNG | `TestTieBreaking_NoTie_PreservesRNGState` |
| BC-5 | Nil RNG → positional tie-breaking | `TestTieBreaking_NilRNG_Positional` |
| BC-6 | H29 erratum documents PR #467 changes | Manual review |

## Key Design Decisions

- `NewRoutingPolicy` factory gains `*rand.Rand` parameter; `nil` preserves positional behavior for backward compat
- `ClusterSimulator` passes `rng.ForSubsystem(SubsystemRouter)` with exclusive ownership
- Two-pass argmax (find best, collect tied, random pick) — RNG consumed only on actual ties
- `AlwaysBusiest` intentionally keeps positional tie-breaking (pathological template)
- Golden dataset unaffected (single-instance, no routing policies)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] 5 new behavioral tests (uniformity, determinism, RNG preservation, nil-RNG positional)
- [x] All tests behavioral (not structural) — verified by convergence review

Fixes #565, fixes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)