### PR TITLE
feat(sim): MaxModelLen enforcement and MaxOutputLen budget (#567)

### DIFF
--- a/.claude/skills/convergence-review/design-prompts.md
+++ b/.claude/skills/convergence-review/design-prompts.md
@@ -71,7 +71,7 @@ DESIGN DOCUMENT:
 YOUR FOCUS: Module Contract Completeness (design guidelines Section 4.3)
 - Does every new or modified module have all 6 contract aspects?
   (observes / controls / owns / invariants / events / extension friction)
-- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-8)?
+- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-9)?
 - Is the extension friction count specified and within reference targets (Section 4.5)?
 - Are behavioral contracts testable? Could someone write a GIVEN/WHEN/THEN test from the contract alone?
 - Are failure modes specified? What happens under overload, misconfiguration, degenerate inputs?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Full details (verification strategies, evidence): see [`docs/contributing/standa
 - **INV-6 Determinism**: Same seed must produce byte-identical stdout across runs. Wall-clock timing goes to stderr.
 - **INV-7 Signal freshness**: Routing snapshot signals have tiered freshness — InFlightRequests (synchronous) vs QueueDepth/BatchSize/KVUtilization (Periodic when `--snapshot-refresh-interval > 0`, Immediate when 0). See `docs/contributing/standards/invariants.md` for the full hierarchy.
 - **INV-8 Work-conserving**: After every step completion, if `WaitQ.Len() > 0`, a `StepEvent` must exist in the event queue. The simulator must not idle while work is waiting.
+- **INV-9 Oracle knowledge boundary**: Servability decisions (enqueue guard, admission, routing, priority) must not read `Request.OutputTokens`. The control plane uses `MaxOutputLen` (client budget) or input-only checks. Only the execution engine may access `OutputTokens` for token generation and completion detection. See `docs/contributing/standards/invariants.md`.
 
 ### Engineering Principles
 
@@ -201,7 +202,7 @@ inference-sim/
 ├── .github/workflows/         # CI configuration (build, lint, test)
 ├── main.go                    # CLI entry point (Cobra)
 ├── cmd/
-│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model)
+│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model, --max-model-len)
 │   ├── observe.go             # Real mode HTTP client (OpenAI-compatible, streaming + non-streaming)
 │   ├── convert.go             # `blis convert` subcommands (servegen, csv-trace, preset, inference-perf)
 │   ├── compose.go             # `blis compose` for merging v2 specs
@@ -210,7 +211,7 @@ inference-sim/
 ├── sim/                       # Core single-instance simulator
 │   ├── config.go              # Module-scoped sub-config types (KVCacheConfig, BatchConfig, LatencyCoeffs, ModelHardwareConfig, PolicyConfig, WorkloadConfig) — composed into SimConfig via embedding (R16)
 │   ├── doc.go                 # Package reading guide: start with request.go, event.go, simulator.go
-│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor, event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
+│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor (validates MaxModelLen vs KV capacity), event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, EnqueueRequest (MaxModelLen + KV capacity guards), processCompletions (runtime length cap), observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
 │   ├── admission.go           # AdmissionPolicy interface (accepts *RouterState), AlwaysAdmit, TokenBucket, RejectAll, NewAdmissionPolicy factory
 │   ├── routing.go             # RoutingPolicy interface (accepts *RouterState), RoutingSnapshot (with EffectiveLoad() for canonical load calculation), RoutingDecision (with Priority hint), RoundRobin, LeastLoaded, WeightedScoring (composable scorer pipeline), AlwaysBusiest templates, NewRoutingPolicy factory
 │   ├── routing_scorers.go     # ScorerConfig, scorer implementations (queue-depth, kv-utilization, load-balance), ParseScorerConfigs, IsValidScorer, DefaultScorerConfigs, newScorerWithObserver factory
@@ -222,7 +223,7 @@ inference-sim/
 │   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
 │   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
 │   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft)
-│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted), Request lifecycle and state machine, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.)
+│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted), Request lifecycle and state machine, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.), MaxOutputLen (client output budget for enqueue guard)
 │   ├── kv_store.go            # KVStore interface (11 methods: +SetClock, +ConsumePendingTransferLatency), NewKVStoreFromConfig registration variable, MustNewKVCacheState/MustNewKVStoreFromConfig nil-guarded wrappers
 │   ├── batch.go               # Batch struct
 │   ├── batch_formation.go     # BatchFormation interface, BatchContext/BatchResult types, VLLMBatchFormation (FCFS + chunked-prefill + preemption), NewBatchFormation() factory
@@ -373,7 +374,7 @@ Note: Admission and Routing steps apply in cluster mode (multi-instance). Single
 ### Standards (what rules apply)
 
 - `docs/contributing/standards/rules.md`: **23 antipattern rules** (R1-R23) — each with evidence, checks, enforcement locations
-- `docs/contributing/standards/invariants.md`: **8 system invariants** (INV-1 through INV-8) — with verification strategies
+- `docs/contributing/standards/invariants.md`: **9 system invariants** (INV-1 through INV-9) — with verification strategies
 - `docs/contributing/standards/principles.md`: **Engineering principles** — separation of concerns, interface design, BDD/TDD
 - `docs/contributing/standards/experiments.md`: **Experiment standards** — hypothesis families (6 families × type classification), rigor requirements, root cause verification (RCV-1 through RCV-6), iterative review protocol (summary; see `docs/contributing/convergence.md`), findings classification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,7 +377,7 @@ Follow `docs/contributing/hypothesis.md` for the full process (Steps 0-10). Key 
 |---|---|---|
 | `CLAUDE.md` | Code architecture, file organization, CLI flags, compact rule/invariant tables | Always — authoritative for current codebase state |
 | `docs/contributing/standards/rules.md` | 23 antipattern rules with evidence, checks, enforcement | When reviewing or writing code |
-| `docs/contributing/standards/invariants.md` | 8 system invariants (INV-1 through INV-8) with verification strategies | When touching request lifecycle, KV cache, or metrics |
+| `docs/contributing/standards/invariants.md` | 9 system invariants (INV-1 through INV-9) with verification strategies | When touching request lifecycle, KV cache, or metrics |
 | `docs/contributing/standards/experiments.md` | Experiment taxonomy, rigor requirements, findings classification | When running hypothesis experiments |
 | `docs/contributing/pr-workflow.md` | End-to-end PR lifecycle (worktree → plan → review → implement → audit → PR) | Before starting any PR |
 | `docs/concepts/` | System architecture, core engine, concepts glossary, roofline estimation | When learning how BLIS works before contributing |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ var (
 	outputTokensMin           int       // Min Output Token Count
 	outputTokensMax           int       // Max Output Token Count
 	latencyModelBackend string // CLI --latency-model flag: selects latency model backend (Cobra-bound, NEVER mutated inside Run)
+	maxModelLen         int    // CLI --max-model-len: max total sequence length (input + output); 0 = unlimited
 
 	// CLI flags for model, GPU, TP, vllm version
 	model             string // LLM name
@@ -414,6 +415,73 @@ var runCmd = &cobra.Command{
 					}
 				}
 			}
+
+			// Auto-derive --max-model-len from HF config when not explicitly set (R18).
+			// Mirrors vLLM's _auto_fit_max_model_len(): uses max_position_embeddings,
+			// applies rope_scaling factor for older models, then caps at KV-feasible max.
+			if !cmd.Flags().Changed("max-model-len") {
+				maxPosEmb := hfConfig.MustGetInt("max_position_embeddings", 0)
+				if maxPosEmb > 0 {
+					maxModelLen = maxPosEmb
+
+					// Apply rope_scaling factor matching vLLM's blacklist approach:
+					// vLLM excludes "su", "longrope", and "llama3" rope types from factor
+					// application (these types encode the full context in max_position_embeddings).
+					// All other types (linear, dynamic, yarn, default, etc.) apply the factor.
+					// For "yarn", vLLM uses original_max_position_embeddings as the base.
+					if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok {
+						if ropeMap, ok := ropeScaling.(map[string]any); ok {
+							ropeType, _ := ropeMap["type"].(string)
+							if ropeType == "" {
+								ropeType, _ = ropeMap["rope_type"].(string) // some configs use rope_type
+							}
+							// Blacklist: these types already embed scaled context in max_position_embeddings
+							excluded := ropeType == "su" || ropeType == "longrope" || ropeType == "llama3"
+							if !excluded {
+								if factor, ok := ropeMap["factor"].(float64); ok && factor > 1.0 {
+									// For yarn, use original_max_position_embeddings as base if available
+									base := maxPosEmb
+									if ropeType == "yarn" {
+										if orig, ok := ropeMap["original_max_position_embeddings"].(float64); ok && int(orig) > 0 {
+											base = int(orig)
+										}
+									}
+									scaled := int(float64(base) * factor)
+									logrus.Infof("--latency-model: applying %s rope_scaling factor %.1f: %d → %d", ropeType, factor, base, scaled)
+									maxModelLen = scaled
+								}
+							}
+						}
+					}
+
+					logrus.Infof("--latency-model: auto-derived max-model-len=%d from max_position_embeddings", maxModelLen)
+				}
+			}
+
+			// Cap maxModelLen at KV-feasible maximum (matches vLLM's _maybe_limit_model_len).
+			// Without this, auto-derived max_position_embeddings can exceed KV capacity
+			// for models with large context windows on small GPU configs (e.g., 128K context, TP=1).
+			// Overflow-safe KV feasible max: compare in block space to avoid int64 multiplication overflow.
+			// Instead of computing totalKVBlocks * blockSizeTokens (which could overflow for extreme configs),
+			// we check whether ceil(maxModelLen / blockSizeTokens) > totalKVBlocks — the same comparison
+			// used in NewSimulator's startup validation.
+			if maxModelLen > 0 && blockSizeTokens > 0 {
+				blocksNeeded := int64(maxModelLen) / blockSizeTokens
+				if int64(maxModelLen)%blockSizeTokens != 0 {
+					blocksNeeded++
+				}
+				if blocksNeeded > totalKVBlocks {
+					kvFeasibleMax := int(totalKVBlocks * blockSizeTokens) // safe: totalKVBlocks * 16 fits int64 for all real GPUs
+					logrus.Warnf("--latency-model: max-model-len %d exceeds KV capacity (%d blocks × %d tokens); capping to %d tokens",
+						maxModelLen, totalKVBlocks, blockSizeTokens, kvFeasibleMax)
+					maxModelLen = kvFeasibleMax
+				}
+			}
+		}
+
+		// R3: Validate --max-model-len
+		if maxModelLen < 0 {
+			logrus.Fatalf("--max-model-len must be >= 0, got %d", maxModelLen)
 		}
 
 		// R3: Validate workload generation flags (before any synthesis path consumes them)
@@ -709,7 +777,7 @@ var runCmd = &cobra.Command{
 					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency),
 				BatchConfig:         sim.NewBatchConfig(maxRunningReqs, maxScheduledTokens, longPrefillTokenThreshold),
 				LatencyCoeffs:       sim.NewLatencyCoeffs(betaCoeffs, alphaCoeffs),
-				ModelHardwareConfig: sim.NewModelHardwareConfig(modelConfig, hwConfig, model, gpu, tensorParallelism, backend),
+				ModelHardwareConfig: sim.NewModelHardwareConfig(modelConfig, hwConfig, model, gpu, tensorParallelism, backend, maxModelLen),
 				PolicyConfig:        sim.NewPolicyConfig(priorityPolicy, scheduler),
 			},
 			NumInstances:            numInstances,
@@ -886,6 +954,7 @@ func init() {
 	runCmd.Flags().IntVar(&tensorParallelism, "tp", 0, "Tensor parallelism")
 	runCmd.Flags().StringVar(&vllmVersion, "vllm-version", "", "vLLM version")
 	runCmd.Flags().StringVar(&latencyModelBackend, "latency-model", "", "Latency model backend: blackbox (default), roofline, crossmodel")
+	runCmd.Flags().IntVar(&maxModelLen, "max-model-len", 0, "Max total sequence length (input + output); 0 = unlimited. Auto-derived from HF config for roofline/crossmodel when not set.")
 
 	// GuideLLM-style distribution-based workload generation config
 	runCmd.Flags().Float64Var(&rate, "rate", 1.0, "Requests arrival per second")

--- a/docs/concepts/core-engine.md
+++ b/docs/concepts/core-engine.md
@@ -2,7 +2,7 @@
 
 This page describes BLIS's single-instance discrete event simulation engine. For multi-instance cluster orchestration, see [Cluster Architecture](architecture.md).
 
-> **Canonical sources:** System invariants (INV-1 through INV-8) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
+> **Canonical sources:** System invariants (INV-1 through INV-9) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
 
 ## Overview
 
@@ -100,7 +100,7 @@ Requests follow a linear state machine with one exception (preemption):
 stateDiagram-v2
     [*] --> Arrival
     Arrival --> Queued : alpha queueing delay
-    Arrival --> DroppedUnservable : input too large for KV cache
+    Arrival --> DroppedUnservable : exceeds MaxModelLen or KV capacity
 
     state "Queued" as Queued
     note right of Queued
@@ -169,7 +169,12 @@ Preempted requests reset to the beginning of prefill (ProgressIndex = 0) and the
 
 ### Dropped Requests
 
-Requests whose input tokens require more KV blocks than the total cache capacity are dropped at enqueue time with a `DroppedUnservable` counter increment. This prevents livelock where the simulator would endlessly preempt and re-enqueue a request that can never fit.
+Requests are dropped as unservable at enqueue time (incrementing `DroppedUnservable`) via two guards:
+
+1. **MaxModelLen guard** — when `--max-model-len` is set, requests whose total sequence length exceeds the context window are rejected. When the request declares an output budget (`MaxOutputLen > 0`), the check is `input + budget > maxModelLen`. Otherwise, input length alone is checked (vLLM defaults `max_tokens` to `max_model_len - seq_len`; the runtime stop in `processCompletions` handles output growth).
+2. **KV capacity guard** — requests whose input tokens require more KV blocks than the total cache capacity are rejected. This prevents livelock where the simulator would endlessly preempt and re-enqueue a request that can never fit.
+
+Both guards fire before the request enters the wait queue, mirroring vLLM's pre-engine rejection. Additionally, when `--max-model-len` is set, a runtime length cap force-completes any request whose `ProgressIndex` reaches `MaxModelLen` during decode (defense-in-depth).
 
 ## Batch Formation
 

--- a/docs/contributing/standards/invariants.md
+++ b/docs/contributing/standards/invariants.md
@@ -2,7 +2,7 @@
 
 Invariants are properties that must hold at all times during and after simulation. They are verified by invariant tests (see R7) and checked during self-audit (Step 4.75).
 
-**Hypothesis family mapping:** INV-1 through INV-3, INV-5, and INV-6 belong to the **Scheduler invariants (safety/liveness)** family. INV-4 (KV cache conservation), INV-7 (signal freshness), and INV-8 (work-conserving property) belong to the **Structural model** family. See `docs/contributing/standards/experiments.md` for hypothesis family definitions.
+**Hypothesis family mapping:** INV-1 through INV-3, INV-5, and INV-6 belong to the **Scheduler invariants (safety/liveness)** family. INV-4 (KV cache conservation), INV-7 (signal freshness), INV-8 (work-conserving property), and INV-9 (oracle knowledge boundary) belong to the **Structural model** family. See `docs/contributing/standards/experiments.md` for hypothesis family definitions.
 
 ## INV-1: Request Conservation
 
@@ -105,3 +105,19 @@ Invariants are properties that must hold at all times during and after simulatio
 **Code location:** Search for `// Work-conserving:` comment in `sim/simulator.go` — the `else` branch of `len(remaining) > 0` checks `WaitQ.Len() > 0` and schedules a new `StepEvent`.
 
 **Hypothesis family:** Structural model (same as INV-4, INV-7).
+
+---
+
+## INV-9: Oracle Knowledge Boundary
+
+**Statement:** Servability decisions — enqueue guard (`EnqueueRequest`), admission control (`AdmissionPolicy`), routing (`RoutingPolicy`), and priority scoring (`PriorityPolicy`) — must not read `Request.OutputTokens` or `len(Request.OutputTokens)`. The control plane uses `Request.MaxOutputLen` (client-declared output budget) for sequence-length checks against `MaxModelLen`. When `MaxOutputLen == 0` (no budget), only input length is checked; the runtime stop in `processCompletions` enforces output growth limits. Only the execution engine (`executeBatchStep`, `processCompletions`, `recordRequestCompletion`, `FormBatch` step planning) may access `OutputTokens` for token generation, completion detection, and per-step resource allocation.
+
+**Rationale:** In real inference serving (vLLM), the engine does not know actual output length at admission time — only the client's declared `max_tokens` budget. BLIS's `Request.OutputTokens` is oracle knowledge (pre-determined for simulation). Using it for servability decisions would make the simulator's control plane behave differently from a real system, invalidating capacity planning results. See issue #567 ("Architectural Principle: Oracle Knowledge Boundary").
+
+**Scope:** The boundary applies to *servability* decisions (admit/reject/route), not to all scheduler operations. `FormBatch` legitimately reads `OutputTokens` for decode-phase step planning (whether to allocate a decode token), which mirrors vLLM's scheduler reading sequence state for per-step execution. The distinction: "should this request enter the system?" (servability — no oracle) vs. "what should this request do in the current step?" (execution — oracle allowed).
+
+**Verification:** `sim/simulator_test.go` — `TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary`: a request with `OutputTokens=1000` but `MaxOutputLen=0` and `MaxModelLen=512` is NOT rejected (input=200 < 512 passes input-only check), proving the enqueue guard does not peek at `OutputTokens`. Grep-based verification: `admission.go`, `routing.go`, `routing_scorers.go`, `routing_prefix_scorer.go`, `scheduler.go`, `priority.go` contain zero references to `OutputTokens`.
+
+**Evidence:** Issue #567 — the original implementation's BC-4 fallback (`effectiveMaxOutput = len(r.OutputTokens)`) violated this boundary. Fixed in the same PR after convergence review caught it.
+
+**Hypothesis family:** Structural model (same as INV-4, INV-7, INV-8).

--- a/docs/guide/kv-cache.md
+++ b/docs/guide/kv-cache.md
@@ -38,7 +38,15 @@ Prefix caching is automatic when using the `prefix-affinity` scorer with `weight
 ## Minimum KV Block Requirements
 
 !!! danger "DroppedUnservable rejection"
-    When `ceil(inputTokens / blockSize) > TotalCapacity()`, BLIS drops the request as **unservable** — it physically cannot fit in memory. This mirrors vLLM's pre-engine rejection path.
+    Requests are dropped as **unservable** (incrementing `DroppedUnservable`) in two cases:
+
+    1. **MaxModelLen guard** — when `--max-model-len` is set, requests whose total sequence length (input + output budget) exceeds the context window are rejected before entering the queue. This mirrors vLLM's `--max-model-len` validation.
+    2. **KV capacity guard** — when `ceil(inputTokens / blockSize) > TotalCapacity()`, the request physically cannot fit in GPU memory. This mirrors vLLM's pre-engine rejection path.
+
+    Both guards fire at enqueue time, before the request enters the wait queue.
+
+!!! info "Runtime length cap"
+    When `--max-model-len` is set, requests that grow beyond the limit during decode are force-completed. This is a defense-in-depth mechanism — under normal operation the enqueue guard prevents oversized requests, but the runtime cap protects against unbounded growth if a request bypasses the guard.
 
 Compute the minimum blocks needed for your workload:
 

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -103,6 +103,9 @@ When choosing between TP and replication (more instances): TP reduces per-reques
 !!! note "Automatic KV block calculation"
     When using roofline or crossmodel mode, `--total-kv-blocks` is automatically derived from model architecture and GPU memory if not explicitly set. The auto-calculated value accounts for TP (KV heads are sharded across ranks; total GPU memory scales with GPU count). Override with `--total-kv-blocks <N>` for non-standard deployments. The auto-calculation uses reference constants (90% GPU utilization, standard activation/overhead budgets matching the llm-d-benchmark capacity planner) and requires SwiGLU-family activations.
 
+!!! note "Automatic MaxModelLen derivation"
+    When using roofline or crossmodel mode and `--max-model-len` is not explicitly set, BLIS auto-derives it from `max_position_embeddings` in the HuggingFace `config.json`. For older models with `rope_scaling` (e.g., LongChat, Yi), the scaling factor is applied. The derived value is then capped at the KV-feasible maximum (`total_kv_blocks * block_size`) to prevent context windows from exceeding GPU memory capacity. Override with `--max-model-len <N>` when needed.
+
 ## Cross-Model Mode (Physics-Informed)
 
 Cross-model mode estimates step time using 7 globally-fitted coefficients (4 beta for step time + 3 alpha for CPU overhead) that work across model architectures. Unlike blackbox (per-model coefficients) or roofline (no MoE awareness), cross-model uses architecture features from `config.json` to scale a single coefficient set.

--- a/docs/guide/results.md
+++ b/docs/guide/results.md
@@ -42,7 +42,7 @@ When anomalies are detected, BLIS prints `=== Anomaly Counters ===`:
 | **Priority Inversions** | A lower-priority request was scheduled before a higher-priority one | Check scheduler choice — use `priority-fcfs` for SLO workloads |
 | **HOL Blocking Events** | A long prefill blocked shorter requests | Enable chunked prefill: `--long-prefill-token-threshold 256` |
 | **Rejected Requests** | Admission policy rejected the request | Check token bucket capacity or admission policy |
-| **Dropped Unservable** | Request needs more KV blocks than exist | Increase `--total-kv-blocks` or reduce max input tokens |
+| **Dropped Unservable** | Request exceeds `--max-model-len` context window or needs more KV blocks than exist | Check `--max-model-len` setting; increase `--total-kv-blocks` or reduce max input tokens |
 
 ## KV Cache Metrics
 

--- a/docs/guide/skills-and-plugins.md
+++ b/docs/guide/skills-and-plugins.md
@@ -22,7 +22,7 @@ Skills and plugins are organized into five layers, from most specific to most ge
 | **Official plugins** | `claude-plugins-official` | Anthropic official tools | `commit-commands` (git workflow), `pr-review-toolkit` (PR review), `code-review`, `feature-dev`, `claude-md-management` |
 | **Community plugins** | `awesome-claude-plugins` | Community-contributed tools | `audit-project` (multi-agent code review), `bug-fix`, `debugger`, `test-writer-fixer` |
 
-Project skills take precedence -- they encode BLIS-specific conventions (23 antipattern rules, 8 system invariants, convergence protocol) that generic tools do not know about.
+Project skills take precedence -- they encode BLIS-specific conventions (23 antipattern rules, 9 system invariants, convergence protocol) that generic tools do not know about.
 
 ## Marketplaces
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,6 +75,7 @@ Maps to `ModelHardwareConfig`.
 | `--hardware` | string | "" | GPU type (e.g., `H100`, `A100`). If empty, loaded from `defaults.yaml`. |
 | `--tp` | int | 0 | Tensor parallelism degree. If 0, loaded from `defaults.yaml`. |
 | `--vllm-version` | string | "" | vLLM version string. If empty, loaded from `defaults.yaml`. |
+| `--max-model-len` | int | 0 | Max total sequence length (input + output) in tokens. 0 = unlimited. Mirrors vLLM's `--max-model-len`. Auto-derived from `max_position_embeddings` in HuggingFace `config.json` for roofline/crossmodel backends (with `rope_scaling` support and KV-feasible capping). |
 
 ### Roofline Mode
 
@@ -375,7 +376,7 @@ For environments where live profiling is not feasible, the [Roofline model](../c
 | **KVCacheConfig** | `--total-kv-blocks`, `--block-size-in-tokens`, `--kv-cpu-blocks`, `--kv-offload-threshold`, `--kv-transfer-bandwidth`, `--kv-transfer-base-latency` |
 | **BatchConfig** | `--max-num-running-reqs`, `--max-num-scheduled-tokens`, `--long-prefill-token-threshold` |
 | **LatencyCoeffs** | `--alpha-coeffs`, `--beta-coeffs` |
-| **ModelHardwareConfig** | `--model`, `--hardware`, `--tp`, `--vllm-version`, `--latency-model`, `--model-config-folder`, `--hardware-config` |
+| **ModelHardwareConfig** | `--model`, `--hardware`, `--tp`, `--vllm-version`, `--latency-model`, `--model-config-folder`, `--hardware-config`, `--max-model-len` |
 | **PolicyConfig** | `--scheduler`, `--priority-policy` |
 | **WorkloadConfig** | `--workload`, `--workload-spec`, `--workload-traces-filepath`, `--defaults-filepath`, `--rate`, `--num-requests`, `--prompt-tokens*`, `--output-tokens*`, `--prefix-tokens` |
 | **DeploymentConfig** | `--num-instances`, `--admission-policy`, `--admission-latency`, `--token-bucket-capacity`, `--token-bucket-refill-rate`, `--routing-policy`, `--routing-latency`, `--routing-scorers`, `--snapshot-refresh-interval`, `--trace-level`, `--counterfactual-k` |

--- a/sim/batch_formation_test.go
+++ b/sim/batch_formation_test.go
@@ -14,7 +14,7 @@ func TestVLLMBatchFormation_ImplementsInterface(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	if bf == nil {
@@ -49,7 +49,7 @@ func TestVLLMBatchFormation_TokenBudgetEnforced(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 50, 0), // tight token budget
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -102,7 +102,7 @@ func TestVLLMBatchFormation_BatchSizeEnforced(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(200, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(2, 10000, 0), // tight batch size limit
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -157,7 +157,7 @@ func TestVLLMBatchFormation_PreemptionReleasesKV(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -223,7 +223,7 @@ func TestVLLMBatchFormation_PreemptionStopsDequeue(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0), // very tight
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -278,7 +278,7 @@ func TestVLLMBatchFormation_CircuitBreaker(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0), // very small
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -323,7 +323,7 @@ func TestVLLMBatchFormation_KVAllocationFailure_StopsDequeue(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0), // limited KV blocks
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -431,7 +431,7 @@ func TestVLLMBatchFormation_Phase1_EvictedNotRevisited(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(6, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 0, 0}, []float64{100, 1, 0}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -548,7 +548,7 @@ func TestVLLMBatchFormation_LivelockResolution(t *testing.T) {
 			[]float64{5752.705191348184, 17.25086436834028, 5.999143920128404},   // beta
 			[]float64{232.46191091038054, 1.752360364195244, 3357.4400353290152}, // alpha
 		),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 		PolicyConfig:        NewPolicyConfig("constant", "fcfs"),
 	}
 

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -21,7 +21,7 @@ func newTestDeploymentConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "", 0),
 		},
 		NumInstances: numInstances,
 	}
@@ -58,7 +58,7 @@ func TestDeploymentConfig_ToSimConfig_ReturnsEmbeddedSimConfig(t *testing.T) {
 			KVCacheConfig:       sim.NewKVCacheConfig(500, 32, 0, 0, 0, 42),
 			BatchConfig:         sim.NewBatchConfig(128, 4096, 512),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1, 2, 3}, []float64{4, 5, 6}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 2, "roofline"),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 2, "roofline", 0),
 			PolicyConfig:        sim.NewPolicyConfig("slo-based", "priority-fcfs"),
 		},
 		NumInstances:    3,
@@ -136,7 +136,7 @@ func TestClusterSimulator_SingleInstance_GoldenEquivalence(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", 0),
 				},
 				NumInstances: 1,
 			}
@@ -186,7 +186,7 @@ func TestClusterSimulator_SingleInstance_GoldenInvariants(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", 0),
 				},
 				NumInstances: 1,
 			}

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -18,7 +18,7 @@ func newTestSimConfig() sim.SimConfig {
 		KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 }
 
@@ -50,7 +50,7 @@ func TestInstanceSimulator_GoldenDataset_Equivalence(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 				},
 			)
 
@@ -104,7 +104,7 @@ func TestInstanceSimulator_GoldenDataset_Invariants(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 				},
 			)
 

--- a/sim/cluster/metrics_substrate_test.go
+++ b/sim/cluster/metrics_substrate_test.go
@@ -25,7 +25,7 @@ func msClusterConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 100000, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{5000, 10, 3}, []float64{1000, 2, 500}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "test-gpu", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "test-gpu", 1, "", 0),
 			PolicyConfig:        sim.NewPolicyConfig("constant", "fcfs"),
 		},
 		NumInstances:    numInstances,

--- a/sim/cluster/prefix_routing_test.go
+++ b/sim/cluster/prefix_routing_test.go
@@ -63,7 +63,7 @@ func baseDeploymentConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(2000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(64, 65536, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 50, 25}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "", 0, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "", 0, "", 0),
 		},
 		NumInstances: numInstances,
 		TraceLevel:   "decisions",

--- a/sim/cluster/snapshot_test.go
+++ b/sim/cluster/snapshot_test.go
@@ -15,7 +15,7 @@ func newTestInstance(id InstanceID, totalKVBlocks int64) *InstanceSimulator {
 		KVCacheConfig:       sim.NewKVCacheConfig(totalKVBlocks, 16, 0, 0, 0, 0),
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 	return NewInstanceSimulator(id, cfg)
 }

--- a/sim/config.go
+++ b/sim/config.go
@@ -79,13 +79,17 @@ type ModelHardwareConfig struct {
 	GPU         string        // GPU type (e.g., "H100")
 	TP          int           // tensor parallelism degree
 	Backend     string        // latency model backend: "" or "blackbox" (default), "roofline", "crossmodel"
+	MaxModelLen int           // max total sequence length (input + output); 0 = unlimited (mirrors vLLM --max-model-len)
 }
 
 // NewModelHardwareConfig creates a ModelHardwareConfig with all fields explicitly set.
 // This is the canonical constructor — all construction sites must use it (R4).
 // Parameter order matches struct field order.
 func NewModelHardwareConfig(modelConfig ModelConfig, hwConfig HardwareCalib,
-	model, gpu string, tp int, backend string) ModelHardwareConfig {
+	model, gpu string, tp int, backend string, maxModelLen int) ModelHardwareConfig {
+	if maxModelLen < 0 {
+		panic(fmt.Sprintf("NewModelHardwareConfig: MaxModelLen must be >= 0, got %d", maxModelLen))
+	}
 	return ModelHardwareConfig{
 		ModelConfig: modelConfig,
 		HWConfig:    hwConfig,
@@ -93,6 +97,7 @@ func NewModelHardwareConfig(modelConfig ModelConfig, hwConfig HardwareCalib,
 		GPU:         gpu,
 		TP:          tp,
 		Backend:     backend,
+		MaxModelLen: maxModelLen,
 	}
 }
 

--- a/sim/config_test.go
+++ b/sim/config_test.go
@@ -42,7 +42,7 @@ func TestNewLatencyCoeffs_FieldEquivalence(t *testing.T) {
 func TestNewModelHardwareConfig_FieldEquivalence(t *testing.T) {
 	mc := ModelConfig{NumLayers: 32}
 	hw := HardwareCalib{TFlopsPeak: 1000.0, MemoryGiB: 80.0}
-	got := NewModelHardwareConfig(mc, hw, "llama", "H100", 2, "roofline")
+	got := NewModelHardwareConfig(mc, hw, "llama", "H100", 2, "roofline", 8192)
 	want := ModelHardwareConfig{
 		ModelConfig: mc,
 		HWConfig:    hw,
@@ -50,6 +50,7 @@ func TestNewModelHardwareConfig_FieldEquivalence(t *testing.T) {
 		GPU:         "H100",
 		TP:          2,
 		Backend:     "roofline",
+		MaxModelLen: 8192,
 	}
 	assert.Equal(t, want, got)
 }

--- a/sim/latency/config_test.go
+++ b/sim/latency/config_test.go
@@ -460,7 +460,7 @@ func TestNewLatencyModel_RooflineZeroNumHeads_ReturnsError(t *testing.T) {
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 0, NumLayers: 32, HiddenDim: 4096},
 		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
-		"", "", 1, "roofline",
+		"", "", 1, "roofline", 0,
 	)
 
 	// WHEN NewLatencyModel is called (roofline validation happens here)
@@ -481,7 +481,7 @@ func TestNewLatencyModel_RooflineZeroTP_ReturnsError(t *testing.T) {
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096},
 		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
-		"", "", 0, "roofline",
+		"", "", 0, "roofline", 0,
 	)
 
 	// WHEN NewLatencyModel is called (roofline validation happens here)

--- a/sim/latency/crossmodel_test.go
+++ b/sim/latency/crossmodel_test.go
@@ -160,7 +160,7 @@ func TestNewLatencyModel_CrossModelMode(t *testing.T) {
 		[]float64{116.110, 1226.868, 19.943, 9445.157},
 		[]float64{13732.0, 0.0, 860.6},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	assert.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestNewLatencyModel_CrossModelMode_MoE(t *testing.T) {
 		[]float64{116.110, 1226.868, 19.943, 9445.157},
 		[]float64{13732.0, 0.0, 860.6},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	assert.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestNewLatencyModel_CrossModelMode_MissingNumLayers(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NumLayers")
@@ -219,7 +219,7 @@ func TestNewLatencyModel_CrossModelMode_MissingNumHeads(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NumHeads")
@@ -232,7 +232,7 @@ func TestNewLatencyModel_CrossModelMode_MissingHiddenDim(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HiddenDim")
@@ -245,7 +245,7 @@ func TestNewLatencyModel_CrossModelMode_ZeroTP(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 0, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 0, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "TP")
@@ -258,7 +258,7 @@ func TestNewLatencyModel_CrossModelMode_ShortBeta(t *testing.T) {
 		[]float64{116, 1226, 19}, // only 3, need 4
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "4")

--- a/sim/latency/latency_test.go
+++ b/sim/latency/latency_test.go
@@ -227,7 +227,7 @@ func TestRooflineLatencyModel_QueueingTime_Positive(t *testing.T) {
 func TestNewLatencyModel_BlackboxMode(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0),
 	}
 
 	model, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -267,7 +267,7 @@ func TestNewLatencyModel_BlackboxMode(t *testing.T) {
 func TestNewLatencyModel_RooflineMode(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs(nil, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(testModelConfig(), testHardwareCalib(), "", "", 2, "roofline"),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(testModelConfig(), testHardwareCalib(), "", "", 2, "roofline", 0),
 	}
 
 	model, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -294,7 +294,7 @@ func TestNewLatencyModel_RooflineMode(t *testing.T) {
 func TestNewLatencyModel_InvalidRoofline(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs(nil, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "roofline"),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "roofline", 0),
 	}
 
 	_, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -319,7 +319,7 @@ func TestNewLatencyModel_ShortAlphaCoeffs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, tc.alpha)
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, tc.backend)
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, tc.backend, 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for short AlphaCoeffs, got nil")
@@ -340,7 +340,7 @@ func TestNewLatencyModel_ShortBetaCoeffs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, []float64{100, 1, 100})
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for short BetaCoeffs, got nil")
@@ -352,7 +352,7 @@ func TestNewLatencyModel_ShortBetaCoeffs(t *testing.T) {
 // TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError verifies BC-4: NaN in alpha rejected.
 func TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{5000, 10, 5}, []float64{math.NaN(), 1.0, 100.0})
-	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""))
+	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0))
 	if err == nil {
 		t.Fatal("expected error for NaN AlphaCoeffs, got nil")
 	}
@@ -361,7 +361,7 @@ func TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError(t *testing.T) {
 // TestNewLatencyModel_InfBetaCoeffs_ReturnsError verifies BC-4: Inf in beta rejected.
 func TestNewLatencyModel_InfBetaCoeffs_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{math.Inf(1), 10, 5}, []float64{100, 1.0, 100.0})
-	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""))
+	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0))
 	if err == nil {
 		t.Fatal("expected error for Inf BetaCoeffs, got nil")
 	}
@@ -370,7 +370,7 @@ func TestNewLatencyModel_InfBetaCoeffs_ReturnsError(t *testing.T) {
 // TestNewLatencyModel_UnknownBackend_ReturnsError verifies BC-6: unknown backend → error.
 func TestNewLatencyModel_UnknownBackend_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{1000, 10, 2}, []float64{500, 1, 100})
-	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "nonexistent")
+	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "nonexistent", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
@@ -394,7 +394,7 @@ func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, tc.alpha)
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for negative coefficient")
@@ -412,7 +412,7 @@ func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
 // THEN the return value is >= 1 (livelock protection via R19)
 func TestBlackboxLatencyModel_StepTime_FloorAtOne(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{0, 0, 0}, []float64{0, 0, 0})
-	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	if err != nil {
 		t.Fatalf("NewLatencyModel: %v", err)

--- a/sim/metrics_substrate_test.go
+++ b/sim/metrics_substrate_test.go
@@ -51,7 +51,7 @@ func msConfig(horizon int64) SimConfig {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 100000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs(msBeta(), msAlpha()),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "test-gpu", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "test-gpu", 1, "", 0),
 		PolicyConfig:        NewPolicyConfig("constant", "fcfs"),
 		WorkloadConfig:      NewWorkloadConfig(),
 	}

--- a/sim/request.go
+++ b/sim/request.go
@@ -30,6 +30,7 @@ type Request struct {
 
 	InputTokens  []int // Prompt tokens
 	OutputTokens []int // Pre-specified output tokens (already known for the simulation)
+	MaxOutputLen int   // Client output budget (vLLM max_tokens); 0 = no budget (input-only check, runtime stop enforces limit)
 
 	State         RequestState // queued, running, completed
 	ProgressIndex int64  // Total number of input tokens processed so far + number of output tokens generated so far

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -76,6 +76,7 @@ type Simulator struct {
 	batchFormation       BatchFormation
 	model                  string
 	gpu                    string
+	maxModelLen            int // max total sequence length (0 = unlimited)
 	rng                    *PartitionedRNG // partitioned RNG for deterministic multi-subsystem simulation
 	priorityPolicy         PriorityPolicy
 	scheduler              InstanceScheduler
@@ -100,6 +101,20 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	if cfg.LongPrefillTokenThreshold < 0 {
 		return nil, fmt.Errorf("NewSimulator: LongPrefillTokenThreshold must be >= 0, got %d", cfg.LongPrefillTokenThreshold)
 	}
+	if cfg.MaxModelLen > 0 {
+		if cfg.BlockSizeTokens <= 0 {
+			return nil, fmt.Errorf("NewSimulator: BlockSizeTokens must be > 0 when MaxModelLen is set, got %d", cfg.BlockSizeTokens)
+		}
+		// Overflow-safe ceiling division: avoids int64 wraparound for large MaxModelLen values (R11).
+		blocksForMaxLen := int64(cfg.MaxModelLen) / cfg.BlockSizeTokens
+		if int64(cfg.MaxModelLen)%cfg.BlockSizeTokens != 0 {
+			blocksForMaxLen++
+		}
+		if blocksForMaxLen > cfg.TotalKVBlocks {
+			return nil, fmt.Errorf("NewSimulator: KV cache too small for MaxModelLen: need %d blocks (ceil(%d/%d)) but TotalKVBlocks=%d",
+				blocksForMaxLen, cfg.MaxModelLen, cfg.BlockSizeTokens, cfg.TotalKVBlocks)
+		}
+	}
 	batchFormation := NewBatchFormation()
 
 	s := &Simulator{
@@ -119,6 +134,7 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 		batchFormation:            batchFormation,
 		model:                     cfg.Model,
 		gpu:                       cfg.GPU,
+		maxModelLen:               cfg.MaxModelLen,
 		latencyModel:              latencyModel,
 	}
 	s.rng = NewPartitionedRNG(NewSimulationKey(cfg.Seed))
@@ -226,11 +242,46 @@ func (sim *Simulator) CurrentClock() int64 { return sim.Clock }
 func (sim *Simulator) SimHorizon() int64 { return sim.Horizon }
 
 // EnqueueRequest adds a newly arrived request to the waiting queue.
-// Requests whose input tokens require more KV blocks than the total cache
-// capacity are dropped with a warning (R19: livelock protection). This mirrors
-// real vLLM behavior where oversized requests are rejected before entering
-// the engine.
+// Two guards prevent unservable requests from entering the queue:
+//  1. MaxModelLen guard (when maxModelLen > 0): validates the request fits within
+//     the model's context window. First checks input >= maxModelLen (vLLM uses >=:
+//     input filling the entire context leaves no room for output). Then, when
+//     MaxOutputLen > 0 (client budget), checks input + budget <= maxModelLen.
+//     When MaxOutputLen == 0, the input check is sufficient (vLLM defaults
+//     max_tokens to max_model_len - seq_len; the runtime stop in processCompletions
+//     handles output growth). The control plane never peeks at len(OutputTokens) —
+//     respecting the oracle knowledge boundary (INV-9, #567).
+//  2. KV capacity guard (defense-in-depth, always active): drops requests whose input
+//     tokens alone require more KV blocks than total cache capacity (R19: livelock protection).
+//
+// Both guards mirror real vLLM behavior where oversized requests are rejected
+// before entering the engine.
 func (sim *Simulator) EnqueueRequest(r *Request) {
+	// Guard 1: MaxModelLen check (BC-2, BC-3)
+	if sim.maxModelLen > 0 {
+		// vLLM uses >= for the input check (serving.py:1542): input that fills
+		// the entire context window leaves no room for even one output token.
+		if len(r.InputTokens) >= sim.maxModelLen {
+			logrus.Warnf("dropping request %s: input length %d >= MaxModelLen %d (no room for output)",
+				r.ID, len(r.InputTokens), sim.maxModelLen)
+			sim.Metrics.DroppedUnservable++
+			delete(sim.Metrics.Requests, r.ID)
+			return
+		}
+		if r.MaxOutputLen > 0 {
+			// Client declared a budget: check input + budget fits context window
+			totalSeqLen := len(r.InputTokens) + r.MaxOutputLen
+			if totalSeqLen > sim.maxModelLen {
+				logrus.Warnf("dropping request %s: total sequence length %d (input=%d + budget=%d) exceeds MaxModelLen %d",
+					r.ID, totalSeqLen, len(r.InputTokens), r.MaxOutputLen, sim.maxModelLen)
+				sim.Metrics.DroppedUnservable++
+				delete(sim.Metrics.Requests, r.ID)
+				return
+			}
+		}
+	}
+
+	// Guard 2: KV capacity check (defense-in-depth, always active)
 	blocksNeeded := (int64(len(r.InputTokens)) + sim.KVCache.BlockSize() - 1) / sim.KVCache.BlockSize()
 	if blocksNeeded > sim.KVCache.TotalCapacity() {
 		logrus.Warnf("dropping request %s: input requires %d KV blocks but cache has only %d total",
@@ -275,7 +326,11 @@ func (sim *Simulator) recordRequestCompletion(req *Request) {
 	logrus.Debugf("Finished req: ID: %s at time: %d", req.ID, lat+req.ArrivalTime)
 	if len(req.OutputTokens) > 0 {
 		reqTotalOutput := lat - req.FirstTokenTime
-		// TPOT calculation in vLLM excludes the first generated token
+		// TPOT calculation in vLLM excludes the first generated token.
+		// NOTE: For length-capped requests (BC-5), this denominator uses the
+		// pre-determined output token count rather than actual decode steps completed.
+		// The resulting average ITL (stored in RequestITLs) will be underestimated.
+		// Acceptable for a defense-in-depth path that should rarely fire.
 		sim.Metrics.RequestITLs[req.ID] = float64(reqTotalOutput) / float64(max(len(req.OutputTokens)-1, 1))
 	} else {
 		sim.Metrics.RequestITLs[req.ID] = 0
@@ -429,6 +484,29 @@ func (sim *Simulator) processCompletions(now, currStepAdvance int64) []*Request 
 			})
 
 			// Record completion metrics
+			sim.recordRequestCompletion(req)
+		} else if sim.maxModelLen > 0 && req.ProgressIndex >= int64(sim.maxModelLen) {
+			// BC-5: Runtime length cap — defense-in-depth.
+			// Force-complete any request that has reached MaxModelLen.
+			// This should not fire under normal operation (enqueue guard prevents it),
+			// but protects against unbounded growth if a request bypasses the guard.
+			//
+			// NOTE (R23 exception): Final-token KV allocation is intentionally skipped here.
+			// R23 requires parallel code paths to apply equivalent transformations, but
+			// the normal completion path's AllocateKVBlocks for the last token (to commit
+			// it to the prefix cache) is not useful for a force-terminated request whose
+			// blocks are immediately released. The token at the cap boundary was already
+			// processed by executeBatchStep; the partially-filled last block is not
+			// committed to the prefix cache.
+			logrus.Warnf("[tick %07d] force-completing request %s: ProgressIndex %d >= MaxModelLen %d (length-capped)",
+				now, req.ID, req.ProgressIndex, sim.maxModelLen)
+			req.State = StateCompleted
+			sim.KVCache.ReleaseKVBlocks(req)
+			req.FinishedStepIdx = sim.stepCount
+			sim.Schedule(&RequestLeftEvent{
+				time:    now + currStepAdvance,
+				Request: req,
+			})
 			sim.recordRequestCompletion(req)
 		} else {
 			remaining = append(remaining, req)

--- a/sim/simulator_preempt_test.go
+++ b/sim/simulator_preempt_test.go
@@ -13,7 +13,7 @@ func TestPreempt_EmptyBatch_ReturnsFalse(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(config.TotalKVBlocks, config.BlockSizeTokens)
@@ -67,7 +67,7 @@ func TestPreempt_InsufficientBlocks_EvictsAllThenReturnsFalse(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(config.TotalKVBlocks, config.BlockSizeTokens)

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -47,7 +47,7 @@ func TestSimulator_GoldenDataset(t *testing.T) {
 				KVCacheConfig:       NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 				BatchConfig:         NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 				LatencyCoeffs:       NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 			})
 
 			requests := testGenerateRequests(tc.Seed, math.MaxInt64, tc.Rate/1e6,
@@ -158,7 +158,7 @@ func TestSimulator_WorkloadRNG_NotNil(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, "", 0),
 	})
 
 	rng := sim.WorkloadRNG()
@@ -180,7 +180,7 @@ func TestSimulator_DeterministicWorkload(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 
 	requests := testGenerateRequests(42, math.MaxInt64, 10.0/1e6, 50,
@@ -225,7 +225,7 @@ func newTestSimConfig() SimConfig {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, "", 0),
 	}
 }
 
@@ -330,7 +330,7 @@ func TestMustNewLatencyModel_NilFunc_Panics(t *testing.T) {
 		}
 	}()
 	coeffs := NewLatencyCoeffs([]float64{1, 2, 3}, []float64{1, 2, 3})
-	hw := NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "")
+	hw := NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0)
 	_, _ = MustNewLatencyModel(coeffs, hw) //nolint:errcheck // expected to panic before returning
 }
 
@@ -344,6 +344,45 @@ func TestNewSimulator_NilLatencyModel_ReturnsError(t *testing.T) {
 	if err.Error() != "NewSimulator: latencyModel must not be nil" {
 		t.Errorf("unexpected error message: %v", err)
 	}
+}
+
+// BC-1: KV cache too small for MaxModelLen → error
+func TestNewSimulator_MaxModelLen_KVTooSmall(t *testing.T) {
+	cfg := newTestSimConfig()
+	// 1024 tokens / 16 block size = 64 blocks needed, but only 50 available
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 1024)
+	cfg.KVCacheConfig = NewKVCacheConfig(50, 16, 0, 0, 0, 0)
+
+	kvStore := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
+	latencyModel, err := MustNewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
+	if err != nil {
+		t.Fatalf("MustNewLatencyModel: %v", err)
+	}
+	_, err = NewSimulator(cfg, kvStore, latencyModel)
+	if err == nil {
+		t.Fatal("expected error when KV cache too small for MaxModelLen")
+	}
+	if !strings.Contains(err.Error(), "KV cache too small for MaxModelLen") {
+		t.Errorf("error should mention KV cache too small, got: %v", err)
+	}
+}
+
+// BC-1: KV cache sufficient for MaxModelLen → no error
+func TestNewSimulator_MaxModelLen_KVSufficient(t *testing.T) {
+	cfg := newTestSimConfig()
+	// 1024 tokens / 16 block size = 64 blocks needed, 100 available
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 1024)
+	cfg.KVCacheConfig = NewKVCacheConfig(100, 16, 0, 0, 0, 0)
+	_ = mustNewSimulator(t, cfg) // should not error
+}
+
+// BC-3: MaxModelLen=0 bypasses the KV check
+func TestNewSimulator_MaxModelLen_Zero_NoValidation(t *testing.T) {
+	cfg := newTestSimConfig()
+	// MaxModelLen=0 (default) — no validation even with small KV cache
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 0)
+	cfg.KVCacheConfig = NewKVCacheConfig(1, 16, 0, 0, 0, 0)
+	_ = mustNewSimulator(t, cfg) // should not error
 }
 
 // TestNewSimulator_NoWorkload_EmptyQueue verifies that a SimConfig with no injected
@@ -526,7 +565,7 @@ func TestSimulator_RequestConservation_InfiniteHorizon_AllRequestsComplete(t *te
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -583,7 +622,7 @@ func TestSimulator_RequestConservation_FiniteHorizon_ThreeTermEquation(t *testin
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation-finite", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation-finite", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -648,7 +687,7 @@ func TestSimulator_Causality_FullChain_ArrivalToCompletion(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-causality", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-causality", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -704,7 +743,7 @@ func TestSimulator_ClockMonotonicity_NeverDecreases(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-monotonicity", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-monotonicity", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -747,7 +786,7 @@ func TestInjectArrival_BeyondHorizon_Warns(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{50, 0.1, 50}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	sim := mustNewSimulator(t, cfg)
 	req := &Request{
@@ -772,7 +811,7 @@ func TestSimulator_Determinism_ByteIdenticalJSON(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-determinism", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-determinism", "H100", 1, "", 0),
 	}
 
 	// Run 1
@@ -852,7 +891,7 @@ func TestSimulator_KVBlockConservation_PostSimulation_ZeroLeak(t *testing.T) {
 				KVCacheConfig:       NewKVCacheConfig(10000, 16, tt.kvCPUBlocks, 0.8, 100.0, 0),
 				BatchConfig:         NewBatchConfig(256, 2048, 0),
 				LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-kv-conservation", "H100", 1, ""),
+				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-kv-conservation", "H100", 1, "", 0),
 			}
 
 			sim := mustNewSimulator(t, cfg)
@@ -923,7 +962,7 @@ func TestWorkConserving_StepRestartsWhenWaitQNonEmpty(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(1, 2048, 0), // KEY: only one request can run at a time
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-work-conserving", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-work-conserving", "H100", 1, "", 0),
 	}
 
 	s := mustNewSimulator(t, cfg)
@@ -1087,6 +1126,361 @@ func TestEnqueueRequest_NormalInput_Enqueued(t *testing.T) {
 	// AND TotalInputTokens must include the request's tokens
 	if sim.Metrics.TotalInputTokens != 100 {
 		t.Errorf("TotalInputTokens = %d, want 100", sim.Metrics.TotalInputTokens)
+	}
+}
+
+// BC-2: Request with explicit budget exceeding MaxModelLen is dropped
+func TestEnqueueRequest_MaxModelLen_Exceeded_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Request: 300 input + 300 budget = 600 > MaxModelLen(512)
+	req := &Request{
+		ID:           "too_long",
+		InputTokens:  make([]int, 300),
+		OutputTokens: make([]int, 300),
+		MaxOutputLen: 300, // client declares output budget
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+	if _, exists := sim.Metrics.Requests[req.ID]; exists {
+		t.Error("dropped request should be removed from Metrics.Requests")
+	}
+}
+
+// BC-3: MaxModelLen=0 falls through to KV check only
+func TestEnqueueRequest_MaxModelLen_Zero_FallsThroughToKV(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Large request that fits KV (100 tokens, 1000 blocks available) but would fail MaxModelLen if it were set
+	req := &Request{
+		ID:           "large_but_fits_kv",
+		InputTokens:  make([]int, 100),
+		OutputTokens: make([]int, 1000),
+		State:        StateQueued,
+	}
+
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (MaxModelLen=0 should not reject)", sim.WaitQ.Len())
+	}
+}
+
+// BC-4: MaxOutputLen=0 → input-only check (oracle knowledge boundary: control plane
+// never peeks at len(OutputTokens)). Runtime stop enforces output growth limit.
+func TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Case 1: MaxOutputLen=0, input fits → enqueued (input-only check)
+	// Even though len(OutputTokens)=1000 would exceed MaxModelLen=512 if peeked at,
+	// the control plane doesn't see actual output length — only runtime stop handles it.
+	reqFits := &Request{
+		ID:           "input_fits_oracle",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 1000), // actual output exceeds context, but control plane can't see this
+		MaxOutputLen: 0,                 // no client budget → input-only check
+		State:        StateQueued,
+	}
+	sim.EnqueueRequest(reqFits)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (MaxOutputLen=0 should only check input)", sim.WaitQ.Len())
+	}
+
+	// Case 2: MaxOutputLen=0, input exceeds MaxModelLen → dropped
+	reqInputTooBig := &Request{
+		ID:           "input_too_big",
+		InputTokens:  make([]int, 600), // 600 > 512
+		OutputTokens: make([]int, 10),
+		MaxOutputLen: 0,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[reqInputTooBig.ID] = NewRequestMetrics(reqInputTooBig, 0)
+	sim.EnqueueRequest(reqInputTooBig)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (input exceeds MaxModelLen)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+
+	// Case 3: MaxOutputLen=400 (client budget) → total: 200 + 400 = 600 > 512 → dropped
+	reqBudgetExceeds := &Request{
+		ID:           "budget_exceeds",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 100), // actual output is 100, but client budget says 400
+		MaxOutputLen: 400,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[reqBudgetExceeds.ID] = NewRequestMetrics(reqBudgetExceeds, 0)
+	sim.EnqueueRequest(reqBudgetExceeds)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (budget-exceeded request should be dropped)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 2 {
+		t.Errorf("DroppedUnservable = %d, want 2", sim.Metrics.DroppedUnservable)
+	}
+}
+
+// Boundary test: input == maxModelLen with no budget → dropped (vLLM uses >= at serving.py:1542).
+// A request whose input fills the entire context leaves no room for output.
+func TestEnqueueRequest_InputEqualsMaxModelLen_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// input == MaxModelLen: fills the entire context, no room for output
+	req := &Request{
+		ID:           "exact_boundary",
+		InputTokens:  make([]int, 512), // == MaxModelLen
+		OutputTokens: make([]int, 10),
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0 (input==MaxModelLen should be rejected)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+}
+
+// Boundary test: input + budget == maxModelLen → accepted (exact fit, not exceeded).
+func TestEnqueueRequest_ExactFit_Accepted(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// input=200 + budget=312 = 512 == MaxModelLen → exact fit, should be accepted
+	req := &Request{
+		ID:           "exact_fit",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 312),
+		MaxOutputLen: 312,
+		State:        StateQueued,
+	}
+	sim.EnqueueRequest(req)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (exact fit should be accepted)", sim.WaitQ.Len())
+	}
+}
+
+// BC-5: Runtime length cap force-completes request at MaxModelLen boundary.
+// This is a defense-in-depth test: we directly place a request in the running batch
+// with ProgressIndex already at MaxModelLen to simulate bypass of enqueue guard.
+func TestProcessCompletions_RuntimeLengthCap(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 100),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Create a request with ProgressIndex at MaxModelLen boundary (bypassing enqueue guard)
+	req := &Request{
+		ID:           "length_capped",
+		InputTokens:  make([]int, 50),
+		OutputTokens: make([]int, 200), // would normally be longer than MaxModelLen
+		State:        StateRunning,
+		ProgressIndex: 100, // == MaxModelLen → should be force-completed
+		ArrivalTime:  0,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.RunningBatch = &Batch{Requests: []*Request{req}}
+
+	// Simulate processCompletions
+	remaining := sim.processCompletions(1000, 5000)
+
+	// THEN the request is force-completed
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %d, want 0 (length-capped request should be completed)", len(remaining))
+	}
+	if req.State != StateCompleted {
+		t.Errorf("req.State = %s, want completed", req.State)
+	}
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests = %d, want 1", sim.Metrics.CompletedRequests)
+	}
+
+	// Conservation: no requests lost
+	if sim.WaitQ.Len()+len(remaining)+sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("conservation violated: queued=%d + remaining=%d + completed=%d != 1",
+			sim.WaitQ.Len(), len(remaining), sim.Metrics.CompletedRequests)
+	}
+}
+
+// BC-7: INV-1 conservation holds when MaxModelLen drops requests.
+// End-to-end test: inject mix of requests (some exceed budget, some fit),
+// run to completion, verify injected == completed + dropped.
+func TestSimulator_Conservation_WithMaxModelLen_Drops(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             10_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 200),
+	}
+	sim := mustNewSimulator(t, cfg)
+	rng := sim.WorkloadRNG()
+
+	// Inject 20 requests: 10 that fit (input=50, output=50, budget=100 → 150 < 200)
+	// and 10 that exceed (input=50, output=50, budget=200 → 250 > 200)
+	numInjected := 0
+	for i := 0; i < 10; i++ {
+		req := &Request{
+			ID:           fmt.Sprintf("fits_%d", i),
+			InputTokens:  GenerateRandomTokenIDs(rng, 50),
+			OutputTokens: GenerateRandomTokenIDs(rng, 50),
+			MaxOutputLen: 100,
+			ArrivalTime:  int64(i * 100000),
+			State:        StateQueued,
+		}
+		sim.InjectArrival(req)
+		numInjected++
+	}
+	for i := 0; i < 10; i++ {
+		req := &Request{
+			ID:           fmt.Sprintf("exceeds_%d", i),
+			InputTokens:  GenerateRandomTokenIDs(rng, 50),
+			OutputTokens: GenerateRandomTokenIDs(rng, 50),
+			MaxOutputLen: 200, // 50 + 200 = 250 > MaxModelLen(200)
+			ArrivalTime:  int64(i * 100000),
+			State:        StateQueued,
+		}
+		sim.InjectArrival(req)
+		numInjected++
+	}
+
+	sim.Run()
+
+	// INV-1: injected == completed + still_queued + still_running + dropped
+	total := sim.Metrics.CompletedRequests + sim.Metrics.StillQueued +
+		sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != numInjected {
+		t.Errorf("INV-1 violation: completed(%d) + queued(%d) + running(%d) + dropped(%d) = %d, want %d",
+			sim.Metrics.CompletedRequests, sim.Metrics.StillQueued,
+			sim.Metrics.StillRunning, sim.Metrics.DroppedUnservable,
+			total, numInjected)
+	}
+
+	// Verify: 10 requests should be dropped, 10 should complete
+	if sim.Metrics.DroppedUnservable != 10 {
+		t.Errorf("DroppedUnservable = %d, want 10", sim.Metrics.DroppedUnservable)
+	}
+	if sim.Metrics.CompletedRequests != 10 {
+		t.Errorf("CompletedRequests = %d, want 10", sim.Metrics.CompletedRequests)
+	}
+}
+
+// R3: NewModelHardwareConfig panics on negative MaxModelLen
+func TestNewModelHardwareConfig_NegativeMaxModelLen_Panics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for negative MaxModelLen")
+		}
+		msg := fmt.Sprintf("%v", r)
+		if !strings.Contains(msg, "MaxModelLen") {
+			t.Errorf("panic message %q should contain MaxModelLen", msg)
+		}
+	}()
+	NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", -1)
+}
+
+// INV-9: Oracle Knowledge Boundary — control-plane functions must not reference OutputTokens.
+// This is a structural enforcement test: it reads the source files for servability-decision
+// functions and verifies zero references to OutputTokens.
+func TestINV9_OracleKnowledgeBoundary_NoOutputTokensInControlPlane(t *testing.T) {
+	// Control-plane files that must not reference OutputTokens
+	controlPlaneFiles := []string{
+		"admission.go",
+		"routing.go",
+		"routing_scorers.go",
+		"routing_prefix_scorer.go",
+		"scheduler.go",
+		"priority.go",
+	}
+
+	for _, filename := range controlPlaneFiles {
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", filename, err)
+		}
+		content := string(data)
+		if strings.Contains(content, "OutputTokens") {
+			t.Errorf("INV-9 violation: %s references OutputTokens — control-plane code must not access oracle output length", filename)
+		}
+	}
+
+	// Additionally verify EnqueueRequest specifically (it's in simulator.go, which
+	// also contains execution-engine code that legitimately uses OutputTokens).
+	data, err := os.ReadFile("simulator.go")
+	if err != nil {
+		t.Fatalf("failed to read simulator.go: %v", err)
+	}
+	content := string(data)
+	// Extract EnqueueRequest function body (between "func (sim *Simulator) EnqueueRequest" and the next "func ")
+	startIdx := strings.Index(content, "func (sim *Simulator) EnqueueRequest")
+	if startIdx < 0 {
+		t.Fatal("EnqueueRequest function not found in simulator.go")
+	}
+	endIdx := strings.Index(content[startIdx+1:], "\nfunc ")
+	if endIdx < 0 {
+		t.Fatal("could not find end of EnqueueRequest function")
+	}
+	enqueueBody := content[startIdx : startIdx+1+endIdx]
+	if strings.Contains(enqueueBody, "OutputTokens") {
+		t.Error("INV-9 violation: EnqueueRequest references OutputTokens — enqueue guard must not access oracle output length")
 	}
 }
 
@@ -1322,7 +1716,7 @@ func TestNewSimulator_NonRooflineZeroNumHeads_Succeeds(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1, 2, 3}, []float64{1, 2, 3}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{NumHeads: 0}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{NumHeads: 0}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 
 	// WHEN NewSimulator is called


### PR DESCRIPTION
## Summary

- Add vLLM-equivalent `--max-model-len` enforcement at three layers: startup validation, enqueue guard, and runtime stop
- Introduce `MaxOutputLen` field on `Request` for client output budget (oracle knowledge boundary, INV-9)
- Auto-derive `MaxModelLen` from HF `max_position_embeddings` for roofline/crossmodel backends, with rope_scaling blacklist and KV-feasible capping
- Codify INV-9 (Oracle Knowledge Boundary) as the 9th system invariant

## Test plan

- [x] 12 new tests: BC-1 through BC-5, BC-7 conservation, boundary tests (input==MaxModelLen, exact fit), R3 constructor panic, INV-9 structural enforcement
- [x] `go build ./...` clean
- [x] `go test ./... -count=1` all pass
- [x] `golangci-lint run ./...` 0 issues
- [x] Golden dataset output byte-identical (BC-8)
- [x] 5-round convergence review (50 perspective reviews)
- [x] Verified against real vLLM source (`training/vllm/`)

Partially addresses #529 (reasoning workload livelock) for roofline/crossmodel backends.
Blackbox gap tracked in #578.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)