### PR TITLE
refactor(sim): remove dead HardwareCalib fields

### DIFF
--- a/docs/concepts/roofline.md
+++ b/docs/concepts/roofline.md
@@ -79,15 +79,11 @@ Alternatively, download the `config.json` manually:
 ```json
 {
     "<GPU_name>": {
-        "TFlopsPeak":        989.5,
-        "BwPeakTBs":         3.35,
-        "BwEffConstant":     0.72,
-        "TOverheadMicros":   500.0,
-        "perLayerOverhead":  20.0,
-        "mfuPrefill":        0.65,
-        "mfuDecode":         0.12,
-        "allReduceLatency":  20.0,
-        "MemoryGiB":         80.0
+        "TFlopsPeak":  989.5,
+        "BwPeakTBs":   3.35,
+        "mfuPrefill":  0.45,
+        "mfuDecode":   0.30,
+        "MemoryGiB":   80.0
     }
 }
 ```
@@ -96,12 +92,8 @@ Alternatively, download the `config.json` manually:
 |-------|-------------|
 | `TFlopsPeak` | Peak BF16 TFLOPS from GPU datasheet |
 | `BwPeakTBs` | Peak HBM bandwidth in TB/s from GPU datasheet |
-| `BwEffConstant` | Fraction of peak BW achieved in practice (0-1) |
-| `TOverheadMicros` | Per-step overhead in microseconds |
-| `perLayerOverhead` | CPU scheduling overhead per transformer layer in microseconds |
-| `mfuPrefill` | Static MFU for prefill (used when MFU database is unavailable) |
-| `mfuDecode` | Static MFU for decode (used when MFU database is unavailable) |
-| `allReduceLatency` | All-reduce latency in microseconds (multi-GPU TP) |
+| `mfuPrefill` | Model FLOPS Utilization for prefill phase (compute-bound) |
+| `mfuDecode` | Model FLOPS Utilization for decode phase (memory-bound) |
 | `MemoryGiB` | GPU memory capacity in GiB. Used by `CalculateKVBlocks` to auto-derive `--total-kv-blocks` when roofline or crossmodel mode is active and the flag is not explicitly set. |
 
 > Note: The Peak TFLOPS and BW for a given GPU family might vary by GPU connectivity (e.g. SXM vs PCIe). We recommend a separate entry for each GPU connectivity type - e.g. A100-SXM, A100-PCIe etc in `hardware_config.json`.

--- a/hardware_config.json
+++ b/hardware_config.json
@@ -1,36 +1,24 @@
 {
     "H100": {
-		"TFlopsPeak":        989.5,
-		"BwPeakTBs":         3.35,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.45,
-		"mfuDecode":        0.30,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"TFlopsPeak":  989.5,
+		"BwPeakTBs":   3.35,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	},
 	"A100-SXM": {
-		"TFlopsPeak":        312,
-		"BwPeakTBs":         2.039,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.45,
-		"mfuDecode":        0.30,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"TFlopsPeak":  312,
+		"BwPeakTBs":   2.039,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	},
 	"A100-80": {
-		"_comment":          "Alias for A100-SXM — defaults.yaml uses A100-80 for all A100 model entries (BC-14)",
-		"TFlopsPeak":        312,
-		"BwPeakTBs":         2.039,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.45,
-		"mfuDecode":        0.30,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"_comment":    "Alias for A100-SXM — defaults.yaml uses A100-80 for all A100 model entries (BC-14)",
+		"TFlopsPeak":  312,
+		"BwPeakTBs":   2.039,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	}
 }

--- a/sim/latency/config.go
+++ b/sim/latency/config.go
@@ -261,9 +261,6 @@ func ValidateRooflineConfig(mc sim.ModelConfig, hc sim.HardwareCalib) error {
 	if invalidPositiveFloat(hc.BwPeakTBs) {
 		problems = append(problems, fmt.Sprintf("HardwareCalib.BwPeakTBs must be a valid positive number, got %v", hc.BwPeakTBs))
 	}
-	if invalidPositiveFloat(hc.BwEffConstant) {
-		problems = append(problems, fmt.Sprintf("HardwareCalib.BwEffConstant must be a valid positive number, got %v", hc.BwEffConstant))
-	}
 	if invalidPositiveFloat(hc.MfuPrefill) {
 		problems = append(problems, fmt.Sprintf("HardwareCalib.MfuPrefill must be a valid positive number, got %v", hc.MfuPrefill))
 	}

--- a/sim/latency/config_test.go
+++ b/sim/latency/config_test.go
@@ -332,7 +332,7 @@ func TestGetModelConfig_StandardFieldsTakePrecedenceOverFallbacks(t *testing.T) 
 }
 
 func TestValidateRooflineConfig_ZeroModelFields_ReturnsError(t *testing.T) {
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
 
 	tests := []struct {
 		name  string
@@ -374,7 +374,7 @@ func TestValidateRooflineConfig_ZeroHardwareFields_ReturnsAllErrors(t *testing.T
 		t.Fatal("expected error for zero hardware fields, got nil")
 	}
 	errMsg := err.Error()
-	for _, field := range []string{"TFlopsPeak", "BwPeakTBs", "BwEffConstant", "MfuPrefill", "MfuDecode"} {
+	for _, field := range []string{"TFlopsPeak", "BwPeakTBs", "MfuPrefill", "MfuDecode"} {
 		if !strings.Contains(errMsg, field) {
 			t.Errorf("error should mention %s, got: %v", field, errMsg)
 		}
@@ -385,12 +385,11 @@ func TestValidateRooflineConfig_NaNInfFields_ReturnsErrors(t *testing.T) {
 	// GIVEN a HardwareCalib with NaN and Inf fields (bypass <= 0 check)
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096}
 	hc := sim.HardwareCalib{
-		TFlopsPeak:    math.NaN(),
-		BwPeakTBs:     math.Inf(1),
-		BwEffConstant: 0.7,
-		MfuPrefill:    0.5,
-		MfuDecode:     math.NaN(),
-		MemoryGiB:     math.Inf(-1),
+		TFlopsPeak: math.NaN(),
+		BwPeakTBs:  math.Inf(1),
+		MfuPrefill: 0.5,
+		MfuDecode:  math.NaN(),
+		MemoryGiB:  math.Inf(-1),
 	}
 
 	// WHEN ValidateRooflineConfig is called
@@ -412,7 +411,7 @@ func TestValidateRooflineConfig_NaNMemoryGiB_ReturnsError(t *testing.T) {
 	// NaN != 0 is true in IEEE 754, so NaN passes the outer guard and must
 	// be caught by the inner math.IsNaN check. This test covers that path.
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: math.NaN()}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: math.NaN()}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 
@@ -428,7 +427,7 @@ func TestValidateRooflineConfig_NegativeMemoryGiB_ReturnsError(t *testing.T) {
 	// A plain negative value (not -Inf) exercises the hc.MemoryGiB < 0 branch,
 	// which is distinct from the math.IsInf path tested by NaNInfFields.
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: -80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: -80.0}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 
@@ -443,7 +442,7 @@ func TestValidateRooflineConfig_NegativeMemoryGiB_ReturnsError(t *testing.T) {
 func TestValidateRooflineConfig_ValidConfig_ReturnsNil(t *testing.T) {
 	// GIVEN valid ModelConfig and HardwareCalib
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
 
 	// WHEN ValidateRooflineConfig is called
 	err := latency.ValidateRooflineConfig(mc, hc)
@@ -459,7 +458,7 @@ func TestNewLatencyModel_RooflineZeroNumHeads_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs(nil, []float64{100, 1, 100})
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 0, NumLayers: 32, HiddenDim: 4096},
-		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
+		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
 		"", "", 1, "roofline", 0,
 	)
 
@@ -480,7 +479,7 @@ func TestNewLatencyModel_RooflineZeroTP_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs(nil, []float64{100, 1, 100})
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096},
-		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
+		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
 		"", "", 0, "roofline", 0,
 	)
 
@@ -662,7 +661,7 @@ func TestValidateRooflineConfig_MoE_ExpertsWithoutActive_ReturnsError(t *testing
 		NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
 		NumLocalExperts: 8, NumExpertsPerTok: 0,
 	}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 	if err == nil {
@@ -679,7 +678,7 @@ func TestValidateRooflineConfig_MoE_ActiveExceedsTotal_ReturnsError(t *testing.T
 		NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
 		NumLocalExperts: 8, NumExpertsPerTok: 10,
 	}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 	if err == nil {
@@ -715,7 +714,7 @@ func TestValidateRooflineConfig_MoE_NegativeDimensions_ReturnsError(t *testing.T
 			},
 		},
 	}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -733,7 +732,7 @@ func TestValidateRooflineConfig_MoE_ValidConfig_ReturnsNil(t *testing.T) {
 		IntermediateDim: 14336,
 		NumLocalExperts: 8, NumExpertsPerTok: 2,
 	}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 	if err != nil {

--- a/sim/latency/kv_capacity_test.go
+++ b/sim/latency/kv_capacity_test.go
@@ -30,12 +30,11 @@ func validDenseModelConfig() sim.ModelConfig {
 // validHWConfig returns an H100-like HardwareCalib with 80 GiB memory.
 func validHWConfig() sim.HardwareCalib {
 	return sim.HardwareCalib{
-		TFlopsPeak:    989.5,
-		BwPeakTBs:     3.35,
-		BwEffConstant: 0.72,
-		MfuPrefill:    0.65,
-		MfuDecode:     0.12,
-		MemoryGiB:     80.0,
+		TFlopsPeak: 989.5,
+		BwPeakTBs:  3.35,
+		MfuPrefill: 0.65,
+		MfuDecode:  0.12,
+		MemoryGiB:  80.0,
 	}
 }
 

--- a/sim/latency/roofline_test.go
+++ b/sim/latency/roofline_test.go
@@ -181,20 +181,13 @@ func TestCalculateMemoryAccessBytes_Conservation_TotalEqualsSumOfComponents(t *t
 }
 
 // testHardwareCalib returns an H100-like hardware config for roofline tests.
-// Note: BwEffConstant, TOverheadMicros, PerLayerOverhead, AllReduceLatency are
-// present for struct completeness and ValidateRooflineConfig but are NOT consumed
-// by rooflineStepTime() (single-crossover model uses raw peak bandwidth, no overheads).
 func testHardwareCalib() sim.HardwareCalib {
 	return sim.HardwareCalib{
-		TFlopsPeak:       989.0,
-		BwPeakTBs:        3.35,
-		BwEffConstant:    0.7,
-		TOverheadMicros:  50.0,
-		PerLayerOverhead: 5.0,
-		MfuPrefill:       0.55,
-		MfuDecode:        0.30,
-		AllReduceLatency: 10.0,
-		MemoryGiB:        80.0,
+		TFlopsPeak: 989.0,
+		BwPeakTBs:  3.35,
+		MfuPrefill: 0.55,
+		MfuDecode:  0.30,
+		MemoryGiB:  80.0,
 	}
 }
 

--- a/sim/model_hardware_config.go
+++ b/sim/model_hardware_config.go
@@ -22,13 +22,9 @@ type ModelConfig struct {
 // Used by the roofline latency model for compute/memory bandwidth estimation.
 // Parsing functions are in sim/latency/config.go.
 type HardwareCalib struct {
-	TFlopsPeak       float64 `json:"TFlopsPeak"`      // Tera (10^12) FLOP/s
-	BwPeakTBs        float64 `json:"BwPeakTBs"`       // in TB/s
-	BwEffConstant    float64 `json:"BwEffConstant"`   // scaling factor to convert Peak BW to Effective BW
-	TOverheadMicros  float64 `json:"TOverheadMicros"` // Per-step Overheads unaccounted for
-	PerLayerOverhead float64 `json:"perLayerOverhead"`
-	MfuPrefill       float64 `json:"mfuPrefill"`
-	MfuDecode        float64 `json:"mfuDecode"`
-	AllReduceLatency float64 `json:"allReduceLatency"`
-	MemoryGiB        float64 `json:"MemoryGiB"` // GPU memory capacity in GiB
+	TFlopsPeak float64 `json:"TFlopsPeak"` // Tera (10^12) FLOP/s
+	BwPeakTBs  float64 `json:"BwPeakTBs"`  // in TB/s
+	MfuPrefill float64 `json:"mfuPrefill"`
+	MfuDecode  float64 `json:"mfuDecode"`
+	MemoryGiB  float64 `json:"MemoryGiB"` // GPU memory capacity in GiB
 }


### PR DESCRIPTION
## Summary
- Removes 4 dead fields from `HardwareCalib` struct: `BwEffConstant`, `TOverheadMicros`, `PerLayerOverhead`, `AllReduceLatency`
- These fields were parsed from `hardware_config.json` but never consumed by any runtime code path (roofline, crossmodel, or blackbox)
- Cleans up `hardware_config.json`, validation logic, test struct literals, and documentation to match

## Motivation
Identified during roofline model review (Discussion #589). The fields were vestigial from an earlier roofline port that was later simplified. Keeping them causes confusion for users editing `hardware_config.json` and for reviewers auditing the physics model.

## Changes
| File | Change |
|------|--------|
| `sim/model_hardware_config.go` | Remove 4 fields from `HardwareCalib` struct |
| `sim/latency/config.go` | Remove `BwEffConstant` validation check |
| `hardware_config.json` | Remove dead fields from all 3 GPU entries |
| `sim/latency/roofline_test.go` | Update `testHardwareCalib()` helper |
| `sim/latency/config_test.go` | Update ~14 struct literals across test functions |
| `sim/latency/kv_capacity_test.go` | Update `validHWConfig()` helper |
| `docs/concepts/roofline.md` | Update example JSON and field table |

## Test plan
- [x] `go build ./...` — compiles cleanly
- [x] `go test ./...` — all 11 packages pass
- [x] `go vet ./...` — no issues
- [x] R4 audit: grepped for all construction sites of `HardwareCalib{}` — every one updated

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)