### PR TITLE
merge: bring pd branch up to date with main

### DIFF
--- a/.claude/skills/convergence-review/design-prompts.md
+++ b/.claude/skills/convergence-review/design-prompts.md
@@ -71,7 +71,7 @@ DESIGN DOCUMENT:
 YOUR FOCUS: Module Contract Completeness (design guidelines Section 4.3)
 - Does every new or modified module have all 6 contract aspects?
   (observes / controls / owns / invariants / events / extension friction)
-- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-8)?
+- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-9)?
 - Is the extension friction count specified and within reference targets (Section 4.5)?
 - Are behavioral contracts testable? Could someone write a GIVEN/WHEN/THEN test from the contract alone?
 - Are failure modes specified? What happens under overload, misconfiguration, degenerate inputs?

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,43 @@
+name: Claude Code Action
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: [self-hosted]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+        with:
+          anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
+          claude_args: '--model aws/claude-opus-4-6 --allowed-tools Skill Agent'
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-plugins-official.git
+            https://github.com/obra/superpowers-marketplace.git
+          plugins: |
+            code-review@claude-plugins-official
+            code-simplifier@claude-plugins-official
+            frontend-design@claude-plugins-official
+            superpowers@superpowers-marketplace

--- a/.gitignore
+++ b/.gitignore
@@ -59,16 +59,7 @@ largesweep/
 *.zip
 
 # Training data pipeline (large data files — keep .py and .md only)
-training/default_args/
-training/vllm/
-training/replay_data/
-training/model_configs/
-training/__pycache__/
-training/*.csv
-training/*.pdf
-training/*.boxnote
-training/hftoken.txt
-training/cmd/
+training
 
 # Hypothesis experiment output (generated, reproducible from run.sh)
 hypotheses/*/output/
@@ -96,3 +87,5 @@ saturation_regimes.xlsx
 traces.csv
 
 prompts.md
+
+actions-runner/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The simulator is CPU-only, deterministic, and designed for capacity planning, po
 go build -o blis main.go
 
 # Run with default model
-./blis run --model meta-llama/llama-3.1-8b-instruct
+./blis run --model qwen/qwen3-14b
 
 # Convert workload formats
 ./blis convert preset --name chatbot --rate 10 --num-requests 100
@@ -97,6 +97,7 @@ Full details (verification strategies, evidence): see [`docs/contributing/standa
 - **INV-6 Determinism**: Same seed must produce byte-identical stdout across runs. Wall-clock timing goes to stderr.
 - **INV-7 Signal freshness**: Routing snapshot signals have tiered freshness — InFlightRequests (synchronous) vs QueueDepth/BatchSize/KVUtilization (Periodic when `--snapshot-refresh-interval > 0`, Immediate when 0). See `docs/contributing/standards/invariants.md` for the full hierarchy.
 - **INV-8 Work-conserving**: After every step completion, if `WaitQ.Len() > 0`, a `StepEvent` must exist in the event queue. The simulator must not idle while work is waiting.
+- **INV-9 Oracle knowledge boundary**: Servability decisions (enqueue guard, admission, routing, priority) must not read `Request.OutputTokens`. The control plane uses `MaxOutputLen` (client budget) or input-only checks. Only the execution engine may access `OutputTokens` for token generation and completion detection. See `docs/contributing/standards/invariants.md`.
 - **INV-PD-1 KV completeness**: `decode_enqueue_time >= transfer_complete_time` for every disaggregated request.
 - **INV-PD-2 Pool exclusivity**: Prefill sub-requests on prefill instances only; decode on decode only.
 - **INV-PD-3 Transfer conservation**: `initiated_transfers == completed_transfers` at simulation end.
@@ -206,7 +207,7 @@ inference-sim/
 ├── .github/workflows/         # CI configuration (build, lint, test)
 ├── main.go                    # CLI entry point (Cobra)
 ├── cmd/
-│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model, --prefill-instances, --decode-instances, --pd-decider, --pd-prefix-threshold, --pd-transfer-bandwidth, --pd-transfer-base-latency, --pd-kv-bytes-per-token, --prefill-routing-scorers, --decode-routing-scorers)
+│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model, --max-model-len, --prefill-instances, --decode-instances, --pd-decider, --pd-prefix-threshold, --pd-transfer-bandwidth, --pd-transfer-base-latency, --pd-kv-bytes-per-token, --prefill-routing-scorers, --decode-routing-scorers)
 │   ├── observe.go             # Real mode HTTP client (OpenAI-compatible, streaming + non-streaming)
 │   ├── convert.go             # `blis convert` subcommands (servegen, csv-trace, preset, inference-perf)
 │   ├── compose.go             # `blis compose` for merging v2 specs
@@ -215,7 +216,7 @@ inference-sim/
 ├── sim/                       # Core single-instance simulator
 │   ├── config.go              # Module-scoped sub-config types (KVCacheConfig, BatchConfig, LatencyCoeffs, ModelHardwareConfig, PolicyConfig, WorkloadConfig) — composed into SimConfig via embedding (R16)
 │   ├── doc.go                 # Package reading guide: start with request.go, event.go, simulator.go
-│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor, event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
+│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor (validates MaxModelLen vs KV capacity), event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, EnqueueRequest (MaxModelLen + KV capacity guards), processCompletions (runtime length cap), observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
 │   ├── admission.go           # AdmissionPolicy interface (accepts *RouterState), AlwaysAdmit, TokenBucket, RejectAll, NewAdmissionPolicy factory
 │   ├── disaggregation.go     # DisaggregationDecider interface, DisaggregationDecision type, NeverDisaggregate, AlwaysDisaggregate, NewDisaggregationDecider factory; DisaggregationObserver interface; PrefixThresholdDecider (prefix-aware, router-side cache, globalVirtualInstance), NewPrefixThresholdDecider(threshold, blockSize)
 │   ├── routing.go             # RoutingPolicy interface (accepts *RouterState), RoutingSnapshot (with EffectiveLoad() for canonical load calculation), RoutingDecision (with Priority hint), RoundRobin, LeastLoaded, WeightedScoring (composable scorer pipeline), AlwaysBusiest templates, NewRoutingPolicy factory
@@ -228,7 +229,7 @@ inference-sim/
 │   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
 │   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
 │   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft)
-│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted), Request lifecycle and state machine, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.)
+│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted), Request lifecycle and state machine, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.), MaxOutputLen (client output budget for enqueue guard)
 │   ├── kv_store.go            # KVStore interface (11 methods: +SetClock, +ConsumePendingTransferLatency), NewKVStoreFromConfig registration variable, MustNewKVCacheState/MustNewKVStoreFromConfig nil-guarded wrappers
 │   ├── batch.go               # Batch struct
 │   ├── batch_formation.go     # BatchFormation interface, BatchContext/BatchResult types, VLLMBatchFormation (FCFS + chunked-prefill + preemption), NewBatchFormation() factory
@@ -236,7 +237,7 @@ inference-sim/
 │   ├── metrics.go             # TTFT, TPOT, E2E collection and SaveResults()
 │   ├── metrics_utils.go       # Percentile/mean calculation, MetricsOutput JSON struct, NewRequestMetrics canonical constructor
 │   ├── rng.go                 # PartitionedRNG for deterministic multi-subsystem simulation
-│   ├── model_hardware_config.go # ModelConfig, HardwareCalib structs (config types stay in sim/); HardwareCalib includes MemoryGiB (used by KV capacity auto-calculation in roofline/crossmodel modes)
+│   ├── model_hardware_config.go # ModelConfig, HardwareCalib structs (config types stay in sim/); HardwareCalib includes MemoryGiB (used by KV capacity auto-calculation in roofline/crossmodel modes). Note: MaxModelLen is int64 (aligned with ProgressIndex, TotalKVBlocks, BlockSizeTokens).
 │   └── internal/              # Shared internal packages
 │       ├── hash/              # Block-level hashing for prefix cache
 │       ├── testutil/          # Shared test infrastructure (golden dataset loading)
@@ -247,6 +248,7 @@ inference-sim/
 │   └── register.go            # NewKVStore factory + init()-based registration into sim/
 ├── sim/latency/               # Latency model implementations (PKG-2)
 │   ├── latency.go             # BlackboxLatencyModel (alpha/beta regression), RooflineLatencyModel (analytical FLOPs/bandwidth), CrossModelLatencyModel (physics-informed cross-model), NewLatencyModel(LatencyCoeffs, ModelHardwareConfig) factory
+│   ├── trained_roofline.go    # TrainedRooflineLatencyModel: roofline basis functions × learned corrections (7β + 3α from training pipeline)
 │   ├── crossmodel.go          # CrossModelLatencyModel: physics-informed step time from architecture features (MoE-aware)
 │   ├── roofline.go            # rooflineStepTime(), calculateTransformerFlops(), calculateMemoryAccessBytes(), StepConfig/PrefillRequestConfig/DecodeRequestConfig types
 │   ├── kv_capacity.go         # CalculateKVBlocks: auto-derive total KV cache blocks from model architecture + GPU memory; KVCapacityParams, ExtractKVCapacityParams, computeModelWeightBytes
@@ -351,7 +353,7 @@ inference-sim/
 
 ### Latency Estimation
 
-Three modes, selected by `latency.NewLatencyModel()` factory (in `sim/latency/`) based on `--latency-model` flag:
+Four modes, selected by `latency.NewLatencyModel()` factory (in `sim/latency/`) based on `--latency-model` flag:
 
 1. **Blackbox mode** (default): Uses trained alpha/beta coefficients from `defaults.yaml`
    - Alpha coefficients: queueing time estimation
@@ -369,12 +371,19 @@ Three modes, selected by `latency.NewLatencyModel()` factory (in `sim/latency/`)
    - MoE-aware: correctly models sparse activation patterns (unlike roofline which overestimates ~4x for MoE)
    - **`--latency-model crossmodel`**: Same auto-fetch chain as roofline. Usage: `./blis run --model <name> --latency-model crossmodel --hardware <GPU> --tp <N>`
 
+4. **Trained-roofline mode**: Roofline basis functions × learned correction coefficients via `sim/latency/trained_roofline.go`
+   - Uses 10 globally-fitted coefficients — 7 beta (prefill/decode roofline corrections, weight loading, TP communication, per-layer overhead, per-request scheduling, per-step overhead) + 3 alpha (API processing, post-decode fixed, per-output-token) — from `trained_roofline_defaults` in `defaults.yaml`
+   - Computes 6 analytical basis functions from HuggingFace `config.json` and hardware specs, applies learned β corrections
+   - Achieves 7% MAPE on GPU combined step time (test split) across 4 architectures (137K real vLLM requests)
+   - Key difference from pure roofline: no MFU scaling (β₁/β₂ ARE the corrections); 3-matrix SwiGLU (not roofline's 2-matrix)
+   - **`--latency-model trained-roofline`**: Same auto-fetch chain as roofline/crossmodel. Usage: `./blis run --model <name> --latency-model trained-roofline --hardware <GPU> --tp <N>`
+
 ### Key Data Flow
 
 ```
 Request Arrival → Admission → Routing → WaitQueue → Batch Formation → Step Execution → Completion
                                             ↓              ↓
-                                      KV Allocation   Latency Estimation (alpha/beta, roofline, or cross-model)
+                                      KV Allocation   Latency Estimation (alpha/beta, roofline, cross-model, or trained-roofline)
 ```
 Note: Admission and Routing steps apply in cluster mode (multi-instance). Single-instance mode skips directly to WaitQueue.
 
@@ -395,7 +404,7 @@ CLI flags: `--pd-decider` (never/always/prefix-threshold), `--pd-prefix-threshol
 ### Standards (what rules apply)
 
 - `docs/contributing/standards/rules.md`: **23 antipattern rules** (R1-R23) — each with evidence, checks, enforcement locations
-- `docs/contributing/standards/invariants.md`: **8 system invariants** (INV-1 through INV-8) — with verification strategies
+- `docs/contributing/standards/invariants.md`: **9 system invariants** (INV-1 through INV-9) — with verification strategies
 - `docs/contributing/standards/principles.md`: **Engineering principles** — separation of concerns, interface design, BDD/TDD
 - `docs/contributing/standards/experiments.md`: **Experiment standards** — hypothesis families (6 families × type classification), rigor requirements, root cause verification (RCV-1 through RCV-6), iterative review protocol (summary; see `docs/contributing/convergence.md`), findings classification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,7 @@ BLIS has four extension types. Identify which type your change is, then follow t
 When adding a new model configuration:
 
 1. Add an entry to the `defaults:` section with `GPU`, `tensor_parallelism`, and `vllm_version`
-2. Add an `hf_repo` field mapping the BLIS model name (lowercase) to the case-sensitive HuggingFace repository path (e.g., `hf_repo: meta-llama/Llama-3.1-8B-Instruct`). This enables `--latency-model roofline` auto-fetch. Models without real HuggingFace repos (e.g., synthetic benchmarks) may omit `hf_repo` — document why with a YAML comment.
+2. Add an `hf_repo` field mapping the BLIS model name (lowercase) to the case-sensitive HuggingFace repository path (e.g., `hf_repo: Qwen/Qwen3-14B`). This enables `--latency-model roofline` auto-fetch. Models without real HuggingFace repos (e.g., synthetic benchmarks) may omit `hf_repo` — document why with a YAML comment.
 3. If trained coefficients exist, add a corresponding entry to the `models:` list
 
 ### Policy Template (lightest — ~3 files)
@@ -377,7 +377,7 @@ Follow `docs/contributing/hypothesis.md` for the full process (Steps 0-10). Key 
 |---|---|---|
 | `CLAUDE.md` | Code architecture, file organization, CLI flags, compact rule/invariant tables | Always — authoritative for current codebase state |
 | `docs/contributing/standards/rules.md` | 23 antipattern rules with evidence, checks, enforcement | When reviewing or writing code |
-| `docs/contributing/standards/invariants.md` | 8 system invariants (INV-1 through INV-8) with verification strategies | When touching request lifecycle, KV cache, or metrics |
+| `docs/contributing/standards/invariants.md` | 9 system invariants (INV-1 through INV-9) with verification strategies | When touching request lifecycle, KV cache, or metrics |
 | `docs/contributing/standards/experiments.md` | Experiment taxonomy, rigor requirements, findings classification | When running hypothesis experiments |
 | `docs/contributing/pr-workflow.md` | End-to-end PR lifecycle (worktree → plan → review → implement → audit → PR) | Before starting any PR |
 | `docs/concepts/` | System architecture, core engine, concepts glossary, roofline estimation | When learning how BLIS works before contributing |

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ go build -o blis main.go
 
 ## Quick Start
 
-Run BLIS for `meta-llama/llama-3.1-8b-instruct` with default configs:
+Run BLIS for `qwen/qwen3-14b` with default configs:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct
+./blis run --model qwen/qwen3-14b
 ```
 
 You should see JSON output like:
@@ -92,13 +92,13 @@ You should see JSON output like:
 ### Multi-client workload specification
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct --workload-spec examples/servegen-language.yaml
+./blis run --model qwen/qwen3-14b --workload-spec examples/servegen-language.yaml
 ```
 
 ### Cluster simulation with weighted routing
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --routing-policy weighted \
   --routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2"
 ```
@@ -106,8 +106,16 @@ You should see JSON output like:
 ### Roofline mode (analytical, no trained coefficients)
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct --latency-model roofline --hardware H100 --tp 2
+./blis run --model qwen/qwen3-14b --latency-model roofline --hardware H100 --tp 1
 ```
+
+> **Tip:** Roofline, trained-roofline, and cross-model modes auto-fetch model configs from HuggingFace. Set `HF_TOKEN` to access gated models (e.g., LLaMA) and avoid rate limits:
+>
+> ```bash
+> export HF_TOKEN=your_token_here
+> ```
+>
+> See [HuggingFace access tokens](https://huggingface.co/docs/hub/en/security-tokens) to create a token.
 
 ### Convert workload formats
 

--- a/cmd/default_config.go
+++ b/cmd/default_config.go
@@ -29,12 +29,21 @@ type Config struct {
 	Defaults           map[string]DefaultConfig `yaml:"defaults"`
 	Version            string                   `yaml:"version"`
 	Workloads          map[string]Workload      `yaml:"workloads"`
-	CrossModelDefaults *CrossModelDefaults       `yaml:"crossmodel_defaults,omitempty"`
+	CrossModelDefaults       *CrossModelDefaults       `yaml:"crossmodel_defaults,omitempty"`
+	TrainedRooflineDefaults  *TrainedRooflineDefaults  `yaml:"trained_roofline_defaults,omitempty"`
 }
 
 // CrossModelDefaults holds globally-fitted physics coefficients for cross-model latency estimation.
 // These are model-independent: a single set works across architectures via config.json features.
 type CrossModelDefaults struct {
+	BetaCoeffs  []float64 `yaml:"beta_coeffs"`
+	AlphaCoeffs []float64 `yaml:"alpha_coeffs"`
+}
+
+// TrainedRooflineDefaults holds globally-fitted roofline correction coefficients.
+// These are model-independent: analytical basis functions from config.json scale the coefficients.
+// BetaCoeffs has 7 elements (β₁-β₇), AlphaCoeffs has 3 elements (α₀-α₂).
+type TrainedRooflineDefaults struct {
 	BetaCoeffs  []float64 `yaml:"beta_coeffs"`
 	AlphaCoeffs []float64 `yaml:"alpha_coeffs"`
 }

--- a/cmd/default_config_test.go
+++ b/cmd/default_config_test.go
@@ -59,7 +59,7 @@ func TestGetCoefficients_ReturnsModelDefaultKVBlocks(t *testing.T) {
 	// GIVEN a known model in defaults.yaml
 	alpha, beta, kvBlocks := GetCoefficients(
 		"meta-llama/llama-3.1-8b-instruct",
-		1, "H100", "vllm/vllm-openai:v0.8.4",
+		1, "H100", "vllm/vllm-openai:v0.11.0",
 		path,
 	)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ var (
 	outputTokensMin           int       // Min Output Token Count
 	outputTokensMax           int       // Max Output Token Count
 	latencyModelBackend string // CLI --latency-model flag: selects latency model backend (Cobra-bound, NEVER mutated inside Run)
+	maxModelLen         int64  // CLI --max-model-len: max total sequence length (input + output); 0 = unlimited
 
 	// CLI flags for model, GPU, TP, vllm version
 	model             string // LLM name
@@ -113,6 +114,87 @@ var (
 	// results file path
 	resultsPath string // File to save BLIS results to
 )
+
+// applyRopeScaling applies rope_scaling factor to maxPosEmb if applicable.
+// Returns the (possibly scaled) value and whether scaling was applied.
+// modelType is the HuggingFace model_type string (empty if not present).
+// ropeScaling is the raw rope_scaling value from config.json (nil if not present).
+//
+// Blacklist approach matching vLLM's _get_and_verify_max_len:
+// Types "su", "longrope", "llama3" are excluded (these encode full context in max_position_embeddings).
+// All other types (linear, dynamic, yarn, default, mrope, etc.) apply the factor.
+// "mrope" is intentionally NOT excluded: vLLM normalizes mrope → "default" via patch_rope_scaling_dict
+// and then applies the factor. BLIS reads raw JSON where mrope falls through the blacklist — same result.
+// For "yarn", original_max_position_embeddings is used as base when present.
+// gemma3 model_type skips rope_scaling entirely (max_position_embeddings is pre-scaled).
+// Uses substring match to handle both "gemma3" (top-level) and "gemma3_text" (after text_config pivot).
+func applyRopeScaling(maxPosEmb int, modelType string, ropeScaling any) (scaled int, applied bool) {
+	// R3: degenerate base guard
+	if maxPosEmb <= 0 {
+		return maxPosEmb, false
+	}
+
+	// gemma3 model_type: skip rope_scaling entirely (BC-3).
+	// Note: ParseHFConfig's text_config pivot overwrites model_type from "gemma3" to
+	// "gemma3_text" for multimodal models. Use strings.Contains to match both variants,
+	// aligning with vLLM's substring check ("gemma3" not in hf_config.model_type).
+	if strings.Contains(modelType, "gemma3") {
+		return maxPosEmb, false
+	}
+
+	// No rope_scaling present
+	if ropeScaling == nil {
+		return maxPosEmb, false
+	}
+
+	// rope_scaling must be a JSON object (map[string]any)
+	ropeMap, ok := ropeScaling.(map[string]any)
+	if !ok {
+		return maxPosEmb, false
+	}
+
+	// Read type (some configs use "rope_type" instead of "type")
+	ropeType, _ := ropeMap["type"].(string)
+	if ropeType == "" {
+		ropeType, _ = ropeMap["rope_type"].(string)
+	}
+
+	// Blacklist: these types already embed scaled context in max_position_embeddings
+	if ropeType == "su" || ropeType == "longrope" || ropeType == "llama3" {
+		return maxPosEmb, false
+	}
+
+	// Extract factor
+	factor, ok := ropeMap["factor"].(float64)
+	if !ok || factor <= 1.0 {
+		return maxPosEmb, false
+	}
+
+	// NaN/Inf defense-in-depth (standard JSON can't produce these, but non-standard sources might)
+	if math.IsNaN(factor) || math.IsInf(factor, 0) {
+		return maxPosEmb, false
+	}
+
+	// For yarn, use original_max_position_embeddings as base if available (BC-4)
+	base := maxPosEmb
+	if ropeType == "yarn" {
+		if orig, ok := ropeMap["original_max_position_embeddings"].(float64); ok && orig > 0 {
+			// Overflow guard on original_max_position_embeddings
+			if orig >= float64(math.MaxInt) {
+				return maxPosEmb, false
+			}
+			base = int(orig)
+		}
+	}
+
+	// Compute scaled value with overflow guard
+	product := float64(base) * factor
+	if product >= float64(math.MaxInt) || product < 0 {
+		return maxPosEmb, false
+	}
+
+	return int(product), true
+}
 
 // rootCmd is the base command for the CLI
 var rootCmd = &cobra.Command{
@@ -313,6 +395,78 @@ var runCmd = &cobra.Command{
 			}
 		}
 
+		// --latency-model trained-roofline: auto-resolve model config and load global coefficients
+		if backend == "trained-roofline" {
+			if gpu == "" {
+				logrus.Fatalf("--latency-model trained-roofline requires --hardware (GPU type)")
+			}
+			if tensorParallelism <= 0 {
+				logrus.Fatalf("--latency-model trained-roofline requires --tp > 0")
+			}
+
+			// Resolve model config folder (same auto-fetch chain as roofline/crossmodel)
+			resolved, err := resolveModelConfig(model, modelConfigFolder, defaultsFilePath)
+			if err != nil {
+				logrus.Fatalf("%v", err)
+			}
+			modelConfigFolder = resolved
+
+			// Resolve hardware config
+			resolvedHW, err := resolveHardwareConfig(hwConfigPath, defaultsFilePath)
+			if err != nil {
+				logrus.Fatalf("%v", err)
+			}
+			hwConfigPath = resolvedHW
+
+			// Load trained-roofline defaults from defaults.yaml (R18: use Flags().Changed)
+			if _, statErr := os.Stat(defaultsFilePath); statErr == nil {
+				data, readErr := os.ReadFile(defaultsFilePath)
+				if readErr != nil {
+					logrus.Warnf("--latency-model trained-roofline: failed to read %s: %v", defaultsFilePath, readErr)
+				} else {
+					var cfg Config
+					decoder := yaml.NewDecoder(bytes.NewReader(data))
+					decoder.KnownFields(true) // R10: strict YAML parsing
+					if yamlErr := decoder.Decode(&cfg); yamlErr != nil {
+						logrus.Fatalf("--latency-model trained-roofline: failed to parse %s: %v", defaultsFilePath, yamlErr)
+					}
+					if cfg.TrainedRooflineDefaults != nil {
+						if !cmd.Flags().Changed("beta-coeffs") {
+							betaCoeffs = cfg.TrainedRooflineDefaults.BetaCoeffs
+							logrus.Infof("--latency-model: loaded trained-roofline beta coefficients from defaults.yaml")
+						}
+						if !cmd.Flags().Changed("alpha-coeffs") {
+							alphaCoeffs = cfg.TrainedRooflineDefaults.AlphaCoeffs
+							logrus.Infof("--latency-model: loaded trained-roofline alpha coefficients from defaults.yaml")
+						}
+					}
+				}
+				// Also load KV blocks from per-model config if available
+				if vllmVersion == "" {
+					_, _, ver := GetDefaultSpecs(model)
+					if len(ver) > 0 {
+						vllmVersion = ver
+					}
+				}
+				_, _, kvBlocks := GetCoefficients(model, tensorParallelism, gpu, vllmVersion, defaultsFilePath)
+				if !cmd.Flags().Changed("total-kv-blocks") && kvBlocks > 0 {
+					totalKVBlocks = kvBlocks
+					logrus.Infof("--latency-model: loaded total-kv-blocks=%d from defaults.yaml", kvBlocks)
+				}
+			}
+			// Validate trained-roofline coefficients were loaded
+			if !cmd.Flags().Changed("beta-coeffs") && (len(betaCoeffs) < 7 || allZeros(betaCoeffs)) {
+				logrus.Fatalf("--latency-model trained-roofline: no trained_roofline_defaults found in %s and no --beta-coeffs provided. "+
+					"Add trained_roofline_defaults to defaults.yaml or provide --beta-coeffs explicitly",
+					defaultsFilePath)
+			}
+			// Warn if alpha coefficients are zero (user provided --beta-coeffs but not --alpha-coeffs)
+			if allZeros(alphaCoeffs) && !cmd.Flags().Changed("alpha-coeffs") {
+				logrus.Warnf("--latency-model trained-roofline: no trained alpha coefficients found; "+
+					"QueueingTime, PostDecodeFixedOverhead, and OutputTokenProcessingTime will use zero alpha (may underestimate TTFT/E2E)")
+			}
+		}
+
 		if !cmd.Flags().Changed("alpha-coeffs") && !cmd.Flags().Changed("beta-coeffs") && len(modelConfigFolder) == 0 && len(hwConfigPath) == 0 { // default all 0s
 			// GPU, TP, vLLM version configuration
 			hardware, tp, version := GetDefaultSpecs(model) // pick default config for tp, GPU, vllmVersion
@@ -360,14 +514,14 @@ var runCmd = &cobra.Command{
 		}
 		// Zero-coefficients safety guard: prevents silently running with zero step times
 		// when blackbox mode has no trained coefficients (would produce meaningless results).
-		if backend != "roofline" && backend != "crossmodel" && allZeros(alphaCoeffs) && allZeros(betaCoeffs) {
+		if backend != "roofline" && backend != "crossmodel" && backend != "trained-roofline" && allZeros(alphaCoeffs) && allZeros(betaCoeffs) {
 			logrus.Fatalf("No trained coefficients found for model=%s, GPU=%s, TP=%d. "+
-				"Provide --alpha-coeffs/--beta-coeffs, use --latency-model roofline, or use --latency-model crossmodel",
+				"Provide --alpha-coeffs/--beta-coeffs, use --latency-model roofline, crossmodel, or trained-roofline",
 				model, gpu, tensorParallelism)
 		}
 		// Analytical backends (roofline, crossmodel): parse HFConfig once, use for
 		// both model config extraction and KV capacity auto-calculation.
-		if backend == "roofline" || backend == "crossmodel" {
+		if backend == "roofline" || backend == "crossmodel" || backend == "trained-roofline" {
 			hfPath := filepath.Join(modelConfigFolder, "config.json")
 			hfConfig, err := latency.ParseHFConfig(hfPath)
 			if err != nil {
@@ -390,13 +544,15 @@ var runCmd = &cobra.Command{
 					"Roofline step time estimates may be inaccurate for quantized models",
 					modelConfig.BytesPerParam)
 			}
-			// Check for MoE model indicators in the raw HF config (roofline-only warning;
-			// crossmodel handles MoE explicitly via the beta2 dispatch term)
-			if backend == "roofline" {
-				if hfConfig.MustGetInt("num_local_experts", 0) > 1 {
-					logrus.Warnf("--latency-model: model appears to be MoE (Mixture-of-Experts). " +
-						"Roofline estimation assumes dense transformers and may overestimate MoE latency")
-				}
+			// MoE informational note: roofline models per-routed-expert FLOPs (top_k active)
+			// and all-expert weight bandwidth (E experts loaded from HBM per step).
+			// Shared expert FLOPs/weights and gate/router weights are NOT modeled in
+			// roofline step time (they are included in KV capacity weight estimation).
+			// Remaining approximations: no expert-load-imbalance or MoE dispatch overhead.
+			if backend == "roofline" && modelConfig.NumLocalExperts > 1 {
+				logrus.Infof("--latency-model: MoE model detected (%d experts, top_%d). "+
+					"Roofline models per-expert FLOPs and active weights; dispatch overhead is not modeled",
+					modelConfig.NumLocalExperts, modelConfig.NumExpertsPerTok)
 			}
 
 			// KV capacity auto-calculation: derive total-kv-blocks from model + hardware
@@ -427,6 +583,73 @@ var runCmd = &cobra.Command{
 					}
 				}
 			}
+
+			// Auto-derive --max-model-len from HF config when not explicitly set (R18).
+			// Mirrors vLLM's _auto_fit_max_model_len(): uses max_position_embeddings,
+			// applies rope_scaling factor for older models, then caps at KV-feasible max.
+			if !cmd.Flags().Changed("max-model-len") {
+				maxPosEmb := hfConfig.MustGetInt("max_position_embeddings", 0)
+				if maxPosEmb > 0 {
+					maxModelLen = int64(maxPosEmb)
+
+					// Apply rope_scaling factor via pure function (extracted for testability).
+					// See applyRopeScaling godoc for blacklist details and vLLM fidelity notes.
+					modelType, _ := hfConfig.Raw["model_type"].(string)
+					scaled, applied := applyRopeScaling(maxPosEmb, modelType, hfConfig.Raw["rope_scaling"])
+					if applied {
+						// Recover rope type and factor for diagnostic logging
+						ropeType := ""
+						factor := 0.0
+						if ropeMap, ok := hfConfig.Raw["rope_scaling"].(map[string]any); ok {
+							ropeType, _ = ropeMap["type"].(string)
+							if ropeType == "" {
+								ropeType, _ = ropeMap["rope_type"].(string)
+							}
+							factor, _ = ropeMap["factor"].(float64)
+						}
+						logrus.Infof("--latency-model: applying %s rope_scaling factor %.1f: %d → %d", ropeType, factor, maxPosEmb, scaled)
+						maxModelLen = int64(scaled)
+					} else if strings.Contains(modelType, "gemma3") {
+						logrus.Infof("--latency-model: skipping rope_scaling for gemma3 (max_position_embeddings is pre-scaled)")
+					} else if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok && ropeScaling != nil {
+						// Factor not applied — could be excluded type, missing/invalid factor, or overflow
+						if ropeMap, ok := ropeScaling.(map[string]any); ok {
+							if _, hasKey := ropeMap["factor"]; hasKey {
+								logrus.Warnf("--latency-model: rope_scaling.factor present but not applied (excluded type, invalid value, or overflow); using max_position_embeddings as-is")
+							}
+						} else {
+							logrus.Warnf("--latency-model: rope_scaling present but not a JSON object (type %T); ignoring", ropeScaling)
+						}
+					}
+
+					logrus.Infof("--latency-model: auto-derived max-model-len=%d from max_position_embeddings", maxModelLen)
+				}
+			}
+
+			// Cap maxModelLen at KV-feasible maximum (matches vLLM's _maybe_limit_model_len).
+			// Without this, auto-derived max_position_embeddings can exceed KV capacity
+			// for models with large context windows on small GPU configs (e.g., 128K context, TP=1).
+			// Overflow-safe KV feasible max: compare in block space to avoid int64 multiplication overflow.
+			// Instead of computing totalKVBlocks * blockSizeTokens (which could overflow for extreme configs),
+			// we check whether ceil(maxModelLen / blockSizeTokens) > totalKVBlocks — the same comparison
+			// used in NewSimulator's startup validation.
+			if maxModelLen > 0 && blockSizeTokens > 0 {
+				blocksNeeded := maxModelLen / blockSizeTokens
+				if maxModelLen%blockSizeTokens != 0 {
+					blocksNeeded++
+				}
+				if blocksNeeded > totalKVBlocks {
+					kvFeasibleMax := totalKVBlocks * blockSizeTokens // product bounded by maxModelLen (blocksNeeded > totalKVBlocks)
+					logrus.Warnf("--latency-model: max-model-len %d exceeds KV capacity (%d blocks × %d tokens); capping to %d tokens",
+						maxModelLen, totalKVBlocks, blockSizeTokens, kvFeasibleMax)
+					maxModelLen = kvFeasibleMax
+				}
+			}
+		}
+
+		// R3: Validate --max-model-len
+		if maxModelLen < 0 {
+			logrus.Fatalf("--max-model-len must be >= 0, got %d", maxModelLen)
 		}
 
 		// R3: Validate workload generation flags (before any synthesis path consumes them)
@@ -772,7 +995,7 @@ var runCmd = &cobra.Command{
 					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency),
 				BatchConfig:         sim.NewBatchConfig(maxRunningReqs, maxScheduledTokens, longPrefillTokenThreshold),
 				LatencyCoeffs:       sim.NewLatencyCoeffs(betaCoeffs, alphaCoeffs),
-				ModelHardwareConfig: sim.NewModelHardwareConfig(modelConfig, hwConfig, model, gpu, tensorParallelism, backend),
+				ModelHardwareConfig: sim.NewModelHardwareConfig(modelConfig, hwConfig, model, gpu, tensorParallelism, backend, maxModelLen),
 				PolicyConfig:        sim.NewPolicyConfig(priorityPolicy, scheduler),
 			},
 			NumInstances:            numInstances,
@@ -856,12 +1079,13 @@ var runCmd = &cobra.Command{
 		}
 
 		// Print anomaly counters if any detected
-		if rawMetrics.PriorityInversions > 0 || rawMetrics.HOLBlockingEvents > 0 || rawMetrics.RejectedRequests > 0 || rawMetrics.DroppedUnservable > 0 || cs.DroppedKVAllocations() > 0 {
+		if rawMetrics.PriorityInversions > 0 || rawMetrics.HOLBlockingEvents > 0 || rawMetrics.RejectedRequests > 0 || rawMetrics.DroppedUnservable > 0 || rawMetrics.LengthCappedRequests > 0 || cs.DroppedKVAllocations() > 0 {
 			fmt.Println("=== Anomaly Counters ===")
 			fmt.Printf("Priority Inversions: %d\n", rawMetrics.PriorityInversions)
 			fmt.Printf("HOL Blocking Events: %d\n", rawMetrics.HOLBlockingEvents)
 			fmt.Printf("Rejected Requests: %d\n", rawMetrics.RejectedRequests)
 			fmt.Printf("Dropped Unservable: %d\n", rawMetrics.DroppedUnservable)
+			fmt.Printf("Length-Capped Requests: %d\n", rawMetrics.LengthCappedRequests)
 			if cs.DroppedKVAllocations() > 0 {
 				fmt.Printf("Dropped KV Allocations: %d\n", cs.DroppedKVAllocations())
 			}
@@ -1007,7 +1231,8 @@ func init() {
 	runCmd.Flags().StringVar(&gpu, "hardware", "", "GPU type")
 	runCmd.Flags().IntVar(&tensorParallelism, "tp", 0, "Tensor parallelism")
 	runCmd.Flags().StringVar(&vllmVersion, "vllm-version", "", "vLLM version")
-	runCmd.Flags().StringVar(&latencyModelBackend, "latency-model", "", "Latency model backend: blackbox (default), roofline, crossmodel")
+	runCmd.Flags().StringVar(&latencyModelBackend, "latency-model", "", "Latency model backend: blackbox (default), roofline, crossmodel, trained-roofline")
+	runCmd.Flags().Int64Var(&maxModelLen, "max-model-len", 0, "Max total sequence length (input + output); 0 = unlimited. Auto-derived from HF config for roofline/crossmodel when not set.")
 
 	// GuideLLM-style distribution-based workload generation config
 	runCmd.Flags().Float64Var(&rate, "rate", 1.0, "Requests arrival per second")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"testing"
@@ -110,4 +111,81 @@ func TestRunCmd_MaxScheduledTokens_FlagRegistered(t *testing.T) {
 	defVal, err := strconv.ParseInt(flag.DefValue, 10, 64)
 	assert.NoError(t, err)
 	assert.Greater(t, defVal, int64(0), "default must be > 0 (passes validation)")
+}
+
+// TestApplyRopeScaling validates the pure function extraction of rope_scaling logic.
+// Covers BC-1 (mrope), BC-2 (blacklist), BC-3 (gemma3), BC-4 (yarn), BC-8 (invalid input), BC-9 (never panics).
+func TestApplyRopeScaling(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxPosEmb   int
+		modelType   string
+		ropeScaling any
+		wantScaled  int
+		wantApplied bool
+	}{
+		// Basic cases
+		{name: "nil rope_scaling", maxPosEmb: 8192, modelType: "", ropeScaling: nil, wantScaled: 8192, wantApplied: false},
+		{name: "linear factor 4", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: 32768, wantApplied: true},
+		{name: "dynamic factor 2", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"type": "dynamic", "factor": 2.0}, wantScaled: 8192, wantApplied: true},
+		{name: "default factor 2", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"type": "default", "factor": 2.0}, wantScaled: 8192, wantApplied: true},
+
+		// BC-1: mrope — intentionally not excluded (vLLM normalizes mrope → "default" and applies factor)
+		{name: "mrope factor 8", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "mrope", "factor": 8.0}, wantScaled: 65536, wantApplied: true},
+
+		// BC-2: Blacklist — su, longrope, llama3 excluded
+		{name: "su excluded", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "su", "factor": 4.0}, wantScaled: 8192, wantApplied: false},
+		{name: "longrope excluded", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "longrope", "factor": 4.0}, wantScaled: 8192, wantApplied: false},
+		{name: "llama3 excluded", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "llama3", "factor": 4.0}, wantScaled: 8192, wantApplied: false},
+
+		// BC-3: gemma3 model_type exclusion (substring match covers text_config pivot)
+		{name: "gemma3 skips rope_scaling", maxPosEmb: 8192, modelType: "gemma3", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: 8192, wantApplied: false},
+		{name: "gemma3_text skips rope_scaling", maxPosEmb: 8192, modelType: "gemma3_text", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: 8192, wantApplied: false},
+
+		// BC-4: yarn uses original_max_position_embeddings
+		{name: "yarn with original", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "yarn", "factor": 4.0, "original_max_position_embeddings": 2048.0}, wantScaled: 8192, wantApplied: true},
+		{name: "yarn without original", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"type": "yarn", "factor": 2.0}, wantScaled: 8192, wantApplied: true},
+
+		// BC-8: Invalid inputs — warn and ignore
+		{name: "non-object rope_scaling string", maxPosEmb: 8192, modelType: "", ropeScaling: "not-a-map", wantScaled: 8192, wantApplied: false},
+		{name: "non-object rope_scaling array", maxPosEmb: 8192, modelType: "", ropeScaling: []any{1.0, 2.0}, wantScaled: 8192, wantApplied: false},
+		{name: "factor not float64", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": "four"}, wantScaled: 8192, wantApplied: false},
+		{name: "factor lte 1", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": 1.0}, wantScaled: 8192, wantApplied: false},
+		{name: "no factor key", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear"}, wantScaled: 8192, wantApplied: false},
+		{name: "null type with factor", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"type": nil, "factor": 2.0}, wantScaled: 8192, wantApplied: true},
+		{name: "empty type with factor", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"factor": 2.0}, wantScaled: 8192, wantApplied: true},
+
+		// rope_type fallback key
+		{name: "rope_type fallback", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"rope_type": "linear", "factor": 3.0}, wantScaled: 12288, wantApplied: true},
+
+		// NaN/Inf defense-in-depth
+		{name: "NaN factor", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": math.NaN()}, wantScaled: 8192, wantApplied: false},
+		{name: "Inf factor", maxPosEmb: 8192, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": math.Inf(1)}, wantScaled: 8192, wantApplied: false},
+
+		// Overflow guards
+		{name: "overflow guard fires", maxPosEmb: math.MaxInt / 2, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: math.MaxInt / 2, wantApplied: false},
+		{name: "yarn orig overflow", maxPosEmb: 4096, modelType: "", ropeScaling: map[string]any{"type": "yarn", "factor": 2.0, "original_max_position_embeddings": float64(math.MaxInt)}, wantScaled: 4096, wantApplied: false},
+
+		// Degenerate base guards (R3)
+		{name: "maxPosEmb zero", maxPosEmb: 0, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: 0, wantApplied: false},
+		{name: "maxPosEmb negative", maxPosEmb: -1, modelType: "", ropeScaling: map[string]any{"type": "linear", "factor": 4.0}, wantScaled: -1, wantApplied: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scaled, applied := applyRopeScaling(tc.maxPosEmb, tc.modelType, tc.ropeScaling)
+			assert.Equal(t, tc.wantScaled, scaled, "scaled value")
+			assert.Equal(t, tc.wantApplied, applied, "applied flag")
+		})
+	}
+}
+
+// Regression: yarn with original uses original as base, not maxPosEmb
+func TestApplyRopeScaling_YarnOriginal_UsesOriginalAsBase(t *testing.T) {
+	scaled, applied := applyRopeScaling(8192, "", map[string]any{
+		"type": "yarn", "factor": 4.0, "original_max_position_embeddings": 2048.0,
+	})
+	// 2048 * 4 = 8192, NOT 8192 * 4 = 32768
+	assert.Equal(t, 8192, scaled)
+	assert.True(t, applied)
 }

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -7,7 +7,7 @@ defaults:
   meta-llama/llama-3.1-8b-instruct:
     GPU: H100
     tensor_parallelism: 1
-    vllm_version: vllm/vllm-openai:v0.8.4
+    vllm_version: vllm/vllm-openai:v0.11.0
     hf_repo: meta-llama/Llama-3.1-8B-Instruct
   meta-llama/llama-3.3-70b-instruct:
     GPU: H100
@@ -62,17 +62,17 @@ defaults:
   qwen/qwen2.5-3b-instruct:
     GPU: H100
     tensor_parallelism: 1
-    vllm_version: vllm/vllm-openai:v0.8.4
+    vllm_version: vllm/vllm-openai:v0.11.0
     hf_repo: Qwen/Qwen2.5-3B-Instruct
   qwen/qwen3-14b:
     GPU: H100
     tensor_parallelism: 1
-    vllm_version: vllm/vllm-openai:v0.8.4
+    vllm_version: vllm/vllm-openai:v0.11.0
     hf_repo: Qwen/Qwen3-14B
   qwen/qwen2.5-7b-instruct:
     GPU: H100
-    tensor_parallelism: 4
-    vllm_version: vllm/vllm-openai:v0.8.4
+    tensor_parallelism: 1
+    vllm_version: vllm/vllm-openai:v0.11.0
     hf_repo: Qwen/Qwen2.5-7B-Instruct
   redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic:
     GPU: H100
@@ -301,7 +301,7 @@ models:
   id: meta-llama/llama-3.1-8b-instruct
   tensor_parallelism: 1
   total_kv_blocks: 29205
-  vllm_version: vllm/vllm-openai:v0.8.4
+  vllm_version: vllm/vllm-openai:v0.11.0
 - GPU: A100-80
   alpha_coeffs:
   - 2943.6134268743335
@@ -720,7 +720,7 @@ models:
   id: qwen/qwen2.5-3b-instruct
   tensor_parallelism: 1
   total_kv_blocks: 117925
-  vllm_version: vllm/vllm-openai:v0.8.4
+  vllm_version: vllm/vllm-openai:v0.11.0
 - GPU: H100
   alpha_coeffs:
   - 8888.089034078324
@@ -733,7 +733,7 @@ models:
   id: qwen/qwen3-14b
   tensor_parallelism: 1
   total_kv_blocks: 17600
-  vllm_version: vllm/vllm-openai:v0.8.4
+  vllm_version: vllm/vllm-openai:v0.11.0
 - GPU: A100-80
   alpha_coeffs:
   - 8970.33939991319
@@ -761,7 +761,7 @@ models:
   id: qwen/qwen2.5-7b-instruct
   tensor_parallelism: 1
   total_kv_blocks: 67659
-  vllm_version: vllm/vllm-openai:v0.8.4
+  vllm_version: vllm/vllm-openai:v0.11.0
 - GPU: A100-80
   alpha_coeffs:
   - 7025.080179905166
@@ -1749,4 +1749,11 @@ crossmodel_defaults:
   beta_coeffs: [116.110, 1226.868, 19.943, 9445.157]
   # α₀=pre-scheduling fixed overhead, α₁=per-token preprocessing (≈0), α₂=per-output-token processing.
   alpha_coeffs: [13732.0, 0.0, 860.6]
+trained_roofline_defaults:
+  # Globally-fitted roofline correction coefficients from training/output/fit/coefficients.json.
+  # Fitted via 3-phase NNLS from 13 experiments (4 models × 3-4 profiles, 137K requests).
+  # β₁-β₄ are dimensionless roofline corrections, β₅ is µs/layer, β₆ is µs/req, β₇ is µs/step.
+  beta_coeffs: [0.7726491335309499, 1.127489556719325, 1.0559901872766853, 0.0, 43.500541908701074, 48.80613214319187, 0.0]
+  # α₀=API processing overhead (µs), α₁=post-decode fixed (µs), α₂=per-output-token detokenization (µs/tok).
+  alpha_coeffs: [9315.338771116985, 1849.5902371340574, 1.7079389122469397]
 version: 0.0.1

--- a/docs/concepts/core-engine.md
+++ b/docs/concepts/core-engine.md
@@ -2,7 +2,7 @@
 
 This page describes BLIS's single-instance discrete event simulation engine. For multi-instance cluster orchestration, see [Cluster Architecture](architecture.md).
 
-> **Canonical sources:** System invariants (INV-1 through INV-8) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
+> **Canonical sources:** System invariants (INV-1 through INV-9) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
 
 ## Overview
 
@@ -100,7 +100,7 @@ Requests follow a linear state machine with one exception (preemption):
 stateDiagram-v2
     [*] --> Arrival
     Arrival --> Queued : alpha queueing delay
-    Arrival --> DroppedUnservable : input too large for KV cache
+    Arrival --> DroppedUnservable : exceeds MaxModelLen or KV capacity
 
     state "Queued" as Queued
     note right of Queued
@@ -169,7 +169,12 @@ Preempted requests reset to the beginning of prefill (ProgressIndex = 0) and the
 
 ### Dropped Requests
 
-Requests whose input tokens require more KV blocks than the total cache capacity are dropped at enqueue time with a `DroppedUnservable` counter increment. This prevents livelock where the simulator would endlessly preempt and re-enqueue a request that can never fit.
+Requests are dropped as unservable at enqueue time (incrementing `DroppedUnservable`) via two guards:
+
+1. **MaxModelLen guard** — when `--max-model-len` is set, requests whose total sequence length exceeds the context window are rejected. When the request declares an output budget (`MaxOutputLen > 0`), the check is `input + budget > maxModelLen`. Otherwise, input length alone is checked (vLLM defaults `max_tokens` to `max_model_len - seq_len`; the runtime stop in `processCompletions` handles output growth).
+2. **KV capacity guard** — requests whose input tokens require more KV blocks than the total cache capacity are rejected. This prevents livelock where the simulator would endlessly preempt and re-enqueue a request that can never fit.
+
+Both guards fire before the request enters the wait queue, mirroring vLLM's pre-engine rejection. Additionally, when `--max-model-len` is set, a runtime length cap force-completes any request whose `ProgressIndex` reaches `MaxModelLen` during decode (defense-in-depth).
 
 ## Batch Formation
 
@@ -235,7 +240,7 @@ When `--kv-cpu-blocks` is set to a positive value, BLIS enables a two-tier cache
 
 ## Latency Models
 
-BLIS predicts GPU step time through one of three latency model backends. The choice is made via the `--latency-model` flag or automatically based on available configuration.
+BLIS predicts GPU step time through one of four latency model backends. The choice is made via the `--latency-model` flag or automatically based on available configuration.
 
 ### Blackbox Model (Default)
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -70,7 +70,15 @@ GPU memory organized as blocks that store key-value tensors computed during atte
 
 ### Latency Model
 
-The component that predicts GPU execution time for a batch step. Three modes: *Blackbox* (trained regression coefficients), *Roofline* (analytical FLOPs/bandwidth estimation), and *Cross-Model* (physics-informed, MoE-aware). See [Core Engine: Latency Models](core-engine.md#latency-models), [Roofline Estimation](roofline.md), and [Latency Models Guide](../guide/latency-models.md).
+The component that predicts GPU execution time for a batch step. Four modes: *Blackbox* (trained regression coefficients), *Roofline* (analytical FLOPs/bandwidth estimation), *Cross-Model* (physics-informed, MoE-aware), and *Trained-Roofline* (roofline basis functions × learned corrections from real vLLM traces). See [Core Engine: Latency Models](core-engine.md#latency-models), [Roofline Estimation](roofline.md), and [Latency Models Guide](../guide/latency-models.md).
+
+### MaxModelLen
+
+Maximum total sequence length (input + output) for a single request, in tokens. Mirrors vLLM's `--max-model-len`. When set (> 0), requests whose input alone fills the context window (`input >= MaxModelLen`) or whose input + output budget exceeds it are dropped before entering the wait queue. A runtime cap force-completes any request whose progress reaches this limit (defense-in-depth). Set to 0 for unlimited. Auto-derived from `max_position_embeddings` in roofline/crossmodel modes, with `rope_scaling` factor application and KV-feasible capping. See [Configuration Reference](../reference/configuration.md#simulation-control).
+
+### Oracle Knowledge Boundary (INV-9)
+
+The principle that control-plane decisions (admission, routing, scheduling, priority) must not read `Request.OutputTokens`. The actual output token count is oracle knowledge — known only after generation completes. The control plane uses `MaxOutputLen` (client-declared output budget) or input-only checks instead. Only the execution engine (batch step processing, completion detection) may access `OutputTokens` for token generation and determining when a request finishes. See [Standards: Invariants](../contributing/standards/invariants.md).
 
 ### Pending Requests
 

--- a/docs/concepts/roofline.md
+++ b/docs/concepts/roofline.md
@@ -1,6 +1,9 @@
 # Roofline Step Time Estimation Logic
 
-This document describes the analytical approach used to estimate the GPU latency for a single inference step using a roofline model. This requires no training, and works off-the-shelf for any Huggingface LLM whose `config.json` is saved under `model_configs/`. For Mixture-of-Experts (MoE) models, use `--latency-model crossmodel` instead — see [Cross-Model Mode](../guide/latency-models.md#cross-model-mode-physics-informed).
+This document describes the analytical approach used to estimate the GPU latency for a single inference step using a roofline model. This requires no training, and works off-the-shelf for any Huggingface LLM whose `config.json` is saved under `model_configs/`.
+
+!!! tip "Trained-Roofline: higher accuracy"
+    For higher accuracy (7% MAPE GPU combined), use `--latency-model trained-roofline` which applies learned correction factors to these roofline basis functions. See [Trained-Roofline Mode](../guide/latency-models.md#trained-roofline-mode-recommended-for-new-models). For legacy MoE workflows, `--latency-model crossmodel` is also available — see [Cross-Model Mode](../guide/latency-models.md#cross-model-mode-physics-informed).
 
 
 ## 1. Why Roofline?
@@ -57,7 +60,7 @@ The final step time is the sum of independent phases and overheads:
 The simplest way to run roofline mode is with `--latency-model roofline`, which auto-resolves the model config:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct --latency-model roofline --hardware H100 --tp 1
+./blis run --model qwen/qwen3-14b --latency-model roofline --hardware H100 --tp 1
 ```
 
 The flag automatically:
@@ -70,7 +73,7 @@ For models not in `defaults.yaml`, add an `hf_repo` entry mapping the BLIS model
 
 Alternatively, download the `config.json` manually:
 
-* Download the `config.json` for the LLM of your choice into `model_configs/`. [This](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct/blob/main/config.json) is an example config.json for `meta-llama/Llama-3.3-70B-Instruct`. The recommended file structure is `model_configs/llama-3.1-8b-instruct/config.json`.
+* Download the `config.json` for the LLM of your choice into `model_configs/`. [This](https://huggingface.co/Qwen/Qwen3-14B/blob/main/config.json) is an example config.json for `Qwen/Qwen3-14B`. The recommended file structure is `model_configs/qwen3-14b/config.json`.
 
 ### Adding a new GPU
 
@@ -79,15 +82,11 @@ Alternatively, download the `config.json` manually:
 ```json
 {
     "<GPU_name>": {
-        "TFlopsPeak":        989.5,
-        "BwPeakTBs":         3.35,
-        "BwEffConstant":     0.72,
-        "TOverheadMicros":   500.0,
-        "perLayerOverhead":  20.0,
-        "mfuPrefill":        0.65,
-        "mfuDecode":         0.12,
-        "allReduceLatency":  20.0,
-        "MemoryGiB":         80.0
+        "TFlopsPeak":  989.5,
+        "BwPeakTBs":   3.35,
+        "mfuPrefill":  0.45,
+        "mfuDecode":   0.30,
+        "MemoryGiB":   80.0
     }
 }
 ```
@@ -96,12 +95,8 @@ Alternatively, download the `config.json` manually:
 |-------|-------------|
 | `TFlopsPeak` | Peak BF16 TFLOPS from GPU datasheet |
 | `BwPeakTBs` | Peak HBM bandwidth in TB/s from GPU datasheet |
-| `BwEffConstant` | Fraction of peak BW achieved in practice (0-1) |
-| `TOverheadMicros` | Per-step overhead in microseconds |
-| `perLayerOverhead` | CPU scheduling overhead per transformer layer in microseconds |
-| `mfuPrefill` | Static MFU for prefill (used when MFU database is unavailable) |
-| `mfuDecode` | Static MFU for decode (used when MFU database is unavailable) |
-| `allReduceLatency` | All-reduce latency in microseconds (multi-GPU TP) |
+| `mfuPrefill` | Model FLOPS Utilization for prefill phase (compute-bound) |
+| `mfuDecode` | Model FLOPS Utilization for decode phase (memory-bound) |
 | `MemoryGiB` | GPU memory capacity in GiB. Used by `CalculateKVBlocks` to auto-derive `--total-kv-blocks` when roofline or crossmodel mode is active and the flag is not explicitly set. |
 
 > Note: The Peak TFLOPS and BW for a given GPU family might vary by GPU connectivity (e.g. SXM vs PCIe). We recommend a separate entry for each GPU connectivity type - e.g. A100-SXM, A100-PCIe etc in `hardware_config.json`.

--- a/docs/contributing/extension-recipes.md
+++ b/docs/contributing/extension-recipes.md
@@ -95,18 +95,22 @@ Examples:
 
 To add a new latency estimation backend (e.g., SGLang RadixAttention, TensorRT-LLM, neural surrogate):
 
-1. **Implement the `LatencyModel` interface** in `sim/latency/latency.go` (or a new file in `sim/latency/` for complex models) — 3 methods:
+1. **Implement the `LatencyModel` interface** in `sim/latency/latency.go` (or a new file in `sim/latency/` for complex models) — 4 methods:
    - `StepTime(batch []*Request) int64` — estimate batch step duration from request states
    - `QueueingTime(req *Request) int64` — estimate arrival-to-queue delay
    - `OutputTokenProcessingTime() int64` — per-token post-processing overhead
-2. **Register in `NewLatencyModel` factory** in `sim/latency/latency.go`: add a `case` branch in the `switch hw.Backend` block. The backend string (e.g., `"crossmodel"`) is set by the `--latency-model` CLI flag and stored in `ModelHardwareConfig.Backend`. The factory signature is `NewLatencyModel(LatencyCoeffs, ModelHardwareConfig)`.
-3. **Add behavioral tests** in `sim/latency/` — monotonicity (more tokens → longer step time), positive output, boundary cases (empty batch)
-4. Extension friction: **2 touch points** (implementation + factory branch)
+   - `PostDecodeFixedOverhead() int64` — fixed per-request completion overhead (return 0 if not applicable)
+2. **Register the backend name** in `sim/bundle.go`: add `"your-backend": true` to `validLatencyBackends` map.
+3. **Register in `NewLatencyModel` factory** in `sim/latency/latency.go`: add a `case` branch in the `switch hw.Backend` block. The backend string (e.g., `"trained-roofline"`) is set by the `--latency-model` CLI flag and stored in `ModelHardwareConfig.Backend`. The factory signature is `NewLatencyModel(LatencyCoeffs, ModelHardwareConfig)`.
+4. **Add CLI wiring** (if needed) in `cmd/root.go`: add a loading block for your backend's coefficients from `defaults.yaml`. If your backend needs a custom defaults section, add a struct to `cmd/default_config.go`.
+5. **Add behavioral tests** in `sim/latency/` — monotonicity (more tokens → longer step time), positive output, boundary cases (empty batch)
+6. Extension friction: **3-5 touch points** (implementation + bundle map + factory branch; optionally CLI wiring + defaults struct)
 
 Examples:
 - See `BlackboxLatencyModel` in `sim/latency/latency.go` for a simple stateless model (alpha/beta regression)
 - See `RooflineLatencyModel` in `sim/latency/latency.go` for a model that uses hardware config (FLOPs/bandwidth)
 - See `CrossModelLatencyModel` in `sim/latency/crossmodel.go` for a physics-informed model that derives step time from HuggingFace architecture features (MoE-aware)
+- See `TrainedRooflineLatencyModel` in `sim/latency/trained_roofline.go` for a data-driven model with roofline basis functions × learned corrections (zero-allocation hot path, 7% MAPE)
 
 ## Adding New Disaggregation Deciders
 

--- a/docs/contributing/standards/invariants.md
+++ b/docs/contributing/standards/invariants.md
@@ -2,7 +2,7 @@
 
 Invariants are properties that must hold at all times during and after simulation. They are verified by invariant tests (see R7) and checked during self-audit (Step 4.75).
 
-**Hypothesis family mapping:** INV-1 through INV-3, INV-5, and INV-6 belong to the **Scheduler invariants (safety/liveness)** family. INV-4 (KV cache conservation), INV-7 (signal freshness), and INV-8 (work-conserving property) belong to the **Structural model** family. See `docs/contributing/standards/experiments.md` for hypothesis family definitions.
+**Hypothesis family mapping:** INV-1 through INV-3, INV-5, and INV-6 belong to the **Scheduler invariants (safety/liveness)** family. INV-4 (KV cache conservation), INV-7 (signal freshness), INV-8 (work-conserving property), and INV-9 (oracle knowledge boundary) belong to the **Structural model** family. See `docs/contributing/standards/experiments.md` for hypothesis family definitions.
 
 ## INV-1: Request Conservation
 
@@ -105,6 +105,22 @@ Invariants are properties that must hold at all times during and after simulatio
 **Code location:** Search for `// Work-conserving:` comment in `sim/simulator.go` — the `else` branch of `len(remaining) > 0` checks `WaitQ.Len() > 0` and schedules a new `StepEvent`.
 
 **Hypothesis family:** Structural model (same as INV-4, INV-7).
+
+---
+
+## INV-9: Oracle Knowledge Boundary
+
+**Statement:** Servability decisions — enqueue guard (`EnqueueRequest`), admission control (`AdmissionPolicy`), routing (`RoutingPolicy`), and priority scoring (`PriorityPolicy`) — must not read `Request.OutputTokens` or `len(Request.OutputTokens)`. The control plane uses `Request.MaxOutputLen` (client-declared output budget) for sequence-length checks against `MaxModelLen`. When `MaxOutputLen == 0` (no budget), only input length is checked; the runtime stop in `processCompletions` enforces output growth limits. Only the execution engine (`executeBatchStep`, `processCompletions`, `recordRequestCompletion`, `FormBatch` step planning) may access `OutputTokens` for token generation, completion detection, and per-step resource allocation.
+
+**Rationale:** In real inference serving (vLLM), the engine does not know actual output length at admission time — only the client's declared `max_tokens` budget. BLIS's `Request.OutputTokens` is oracle knowledge (pre-determined for simulation). Using it for servability decisions would make the simulator's control plane behave differently from a real system, invalidating capacity planning results. See issue #567 ("Architectural Principle: Oracle Knowledge Boundary").
+
+**Scope:** The boundary applies to *servability* decisions (admit/reject/route), not to all scheduler operations. `FormBatch` legitimately reads `OutputTokens` for decode-phase step planning (whether to allocate a decode token), which mirrors vLLM's scheduler reading sequence state for per-step execution. The distinction: "should this request enter the system?" (servability — no oracle) vs. "what should this request do in the current step?" (execution — oracle allowed).
+
+**Verification:** `sim/simulator_test.go` — `TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary`: a request with `OutputTokens=1000` but `MaxOutputLen=0` and `MaxModelLen=512` is NOT rejected (input=200 < 512 passes input-only check), proving the enqueue guard does not peek at `OutputTokens`. Grep-based verification: `admission.go`, `routing.go`, `routing_scorers.go`, `routing_prefix_scorer.go`, `scheduler.go`, `priority.go` contain zero references to `OutputTokens`.
+
+**Evidence:** Issue #567 — the original implementation's BC-4 fallback (`effectiveMaxOutput = len(r.OutputTokens)`) violated this boundary. Fixed in the same PR after convergence review caught it.
+
+**Hypothesis family:** Structural model (same as INV-4, INV-7, INV-8).
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,7 +16,7 @@ go build -o blis main.go
 ## Verify the Build
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct --num-requests 10
+./blis run --model qwen/qwen3-14b --num-requests 10
 ```
 
 You should see JSON output on stdout containing fields like `ttft_mean_ms`, `e2e_mean_ms`, and `responses_per_sec`. This confirms BLIS is working correctly.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -5,10 +5,10 @@ Run your first BLIS simulation in 30 seconds.
 ## Single-Instance Simulation
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct
+./blis run --model qwen/qwen3-14b
 ```
 
-This runs 100 requests through a single inference instance using pre-trained coefficients for LLaMA 3.1 8B on an H100 GPU with TP=2.
+This runs 100 requests through a single inference instance using pre-trained coefficients for Qwen3 14B on an H100 GPU with TP=1.
 
 ### Reading the Output
 
@@ -39,7 +39,7 @@ Scale to 4 instances with routing:
 
 ```bash
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
+  --model qwen/qwen3-14b \
   --num-instances 4 \
   --routing-policy weighted \
   --rate 100 --num-requests 500
@@ -51,19 +51,32 @@ This simulates a 4-instance cluster receiving 100 requests/second. The `weighted
 
 ```bash
 # Higher traffic rate
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 500 --num-requests 2000
 
 # With decision tracing (see where each request was routed)
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500 \
   --trace-level decisions --summarize-trace
 
-# With roofline mode (no pre-trained coefficients needed)
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model roofline --hardware H100 --tp 2 \
+# With trained-roofline mode (recommended for new models, 7% MAPE)
+./blis run --model qwen/qwen3-14b \
+  --latency-model trained-roofline --hardware H100 --tp 1 \
+  --num-instances 4 --rate 100 --num-requests 500
+
+# With pure roofline mode (analytical, no learned corrections)
+./blis run --model qwen/qwen3-14b \
+  --latency-model roofline --hardware H100 --tp 1 \
   --num-instances 4 --rate 100 --num-requests 500
 ```
+
+> **Tip:** Roofline, trained-roofline, and cross-model modes auto-fetch model configs from HuggingFace. Set `HF_TOKEN` to access gated models (e.g., LLaMA) and avoid rate limits:
+>
+> ```bash
+> export HF_TOKEN=your_token_here
+> ```
+>
+> See [HuggingFace access tokens](https://huggingface.co/docs/hub/en/security-tokens) to create a token.
 
 ## What's Next
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -2,53 +2,53 @@
 
 This tutorial walks through a complete capacity planning exercise: determining how many inference instances you need to serve a target request rate while meeting latency SLOs.
 
-**Scenario:** You're deploying LLaMA 3.1 8B on H100 GPUs with TP=2. Your SLO is TTFT p99 < 500ms. You need to find the minimum number of instances for 500 requests/second.
+**Scenario:** You're deploying Qwen3 14B on H100 GPUs with TP=1. Your SLO is TTFT p99 < 500ms. You need to find the minimum number of instances for 20 requests/second.
 
 ## Step 1: Estimate Instance Capacity
 
-Before scaling up, measure the throughput of a single instance empirically. This works regardless of which [latency model](../guide/latency-models.md) you use (blackbox or roofline).
+Before scaling up, measure the throughput of a single instance empirically. This works regardless of which [latency model](../guide/latency-models.md) you use (blackbox, roofline, trained-roofline, or crossmodel).
 
 Run a single instance at low load to establish the baseline service rate:
 
 ```bash
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
+  --model qwen/qwen3-14b \
   --rate 10 --num-requests 50
 ```
 
-Check the `responses_per_sec` value in the output — this is the single-instance throughput at low utilization. For LLaMA 3.1 8B / H100 / TP=2 with default workload (512 input / 512 output tokens), you'll see roughly **57 requests/second**.
+Check the `responses_per_sec` value in the output — this is the single-instance throughput at low utilization. For Qwen3 14B / H100 / TP=1 with default workload (512 input / 512 output tokens), you'll see roughly **2.5 requests/second**.
 
-This means for 500 req/s, you need at minimum `ceil(500/57) ≈ 9` instances. Let's verify with simulation.
+This means for 20 req/s, you need at minimum `ceil(20/2.5) = 8` instances. Let's verify with simulation.
 
 ## Step 2: Baseline — Single Instance
 
 ```bash
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --rate 50 --num-requests 200
+  --model qwen/qwen3-14b \
+  --rate 2 --num-requests 50
 ```
 
-At 50 req/s (well below the ~57 req/s capacity), TTFT should be low. Note the `ttft_p99_ms` value — this is your best-case baseline.
+At 2 req/s (well below the ~2.5 req/s capacity), TTFT should be low. Note the `ttft_p99_ms` value — this is your best-case baseline.
 
 ## Step 3: Scale Up and Find the Saturation Point
 
-Run simulations at increasing instance counts for 500 req/s:
+Run simulations at increasing instance counts for 20 req/s:
 
 ```bash
-# 4 instances (~228 req/s capacity → heavily overloaded)
+# 4 instances (~10 req/s capacity → heavily overloaded)
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 4 --rate 500 --num-requests 2000
+  --model qwen/qwen3-14b \
+  --num-instances 4 --rate 20 --num-requests 200
 
-# 8 instances (~456 req/s capacity → near saturation)
+# 8 instances (~20 req/s capacity → near saturation)
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 8 --rate 500 --num-requests 2000
+  --model qwen/qwen3-14b \
+  --num-instances 8 --rate 20 --num-requests 200
 
-# 12 instances (~684 req/s capacity → comfortable headroom)
+# 12 instances (~30 req/s capacity → comfortable headroom)
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200
 ```
 
 Compare `ttft_p99_ms` across runs. You'll see:
@@ -76,25 +76,25 @@ Check the output for clues:
 
 ## Step 5: Compare Routing Policies
 
-With 12 instances at 500 req/s, compare routing strategies:
+With 12 instances at 20 req/s, compare routing strategies:
 
 ```bash
 # Round-robin (baseline)
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000 \
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200 \
   --routing-policy round-robin
 
 # Weighted (default profile)
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000 \
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200 \
   --routing-policy weighted
 
 # Least-loaded
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000 \
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200 \
   --routing-policy least-loaded
 ```
 
@@ -102,8 +102,8 @@ For prefix-heavy workloads (like RAG with shared system prompts), try the prefix
 
 ```bash
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000 \
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200 \
   --routing-policy weighted \
   --routing-scorers "prefix-affinity:5,queue-depth:1" \
   --prefix-tokens 512
@@ -115,8 +115,8 @@ For automated comparison across many configurations, use fitness evaluation:
 
 ```bash
 ./blis run \
-  --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 12 --rate 500 --num-requests 2000 \
+  --model qwen/qwen3-14b \
+  --num-instances 12 --rate 20 --num-requests 200 \
   --routing-policy weighted \
   --fitness-weights "p99_ttft:3,mean_e2e:1,throughput:2"
 ```
@@ -126,7 +126,7 @@ For automated comparison across many configurations, use fitness evaluation:
 
 ## Step 7: Validate Against Your SLO
 
-Your SLO: TTFT p99 < 500ms at 500 req/s.
+Your SLO: TTFT p99 < 500ms at 20 req/s.
 
 From the simulations above, find the minimum instance count where `ttft_p99_ms < 500`. That's your capacity plan. Add 20-30% headroom for traffic spikes (real deployments see bursty traffic that exceeds the Poisson assumption).
 

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -4,7 +4,7 @@ Admission control is the first gate in the cluster pipeline. It decides whether 
 
 ```bash
 # Rate-limit a 4-instance cluster with token bucket admission
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 500 --num-requests 2000 \
   --admission-policy token-bucket \
   --token-bucket-capacity 10000 --token-bucket-refill-rate 1000

--- a/docs/guide/cluster.md
+++ b/docs/guide/cluster.md
@@ -4,7 +4,7 @@ This guide covers running multi-instance BLIS simulations — the full pipeline 
 
 ```bash
 # Quick example: 4-instance cluster with tracing
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500 \
   --trace-level decisions --summarize-trace
 ```
@@ -39,11 +39,11 @@ The `--tp` flag sets the tensor parallelism degree for all instances. TP affects
 
 ```bash
 # TP=2: 2 GPUs per instance
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --tp 2 --rate 100 --num-requests 500
 
 # TP=4: 4 GPUs per instance (lower latency, fewer KV blocks per GPU)
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 2 --tp 4 --rate 100 --num-requests 500
 ```
 
@@ -83,7 +83,7 @@ These add simulated delays to the admission and routing pipeline, modeling gRPC 
 Log every routing decision for offline analysis:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500 \
   --trace-level decisions --summarize-trace --counterfactual-k 3
 ```

--- a/docs/guide/experimentation.md
+++ b/docs/guide/experimentation.md
@@ -4,10 +4,10 @@ This guide covers using BLIS as a platform for rigorous, reproducible experiment
 
 ```bash
 # Quick example: compare chunked prefill vs no chunked prefill
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --rate 100 --num-requests 500 --long-prefill-token-threshold 0
 
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --rate 100 --num-requests 500 --long-prefill-token-threshold 256
 ```
 
@@ -31,9 +31,9 @@ The most common experiment workflow for platform engineers:
 5. **Interpret:** Does the simulated TTFT p99 meet your SLO? If not, add instances or tune routing.
 
 ```bash
-# Example: Will 8 instances of LLaMA 3.1 8B handle 400 req/s at TTFT p99 < 500ms?
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --num-instances 8 --rate 400 --num-requests 2000 \
+# Example: Will 8 instances of Qwen3 14B handle 20 req/s at TTFT p99 < 500ms?
+./blis run --model qwen/qwen3-14b \
+  --num-instances 8 --rate 20 --num-requests 200 \
   --routing-policy weighted --seed 42
 ```
 
@@ -64,7 +64,7 @@ source hypotheses/lib/harness.sh
 
 # Run a simulation with standard setup
 blis_run 60 results/baseline.json \
-  --model meta-llama/llama-3.1-8b-instruct \
+  --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500
 ```
 

--- a/docs/guide/kv-cache.md
+++ b/docs/guide/kv-cache.md
@@ -4,7 +4,7 @@ This guide covers KV cache allocation, prefix caching, tiered GPU+CPU offload, a
 
 ```bash
 # Quick example: simulate with reduced KV blocks to observe preemptions
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --total-kv-blocks 5000 --rate 50 --num-requests 200
 ```
 
@@ -17,7 +17,7 @@ KV cache is allocated in **blocks** of `--block-size-in-tokens` tokens (default:
 | `--total-kv-blocks` | Per-model* | Total GPU-tier KV blocks |
 | `--block-size-in-tokens` | 16 | Tokens per block |
 
-*In blackbox mode, `defaults.yaml` overrides the 1,000,000 CLI default per model (e.g., LLaMA 3.1 8B / H100 / TP=2: 132,139 blocks). In roofline or crossmodel mode, the block count is auto-calculated from model architecture and GPU memory, superseding the `defaults.yaml` value. Explicit `--total-kv-blocks` always wins. See [Configuration Reference](../reference/configuration.md#resolution-process).
+*In blackbox mode, `defaults.yaml` overrides the 1,000,000 CLI default per model (e.g., Qwen3 14B / H100 / TP=1: 17,600 blocks). In roofline or crossmodel mode, the block count is auto-calculated from model architecture and GPU memory, superseding the `defaults.yaml` value. Explicit `--total-kv-blocks` always wins. See [Configuration Reference](../reference/configuration.md#resolution-process).
 
 !!! tip "Block size affects prefix cache granularity"
     Prefix caching uses block-aligned hashing (`hash.ComputeBlockHashes`). Smaller block sizes increase cache hit granularity but also increase allocation overhead. Choose block size relative to your typical prefix lengths.
@@ -29,7 +29,7 @@ When requests share common prefixes (e.g., system prompts in RAG), BLIS can reus
 Prefix caching is automatic when using the `prefix-affinity` scorer with `weighted` routing:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --routing-policy weighted \
   --routing-scorers "prefix-affinity:3,queue-depth:1" \
   --prefix-tokens 512 --rate 100 --num-requests 500
@@ -38,7 +38,15 @@ Prefix caching is automatic when using the `prefix-affinity` scorer with `weight
 ## Minimum KV Block Requirements
 
 !!! danger "DroppedUnservable rejection"
-    When `ceil(inputTokens / blockSize) > TotalCapacity()`, BLIS drops the request as **unservable** — it physically cannot fit in memory. This mirrors vLLM's pre-engine rejection path.
+    Requests are dropped as **unservable** (incrementing `DroppedUnservable`) in two cases:
+
+    1. **MaxModelLen guard** — when `--max-model-len` is set, requests whose total sequence length (input + output budget) exceeds the context window are rejected before entering the queue. This mirrors vLLM's `--max-model-len` validation.
+    2. **KV capacity guard** — when `ceil(inputTokens / blockSize) > TotalCapacity()`, the request physically cannot fit in GPU memory. This mirrors vLLM's pre-engine rejection path.
+
+    Both guards fire at enqueue time, before the request enters the wait queue.
+
+!!! info "Runtime length cap"
+    When `--max-model-len` is set, requests that grow beyond the limit during decode are force-completed. This is a defense-in-depth mechanism — under normal operation the enqueue guard prevents oversized requests, but the runtime cap protects against unbounded growth if a request bypasses the guard.
 
 Compute the minimum blocks needed for your workload:
 
@@ -53,7 +61,7 @@ For a workload with max 7,000 input tokens and block size 16: `ceil(7000/16) = 4
 BLIS models tiered KV cache with GPU→CPU offloading:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --kv-cpu-blocks 50000 \
   --kv-offload-threshold 0.9 \
   --kv-transfer-bandwidth 100.0 \
@@ -74,7 +82,7 @@ Long prefill sequences can cause **head-of-line (HOL) blocking** — a 2,048-tok
 Chunked prefill splits long prefills into smaller chunks:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --long-prefill-token-threshold 256 \
   --rate 100 --num-requests 500
 ```
@@ -101,7 +109,7 @@ Preemption rates spike non-linearly as KV blocks decrease past a threshold. The 
 # Sweep KV blocks to find the cliff
 for blocks in 100000 50000 20000 10000 5000 3000; do
   echo "=== blocks=$blocks ==="
-  ./blis run --model meta-llama/llama-3.1-8b-instruct \
+  ./blis run --model qwen/qwen3-14b \
     --total-kv-blocks $blocks --rate 50 --num-requests 200 2>/dev/null \
     | grep -E "preemption_count|completed_requests"
 done

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -1,20 +1,25 @@
 # Latency Models
 
-The `LatencyModel` interface determines how BLIS estimates GPU step time for each batch iteration. BLIS ships three backends -- blackbox (data-driven), roofline (analytical), and cross-model (physics-informed, MoE-aware) -- and the pluggable architecture supports adding custom backends.
+The `LatencyModel` interface determines how BLIS estimates GPU step time for each batch iteration. BLIS ships four backends -- blackbox (data-driven), roofline (analytical), cross-model (physics-informed), and trained-roofline (roofline × learned corrections) -- and the pluggable architecture supports adding custom backends.
 
 ```bash
-# Blackbox mode (default) — uses pre-trained coefficients
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+# Blackbox mode (default) — uses pre-trained per-model coefficients
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500
 
-# Roofline mode — analytical estimation from model architecture
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model roofline --hardware H100 --tp 2 \
+# Roofline mode — pure analytical estimation from model architecture
+./blis run --model qwen/qwen3-14b \
+  --latency-model roofline --hardware H100 --tp 1 \
   --num-instances 4 --rate 100 --num-requests 500
 
-# Cross-model mode — physics-informed estimation from config.json (MoE-aware)
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model crossmodel --hardware H100 --tp 2 \
+# Cross-model mode — physics-informed with hand-engineered features
+./blis run --model qwen/qwen3-14b \
+  --latency-model crossmodel --hardware H100 --tp 1 \
+  --num-instances 4 --rate 100 --num-requests 500
+
+# Trained-roofline mode — roofline basis functions × learned corrections (7% MAPE)
+./blis run --model qwen/qwen3-14b \
+  --latency-model trained-roofline --hardware H100 --tp 1 \
   --num-instances 4 --rate 100 --num-requests 500
 ```
 
@@ -39,7 +44,7 @@ QueueingTime           = alpha0 + alpha1 * input_length
 OutputTokenProcessingTime = alpha2
 ```
 
-All alpha and beta coefficients must be non-negative. Negative values are rejected at construction time (INV-5: causality). Pre-trained coefficient sets exist in `defaults.yaml` for common model/GPU/TP combinations (e.g., `meta-llama/llama-3.1-8b-instruct` on H100 with TP=2).
+All alpha and beta coefficients must be non-negative. Negative values are rejected at construction time (INV-5: causality). Pre-trained coefficient sets exist in `defaults.yaml` for common model/GPU/TP combinations (e.g., `qwen/qwen3-14b` on H100 with TP=1).
 
 !!! note "Alpha overhead is non-blocking"
     Alpha coefficients model CPU post-processing (tokenization, output serialization) that runs concurrently with GPU execution. Alpha time inflates TTFT and ITL metrics but does **not** block step scheduling -- the next batch step is scheduled at `now + stepTime` regardless of alpha overhead. This matches real vLLM's asynchronous post-processing pipeline.
@@ -53,8 +58,8 @@ Roofline mode computes step time analytically from model architecture (FLOPs, pa
 The simplest way to use roofline mode:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model roofline --hardware H100 --tp 2
+./blis run --model qwen/qwen3-14b \
+  --latency-model roofline --hardware H100 --tp 1
 ```
 
 This auto-resolves both required inputs:
@@ -67,7 +72,7 @@ For gated models (e.g., LLaMA), set `HF_TOKEN`:
 ```bash
 export HF_TOKEN=your_token_here
 ./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model roofline --hardware H100 --tp 2
+  --latency-model roofline --hardware H100 --tp 1
 ```
 
 ### Manual Configuration
@@ -103,13 +108,16 @@ When choosing between TP and replication (more instances): TP reduces per-reques
 !!! note "Automatic KV block calculation"
     When using roofline or crossmodel mode, `--total-kv-blocks` is automatically derived from model architecture and GPU memory if not explicitly set. The auto-calculated value accounts for TP (KV heads are sharded across ranks; total GPU memory scales with GPU count). Override with `--total-kv-blocks <N>` for non-standard deployments. The auto-calculation uses reference constants (90% GPU utilization, standard activation/overhead budgets matching the llm-d-benchmark capacity planner) and requires SwiGLU-family activations.
 
+!!! note "Automatic MaxModelLen derivation"
+    When using roofline or crossmodel mode and `--max-model-len` is not explicitly set, BLIS auto-derives it from `max_position_embeddings` in the HuggingFace `config.json`. For models with `rope_scaling`, the scaling factor is applied based on vLLM's blacklist approach: types `linear`, `dynamic`, `yarn`, `default`, and `mrope` apply the factor; types `su`, `longrope`, and `llama3` are excluded (these encode the full context in `max_position_embeddings`). For `yarn`, `original_max_position_embeddings` is used as the base when present. `gemma3` models skip `rope_scaling` entirely (`max_position_embeddings` is pre-scaled). The derived value is then capped at the KV-feasible maximum (`total_kv_blocks * block_size`) to prevent context windows from exceeding GPU memory capacity. Override with `--max-model-len <N>` when needed.
+
 ## Cross-Model Mode (Physics-Informed)
 
 Cross-model mode estimates step time using 7 globally-fitted coefficients (4 beta for step time + 3 alpha for CPU overhead) that work across model architectures. Unlike blackbox (per-model coefficients) or roofline (no MoE awareness), cross-model uses architecture features from `config.json` to scale a single coefficient set.
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
-  --latency-model crossmodel --hardware H100 --tp 2
+./blis run --model qwen/qwen3-14b \
+  --latency-model crossmodel --hardware H100 --tp 1
 ```
 
 **StepTime formula:**
@@ -133,32 +141,79 @@ Where `kvDimScaled = numLayers × numKVHeads × headDim / TP × 1e-6`, `isMoE = 
 !!! note "Automatic KV block calculation"
     Like roofline mode, crossmodel auto-derives `--total-kv-blocks` from model architecture and GPU memory when the flag is not set. Override with `--total-kv-blocks <N>` for non-standard deployments. The auto-calculation uses reference constants (90% GPU utilization, standard activation/overhead budgets matching the llm-d-benchmark capacity planner) and requires SwiGLU-family activations (`silu`, `swiglu`, `geglu`).
 
+## Trained-Roofline Mode (Recommended for New Models)
+
+Trained-roofline mode applies **learned correction factors** to analytical roofline basis functions, combining the physical grounding of roofline with the accuracy of data-driven fitting. Coefficients are fitted from 137K real vLLM requests across 4 architectures (Llama-2-7b, Llama-2-70b, Mixtral-8x7B, CodeLlama-34b) via non-negative least squares regression.
+
+```bash
+./blis run --model meta-llama/llama-3.1-8b-instruct \
+  --latency-model trained-roofline --hardware H100 --tp 2
+```
+
+Same auto-fetch chain as roofline and crossmodel (HuggingFace config + hardware config resolution).
+
+**StepTime formula** (7 terms):
+
+```
+StepTime = β₁ × max(T_pf_compute, T_pf_kv)    # prefill roofline bottleneck × correction
+         + β₂ × max(T_dc_compute, T_dc_kv)    # decode roofline bottleneck × correction
+         + β₃ × T_weight                       # weight loading × correction
+         + β₄ × T_tp                           # TP communication × correction
+         + β₅ × L                              # per-layer overhead (µs/layer)
+         + β₆ × batch_size                     # per-request scheduling (µs/req)
+         + β₇                                  # per-step fixed overhead (µs)
+```
+
+Where each basis function (T_pf_compute, T_pf_kv, etc.) is a full analytical roofline calculation from model architecture + hardware specs. β₁-β₄ are dimensionless correction factors (near 1.0 = roofline is accurate). β₅-β₇ capture overhead not in the roofline model.
+
+**Key differences from roofline mode:**
+
+- **No MFU scaling** -- β₁ and β₂ ARE the MFU corrections. Applying `MfuPrefill`/`MfuDecode` would double-count.
+- **3-matrix SwiGLU** -- uses `6 × d × d_ff` for FFN FLOPs (gate + up + down) vs roofline's 2-matrix convention.
+- **MoE-aware weight loading** -- `min(N, max(k, B×k))` effective experts, not all N.
+
+**Alpha model** (3 coefficients):
+
+- `α₀` = API processing overhead (constant, added to TTFT via `QueueingTime`)
+- `α₁` = Fixed per-request post-decode overhead (added to E2E via `PostDecodeFixedOverhead`)
+- `α₂` = Per-output-token detokenization cost (added to ITL via `OutputTokenProcessingTime`)
+
+**Pre-trained coefficients** (7% MAPE on GPU combined step time, test split) are stored in `trained_roofline_defaults` in `defaults.yaml`. No per-model calibration needed -- the roofline basis functions handle architecture-specific scaling.
+
+!!! note "TTFT accuracy caveat"
+    The "7% MAPE" headline applies to GPU combined step time. The alpha model has higher error: α₀ (pre-queueing) has 93% MAPE because it's a single constant for a highly variable real-world quantity. TTFT predictions have higher error than GPU step time predictions. For TTFT-sensitive analysis, consider calibrating α₀ per-deployment.
+
+!!! note "Chunked prefill limitation"
+    Trained-roofline was fitted on single-step prefill data. When used with `--long-prefill-token-threshold > 0` (chunked prefill), the attention FLOPs formula uses `len(InputTokens)` (total prompt) as context for each chunk, overestimating early-chunk step times. For chunked-prefill workloads, pure roofline mode may be more accurate until coefficients are refit on chunked data.
+
 ## When to Use Which
 
-| Aspect | Blackbox (default) | Roofline | Cross-Model |
-|--------|-------------------|----------|-------------|
-| **When to use** | Model has per-model coefficients in `defaults.yaml` | Quick estimation, no training data | New model from config.json, MoE models |
-| **Data required** | `defaults.yaml` entry for model/GPU/TP | HuggingFace `config.json` + `--hardware` + `--tp` | HuggingFace `config.json` + `--hardware` + `--tp` (global coefficients bundled) |
-| **Accuracy** | Highest (trained on real per-model measurements) | Good mean (analytical FLOPs/bandwidth) | Good mean across architectures (7 global coefficients: 4 beta + 3 alpha) |
-| **MoE support** | Yes (if trained coefficients exist) | No (assumes dense transformers) | Yes (explicit MoE dispatch term via `num_local_experts`) |
-| **Alpha overhead** | Alpha from coefficients (queueing + output processing) | Alpha from coefficients (same as blackbox) | Alpha from coefficients (same as blackbox) |
+| Aspect | Blackbox (default) | Roofline | Cross-Model | Trained-Roofline |
+|--------|-------------------|----------|-------------|------------------|
+| **When to use** | Model has per-model coefficients in `defaults.yaml` | Quick analytical estimate | Hand-engineered physics features | **Recommended** for new models (best accuracy without per-model training) |
+| **Data required** | `defaults.yaml` entry for model/GPU/TP | HF `config.json` + `--hardware` + `--tp` | HF `config.json` + `--hardware` + `--tp` | HF `config.json` + `--hardware` + `--tp` (global coefficients bundled) |
+| **GPU step time accuracy** | Highest (per-model) | Good (analytical) | Good (7 global params) | **7% MAPE** (10 global params, roofline × corrections) |
+| **MoE support** | If trained | No (dense only) | Yes (binary indicator) | Yes (per-expert FLOPs + effective expert count) |
+| **Alpha model** | α₀ + α₁·inputLen | Same as blackbox | Same as blackbox | α₀ (constant), α₁ (post-decode fixed), α₂ (per-token) |
+| **PostDecodeFixedOverhead** | 0 | 0 | 0 | α₁ (~1.85ms) |
 
 !!! tip "Choosing the right mode"
-    **Blackbox** for models with trained coefficients (highest accuracy). **Cross-model** for new models or MoE models without per-model coefficients (global physics coefficients + config.json features). **Roofline** for quick analytical estimates of dense models when no coefficients are available at all.
+    **Trained-roofline** is the recommended default for any model with a HuggingFace `config.json` (7% MAPE GPU combined, MoE-aware, no per-model calibration needed). **Blackbox** for models with per-model coefficients in `defaults.yaml` (slightly higher accuracy due to per-model fitting). **Cross-model** for backward compatibility with existing crossmodel workflows. **Roofline** for pure analytical estimates when no learned corrections are desired.
 
 ## Pluggable Architecture
 
-The `LatencyModel` interface (defined in `sim/latency_model.go`) has three methods:
+The `LatencyModel` interface (defined in `sim/latency_model.go`) has four methods:
 
 | Method | Purpose |
 |--------|---------|
 | `StepTime(batch)` | Duration of one batch step given the running batch |
 | `QueueingTime(req)` | Arrival-to-queue delay for a request |
 | `OutputTokenProcessingTime()` | Per-token post-processing time |
+| `PostDecodeFixedOverhead()` | Fixed per-request overhead at completion (0 for blackbox/roofline/crossmodel) |
 
 All time estimates are in microseconds (ticks).
 
-New backends register via the `NewLatencyModelFunc` variable in `sim/latency_model.go`. The `sim/latency/register.go` file uses `init()` to wire the factory, breaking the import cycle between `sim/` (interface owner) and `sim/latency/` (implementation). To add a custom backend, implement the three methods and register your factory via `init()` in a sub-package. See [Extension Recipes](../contributing/extension-recipes.md) for a step-by-step guide.
+New backends register via the `NewLatencyModelFunc` variable in `sim/latency_model.go`. The `sim/latency/register.go` file uses `init()` to wire the factory, breaking the import cycle between `sim/` (interface owner) and `sim/latency/` (implementation). To add a custom backend, implement the four methods and register your factory via `init()` in a sub-package. See [Extension Recipes](../contributing/extension-recipes.md) for a step-by-step guide.
 
 ## Further Reading
 

--- a/docs/guide/results.md
+++ b/docs/guide/results.md
@@ -4,7 +4,7 @@ This guide covers how to read BLIS output — from the primary JSON metrics to a
 
 ```bash
 # Quick example: run with all diagnostic output enabled
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 200 --num-requests 1000 \
   --trace-level decisions --summarize-trace \
   --fitness-weights "p99_ttft:3,mean_e2e:1,throughput:2"
@@ -42,7 +42,7 @@ When anomalies are detected, BLIS prints `=== Anomaly Counters ===`:
 | **Priority Inversions** | A lower-priority request was scheduled before a higher-priority one | Check scheduler choice — use `priority-fcfs` for SLO workloads |
 | **HOL Blocking Events** | A long prefill blocked shorter requests | Enable chunked prefill: `--long-prefill-token-threshold 256` |
 | **Rejected Requests** | Admission policy rejected the request | Check token bucket capacity or admission policy |
-| **Dropped Unservable** | Request needs more KV blocks than exist | Increase `--total-kv-blocks` or reduce max input tokens |
+| **Dropped Unservable** | Request exceeds `--max-model-len` context window or needs more KV blocks than exist | Check `--max-model-len` setting; increase `--total-kv-blocks` or reduce max input tokens |
 | **Dropped KV Allocations** | Decode sub-request could not allocate KV blocks at the decode instance (PD mode only) | Increase `--total-kv-blocks` on decode instances or reduce decode pool load |
 
 ## KV Cache Metrics
@@ -129,7 +129,7 @@ BLIS models non-GPU overhead (tokenization, API serialization) as `alpha` coeffi
 For detailed analysis, save per-request data:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --rate 100 --num-requests 500 --results-path results.json
 ```
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -4,7 +4,7 @@ This guide covers how BLIS distributes incoming requests across instances in clu
 
 ```bash
 # Quick example: compare round-robin vs weighted routing
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500 \
   --routing-policy weighted --trace-level decisions --summarize-trace
 ```

--- a/docs/guide/scheduling.md
+++ b/docs/guide/scheduling.md
@@ -4,7 +4,7 @@ Routing decides **which instance** receives a request. Scheduling decides **what
 
 ```bash
 # Priority-FCFS scheduling with age-based priority in a 4-instance cluster
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500 \
   --scheduler priority-fcfs --priority-policy slo-based
 ```

--- a/docs/guide/skills-and-plugins.md
+++ b/docs/guide/skills-and-plugins.md
@@ -22,7 +22,7 @@ Skills and plugins are organized into five layers, from most specific to most ge
 | **Official plugins** | `claude-plugins-official` | Anthropic official tools | `commit-commands` (git workflow), `pr-review-toolkit` (PR review), `code-review`, `feature-dev`, `claude-md-management` |
 | **Community plugins** | `awesome-claude-plugins` | Community-contributed tools | `audit-project` (multi-agent code review), `bug-fix`, `debugger`, `test-writer-fixer` |
 
-Project skills take precedence -- they encode BLIS-specific conventions (23 antipattern rules, 8 system invariants, convergence protocol) that generic tools do not know about.
+Project skills take precedence -- they encode BLIS-specific conventions (23 antipattern rules, 9 system invariants, convergence protocol) that generic tools do not know about.
 
 ## Marketplaces
 

--- a/docs/guide/workloads.md
+++ b/docs/guide/workloads.md
@@ -4,7 +4,7 @@ This guide covers how to define the traffic patterns BLIS simulates — from sim
 
 ```bash
 # Quick example: workload-spec YAML
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --workload-spec examples/multiturn-chat-demo.yaml
 ```
 
@@ -52,7 +52,7 @@ clients:
 Pair with prefix-affinity routing for cache reuse:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --workload-spec chat.yaml \
   --routing-policy weighted --routing-scorers "prefix-affinity:3,queue-depth:2"
 ```
@@ -86,7 +86,7 @@ clients:
 Run with aggressive prefix-affinity to maximize cache reuse:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --num-instances 4 --workload-spec rag.yaml \
   --routing-policy weighted --routing-scorers "prefix-affinity:3,queue-depth:1"
 ```
@@ -190,7 +190,7 @@ Context accumulation means round N sees all prior input+output tokens as prefix,
 The simplest way to generate traffic:
 
 ```bash
-./blis run --model meta-llama/llama-3.1-8b-instruct \
+./blis run --model qwen/qwen3-14b \
   --rate 100 --num-requests 500 \
   --prompt-tokens 512 --prompt-tokens-stdev 256 \
   --output-tokens 256 --output-tokens-stdev 128
@@ -413,7 +413,7 @@ BLIS ships with preset workload profiles in `defaults.yaml`. Use them via the CL
 
 ```bash
 # Run directly with a named preset
-./blis run --model meta-llama/llama-3.1-8b-instruct --workload chatbot
+./blis run --model qwen/qwen3-14b --workload chatbot
 
 # Convert a preset to a v2 WorkloadSpec YAML for customization
 ./blis convert preset --name chatbot --rate 10 --num-requests 100 > chatbot.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ The simulator is CPU-only, deterministic, and designed for **capacity planning**
 git clone https://github.com/inference-sim/inference-sim.git
 cd inference-sim
 go build -o blis main.go
-./blis run --model meta-llama/llama-3.1-8b-instruct
+./blis run --model qwen/qwen3-14b
 ```
 
 ---

--- a/docs/plans/2026-03-09-roofline-llm-optimizer-port-design.md
+++ b/docs/plans/2026-03-09-roofline-llm-optimizer-port-design.md
@@ -1,0 +1,61 @@
+# Roofline Physics Port from llm-optimizer
+
+**Status:** Approved
+**Date:** 2026-03-09
+**Species:** Decision record
+**Motivation:** BLIS roofline has 929% E2E MAPE and 215% ITL MAPE against ground-truth vLLM experiments (discussion #522). llm-optimizer achieves 32.4% E2E and 36.5% ITL with a simpler roofline. Port its physics into BLIS's existing step-time structure.
+
+## Problem
+
+Three physics issues in `rooflineStepTime()` cause systematic over-prediction:
+
+1. **Dual ceiling model** — BLIS splits compute into GEMM ops and vector ops with separate ceilings (`peakFlops * mfu` and `peakFlops * 0.10`). The vector ceiling is 10x lower than tensor core peak, adding a large serial term even when vector ops are a small fraction. llm-optimizer uses a single `peakFlops * mfu` ceiling for all ops.
+
+2. **Bandwidth haircut** — BLIS applies `BwEffConstant = 0.72` to peak HBM bandwidth, predicting 39% slower than peak for memory-bound phases. llm-optimizer uses raw peak bandwidth. Modern GPU memory controllers achieve near-peak bandwidth for sequential weight/KV reads.
+
+3. **Overhead stacking** — BLIS adds `TOverheadMicros` (500µs) + `PerLayerOverhead` (20µs × layers) + `AllReduceLatency` (20µs × layers × 2 for TP>1) per step. For Llama-2-7B (32 layers, TP=1), this is 1140µs — 28% of a ~4ms decode step. llm-optimizer has no overhead terms. These constants were not derived from measurement and over-compensate.
+
+Combined, these produce ~3x over-prediction for decode (memory-bound) steps.
+
+## Decision
+
+Port llm-optimizer's single-crossover roofline into `rooflineStepTime()`. Keep BLIS's step-time prediction structure (StepConfig in, µs out) and BLIS's superior model-awareness (actual IntermediateDim, SwiGLU 3-matrix MLP, MoE, FlashAttention-aware memory).
+
+### What changes
+
+**In `rooflineStepTime()` (4 changes):**
+
+1. Remove dual ceiling — replace `gemmFlops/(peak*mfu) + vectorFlops/vectorPeak` with `totalFlops/(peak*mfu)`. The `calculateTransformerFlops()` return map already has `"total"` = gemm_ops + sram_ops; use that directly.
+
+2. Remove bandwidth haircut — replace `peakBW * BwEffConstant` with `peakBW`.
+
+3. Remove all overhead terms — delete `layerFloorS`, `commOverheadS`, `TOverheadMicros` from the step time calculation.
+
+4. Use llm-optimizer MFU defaults — update `hardware_config.json`: `MfuPrefill: 0.45`, `MfuDecode: 0.30`.
+
+**What stays the same:**
+- Function signature and return type
+- Phase separation (prefill loop + decode loop)
+- Phase addition (`prefillTime + decodeTime`)
+- Per-request FLOPs/memory accumulation
+- Weight loading once per phase
+- `calculateTransformerFlops()` — unchanged
+- `calculateMemoryAccessBytes()` — unchanged
+- LatencyModel interface — unchanged
+- KV capacity calculation — unchanged
+
+### What we keep from BLIS (better than llm-optimizer)
+
+| Aspect | llm-optimizer | BLIS (kept) |
+|--------|--------------|-------------|
+| MLP dims | Hardcoded `4 * d_model` | Actual `IntermediateDim` from HF config |
+| MLP matrices | 2-matrix (up/down) | 2-matrix (matching llm-optimizer; HF `intermediate_size` already SwiGLU-scaled). KV capacity uses 3-matrix for conservative weight estimation |
+| MoE | None | Routed expert FLOPs (top_k) and weights (all E); shared expert and gate weights modeled in KV capacity only |
+| Attention memory | Quadratic `[B,H,T,T]` in HBM | FlashAttention-aware (SRAM-local) |
+| Prefill context | Full `T²` | Effective context averaging |
+
+## Risks
+
+- **MFU values are per-GPU constants.** Changing from 0.65/0.12 to 0.45/0.30 affects all models on all GPUs. If the evaluation set (H100 only, 4 models) is not representative, accuracy may degrade on other hardware.
+- **Removing overheads entirely** means small-batch/short-sequence steps have no floor. If real GPU scheduling overhead is ~100-200µs, the roofline will under-predict for very fast steps.
+- **BwEffConstant becomes unused** but remains in `HardwareCalib` struct. It still has meaning for other potential consumers; leave the field, just stop using it in `rooflineStepTime()`.

--- a/docs/plans/2026-03-09-roofline-llm-optimizer-port-plan.md
+++ b/docs/plans/2026-03-09-roofline-llm-optimizer-port-plan.md
@@ -1,0 +1,275 @@
+# Roofline llm-optimizer Physics Port — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace BLIS roofline's dual-ceiling + overhead physics with llm-optimizer's single-crossover model to reduce ITL MAPE from 215% to ~15-25%.
+
+**Architecture:** Only `rooflineStepTime()` changes — the FLOPs and memory calculation functions are untouched. The function keeps its signature, phase separation, and per-request accumulation. Four deletions (dual ceiling, bandwidth haircut, overhead terms) and one update (MFU values in hardware_config.json).
+
+**Tech Stack:** Go, JSON hardware config
+
+---
+
+### Task 1: Simplify rooflineStepTime to single-crossover model
+
+**Files:**
+- Modify: `sim/latency/roofline.go:221-292`
+- Test: `sim/latency/roofline_test.go`
+
+**Step 1: Write a test that verifies the new physics**
+
+Add to `roofline_test.go` — a test that asserts: for a memory-bound decode step, step time equals `total_bytes / peak_bandwidth` (no haircut, no overhead). This will fail against the current implementation.
+
+```go
+func TestRooflineStepTime_SingleCrossover_MemoryBoundDecode(t *testing.T) {
+	// llm-optimizer physics: memory-bound step time = total_bytes / peak_bandwidth
+	// No bandwidth haircut, no overhead terms, single crossover (not dual ceiling).
+	mc := testModelConfig()
+	hc := testHardwareCalib()
+
+	// Single decode request — decode is memory-bound on H100
+	step := StepConfig{
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 512, NumNewDecodeTokens: 1},
+		},
+	}
+	result := rooflineStepTime(mc, hc, step, 1)
+
+	// Compute expected: weights + KV + activations, all at raw peak bandwidth
+	peakBW := hc.BwPeakTBs * 1e12
+	peakFlops := hc.TFlopsPeak * 1e12
+
+	baseMem := calculateMemoryAccessBytes(mc, 0, 0, false)
+	dynamicMem := calculateMemoryAccessBytes(mc, 512, 1, true)
+	totalBytes := baseMem["model_weights"] + (dynamicMem["total"] - dynamicMem["model_weights"])
+
+	flops := calculateTransformerFlops(mc, 512, 1, true, true)
+	totalFlops := flops["total"]
+
+	computeS := totalFlops / (peakFlops * hc.MfuDecode)
+	memoryS := totalBytes / peakBW
+
+	// Decode should be memory-bound (verify assumption)
+	if computeS >= memoryS {
+		t.Skipf("decode is compute-bound with this config, skipping memory-bound test")
+	}
+
+	expectedMicros := int64(math.Round(memoryS * 1e6))
+	if result != expectedMicros {
+		t.Errorf("expected %d µs (total_bytes/peak_bw), got %d µs (delta=%d)",
+			expectedMicros, result, result-expectedMicros)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./sim/latency/ -run TestRooflineStepTime_SingleCrossover -v -count=1`
+Expected: FAIL — current implementation adds haircut + overhead
+
+**Step 3: Rewrite rooflineStepTime**
+
+Replace lines 221-292 of `sim/latency/roofline.go` with:
+
+```go
+// rooflineStepTime computes step latency using the roofline model.
+//
+// Uses single-crossover roofline (llm-optimizer style): for each phase,
+// step_time = max(total_flops / (peak * MFU), total_bytes / peak_bandwidth).
+// No bandwidth haircut, no overhead terms.
+//
+// Precondition: ValidateRooflineConfig(modelConfig, hwConfig) must return nil
+// and tp must be > 0. Callers must validate before first call.
+func rooflineStepTime(modelConfig sim.ModelConfig, hwConfig sim.HardwareCalib, stepConfig StepConfig, tp int) int64 {
+
+	tpFactor := float64(tp)
+	peakFlops := hwConfig.TFlopsPeak * 1e12
+	peakBW := hwConfig.BwPeakTBs * 1e12
+
+	var prefillTimeS, decodeTimeS float64
+
+	// 1. PREFILL PHASE
+	if len(stepConfig.PrefillRequests) > 0 {
+		var pTotalFlops, pDynamicBytes float64
+
+		for _, req := range stepConfig.PrefillRequests {
+			numTokens := int64(req.NumNewPrefillTokens)
+
+			f := calculateTransformerFlops(modelConfig, req.ProgressIndex, numTokens, true, true)
+			pTotalFlops += f["total"] / tpFactor
+
+			m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, numTokens, true)
+			pDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
+		}
+
+		baseMem := calculateMemoryAccessBytes(modelConfig, 0, 0, false)
+		pWeightBytes := baseMem["model_weights"] / tpFactor
+
+		pComputeS := pTotalFlops / (peakFlops * hwConfig.MfuPrefill)
+		pMemoryS := (pWeightBytes + pDynamicBytes) / peakBW
+
+		prefillTimeS = math.Max(pComputeS, pMemoryS)
+	}
+
+	// 2. DECODE PHASE
+	if len(stepConfig.DecodeRequests) > 0 {
+		var dTotalFlops, dDynamicBytes float64
+
+		for _, req := range stepConfig.DecodeRequests {
+			f := calculateTransformerFlops(modelConfig, req.ProgressIndex, 1, true, true)
+			dTotalFlops += f["total"] / tpFactor
+
+			m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, 1, true)
+			dDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
+		}
+
+		baseMem := calculateMemoryAccessBytes(modelConfig, 0, 0, false)
+		dWeightBytes := baseMem["model_weights"] / tpFactor
+
+		dComputeS := dTotalFlops / (peakFlops * hwConfig.MfuDecode)
+		dMemoryS := (dWeightBytes + dDynamicBytes) / peakBW
+
+		decodeTimeS = math.Max(dComputeS, dMemoryS)
+	}
+
+	// 3. COMBINE (no overhead terms)
+	totalMicros := (prefillTimeS + decodeTimeS) * 1e6
+
+	return int64(math.Round(totalMicros))
+}
+```
+
+**Step 4: Update the empty step test**
+
+The empty step test (`TestRooflineStepTime_EmptyStep_ReturnsOverheadOnly`) currently expects positive result from overhead alone. Without overheads, an empty step returns 0. Update:
+
+```go
+func TestRooflineStepTime_EmptyStep_ReturnsZero(t *testing.T) {
+	// No requests = no work = 0 µs (no overhead terms in llm-optimizer model)
+	mc := testModelConfig()
+	hc := testHardwareCalib()
+
+	step := StepConfig{} // empty
+	result := rooflineStepTime(mc, hc, step, 1)
+
+	if result != 0 {
+		t.Errorf("empty step should return 0 µs, got %d µs", result)
+	}
+}
+```
+
+**Step 5: Run all roofline tests**
+
+Run: `go test ./sim/latency/ -run TestRooflineStepTime -v -count=1`
+Expected: All PASS — SingleCrossover test passes, empty step updated, TP scaling and smoke tests still hold (physics changed but invariants preserved)
+
+**Step 6: Run full test suite + lint**
+
+Run: `go test ./sim/... -count=1 && golangci-lint run ./sim/...`
+Expected: All PASS. The `vectorPeak` variable and `effBW` are now unused — the compiler will catch this. The `sort` import may become unused if it was only used indirectly. The linter may flag unused `HardwareCalib` fields, but those are still valid struct fields.
+
+**Step 7: Commit**
+
+```bash
+git add sim/latency/roofline.go sim/latency/roofline_test.go
+git commit -m "refactor(latency): port llm-optimizer single-crossover roofline physics
+
+Replace dual-ceiling model (GEMM + vector ceilings) with single-crossover:
+  step_time = max(total_flops / (peak * MFU), total_bytes / peak_bandwidth)
+
+Remove bandwidth haircut (BwEffConstant no longer used in step time).
+Remove all overhead terms (TOverheadMicros, PerLayerOverhead, AllReduceLatency).
+
+Keeps BLIS's superior model-awareness: actual IntermediateDim, SwiGLU
+3-matrix MLP, MoE support, FlashAttention-aware memory model.
+
+Motivation: BLIS roofline has 215% ITL MAPE vs llm-optimizer's 36.5%.
+The dual ceiling + bandwidth haircut + overhead stacking caused ~3x
+systematic over-prediction for memory-bound decode steps.
+
+Design: docs/plans/2026-03-09-roofline-llm-optimizer-port-design.md"
+```
+
+---
+
+### Task 2: Update hardware_config.json MFU values
+
+**Files:**
+- Modify: `hardware_config.json`
+
+**Step 1: Update MFU values to match llm-optimizer defaults**
+
+Change all GPU entries:
+- `mfuPrefill`: 0.65 → 0.45
+- `mfuDecode`: 0.12 → 0.30
+
+For H100:
+```json
+{
+    "H100": {
+        "TFlopsPeak":        989.5,
+        "BwPeakTBs":         3.35,
+        "BwEffConstant":     0.72,
+        "TOverheadMicros":   500.0,
+        "perLayerOverhead":  20.0,
+        "mfuPrefill":        0.45,
+        "mfuDecode":         0.30,
+        "allReduceLatency":  20.0,
+        "MemoryGiB":         80.0
+    }
+}
+```
+
+Same for A100-SXM and A100-80.
+
+Note: `BwEffConstant`, `TOverheadMicros`, `PerLayerOverhead`, `AllReduceLatency` remain in the file unchanged. They are still valid `HardwareCalib` struct fields and may be used by other consumers (crossmodel, future models). Only `rooflineStepTime()` stopped using them.
+
+**Step 2: Run full test suite**
+
+Run: `go test ./... -count=1`
+Expected: All PASS. The `testHardwareCalib()` helper in `roofline_test.go` uses its own hardcoded values (MfuPrefill=0.55, MfuDecode=0.30), so test behavior doesn't depend on `hardware_config.json`.
+
+**Step 3: Run lint**
+
+Run: `golangci-lint run ./...`
+Expected: Clean
+
+**Step 4: Commit**
+
+```bash
+git add hardware_config.json
+git commit -m "config: update MFU values to llm-optimizer defaults (0.45/0.30)
+
+MfuPrefill: 0.65 → 0.45, MfuDecode: 0.12 → 0.30 for all GPU entries.
+These values match llm-optimizer's defaults which achieve 36.5% ITL MAPE
+on the sim-to-real evaluation (discussion #522).
+
+Other HardwareCalib fields (BwEffConstant, overheads) remain unchanged
+for backward compatibility — they are no longer used by rooflineStepTime()
+but may be consumed by other callers."
+```
+
+---
+
+### Task 3: Verify and commit design doc
+
+**Files:**
+- Existing: `docs/plans/2026-03-09-roofline-llm-optimizer-port-design.md`
+
+**Step 1: Run full build + test + lint**
+
+Run: `go build -o blis main.go && go test ./... -count=1 && golangci-lint run ./...`
+Expected: All pass
+
+**Step 2: Commit design doc**
+
+```bash
+git add docs/plans/2026-03-09-roofline-llm-optimizer-port-design.md docs/plans/2026-03-09-roofline-llm-optimizer-port-plan.md
+git commit -m "docs: add roofline llm-optimizer port design and implementation plan
+
+Design doc: decision record for porting llm-optimizer's single-crossover
+roofline physics into BLIS.
+Implementation plan: 3 tasks (physics rewrite, MFU update, verification).
+
+Motivation: discussion #522 sim-to-real accuracy validation."
+```

--- a/docs/plans/hardening-validation-cleanup-plan.md
+++ b/docs/plans/hardening-validation-cleanup-plan.md
@@ -1,5 +1,9 @@
 # Hardening: CLI Validation, Canonical Constructor, Dead Field Removal, Tiered Cache Test
 
+> **NOTE (R15):** `NewKVCapacityParams` signature was extended from 4 to 6 positional args
+> in PR #559 (MoE roofline). Code snippets in this completed plan reference the original
+> 4-arg signature. See `sim/latency/kv_capacity.go` for the current signature.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Close four independent hardening gaps: CLI validation for distribution-mode token flags, canonical constructor for KV capacity params, removal of a dead `Streaming` field from the simulator, and a round-trip test proving the tiered KV cache reload mechanism exercises hierarchical hashes.

--- a/docs/plans/pr2-kv-capacity-auto-calculate-plan.md
+++ b/docs/plans/pr2-kv-capacity-auto-calculate-plan.md
@@ -1,5 +1,9 @@
 # PR2: Auto-Calculate KV Blocks in Roofline Mode — Implementation Plan
 
+> **NOTE (R15):** `KVCapacityParams` struct gained `MoEExpertFFNDim` and `SharedExpertFFNDim`
+> fields in PR #559 (MoE roofline). Raw struct literals in this completed plan are missing
+> these fields. Use `NewKVCapacityParams(...)` (6 args) for current construction.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Automatically derive `total_kv_blocks` from the model architecture and GPU memory that the user has already provided in roofline mode, eliminating the unrealistic 1M-block default and matching the llm-d-benchmark `capacity_planner.py` reference formula.

--- a/docs/plans/pr472b-crossmodel-backend-plan.md
+++ b/docs/plans/pr472b-crossmodel-backend-plan.md
@@ -1,5 +1,9 @@
 # CrossModelLatencyModel Backend Implementation Plan
 
+> **NOTE (R15):** MoE threshold changed from `NumLocalExperts > 0` to `NumLocalExperts > 1` in
+> PR #559 (MoE roofline). Single-expert models are now treated as dense-equivalent across all
+> consumption paths. References to `> 0` in this completed plan reflect the original design.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add a third latency model backend that predicts GPU step time from model architecture features (layer count, KV dimensions, MoE routing, TP degree) using globally-fitted physics coefficients — enabling capacity planning for new models from their HuggingFace config.json alone, without dedicated profiling.

--- a/docs/plans/pr580-deferred-hardening-plan.md
+++ b/docs/plans/pr580-deferred-hardening-plan.md
@@ -1,0 +1,436 @@
+# PR #580 Deferred Items — Hardening Follow-Up
+
+- **Goal:** Complete the 7 deferred hardening items from issue #580: rope_scaling corrections, unit tests, type alignment, glossary entries, documentation refinements, and two new behavioral tests.
+- **The problem today:** The `mrope` rope_scaling type has no test coverage documenting that it correctly falls through the blacklist (vLLM normalizes it to "default" and applies the factor); rope_scaling logic is embedded in `cmd/root.go` with no unit tests; `MaxModelLen` uses `int` while adjacent fields use `int64`; glossary lacks entries for MaxModelLen and oracle knowledge boundary; rope_scaling docs are vague about which types are excluded; cluster-mode and chunked-prefill interaction tests are missing.
+- **What this PR adds:**
+  1. Correct `mrope` handling in rope_scaling (normalize to "default", apply factor — matching vLLM behavior).
+  2. Extract rope_scaling logic to a pure function with table-driven unit tests covering 10+ cases.
+  3. Change `MaxModelLen` from `int` to `int64` for consistency with `ProgressIndex`, `TotalKVBlocks`, `BlockSizeTokens`.
+  4. Add glossary entries for `MaxModelLen` and `Oracle Knowledge Boundary`.
+  5. Refine rope_scaling documentation with explicit blacklist details.
+  6. Add cluster-mode test verifying DroppedUnservable surfaces when MaxModelLen drops requests.
+  7. Add chunked prefill + MaxModelLen interaction test (no spurious force-completions during multi-chunk prefill).
+- **Why this matters:** Completes the hardening wave from #580, closing validation gaps and improving test coverage for critical control-plane paths.
+- **Architecture:** Changes span `cmd/root.go` (rope_scaling extraction + int→int64), `sim/config.go` + `sim/simulator.go` (int→int64), `sim/internal/testutil/golden.go` + `sim/workload/tracev2.go` (int→int64), `docs/` (glossary + reference), `sim/simulator_test.go` + `sim/cluster/cluster_test.go` (new tests). 11 files total, no new packages or interfaces.
+- **Source:** Issue #580 deferred items (handoff summary from PR #587).
+- **Closes:** Related to #580 (deferred items from PR #587). No auto-close — #580 is already closed.
+- **Behavioral Contracts:** See Part 1, Section B.
+
+---
+
+## Phase 0: Component Context
+
+1. **Building block:** rope_scaling logic in `cmd/root.go` (CLI layer); `MaxModelLen` field in `sim/config.go` → `sim/simulator.go`; metrics pipeline through cluster.
+2. **Adjacent blocks:** HuggingFace config resolution (`cmd/hfconfig.go`), latency model factory (`sim/latency/`), cluster simulation (`sim/cluster/`), batch formation (`sim/batch_formation.go`).
+3. **Invariants touched:** INV-1 (conservation in cluster test), INV-9 (oracle knowledge boundary glossary).
+4. **Construction Site Audit:**
+   - `ModelHardwareConfig.MaxModelLen` (int → int64): canonical constructor `NewModelHardwareConfig` in `sim/config.go:88-102`. All production callers use the constructor (R4 enforced by #393).
+   - `Simulator.maxModelLen` (private, int → int64): assigned in `NewSimulator` at `sim/simulator.go:140`. Lines 277, 287: add `int64()` widening casts on the `int` side (`len()`, `MaxOutputLen`). Line 501: REMOVE existing `int64(sim.maxModelLen)` cast (now redundant). Lines 112-113: REMOVE `int64(cfg.MaxModelLen)` casts.
+   - `cmd/root.go:54` — `maxModelLen int` variable → `int64`. Line 973: `IntVar` → `Int64Var` (Cobra flag binding).
+   - `cmd/root.go:489` — `kvFeasibleMax := int(...)` → `int64(...)` (KV cap computation).
+   - `sim/internal/testutil/golden.go:41` — `MaxModelLen int` in `GoldenTestCase` → `int64` (JSON deserialization, passed to constructor).
+   - `sim/workload/tracev2.go:36` — `MaxModelLen int` in `TraceServerConfig` → `int64` (YAML deserialization).
+   - Test call sites (e.g., `sim/cluster/instance_test.go:53,107`) pass `tc.MaxModelLen` from `GoldenTestCase` → safe after golden.go changes. All other test sites pass untyped integer literals (e.g., `0`, `100`, `4096`) which are compatible with both `int` and `int64` in Go.
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR closes 7 deferred hardening items from #580. The changes are a mix of: (1) a behavioral fix (`mrope` rope type handling), (2) a refactoring extraction (rope_scaling → pure function + tests), (3) a type alignment (`int` → `int64`), (4) documentation additions (glossary, reference docs), and (5) two new behavioral tests (cluster-mode MaxModelLen drops, chunked prefill interaction). No new interfaces or modules. The type change is the highest-risk item due to construction site breadth.
+
+### B) Behavioral Contracts
+
+**Positive contracts:**
+
+```
+BC-1: mrope Normalization
+- GIVEN a HuggingFace config with rope_scaling.type == "mrope" and factor > 1.0
+- WHEN auto-deriving max-model-len
+- THEN the scaling factor is applied (same as "default" type)
+- MECHANISM: applyRopeScaling() normalizes "mrope" → applies factor, matching vLLM behavior.
+
+BC-2: Rope Scaling Blacklist
+- GIVEN a HuggingFace config with rope_scaling.type in {"su", "longrope", "llama3"}
+- WHEN auto-deriving max-model-len
+- THEN the scaling factor is NOT applied (max_position_embeddings used as-is)
+
+BC-3: Gemma3 Model Type Exclusion
+- GIVEN a HuggingFace config with model_type == "gemma3"
+- WHEN auto-deriving max-model-len
+- THEN rope_scaling is skipped entirely (max_position_embeddings is pre-scaled)
+
+BC-4: Yarn Original Max Position
+- GIVEN a HuggingFace config with rope_scaling.type == "yarn" and original_max_position_embeddings present
+- WHEN auto-deriving max-model-len
+- THEN original_max_position_embeddings is used as base (not max_position_embeddings)
+
+BC-5: MaxModelLen int64 Type Consistency
+- GIVEN any code path using MaxModelLen
+- WHEN comparing or computing with ProgressIndex, TotalKVBlocks, or BlockSizeTokens
+- THEN MaxModelLen is int64, eliminating int64(cfg.MaxModelLen) casts in NewSimulator and processCompletions
+- NOTE: len() and MaxOutputLen remain int, so EnqueueRequest comparisons still need int64() widening casts on the int side (not on MaxModelLen)
+- MECHANISM: MaxModelLen field changed from int to int64 in ModelHardwareConfig, Simulator, and 3 auxiliary structs.
+
+BC-6: Cluster DroppedUnservable Surfaces
+- GIVEN a cluster with MaxModelLen configured and requests that exceed it
+- WHEN simulation completes
+- THEN aggregated DroppedUnservable count matches the number of oversized requests
+- AND INV-1 conservation holds across all instances
+
+BC-7: Chunked Prefill + MaxModelLen No Spurious Cap
+- GIVEN LongPrefillTokenThreshold > 0 and MaxModelLen configured
+- WHEN a request with input tokens < MaxModelLen undergoes multi-chunk prefill
+- THEN the request completes normally (no force-completion triggered)
+- AND LengthCappedRequests == 0
+
+BC-8: Rope Scaling Warning on Invalid Input
+- GIVEN rope_scaling with a non-object value or non-float factor
+- WHEN auto-deriving max-model-len
+- THEN a warning is logged and the value is ignored (no crash)
+```
+
+**Error handling contracts:**
+
+```
+BC-9: Rope Scaling Pure Function Returns
+- GIVEN any combination of inputs to applyRopeScaling
+- WHEN the function is called
+- THEN it returns (scaledMaxPosEmb int, applied bool) without side effects
+- AND the function never panics
+```
+
+### C) Component Interaction
+
+```
+cmd/root.go                       sim/config.go                    sim/simulator.go
+┌─────────────────┐              ┌──────────────────┐             ┌──────────────────┐
+│ applyRopeScaling│─(extracted)──│ModelHardwareConfig│────────────│ maxModelLen int64 │
+│ (pure function) │              │ MaxModelLen int64 │             │ EnqueueRequest()  │
+└────────┬────────┘              └──────────────────┘             │ processCompletion │
+         │                              │                          └──────────────────┘
+         │                              │ via NewModelHardwareConfig()        │
+         │                              │                                     │
+    ┌────▼────┐                  ┌──────▼──────┐                  ┌──────────▼──────┐
+    │cmd tests│                  │cluster tests│                  │ sim tests       │
+    │(unit)   │                  │(integration)│                  │ (behavioral)    │
+    └─────────┘                  └─────────────┘                  └─────────────────┘
+```
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| Handoff says "Add mrope to rope_scaling handling" | mrope already falls through correctly (not in blacklist); we add explicit test case + comment documenting intentional non-exclusion | CORRECTION — no behavioral change needed, just test coverage |
+| Handoff says "Requires extracting rope_scaling logic from cmd/root.go into a pure function" | Extract `applyRopeScaling(maxPosEmb int, modelType string, ropeScaling any) (int, bool)` | ADDITION — returning `bool` allows callers to log context |
+| Handoff lists int64 change as "Medium scope" | We do it early (Task 2) since later tasks depend on it. Construction sites: config.go, simulator.go, cmd/root.go (IntVar→Int64Var), golden.go, tracev2.go | REORDER + SCOPE_CHANGE |
+| N/A | `applyRopeScaling` keeps `int` parameter/return despite MaxModelLen becoming `int64` — the function operates on `max_position_embeddings` (always fits in `int`); the widening from `int` to `int64` happens at the assignment `maxModelLen = int64(scaled)` in the caller | ADDITION — intentional type boundary |
+| N/A | Add CLAUDE.md update step to Task 2 noting MaxModelLen is now int64 | ADDITION |
+
+### E) Review Guide
+
+**Tricky:** The int→int64 change touches `sim/config.go`, `sim/simulator.go`, `cmd/root.go`, and every test that constructs `NewModelHardwareConfig` with a `MaxModelLen` argument (but the canonical constructor handles the type so callers just pass the same literal). The `maxModelLen` private field on `Simulator` also changes.
+
+**Scrutinize:** BC-1 (mrope) — verify vLLM truly normalizes mrope to default and applies factor. BC-7 (chunked prefill) — verify the test actually exercises multi-chunk path.
+
+**Safe to skim:** Glossary entries, docs changes.
+
+**Known debt:** BLIS lacks a proactive `FormBatch`-level MaxModelLen token cap (vLLM uses `min(numNewTokens, maxModelLen - 1 - numComputedTokens)`). This causes a 1-token overshoot vs vLLM (BLIS produces `MaxModelLen - inputLen` output tokens, vLLM produces `MaxModelLen - 1 - inputLen`). Not blocking for this PR since the runtime cap in processCompletions catches it. **Follow-up issue to file during this PR:** Add `numNewTokens = min(numNewTokens, maxModelLen - 1 - req.ProgressIndex)` in `sim/batch_formation.go` (both Phase 1 running-request path ~line 88 and Phase 2 new-request path ~line 122) when `maxModelLen > 0`. Title: "Proactive FormBatch MaxModelLen token cap to match vLLM scheduler semantics".
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+Files modified:
+- `cmd/root.go` — extract `applyRopeScaling()`, add mrope comment, `IntVar` → `Int64Var`, int → int64
+- `cmd/root_test.go` — add table-driven rope_scaling unit tests (file already exists)
+- `sim/config.go` — `MaxModelLen int` → `int64`, update constructor parameter type
+- `sim/simulator.go` — `maxModelLen int` → `int64`, update all comparison sites, remove int64 casts
+- `sim/internal/testutil/golden.go` — `MaxModelLen int` → `int64` in GoldenTestCase
+- `sim/workload/tracev2.go` — `MaxModelLen int` → `int64` in TraceServerConfig
+- `sim/simulator_test.go` — add chunked prefill + MaxModelLen test (BC-7)
+- `sim/cluster/cluster_test.go` — add cluster MaxModelLen drop test (BC-6)
+- `docs/concepts/glossary.md` — add MaxModelLen and Oracle Knowledge Boundary entries
+- `docs/guide/latency-models.md` — refine rope_scaling docs
+- `docs/reference/configuration.md` — refine rope_scaling docs
+
+No dead code. No new packages.
+
+### G) Task Breakdown
+
+#### Task 1: Extract applyRopeScaling and add mrope handling (BC-1, BC-2, BC-3, BC-4, BC-8, BC-9)
+
+**Step 1: Write test** — Add table-driven tests for `applyRopeScaling` to existing `cmd/root_test.go`.
+
+**Step 2: Run test** — `go test ./cmd/... -run TestApplyRopeScaling` → fails (function doesn't exist).
+
+**Step 3: Implement** — Extract rope_scaling logic from `cmd/root.go` into `applyRopeScaling(maxPosEmb int, modelType string, ropeScaling any) (scaled int, applied bool)`. No behavioral change needed for `mrope`: it already falls through correctly because it's not in the blacklist `{su, longrope, llama3}`. Add a comment documenting that mrope is intentionally not excluded (vLLM normalizes mrope → "default" and applies the factor). Add overflow guards for `int(float64(base) * factor)` and `int(orig)` conversions. Add NaN/Inf check on factor. Then replace the inline logic in `cmd/root.go` with a call to `applyRopeScaling`, keeping the log messages in the caller (the pure function returns `applied` bool for the caller to decide what to log). Note: `applyRopeScaling` intentionally keeps `int` parameters/return — `max_position_embeddings` always fits in `int`. After Task 2, the caller assignment becomes `maxModelLen = int64(scaled)` (widening, always safe).
+
+**Step 4: Run test** — `go test ./cmd/... -run TestApplyRopeScaling` → passes.
+
+**Step 5: Lint** — `golangci-lint run ./cmd/...`
+
+**Step 6: Commit** — `feat(cmd): extract applyRopeScaling with mrope support (BC-1..BC-4, BC-8, BC-9)`
+
+---
+
+#### Task 2: MaxModelLen int → int64 (BC-5)
+
+**Step 1: Write test** — No new test needed; existing tests validate behavior. The type change is mechanical.
+
+**Step 2: Change `sim/config.go`** — `MaxModelLen int` → `MaxModelLen int64` in `ModelHardwareConfig`. Update `NewModelHardwareConfig` parameter from `maxModelLen int` to `maxModelLen int64`.
+
+**Step 3: Change `sim/simulator.go`** — `maxModelLen int` → `maxModelLen int64` on `Simulator` struct. Specific comparison sites:
+- Line 104: `cfg.MaxModelLen < 0` — works (both int64 now)
+- Line 112-113: `int64(cfg.MaxModelLen)` casts → remove (already int64)
+- Line 118: `cfg.MaxModelLen` in fmt → works
+- Line 140: `maxModelLen: cfg.MaxModelLen` — works (both int64)
+- Line 277: `len(r.InputTokens) >= sim.maxModelLen` → `int64(len(r.InputTokens)) >= sim.maxModelLen`
+- Line 286-287: `totalSeqLen := len(r.InputTokens) + r.MaxOutputLen; totalSeqLen > sim.maxModelLen` → `totalSeqLen := int64(len(r.InputTokens)) + int64(r.MaxOutputLen); totalSeqLen > sim.maxModelLen` (compute in int64 to prevent intermediate int overflow on 32-bit)
+- Line 501: `req.ProgressIndex >= int64(sim.maxModelLen)` → `req.ProgressIndex >= sim.maxModelLen` (remove cast)
+
+**Step 4: Change `cmd/root.go`** — Six changes:
+- Line 54: `maxModelLen int` → `maxModelLen int64`
+- Line 427: `maxModelLen = maxPosEmb` → `maxModelLen = int64(maxPosEmb)` (MustGetInt returns int)
+- After Task 1's extraction: `maxModelLen = int64(scaled)` (applyRopeScaling returns int, caller widens)
+- Lines 484-485: remove redundant `int64(maxModelLen)` casts (already int64)
+- Line 489: `kvFeasibleMax := int(totalKVBlocks * blockSizeTokens)` → `kvFeasibleMax := totalKVBlocks * blockSizeTokens` (both operands already int64, no cast needed). Also update or remove the stale safety comment "fits in int" — the result is now int64.
+- Line 973: `IntVar(&maxModelLen, ...)` → `Int64Var(&maxModelLen, ...)`
+
+**Step 5: Change `sim/internal/testutil/golden.go`** — Line 41: `MaxModelLen int` → `MaxModelLen int64` in `GoldenTestCase`.
+
+**Step 6: Change `sim/workload/tracev2.go`** — Line 36: `MaxModelLen int` → `MaxModelLen int64` in `TraceServerConfig`.
+
+**Step 7: Build & test** — `go build ./... && go test ./...` → all pass.
+
+**Step 8: Update CLAUDE.md** — In the `ModelHardwareConfig` description under File Organization, note `MaxModelLen int64`. Update the `sim/config.go` description to mention the type change.
+
+**Step 9: Lint** — `golangci-lint run ./...`
+
+**Step 10: Commit** — `refactor(sim): MaxModelLen int → int64 for type consistency (BC-5)`
+
+---
+
+#### Task 3: Cluster-mode MaxModelLen drop test (BC-6)
+
+**Step 1: Write test** in `sim/cluster/cluster_test.go`:
+- Configure DeploymentConfig with MaxModelLen set, 2 instances, alpha=[0,0,0] (zero alpha for deterministic event timing).
+- Inject mix of requests: some with input < MaxModelLen (fit), some with input >= MaxModelLen (dropped via Guard 1a), and at least one with input < MaxModelLen but input + MaxOutputLen > MaxModelLen (dropped via Guard 1b).
+- Run simulation.
+- Assert aggregated DroppedUnservable matches count of oversized requests.
+- Assert INV-1 conservation: `completed + still_queued + still_running + dropped == injected`.
+- Assert post-simulation inFlightRequests drains: `inFlightRequests[instID] == 0` for each instance (direct assertion, not just the proxy StillQueued + StillRunning == 0).
+- Assert aggregated Metrics.Requests map excludes dropped request IDs (map-level cleanup, not just counter arithmetic).
+- Note: This test differs from existing `TestClusterSimulator_InFlightRequests_DroppedUnservable_Decrements` (which tests KV-capacity Guard 2) by exercising the MaxModelLen Guard 1 path with a mixed fit/oversized workload.
+
+**Step 2: Run test** — `go test ./sim/cluster/... -run TestClusterSimulator_MaxModelLen_DroppedUnservable` → passes (existing code already works).
+
+**Step 3: Lint** — `golangci-lint run ./sim/cluster/...`
+
+**Step 4: Commit** — `test(cluster): MaxModelLen drop test with conservation (BC-6)`
+
+---
+
+#### Task 4: Chunked prefill + MaxModelLen interaction test (BC-7)
+
+**Step 1: Write test** in `sim/simulator_test.go`:
+- Configure with LongPrefillTokenThreshold > 0 (e.g., 64) and MaxModelLen (e.g., 500).
+- Inject request with input=200, output=50 (total 250 < MaxModelLen).
+- Input is 200 tokens → with threshold=64, prefill splits into multiple chunks.
+- Run simulation.
+- Assert CompletedRequests == 1, LengthCappedRequests == 0.
+- Assert TTFT recorded (req.FirstTokenTime > 0) — verifies TTFT fires on final prefill chunk, not intermediate chunks.
+- Assert TotalOutputTokens == 49 (decode runs PI 201→249 = 49 tokens; normal completion fires at PI == 200 + max(50,1) - 1 = 249).
+
+**Step 2: Run test** — `go test ./sim/... -run TestSimulator_ChunkedPrefill_MaxModelLen_NoSpuriousCap` → passes.
+
+**Step 3: Lint** — `golangci-lint run ./sim/...`
+
+**Step 4: Commit** — `test(sim): chunked prefill + MaxModelLen interaction (BC-7)`
+
+---
+
+#### Task 5: Glossary entries (BC-5 docs)
+
+**Step 1: Add entries** to `docs/concepts/glossary.md`:
+- **MaxModelLen**: Maximum total sequence length (input + output) for a single request, in tokens. Mirrors vLLM's `--max-model-len`. When set, requests whose input alone fills the context window (input >= MaxModelLen) or whose input + output budget exceeds it are dropped before entering the wait queue. A runtime cap force-completes any request whose progress reaches this limit. Set to 0 for unlimited. Auto-derived from `max_position_embeddings` in roofline/crossmodel modes.
+- **Oracle Knowledge Boundary (INV-9)**: The principle that control-plane decisions (admission, routing, scheduling, priority) must not read `Request.OutputTokens`. Output token count is oracle knowledge — known only after generation. The control plane uses `MaxOutputLen` (client-declared budget) or input-only checks. Only the execution engine (batch step, completion detection) may access `OutputTokens`.
+
+**Step 2: Commit** — `docs(glossary): add MaxModelLen and Oracle Knowledge Boundary entries`
+
+---
+
+#### Task 6: Rope scaling documentation refinement
+
+**Step 1: Update** `docs/guide/latency-models.md` — expand the rope_scaling paragraph to explicitly list excluded types and the gemma3 model_type exclusion.
+
+**Step 2: Update** `docs/reference/configuration.md` — refine the `--max-model-len` row to mention the blacklist.
+
+**Step 3: Commit** — `docs(latency): refine rope_scaling exclusion documentation`
+
+---
+
+### H) Test Strategy
+
+| Contract | Task | Test Type | Test Name |
+|----------|------|-----------|-----------|
+| BC-1 | Task 1 | Unit | TestApplyRopeScaling (mrope case) |
+| BC-2 | Task 1 | Unit | TestApplyRopeScaling (su, longrope, llama3 cases) |
+| BC-3 | Task 1 | Unit | TestApplyRopeScaling (gemma3 case) |
+| BC-4 | Task 1 | Unit | TestApplyRopeScaling (yarn + original case) |
+| BC-5 | Task 2 | Existing | All existing MaxModelLen tests pass unchanged |
+| BC-6 | Task 3 | Integration | TestClusterSimulator_MaxModelLen_DroppedUnservable |
+| BC-7 | Task 4 | Behavioral | TestSimulator_ChunkedPrefill_MaxModelLen_NoSpuriousCap |
+| BC-8 | Task 1 | Unit | TestApplyRopeScaling (invalid factor, non-object cases) |
+| BC-9 | Task 1 | Unit | TestApplyRopeScaling (all cases return without panic) |
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation | Task |
+|------|-----------|--------|------------|------|
+| int→int64 breaks construction sites | Low | Medium | R4 audit: canonical constructor + `go build ./...` | Task 2 |
+| Rope scaling extraction changes behavior | Low | Medium | Table-driven tests cover all existing code paths | Task 1 |
+| Chunked prefill test doesn't actually exercise multi-chunk | Medium | Low | Verify LongPrefillTokenThreshold < input tokens, check step count | Task 4 |
+| Golden dataset affected by int64 change | Low | High | Golden dataset uses MaxModelLen=4096. int→int64 type change does not alter JSON deserialization or runtime behavior — golden tests pass unchanged | Task 2 |
+| applyRopeScaling float-to-int overflow | Low | High | Overflow guard checks product > math.MaxInt before int() cast; test case 19 validates | Task 1 |
+
+---
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+**Plan-specific checks:**
+- [x] No unnecessary abstractions (applyRopeScaling is the minimal extraction).
+- [x] No feature creep beyond PR scope.
+- [x] No unexercised flags or interfaces.
+- [x] No partial implementations.
+- [x] No breaking changes without explicit contract updates.
+- [x] No hidden global state impact.
+- [x] All new code will pass golangci-lint.
+- [x] CLAUDE.md updated: MaxModelLen type note.
+- [x] No stale references left in CLAUDE.md.
+- [x] Documentation DRY: glossary is the canonical source for these terms.
+- [x] Deviation log reviewed — no unresolved deviations.
+- [x] Each task produces working, testable code.
+- [x] Task dependencies correctly ordered (Task 2 before Tasks 3-4 since they use int64).
+- [x] All contracts mapped to specific tasks.
+- [x] Golden dataset NOT regenerated (golden uses MaxModelLen=4096; int→int64 doesn't change JSON deser or runtime values).
+- [x] Construction site audit completed.
+
+**Antipattern rules:**
+- [x] R1: applyRopeScaling returns bool for callers to log, no silent drops.
+- [x] R3: MaxModelLen validated in both NewModelHardwareConfig (panic) and NewSimulator (error).
+- [x] R4: Construction site audit for MaxModelLen type change — canonical constructor updated.
+- [x] R6: No logrus.Fatalf in sim/ (new tests only).
+- [x] R7: Cluster test has INV-1 companion assertion.
+- [x] R11: Division by zero not introduced (existing guard on BlockSizeTokens).
+- [x] R23: applyRopeScaling handles all code paths equivalently.
+- [x] All other rules: N/A or already satisfied.
+
+---
+
+## Appendix: File-Level Implementation Details
+
+### File: `cmd/root.go`
+
+**Purpose:** Extract rope_scaling logic to testable pure function, add mrope handling.
+
+**Function signature:**
+```go
+// applyRopeScaling applies rope_scaling factor to maxPosEmb if applicable.
+// Returns the (possibly scaled) value and whether scaling was applied.
+// modelType is the HuggingFace model_type string (empty if not present).
+// ropeScaling is the raw rope_scaling value from config.json (nil if not present).
+func applyRopeScaling(maxPosEmb int, modelType string, ropeScaling any) (scaled int, applied bool) {
+```
+
+**Key logic:** Same as existing inline code, with:
+- `mrope` documented as intentionally not excluded (vLLM normalizes mrope → "default" and applies factor)
+- Overflow guard: after `float64(base) * factor`, check product > `math.MaxInt` before `int()` cast (prevents silent sign-flip on absurd configs). Same guard for `int(orig)` on `original_max_position_embeddings`.
+- Factor=nil (JSON null): improve warning to include `%T` of actual value for debugging
+- NaN/Inf guard: check `math.IsNaN(factor) || math.IsInf(factor, 0)` before `> 1.0` comparison (defense-in-depth for non-standard JSON sources)
+- Warnings returned via the `applied` bool + caller logs. Caller should log distinct messages for: (a) scaling applied, (b) excluded type, (c) no factor/invalid factor, (d) overflow detected. The `applied` bool alone can't distinguish (b)-(d), but the caller can check `ropeScaling != nil && ropeMap exists && factor > 1.0 && !applied` to detect overflow specifically.
+- maxPosEmb <= 0 guard: return (maxPosEmb, false) immediately (R3: validate numeric parameters)
+- gemma3 model_type check first (early return)
+
+### File: `cmd/root_test.go`
+
+**Purpose:** Table-driven tests for applyRopeScaling.
+
+**Test cases:**
+1. No rope_scaling (nil) → maxPosEmb unchanged, applied=false
+2. Linear + factor 4.0 → maxPosEmb * 4, applied=true
+3. Yarn + original_max_position_embeddings → original * factor, applied=true
+4. Yarn without original → maxPosEmb * factor, applied=true
+5. Dynamic + factor 2.0 → maxPosEmb * 2, applied=true
+6. su (excluded) → unchanged, applied=false
+7. longrope (excluded) → unchanged, applied=false
+8. llama3 (excluded) → unchanged, applied=false
+9. gemma3 model_type → unchanged, applied=false (early return)
+10. mrope + factor 8.0 → maxPosEmb * 8, applied=true (BC-1)
+11. default + factor 2.0 → maxPosEmb * 2, applied=true
+12. Non-object rope_scaling (string) → unchanged, applied=false
+13. Factor not float64 → unchanged, applied=false
+14. Factor <= 1.0 → unchanged, applied=false
+15. Empty type string + factor > 1.0 → factor IS applied, applied=true (empty string not in blacklist; treated as "default")
+16. No factor key at all → unchanged, applied=false
+17. JSON array rope_scaling ([]any) → unchanged, applied=false (not a map)
+18. Null type key ({"type": null, "factor": 8.0}) → factor applied, applied=true (null type → empty string → not excluded)
+19. Overflow: maxPosEmb=math.MaxInt/2, factor=4.0 → capped at maxPosEmb, applied=false (overflow guard fires)
+20. original_max_position_embeddings overflow: yarn + orig=1e18 + factor=2 → capped, applied=false
+21. maxPosEmb=0, ropeScaling with factor > 1.0 → unchanged, applied=false (degenerate base guard)
+22. maxPosEmb=-1, ropeScaling with factor > 1.0 → unchanged, applied=false (negative base guard)
+
+### File: `sim/config.go`
+
+**Purpose:** Change `MaxModelLen int` to `MaxModelLen int64`.
+
+**Changes:**
+- `ModelHardwareConfig.MaxModelLen` field: `int` → `int64`
+- `NewModelHardwareConfig` parameter: `maxModelLen int` → `maxModelLen int64`
+
+### File: `sim/simulator.go`
+
+**Purpose:** Change private `maxModelLen int` to `int64`, remove casts.
+
+**Changes:**
+- `Simulator.maxModelLen` field: `int` → `int64`
+- `NewSimulator`: remove `int64(cfg.MaxModelLen)` casts (lines 112-113)
+- `EnqueueRequest`: `len(r.InputTokens) >= sim.maxModelLen` → `int64(len(r.InputTokens)) >= sim.maxModelLen` (line 277); `totalSeqLen` computed as `int64(len(r.InputTokens)) + int64(r.MaxOutputLen)`, then `totalSeqLen > sim.maxModelLen` (line 286-287)
+- `processCompletions`: `req.ProgressIndex >= int64(sim.maxModelLen)` → `req.ProgressIndex >= sim.maxModelLen` (line 501)
+
+### File: `sim/internal/testutil/golden.go`
+
+**Purpose:** Align GoldenTestCase.MaxModelLen with int64.
+
+**Changes:** Line 41: `MaxModelLen int` → `MaxModelLen int64`
+
+### File: `sim/workload/tracev2.go`
+
+**Purpose:** Align TraceServerConfig.MaxModelLen with int64.
+
+**Changes:** Line 36: `MaxModelLen int` → `MaxModelLen int64`
+
+### File: `sim/simulator_test.go`
+
+**Purpose:** Add chunked prefill + MaxModelLen interaction test.
+
+### File: `sim/cluster/cluster_test.go`
+
+**Purpose:** Add cluster-mode MaxModelLen drop test with conservation check.
+
+### File: `docs/concepts/glossary.md`
+
+**Purpose:** Add MaxModelLen and Oracle Knowledge Boundary glossary entries.
+
+### File: `docs/guide/latency-models.md`
+
+**Purpose:** Expand rope_scaling paragraph with explicit blacklist details.
+
+### File: `docs/reference/configuration.md`
+
+**Purpose:** Refine --max-model-len description with blacklist.

--- a/docs/plans/pr580-hardening-followup-plan.md
+++ b/docs/plans/pr580-hardening-followup-plan.md
@@ -1,0 +1,741 @@
+# PR #580: Hardening Follow-Up — PR #567 Review Findings
+
+- **Goal:** Address validation gaps, missing observability counters, and test coverage gaps identified during PR #579's convergence review.
+- **The problem today:** (1) `NewSimulator` accepts negative `MaxModelLen` from library callers bypassing the canonical constructor, silently disabling enforcement. (2) Malformed `rope_scaling` in HuggingFace configs silently falls through with no diagnostic. (3) Force-completed (length-capped) requests are indistinguishable from normal completions in structured output. (4) The BC-5 runtime cap test calls `processCompletions` directly and wouldn't catch a full event-loop regression. (5) INV-9 structural test doesn't scan cluster-level code that handles `*Request` in the routing pipeline.
+- **What this PR adds:**
+  1. Negative `MaxModelLen` validation in `NewSimulator` (defense-in-depth behind the canonical constructor's panic)
+  2. `logrus.Warnf` diagnostics when `rope_scaling` is present but malformed in HF configs
+  3. `LengthCappedRequests` metric counter across the 5-file pattern (metrics → output → cluster aggregation → CLI)
+  4. End-to-end `sim.Run()` test for the BC-5 runtime length cap path
+  5. INV-9 structural test extended to scan `sim/cluster/` control-plane files
+  6. Negative `MaxOutputLen` validation in `EnqueueRequest` (R3 gap)
+  7. `gemma3` model_type exclusion for rope_scaling (matches vLLM's exact `model_type == "gemma3"` check)
+  8. Fixed `kvFeasibleMax` comment accuracy
+- **Why this matters:** These are hardening items that close validation gaps, improve observability, and expand test coverage — reducing the risk of silent regressions in the MaxModelLen enforcement path.
+- **Architecture:** Changes span `sim/simulator.go` (validation + counter), `sim/metrics.go` (field), `sim/metrics_utils.go` (JSON output), `sim/cluster/metrics.go` (aggregation), `sim/cluster/cluster.go` (aggregation), `cmd/root.go` (CLI output + rope_scaling), `sim/simulator_test.go` (tests).
+- **Source:** [Issue #580](https://github.com/inference-sim/inference-sim/issues/580)
+- **Closes:** `Fixes #580`
+- **Behavioral Contracts:** See Part 1, Section B.
+
+---
+
+## Phase 0: Component Context
+
+1. **Building block:** Simulator constructor validation, enqueue guard, metrics pipeline, rope_scaling config parser, INV-9 structural test.
+2. **Adjacent blocks:** `sim/config.go` (canonical constructors already validate), `sim/cluster/cluster.go` (aggregation), `cmd/root.go` (CLI output and HF config parsing).
+3. **Invariants touched:** INV-1 (conservation — LengthCappedRequests must be accounted for), INV-9 (oracle knowledge boundary — extended to cluster/).
+4. **Construction Site Audit:**
+   - `Metrics` struct: `NewMetrics()` is the only constructor. Adding `LengthCappedRequests int` field — update `NewMetrics()` (zero-value is correct).
+   - `MetricsOutput` struct: used only via inline literal in `SaveResults()`. Adding `LengthCappedRequests int` field.
+   - `RawMetrics` struct: used only via inline literal in `CollectRawMetrics()`. Adding `LengthCappedRequests int` field.
+   - No new structs introduced.
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR addresses 8 of 15 items from issue #580 (5 must-fix, 3 should-fix); 7 items deferred with justification. The changes are all hardening: validation gaps closed, observability improved, test coverage expanded. No new features, no behavioral changes to existing passing paths. The `LengthCappedRequests` counter follows the exact 5-file pattern established by `DroppedUnservable`. The rope_scaling improvements add warnings for malformed configs and extend the exclusion blacklist. The INV-9 test extension is a one-line addition.
+
+### B) Behavioral Contracts
+
+**Positive contracts:**
+
+```
+BC-1: Negative MaxModelLen rejection in NewSimulator
+- GIVEN a SimConfig with MaxModelLen < 0
+- WHEN NewSimulator is called
+- THEN it returns a non-nil error containing "MaxModelLen"
+- MECHANISM: Explicit check before the existing MaxModelLen > 0 block
+```
+
+```
+BC-2: LengthCappedRequests counter incremented on force-completion
+- GIVEN a request whose ProgressIndex >= MaxModelLen during processCompletions
+- WHEN the runtime length cap fires (BC-5 path)
+- THEN Metrics.LengthCappedRequests is incremented by 1
+```
+
+```
+BC-3: LengthCappedRequests appears in JSON output
+- GIVEN a simulation with LengthCappedRequests > 0
+- WHEN SaveResults writes JSON
+- THEN the output contains "length_capped_requests" with the correct count
+```
+
+```
+BC-4: LengthCappedRequests aggregated across instances in cluster mode
+- GIVEN a multi-instance simulation where some instances have length-capped requests
+- WHEN cluster metrics are aggregated
+- THEN the aggregated LengthCappedRequests equals the sum across all instances
+```
+
+```
+BC-5: End-to-end runtime cap via sim.Run()
+- GIVEN a simulator with MaxModelLen=100, a request with input=50, OutputTokens=200, MaxOutputLen=0
+- WHEN sim.Run() completes
+- THEN the request is force-completed, conservation holds, KV blocks are released
+```
+
+```
+BC-6: INV-9 structural test covers cluster control-plane files
+- GIVEN the INV-9 test scanning for OutputTokens references
+- WHEN it runs
+- THEN it scans cluster.go, cluster_event.go, snapshot.go, and counterfactual.go in addition to existing sim/ files
+```
+
+**Error handling contracts:**
+
+```
+BC-7: Negative MaxOutputLen warning and drop
+- GIVEN a request with MaxOutputLen < 0
+- WHEN EnqueueRequest is called
+- THEN a warning is logged, DroppedUnservable is incremented, and the request is removed from Requests map
+```
+
+```
+BC-8: Rope_scaling malformed config warnings
+- GIVEN an HF config where rope_scaling exists but is not a JSON object, or factor is not a float64
+- WHEN the rope_scaling block is processed
+- THEN a logrus.Warnf is emitted (no crash, no silent fallthrough)
+```
+
+```
+BC-9: gemma3 excluded from rope_scaling factor application via model_type check
+- GIVEN an HF config where model_type == "gemma3" (exact match)
+- WHEN the rope_scaling block is processed
+- THEN the entire rope_scaling factor application is skipped (matching vLLM's model_type-level exclusion)
+- MECHANISM: Check hfConfig.Raw["model_type"] == "gemma3" before entering the rope_scaling factor block
+```
+
+### C) Component Interaction
+
+```
+cmd/root.go (CLI layer)
+  ├── rope_scaling parsing: adds warnings for malformed configs (BC-8)
+  ├── rope_scaling blacklist: extends to gemma3, mrope (BC-9)
+  ├── kvFeasibleMax comment fix
+  └── Anomaly counters output: prints LengthCappedRequests (BC-3)
+
+sim/simulator.go (core engine)
+  ├── NewSimulator: negative MaxModelLen validation (BC-1)
+  ├── EnqueueRequest: negative MaxOutputLen validation (BC-7)
+  └── processCompletions: increments LengthCappedRequests (BC-2)
+
+sim/metrics.go (metrics struct)
+  └── LengthCappedRequests field + NewMetrics init (BC-2)
+
+sim/metrics_utils.go (JSON output)
+  └── MetricsOutput.LengthCappedRequests field (BC-3)
+
+sim/cluster/cluster.go (aggregation)
+  └── aggregateMetrics: sums LengthCappedRequests (BC-4)
+
+sim/cluster/metrics.go (raw metrics)
+  └── RawMetrics.LengthCappedRequests + CollectRawMetrics (BC-4)
+
+sim/simulator_test.go (tests)
+  ├── TestNewSimulator_NegativeMaxModelLen (BC-1)
+  ├── TestProcessCompletions_RuntimeLengthCap_Counter (BC-2)
+  ├── TestSaveResults_LengthCappedRequests_InJSON (BC-3)
+  ├── TestSimulator_RuntimeLengthCap_E2E (BC-5)
+  ├── TestINV9 extension (BC-6)
+  └── TestEnqueueRequest_NegativeMaxOutputLen (BC-7)
+```
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| INV-9 paths `../cluster/` (issue text) | Uses `cluster/` prefix | CORRECTION: Go test CWD is `sim/`; `cluster/` resolves to `sim/cluster/`. Issue's `../cluster/` would resolve to non-existent directory |
+| INV-9 scan adds `cluster_event.go` (not in issue) | Added | ADDITION: `cluster_event.go` defines routing event types that handle `*Request`; should be scanned for INV-9 |
+| Add `mrope` to rope_scaling blacklist (should-fix) | Deferred | vLLM normalizes mrope→"default" and APPLIES the factor; blacklisting would produce opposite behavior. Needs deeper investigation |
+| Add rope_scaling unit tests (should-fix) | Deferred | Requires extracting rope_scaling into a pure function — scope creep for a hardening PR |
+| Change MaxModelLen type int → int64 (nice-to-have) | Deferred | Low-priority cleanup, would touch many sites |
+| Add glossary entries (nice-to-have) | Deferred | Documentation-only, no code impact |
+| Refine rope_scaling docs (nice-to-have) | Deferred | Documentation-only |
+| Add cluster-mode MaxModelLen drop test (nice-to-have) | Deferred | Cluster-mode tests require more setup; the single-instance E2E test covers the core path |
+| Add chunked prefill + MaxModelLen test (nice-to-have) | Deferred | Interaction testing — lower priority |
+
+### E) Review Guide
+
+**Scrutinize:** The `LengthCappedRequests` 5-file pattern — verify it mirrors `DroppedUnservable` exactly. The negative `MaxOutputLen` validation in `EnqueueRequest` — verify it doesn't break the existing `MaxOutputLen=0` path. The INV-9 test extension — verify the relative paths work from the test's CWD.
+
+**Safe to skim:** Comment fix, blacklist extension (trivial string additions), BC-1 (one-line validation).
+
+**Known debt:** rope_scaling is inline in `cmd/root.go` — extracting to a pure function would enable unit testing. Deferred per deviation log.
+
+**Note:** INV-9 test paths use `cluster/` prefix (not `../cluster/`) because Go test CWD is `sim/` and `sim/cluster/` is a subdirectory.
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+**Files to modify:**
+- `sim/simulator.go` — Add negative MaxModelLen validation in NewSimulator, negative MaxOutputLen validation in EnqueueRequest, increment LengthCappedRequests in processCompletions
+- `sim/metrics.go` — Add LengthCappedRequests field, update SaveResults output
+- `sim/metrics_utils.go` — Add LengthCappedRequests to MetricsOutput
+- `sim/cluster/cluster.go` — Add LengthCappedRequests to aggregateMetrics
+- `sim/cluster/metrics.go` — Add LengthCappedRequests to RawMetrics and CollectRawMetrics
+- `cmd/root.go` — Add rope_scaling warnings, extend blacklist, fix comment, add LengthCappedRequests to anomaly output
+- `sim/simulator_test.go` — All new tests
+
+**No new files. No dead code.**
+
+### G) Task Breakdown
+
+#### Task 1: Negative MaxModelLen validation in NewSimulator (BC-1)
+
+**Contracts:** BC-1
+
+**Test (sim/simulator_test.go):**
+```go
+// BC-1: Negative MaxModelLen rejected by NewSimulator
+// Uses struct literal bypass (not canonical constructor) to simulate library caller
+func TestNewSimulator_NegativeMaxModelLen_Error(t *testing.T) {
+	cfg := newTestSimConfig()
+	cfg.MaxModelLen = -5 // bypass canonical constructor's panic to test NewSimulator validation
+	kvStore := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
+	latencyModel, err := MustNewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
+	if err != nil {
+		t.Fatalf("MustNewLatencyModel: %v", err)
+	}
+	_, err = NewSimulator(cfg, kvStore, latencyModel)
+	if err == nil {
+		t.Fatal("expected error for negative MaxModelLen")
+	}
+	if !strings.Contains(err.Error(), "MaxModelLen") {
+		t.Errorf("error %q should mention MaxModelLen", err.Error())
+	}
+}
+```
+
+**Implementation (sim/simulator.go):** Add before line 104 (`if cfg.MaxModelLen > 0`):
+```go
+if cfg.MaxModelLen < 0 {
+	return nil, fmt.Errorf("NewSimulator: MaxModelLen must be >= 0, got %d", cfg.MaxModelLen)
+}
+```
+
+**Commands:**
+```bash
+cd .worktrees/pr580-hardening-followup
+go test ./sim/... -run TestNewSimulator_NegativeMaxModelLen -count=1
+golangci-lint run ./sim/...
+```
+
+---
+
+#### Task 2: LengthCappedRequests metric counter — 5-file pattern (BC-2, BC-3, BC-4)
+
+**Contracts:** BC-2, BC-3, BC-4
+
+**Step 1: Add field to Metrics (sim/metrics.go):**
+Add after `DroppedUnservable int`:
+```go
+LengthCappedRequests int // Requests force-completed by runtime MaxModelLen cap (BC-5 defense-in-depth)
+```
+
+Update `SaveResults` to include in `MetricsOutput` construction:
+```go
+LengthCappedRequests: m.LengthCappedRequests,
+```
+
+Update `InjectedRequests` computation — length-capped requests ARE completed (they go through `recordRequestCompletion`), so no change to INV-1 formula.
+
+**Step 2: Add field to MetricsOutput (sim/metrics_utils.go):**
+Add after `DroppedUnservable`:
+```go
+LengthCappedRequests    int              `json:"length_capped_requests"`
+```
+
+**Step 3: Increment counter in processCompletions (sim/simulator.go):**
+In the BC-5 runtime cap block (after `logrus.Warnf`):
+```go
+sim.Metrics.LengthCappedRequests++
+```
+
+**Step 4: Aggregate in cluster (sim/cluster/cluster.go):**
+Add after `merged.DroppedUnservable += m.DroppedUnservable`:
+```go
+merged.LengthCappedRequests += m.LengthCappedRequests
+```
+
+**Step 5: Add to RawMetrics and CollectRawMetrics (sim/cluster/metrics.go):**
+Add field to `RawMetrics` after `DroppedUnservable`:
+```go
+LengthCappedRequests int
+```
+Add to `CollectRawMetrics` after `DroppedUnservable: aggregated.DroppedUnservable,`:
+```go
+LengthCappedRequests: aggregated.LengthCappedRequests,
+```
+
+**Step 6: Add CLI output (cmd/root.go):**
+Update the anomaly counter condition and print:
+```go
+// Add LengthCappedRequests to the anomaly counter condition and output
+if rawMetrics.PriorityInversions > 0 || rawMetrics.HOLBlockingEvents > 0 || rawMetrics.RejectedRequests > 0 || rawMetrics.DroppedUnservable > 0 || rawMetrics.LengthCappedRequests > 0 {
+	// ... existing prints ...
+	fmt.Printf("Length-Capped Requests: %d\n", rawMetrics.LengthCappedRequests)
+}
+```
+
+**Tests (sim/simulator_test.go and sim/metrics_test.go):**
+
+Test BC-2 (counter increment — extend existing `TestProcessCompletions_RuntimeLengthCap`):
+Add to the existing test after the `req.State != StateCompleted` assertion:
+```go
+if sim.Metrics.LengthCappedRequests != 1 {
+	t.Errorf("LengthCappedRequests = %d, want 1", sim.Metrics.LengthCappedRequests)
+}
+```
+
+Test BC-3 (JSON output — new test following `TestSaveResults_DroppedUnservable_InJSON` pattern):
+```go
+func TestSaveResults_LengthCappedRequests_InJSON(t *testing.T) {
+	m := NewMetrics()
+	m.LengthCappedRequests = 3
+	m.CompletedRequests = 3
+	m.SimEndedTime = 1_000_000
+
+	tmpFile := filepath.Join(t.TempDir(), "test_output.json")
+	if err := m.SaveResults("test", 10_000_000, 100, tmpFile); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var output MetricsOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+
+	if output.LengthCappedRequests != 3 {
+		t.Errorf("LengthCappedRequests in JSON = %d, want 3", output.LengthCappedRequests)
+	}
+}
+```
+
+**Commands:**
+```bash
+go test ./sim/... -run "TestProcessCompletions_RuntimeLengthCap|TestSaveResults_LengthCapped" -count=1
+go test ./sim/cluster/... -count=1
+golangci-lint run ./sim/... ./sim/cluster/... ./cmd/...
+```
+
+---
+
+#### Task 3: End-to-end runtime cap test via sim.Run() (BC-5)
+
+**Contracts:** BC-5
+
+**Test (sim/simulator_test.go):**
+```go
+// BC-5: End-to-end runtime length cap via sim.Run()
+func TestSimulator_RuntimeLengthCap_E2E(t *testing.T) {
+	// GIVEN a simulator with MaxModelLen=100
+	cfg := SimConfig{
+		Horizon:             10_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{6910, 17.67, 2.84}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 100),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// AND a request that bypasses enqueue guard: input=50, MaxOutputLen=0, OutputTokens=200
+	// MaxOutputLen=0 means input-only check (50 < 100), so enqueue succeeds.
+	// But actual OutputTokens=200 means ProgressIndex will exceed MaxModelLen=100.
+	req := &Request{
+		ID:           "will_be_capped",
+		InputTokens:  GenerateRandomTokenIDs(sim.WorkloadRNG(), 50),
+		OutputTokens: GenerateRandomTokenIDs(sim.WorkloadRNG(), 200),
+		ArrivalTime:  0,
+		State:        StateQueued,
+	}
+	sim.InjectArrival(req)
+
+	// WHEN sim.Run() completes
+	sim.Run()
+
+	// THEN the request completes (force-completed at MaxModelLen boundary)
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests = %d, want 1", sim.Metrics.CompletedRequests)
+	}
+	// AND LengthCappedRequests == 1
+	if sim.Metrics.LengthCappedRequests != 1 {
+		t.Errorf("LengthCappedRequests = %d, want 1", sim.Metrics.LengthCappedRequests)
+	}
+	// AND conservation holds (INV-1)
+	total := sim.Metrics.CompletedRequests + sim.Metrics.StillQueued + sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != 1 {
+		t.Errorf("INV-1: completed(%d)+queued(%d)+running(%d)+dropped(%d) = %d, want 1",
+			sim.Metrics.CompletedRequests, sim.Metrics.StillQueued, sim.Metrics.StillRunning, sim.Metrics.DroppedUnservable, total)
+	}
+	// AND output was truncated: generated fewer tokens than the full 200 output
+	if sim.Metrics.TotalOutputTokens >= 200 {
+		t.Errorf("TotalOutputTokens = %d, want < 200 (force-completion should truncate output)", sim.Metrics.TotalOutputTokens)
+	}
+	if sim.Metrics.TotalOutputTokens == 0 {
+		t.Error("TotalOutputTokens = 0, want > 0 (some decode work should have happened)")
+	}
+	// Regression anchor: exact count for this configuration (MaxModelLen=100 - input=50 = 50 decode steps)
+	if sim.Metrics.TotalOutputTokens != 50 {
+		t.Errorf("TotalOutputTokens = %d, want 50 (regression anchor)", sim.Metrics.TotalOutputTokens)
+	}
+	// AND KV blocks are released
+	if sim.KVCache.UsedBlocks() != 0 {
+		t.Errorf("UsedBlocks = %d, want 0 (KV blocks should be released after force-completion)", sim.KVCache.UsedBlocks())
+	}
+}
+```
+
+**Commands:**
+```bash
+go test ./sim/... -run TestSimulator_RuntimeLengthCap_E2E -count=1
+```
+
+---
+
+#### Task 4: INV-9 structural test extension (BC-6)
+
+**Contracts:** BC-6
+
+**Implementation (sim/simulator_test.go):** Add cluster files to `controlPlaneFiles` list and refine the scan pattern to exclude metric-aggregate fields like `TotalOutputTokens`:
+```go
+controlPlaneFiles := []string{
+	"admission.go",
+	"routing.go",
+	"routing_scorers.go",
+	"routing_prefix_scorer.go",
+	"scheduler.go",
+	"priority.go",
+	"cluster/cluster.go",
+	"cluster/cluster_event.go",
+	"cluster/snapshot.go",
+	"cluster/counterfactual.go",
+}
+```
+
+For cluster files that contain metrics aggregation (`TotalOutputTokens`), the scan must use line-level exclusion to avoid false positives:
+```go
+for _, filename := range controlPlaneFiles {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", filename, err)
+	}
+	for lineNum, line := range strings.Split(string(data), "\n") {
+		// Remove known-safe metric names, then check for remaining OutputTokens references
+		cleaned := strings.ReplaceAll(line, "TotalOutputTokens", "")
+		if strings.Contains(cleaned, "OutputTokens") {
+			t.Errorf("INV-9 violation: %s line %d references OutputTokens — control-plane code must not access oracle output length", filename, lineNum+1)
+		}
+	}
+}
+```
+This replaces the existing simple `strings.Contains(content, "OutputTokens")` check for the full-file scan. The existing `EnqueueRequest`-specific function-body extraction for `simulator.go` remains unchanged.
+
+**Commands:**
+```bash
+go test ./sim/... -run TestINV9_OracleKnowledgeBoundary -count=1
+```
+
+---
+
+#### Task 5: Negative MaxOutputLen validation in EnqueueRequest (BC-7)
+
+**Contracts:** BC-7
+
+**Test (sim/simulator_test.go):**
+```go
+// BC-7: Negative MaxOutputLen → warning + dropped
+func TestEnqueueRequest_NegativeMaxOutputLen_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{6910, 17.67, 2.84}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	req := &Request{
+		ID:           "neg_budget",
+		InputTokens:  make([]int, 100),
+		OutputTokens: make([]int, 50),
+		MaxOutputLen: -1,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0 (negative MaxOutputLen should be dropped)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+}
+```
+
+**Implementation (sim/simulator.go):** Add before the MaxModelLen guard in `EnqueueRequest`:
+```go
+// Guard 0: Negative MaxOutputLen check (R3)
+if r.MaxOutputLen < 0 {
+	logrus.Warnf("dropping request %s: MaxOutputLen %d is negative (R3 validation gap)",
+		r.ID, r.MaxOutputLen)
+	sim.Metrics.DroppedUnservable++
+	delete(sim.Metrics.Requests, r.ID)
+	return
+}
+```
+
+**Commands:**
+```bash
+go test ./sim/... -run TestEnqueueRequest_NegativeMaxOutputLen -count=1
+golangci-lint run ./sim/...
+```
+
+---
+
+#### Task 6: Rope_scaling improvements (BC-8, BC-9) + comment fix
+
+**Contracts:** BC-8, BC-9
+
+**Implementation (cmd/root.go):**
+
+1. Add warnings for malformed rope_scaling (inside the `if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok` block):
+```go
+if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok {
+	if ropeMap, ok := ropeScaling.(map[string]any); ok {
+		// ... existing logic ...
+	} else {
+		logrus.Warnf("--latency-model: rope_scaling present but not a JSON object (type %T); ignoring", ropeScaling)
+	}
+}
+```
+
+2. Inside the factor extraction, add warning when factor is not a float64:
+```go
+if factor, ok := ropeMap["factor"].(float64); ok && factor > 1.0 {
+	// ... existing logic ...
+} else if _, hasKey := ropeMap["factor"]; hasKey {
+	logrus.Warnf("--latency-model: rope_scaling.factor present but not a valid float64; ignoring")
+}
+```
+
+3. Add gemma3 model_type exclusion (before the rope_scaling block, matching vLLM):
+```go
+// vLLM skips rope_scaling entirely for gemma3 models (config.py:1973):
+// "gemma3's max_model_len (128K) is already scaled by RoPE scaling"
+if modelType, ok := hfConfig.Raw["model_type"].(string); ok && modelType == "gemma3" {
+	// Skip rope_scaling entirely — gemma3's max_position_embeddings is pre-scaled
+} else if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok {
+```
+NOTE: mrope is NOT blacklisted — vLLM normalizes mrope→"default" and applies the factor. Blacklisting mrope would produce the opposite behavior. The issue's mrope item is deferred pending deeper investigation.
+
+4. Fix kvFeasibleMax comment:
+```go
+kvFeasibleMax := int(totalKVBlocks * blockSizeTokens) // safe: totalKVBlocks * blockSizeTokens < maxModelLen (blocksNeeded > totalKVBlocks), fits in int
+```
+
+**Commands:**
+```bash
+go build ./...
+golangci-lint run ./cmd/...
+```
+
+---
+
+### H) Test Strategy
+
+| Contract | Task | Test Type | Test Name |
+|----------|------|-----------|-----------|
+| BC-1 | Task 1 | Unit | TestNewSimulator_NegativeMaxModelLen_Error |
+| BC-2 | Task 2 | Unit | TestProcessCompletions_RuntimeLengthCap_Counter |
+| BC-3 | Task 2 | Unit | TestSaveResults_LengthCappedRequests_InJSON |
+| BC-5 | Task 3 | Integration | TestSimulator_RuntimeLengthCap_E2E |
+| BC-6 | Task 4 | Structural | TestINV9_OracleKnowledgeBoundary (extended) |
+| BC-7 | Task 5 | Unit | TestEnqueueRequest_NegativeMaxOutputLen_Dropped |
+| BC-8, BC-9 | Task 6 | Manual | Verified by build + lint (rope_scaling is in cmd/) |
+
+**Invariants verified:** INV-1 (conservation in BC-5 test), INV-9 (extended structural test).
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation | Task |
+|------|-----------|--------|------------|------|
+| LengthCappedRequests breaks INV-1 conservation formula | Low | High | Length-capped requests go through `recordRequestCompletion` → counted in `CompletedRequests`. No formula change needed. Verified in BC-5 E2E test. | Task 3 |
+| Negative MaxOutputLen validation breaks MaxOutputLen=0 path | Low | High | Guard is `< 0`, not `<= 0`. MaxOutputLen=0 means "no budget" (existing behavior). Tested by existing tests. | Task 5 |
+| INV-9 cluster file paths wrong from test CWD | Low | Medium | Test runs in `sim/` directory. `cluster/cluster.go` resolves to `sim/cluster/cluster.go`. Line-level scan excludes `TotalOutputTokens` false positives. | Task 4 |
+| rope_scaling warning triggers on valid configs | Low | Low | Warning only fires when type assertion fails (not a map, factor not float64). Valid configs always have a JSON object with float factor. | Task 6 |
+
+---
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+**Plan-specific checks:**
+- [x] No unnecessary abstractions
+- [x] No feature creep beyond PR scope (nice-to-have items deferred)
+- [x] No unexercised flags or interfaces
+- [x] No partial implementations
+- [x] No breaking changes
+- [x] No hidden global state impact
+- [x] All new code will pass golangci-lint
+- [x] Shared test helpers used (mustNewSimulator, newTestSimConfig)
+- [x] CLAUDE.md updated if needed — no new files/packages, file org unchanged
+- [x] No stale references
+- [x] Documentation DRY — no canonical sources modified
+- [x] Deviation log reviewed — 9 entries (7 deferred + 2 corrections/additions) justified
+- [x] Each task produces working, testable code
+- [x] Task dependencies correctly ordered (Task 2 before Task 3 — counter must exist)
+- [x] All contracts mapped to specific tasks
+- [x] Golden dataset regeneration not needed (no output changes for existing paths)
+- [x] Construction site audit completed (Metrics, MetricsOutput, RawMetrics)
+
+**Antipattern rules:** R1 ✓ (no silent drops), R2 ✓ (no map iteration for output), R3 ✓ (validation added), R4 ✓ (all construction sites updated), R5 ✓ N/A, R6 ✓ (warnings in sim/, Fatalf only in cmd/), R7 ✓ (BC-5 E2E test is invariant-based), R8 ✓ N/A, R9 ✓ N/A, R10 ✓ N/A, R11 ✓ N/A, R12 ✓ N/A, R13 ✓ N/A, R14 ✓ N/A, R15 ✓ N/A, R16 ✓ N/A, R17 ✓ N/A, R18 ✓ N/A, R19 ✓ N/A, R20 ✓ N/A, R21 ✓ N/A, R22 ✓ N/A, R23 ✓ N/A.
+
+---
+
+## Appendix: File-Level Implementation Details
+
+### File: `sim/simulator.go`
+
+**Purpose:** Add negative MaxModelLen validation in NewSimulator, negative MaxOutputLen validation in EnqueueRequest, increment LengthCappedRequests counter in processCompletions.
+
+**Changes:**
+
+1. In `NewSimulator`, after `LongPrefillTokenThreshold` validation (line 103), before `if cfg.MaxModelLen > 0` (line 104):
+```go
+if cfg.MaxModelLen < 0 {
+	return nil, fmt.Errorf("NewSimulator: MaxModelLen must be >= 0, got %d", cfg.MaxModelLen)
+}
+```
+
+2. In `EnqueueRequest`, before the `// Guard 1: MaxModelLen check` block (line 260):
+```go
+// Guard 0: Negative MaxOutputLen check (R3)
+if r.MaxOutputLen < 0 {
+	logrus.Warnf("dropping request %s: MaxOutputLen %d is negative (R3 validation gap)",
+		r.ID, r.MaxOutputLen)
+	sim.Metrics.DroppedUnservable++
+	delete(sim.Metrics.Requests, r.ID)
+	return
+}
+```
+
+3. In `processCompletions`, in the BC-5 runtime cap block (after the `logrus.Warnf`, before `req.State = StateCompleted`):
+```go
+sim.Metrics.LengthCappedRequests++
+```
+
+### File: `sim/metrics.go`
+
+**Purpose:** Add LengthCappedRequests counter field and include in SaveResults output.
+
+**Changes:**
+
+1. Add field after `DroppedUnservable`:
+```go
+LengthCappedRequests int // Requests force-completed by runtime MaxModelLen cap (BC-5 defense-in-depth)
+```
+
+2. In `SaveResults`, add to MetricsOutput construction (after `DroppedUnservable`):
+```go
+LengthCappedRequests: m.LengthCappedRequests,
+```
+
+### File: `sim/metrics_utils.go`
+
+**Purpose:** Add LengthCappedRequests to JSON output struct.
+
+**Changes:** Add after `DroppedUnservable` in MetricsOutput:
+```go
+LengthCappedRequests    int              `json:"length_capped_requests"`
+```
+
+### File: `sim/cluster/cluster.go`
+
+**Purpose:** Aggregate LengthCappedRequests across instances.
+
+**Changes:** In `aggregateMetrics`, after `merged.DroppedUnservable += m.DroppedUnservable`:
+```go
+merged.LengthCappedRequests += m.LengthCappedRequests
+```
+
+### File: `sim/cluster/metrics.go`
+
+**Purpose:** Add LengthCappedRequests to RawMetrics and collection.
+
+**Changes:**
+
+1. In `RawMetrics`, after `DroppedUnservable`:
+```go
+LengthCappedRequests int
+```
+
+2. In `CollectRawMetrics`, after `DroppedUnservable: aggregated.DroppedUnservable,`:
+```go
+LengthCappedRequests: aggregated.LengthCappedRequests,
+```
+
+### File: `cmd/root.go`
+
+**Purpose:** Add rope_scaling warnings, extend blacklist, fix comment, add LengthCappedRequests to anomaly output.
+
+**Changes:**
+
+1. After `if ropeMap, ok := ropeScaling.(map[string]any); ok {`, add else clause:
+```go
+} else {
+	logrus.Warnf("--latency-model: rope_scaling present but not a JSON object (type %T); ignoring", ropeScaling)
+}
+```
+
+2. After factor extraction attempt, add warning for non-float factor:
+```go
+} else if _, hasKey := ropeMap["factor"]; hasKey {
+	logrus.Warnf("--latency-model: rope_scaling.factor present but not a valid float64; ignoring")
+}
+```
+
+3. Add gemma3 model_type exclusion (wrap the existing rope_scaling block):
+```go
+// vLLM skips rope_scaling for gemma3 (_get_and_verify_max_len): max_position_embeddings is pre-scaled
+modelType, _ := hfConfig.Raw["model_type"].(string)
+if modelType != "gemma3" {
+	if ropeScaling, ok := hfConfig.Raw["rope_scaling"]; ok {
+		// ... existing rope_scaling logic unchanged ...
+	}
+}
+```
+
+4. Fix kvFeasibleMax comment:
+```go
+kvFeasibleMax := int(totalKVBlocks * blockSizeTokens) // safe: totalKVBlocks * blockSizeTokens < maxModelLen (blocksNeeded > totalKVBlocks), fits in int
+```
+
+5. Update anomaly counters output to include LengthCappedRequests:
+```go
+if rawMetrics.PriorityInversions > 0 || rawMetrics.HOLBlockingEvents > 0 || rawMetrics.RejectedRequests > 0 || rawMetrics.DroppedUnservable > 0 || rawMetrics.LengthCappedRequests > 0 {
+	// ... existing prints ...
+	fmt.Printf("Length-Capped Requests: %d\n", rawMetrics.LengthCappedRequests)
+}
+```
+
+### File: `sim/simulator_test.go`
+
+**Purpose:** All new tests for BC-1 through BC-7.
+
+All test implementations as described in the task breakdown above.

--- a/docs/plans/trained-roofline-backend-plan.md
+++ b/docs/plans/trained-roofline-backend-plan.md
@@ -1,0 +1,1203 @@
+# Trained-Roofline Latency Backend — Micro Plan
+
+- **Goal:** Add a `trained-roofline` latency model backend that applies learned correction factors to analytical roofline basis functions, fitted from real vLLM traces across 4 model architectures.
+- **The problem today:** BLIS has two latency model families: (1) blackbox, which is per-model and requires per-model coefficient training, and (2) crossmodel, which uses hand-engineered features with manually-fitted coefficients from Iter 3 (4 beta + 3 alpha). The `training/` pipeline has produced a principled 10-parameter model (7 beta + 3 alpha) fitted via NNLS from 13 experiments across 4 architectures, using roofline basis functions as analytical priors. There is no backend in BLIS that can consume these coefficients.
+- **What this PR adds:**
+  1. A new `TrainedRooflineLatencyModel` backend in `sim/latency/` implementing the 7-term step-time formula from `training/DESIGN.md`
+  2. Registration as `--latency-model trained-roofline` with defaults loaded from `defaults.yaml`
+  3. Six analytical basis functions (ported from `training/basis_functions.py`) computing prefill/decode roofline, weight loading, TP communication, per-layer overhead, and scheduling overhead
+  4. Same auto-fetch chain as roofline/crossmodel (HuggingFace config + hardware config resolution)
+- **Why this matters:** The trained-roofline model achieves 7% MAPE on GPU combined step time (test split) across llama-2-7b, llama-2-70b, mixtral-8x7b, and codellama-34b — fitted from 137K real vLLM requests. It provides a principled foundation (roofline prior + learned corrections) that constrains extrapolation to unseen models.
+- **Architecture:** New file `sim/latency/trained_roofline.go` containing the struct, 6 basis functions, and LatencyModel interface implementation. Factory dispatch added to existing `NewLatencyModel` in `latency.go`. CLI handling follows the crossmodel pattern in `cmd/root.go`. Coefficients in `defaults.yaml` under `trained_roofline_defaults`.
+- **Source:** Discussion of `training/` pipeline output, `training/DESIGN.md`, `training/output/fit/coefficients.json`.
+- **Closes:** (new issue TBD — or standalone PR)
+- **Behavioral Contracts:** See Part 1, Section B.
+
+---
+
+## Phase 0: Component Context
+
+1. **Building block:** New latency model backend (policy template behind existing `LatencyModel` interface) — the simplest extension type per design guidelines Section 5.
+2. **Adjacent blocks:** `sim.LatencyModel` interface (3 methods), `NewLatencyModel` factory in `sim/latency/latency.go`, `validLatencyBackends` map in `sim/bundle.go`, `cmd/root.go` CLI handling (3 touch points: trained-roofline block, zero-coefficients guard at ~line 351, analytical HFConfig parsing block at ~line 358), `defaults.yaml` coefficient storage. **Adjacent documentation:** `docs/guide/latency-models.md`, `docs/reference/configuration.md`, `docs/concepts/core-engine.md`, `docs/concepts/glossary.md`.
+3. **Invariants touched:** INV-3 (clock monotonicity) — StepTime must return >= 1. INV-6 (determinism) — no randomness in basis functions.
+4. **Construction Site Audit:**
+   - `HardwareCalib` — NOT modified (no NVLink field added; see Deviation Log).
+   - `ModelHardwareConfig` — NOT modified.
+   - `LatencyCoeffs` — NOT modified (uses existing BetaCoeffs/AlphaCoeffs slices).
+   - `validLatencyBackends` — modified (add entry; single construction site in `sim/bundle.go:65`).
+   - `Config` (cmd/default_config.go) — modified (add field; single construction site — YAML deserialization).
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR adds the fourth latency model backend to BLIS: `trained-roofline`. It implements the 7-term step-time formula from the `training/` pipeline, which applies learned correction coefficients (β₁-β₇) to analytical roofline basis functions. The basis functions compute prefill/decode compute/bandwidth bottlenecks, weight loading time, TP communication time, per-layer overhead, and scheduling overhead — all from model architecture (`config.json`) and hardware specs (`hardware_config.json`). The factory dispatch in `NewLatencyModel` gains a `"trained-roofline"` case. Coefficients load from `defaults.yaml` via the same pattern as `crossmodel`. One method added to the existing `LatencyModel` interface (`PostDecodeFixedOverhead()`) — existing backends return 0 (backward compatible). No new interfaces created, no struct field additions to existing types, no behavioral changes to existing backends.
+
+**Deviation flag:** This PR adds a `PostDecodeFixedOverhead()` method to the `LatencyModel` interface to correctly model α₁ (post-decode fixed overhead) at request completion. Existing backends return 0. See Deviation Log.
+
+### B) Behavioral Contracts
+
+**Positive contracts (what MUST happen):**
+
+```
+BC-1: Backend Registration
+- GIVEN the simulator binary is built
+- WHEN IsValidLatencyBackend("trained-roofline") is called
+- THEN it returns true
+- MECHANISM: entry in validLatencyBackends map
+```
+
+```
+BC-2: Factory Construction
+- GIVEN LatencyCoeffs with BetaCoeffs of length >= 7, AlphaCoeffs of length >= 3,
+  and ModelHardwareConfig with Backend="trained-roofline", valid ModelConfig, valid HardwareCalib, TP > 0
+- WHEN NewLatencyModel is called
+- THEN it returns a non-nil LatencyModel and nil error
+```
+
+```
+BC-3: Step-Time Formula
+- GIVEN a TrainedRooflineLatencyModel and a batch of requests
+- WHEN StepTime(batch) is called
+- THEN the result equals β₁·max(T_pf_compute, T_pf_kv) + β₂·max(T_dc_compute, T_dc_kv)
+  + β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇, rounded to int64, floored at 1
+- MECHANISM: six basis functions computed from model architecture + hardware specs + batch composition
+```
+
+```
+BC-4: Prefill Monotonicity
+- GIVEN a model with fixed architecture and a batch with only prefill requests
+- WHEN more prefill tokens are added (increasing T_pf)
+- THEN StepTime is non-decreasing
+```
+
+```
+BC-5: Decode Monotonicity
+- GIVEN a model with fixed architecture and a batch with only decode requests
+- WHEN more decode requests are added (increasing context length sum)
+- THEN StepTime is non-decreasing
+```
+
+```
+BC-6: Clock Safety (INV-3)
+- GIVEN any inputs (including empty batch)
+- WHEN StepTime is called
+- THEN the result is >= 1
+```
+
+```
+BC-7: QueueingTime Mapping
+- GIVEN AlphaCoeffs [α₀, α₁, α₂]
+- WHEN QueueingTime(req) is called
+- THEN the result equals int64(α₀)
+- MECHANISM: α₀ is the API processing overhead (ARRIVED→QUEUED), constant per-request
+```
+
+```
+BC-8: OutputTokenProcessingTime Mapping
+- GIVEN AlphaCoeffs [α₀, α₁, α₂]
+- WHEN OutputTokenProcessingTime() is called
+- THEN the result equals int64(α₂)
+```
+
+```
+BC-15: PostDecodeFixedOverhead Mapping
+- GIVEN AlphaCoeffs [α₀, α₁, α₂]
+- WHEN PostDecodeFixedOverhead() is called
+- THEN the result equals int64(α₁)
+- MECHANISM: α₁ is the fixed per-request post-decode overhead (FINISHED→DEPARTED), added
+  to E2E in recordRequestCompletion. This new LatencyModel interface method enables correct
+  modeling without rolling α₁ into QueueingTime (which would inflate TTFT).
+```
+
+```
+BC-9: MoE-Aware Weight Loading
+- GIVEN a MoE model (NumLocalExperts > 0) and a batch with B total tokens
+- WHEN StepTime is called
+- THEN the weight loading basis function uses min(N, max(k, B*k)) effective experts
+  (not all N experts as in the pure roofline backend)
+```
+
+```
+BC-10: Defaults Loading
+- GIVEN defaults.yaml with a trained_roofline_defaults section
+- WHEN --latency-model trained-roofline is used without --beta-coeffs/--alpha-coeffs
+- THEN coefficients are loaded from the trained_roofline_defaults section
+```
+
+**Negative contracts (what MUST NOT happen):**
+
+```
+BC-11: No MFU Scaling
+- GIVEN a TrainedRooflineLatencyModel
+- WHEN basis functions compute prefill/decode FLOPs → time
+- THEN they divide by raw peak FLOPS (TFlopsPeak), NOT by TFlopsPeak * MfuPrefill/MfuDecode
+- MECHANISM: β₁ and β₂ are the MFU corrections; applying MfuPrefill/MfuDecode would double-count
+```
+
+```
+BC-12: Existing Backend Isolation
+- GIVEN any existing backend (blackbox, roofline, crossmodel)
+- WHEN --latency-model <existing> is used
+- THEN behavior is byte-identical to before this PR
+```
+
+**Error handling contracts:**
+
+```
+BC-13: Coefficient Length Validation
+- GIVEN BetaCoeffs with fewer than 7 elements
+- WHEN NewLatencyModel is called with Backend="trained-roofline"
+- THEN it returns a non-nil error describing the minimum requirement
+```
+
+```
+BC-14: Config Validation
+- GIVEN ModelConfig with NumHeads <= 0, or HiddenDim <= 0, or NumLayers <= 0,
+  or IntermediateDim <= 0, or NumHeads not divisible by TP,
+  or NumKVHeads not divisible by TP,
+  or TFlopsPeak invalid (<=0, NaN, Inf), or BwPeakTBs invalid (<=0, NaN, Inf)
+- WHEN NewLatencyModel is called with Backend="trained-roofline"
+- THEN it returns a non-nil error for each invalid field
+```
+
+### C) Component Interaction
+
+```
+cmd/root.go (CLI)
+    │  --latency-model trained-roofline --hardware H100 --tp 2
+    │  Resolves model config (auto-fetch), hardware config, loads coefficients
+    ▼
+sim/latency/latency.go  NewLatencyModel()
+    │  Dispatches on hw.Backend == "trained-roofline"
+    │  Validates: 7 betas, 3 alphas, ModelConfig fields, TP > 0
+    ▼
+sim/latency/trained_roofline.go  TrainedRooflineLatencyModel
+    │  Pre-computes: headDim, dKV, kEff, isMoE (frozen at construction)
+    │  StepTime(batch):
+    │    1. Classify requests → prefill/decode
+    │    2. Compute 6 basis functions from model arch + hardware + batch
+    │    3. Return β·X formula, floored at 1
+    │  QueueingTime(req): int64(α₀) — API processing overhead
+    │  OutputTokenProcessingTime(): int64(α₂) — per-token detokenization
+    │  PostDecodeFixedOverhead(): int64(α₁) — fixed post-decode overhead (NEW method)
+    ▼
+sim.LatencyModel interface (4 methods after this PR)
+    │  Used by sim.Simulator.executeBatchStep() for step time + per-token output processing
+    │  Used by sim.Simulator.EnqueueRequest() for queueing overhead
+    │  Used by sim.Simulator.recordRequestCompletion() for post-decode fixed overhead (NEW)
+    ▼
+sim.Simulator (event loop)
+
+Data flow for StepTime:
+  batch []*Request → classify prefill/decode → per-phase FLOPs + bytes
+  → 6 basis values (µs) → 7-term β formula → int64 step time (µs)
+
+State ownership:
+  - TrainedRooflineLatencyModel: owns frozen architecture features + coefficient copies
+  - No mutable state, no clock dependency, no external side effects
+```
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| Training pipeline has 3 separate alpha parameters: α₀ (pre-queue), α₁ (post-decode fixed), α₂ (per-output-token) | Adds `PostDecodeFixedOverhead()` method to LatencyModel interface; returns α₁. QueueingTime = α₀ only (constant, API overhead). OutputTokenProcessingTime = α₂ (per-token detokenization). | ADDITION — The existing LatencyModel interface lacks a per-request completion overhead method. This PR adds `PostDecodeFixedOverhead() int64` to the interface. Existing backends (blackbox, roofline, crossmodel) return 0 (backward compatible — their α model has no fixed post-decode component). Trained-roofline returns int64(α₁) = 1849. The simulator's `recordRequestCompletion` adds this to E2E: `lat = FirstTokenTime + itlSum + PostDecodeFixedOverhead()`. E2E is correct. TTFT is correct (no inflation). QueueingTime is constant (α₀ only, not input-proportional — differs from other backends which compute α₀ + α₁*inputLen). |
+| Training basis_functions.py computes T_tp from NVLink bandwidth | T_tp always returns 0 when NVLink data unavailable | SIMPLIFICATION — β₄=0.0 in the fitted coefficients, so T_tp is multiplied by zero. HardwareCalib does not have NVLink bandwidth and hardware_config.json doesn't include it. Adding it would require R4 construction site audit for a zero-multiplied term. When β₄ becomes nonzero in future refitting, NVLink support can be added. |
+| Training uses `prompt_tokens` (total input length) as the attention context for prefill | Uses `len(req.InputTokens)` to match training semantics exactly | SCOPE_CHANGE — Physically, ProgressIndex would be more correct for chunked prefill. But the training data is entirely single-step prefill where prompt_tokens == tokens_this_step. Using len(InputTokens) maintains coefficient compatibility. |
+| Training uses 3-matrix SwiGLU: 6·d·d_ff for FFN FLOPs AND 3·d·d_ff for weight loading bytes | Same (6·d·d_ff for FLOPs, 3·d·d_ff for weights), differs from roofline.go's 2-matrix (4·d·d_ff FLOPs, 2·d·d_ff weights via `mlpMatrixCount()=2`) | CORRECTION — The coefficients were fitted against 3-matrix SwiGLU formulas for both compute and memory. Using 2-matrix for either would invalidate β₁/β₂/β₃. Implementation must include cross-reference comment to roofline.go's `mlpMatrixCount()` explaining why the difference exists (R23 documented exception). |
+| Training uses `d_ff = cfg["intermediate_size"]` uniformly for all models | Uses `dFF = IntermediateDim` (not MoEExpertFFNDim) | SCOPE_CHANGE — For the 4 training models, `intermediate_size` IS the per-expert FFN dim. Models like Qwen2-MoE where `intermediate_size != moe_intermediate_size` will produce incorrect basis functions. This is a known limitation until the training data includes such models. |
+
+### E) Review Guide
+
+**Tricky part:** The basis function formulas must match `training/basis_functions.py` EXACTLY. The fitted coefficients are only valid with the exact features they were trained on. Pay close attention to: projection formula (2·d + 2·d_kv includes O_proj), attention FLOPs formula (s_i = total prompt tokens, NOT ProgressIndex), FFN FLOPs (k_eff = max(1, k), uses 6·d·d_ff not 4), weight loading MoE formula (min(N, max(k, B·k))), and the max(compute, memory) bottleneck per phase.
+
+**Scrutinize:** BC-11 (no MFU scaling — the existing roofline backend applies MFU, but trained-roofline must NOT), BC-7 (α₁ roll-in semantics), and any division that could produce NaN/Inf.
+
+**Safe to skim:** CLI wiring (follows identical crossmodel pattern), backend registration (one-line map entry), documentation updates.
+
+**Known debt:** T_tp is hardcoded to 0 (β₄=0.0 makes this correct but not general; TP communication cost is absorbed into β₅·L, making it H100-NVLink-specific). QueueingTime is constant (α₀ only, not input-proportional — differs from other backends). The attention FLOPs formula overpredicts for chunked prefill (matches training data; future refit with chunked data would fix). **TTFT accuracy caveat:** The "7% MAPE" headline applies to GPU combined step time only. The alpha model has 93% MAPE (pre-queueing) and 54% MAPE (post-decode) — TTFT predictions will have significantly higher error than GPU step time. MoE models where `IntermediateDim != MoEExpertFFNDim` (e.g., Qwen2-MoE) will produce incorrect basis functions.
+
+---
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+**Files to create:**
+- `sim/latency/trained_roofline.go` — TrainedRooflineLatencyModel struct, 6 basis functions, 3 interface methods
+- `sim/latency/trained_roofline_test.go` — behavioral tests
+
+**Files to modify:**
+- `sim/latency_model.go` — add `PostDecodeFixedOverhead() int64` method to LatencyModel interface
+- `sim/simulator.go` — add `+ sim.latencyModel.PostDecodeFixedOverhead()` to `recordRequestCompletion` (~line 337)
+- `sim/latency/latency.go` — add `"trained-roofline"` case to NewLatencyModel switch; add `PostDecodeFixedOverhead()` returning 0 to BlackboxLatencyModel and RooflineLatencyModel
+- `sim/latency/crossmodel.go` — add `PostDecodeFixedOverhead()` returning 0 to CrossModelLatencyModel
+- `sim/bundle.go` — add `"trained-roofline": true` to validLatencyBackends (line ~65)
+- `sim/config.go` — update `Backend` field comment to include "trained-roofline" (~line 81)
+- `defaults.yaml` — add `trained_roofline_defaults` section
+- `cmd/default_config.go` — add `TrainedRooflineDefaults` struct + field on Config
+- `cmd/root.go` — 4 modification sites: loading block, zero-coefficients guard, HFConfig parsing block, help text
+- `CLAUDE.md` — update latency estimation (4th mode), file tree, Key Data Flow
+- `docs/guide/latency-models.md` — add trained-roofline section + update comparison table
+- `docs/reference/configuration.md` — update flag description + defaults.yaml section
+- `docs/concepts/core-engine.md` — update "Latency Models" subsection
+- `docs/concepts/glossary.md` — update "Latency Model" entry
+- `docs/index.md` — update feature bullet
+- `docs/reference/models.md` — mention trained-roofline in modes section
+
+**Key decisions:**
+- One method added to existing `LatencyModel` interface: `PostDecodeFixedOverhead()` — existing backends return 0 (backward compatible)
+- No MFU scaling in basis functions (β₁/β₂ are the corrections)
+- T_tp = 0 always (β₄=0.0, no NVLink data)
+- α₁ modeled via PostDecodeFixedOverhead() at request completion (not rolled into QueueingTime)
+- Formulas ported from training/basis_functions.py verbatim for coefficient compatibility
+
+### G) Task Breakdown
+
+#### Task 1: Register "trained-roofline" backend name (BC-1)
+
+**Contracts:** BC-1
+
+**Test (failing):**
+
+File: `sim/bundle_test.go` — add to existing test functions:
+
+```go
+// In TestIsValidLatencyBackend:
+assert.True(t, IsValidLatencyBackend("trained-roofline"))
+
+// In TestValidLatencyBackendNames:
+assert.Contains(t, names, "trained-roofline")
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/... -run TestIsValidLatencyBackend -count=1`
+**Expected:** FAIL (trained-roofline not in map)
+
+**Implement:**
+
+File: `sim/bundle.go` line ~65 — add to validLatencyBackends map:
+
+```go
+validLatencyBackends = map[string]bool{"": true, "blackbox": true, "roofline": true, "crossmodel": true, "trained-roofline": true}
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/... -run "TestIsValidLatencyBackend|TestValidLatencyBackendNames" -count=1`
+**Expected:** PASS
+
+**Lint:** `cd .worktrees/trained-roofline-backend && golangci-lint run ./sim/...`
+
+**Commit:** `feat(latency): register trained-roofline backend name (BC-1)`
+
+---
+
+#### Task 2: Add PostDecodeFixedOverhead to interface + Implement TrainedRooflineLatencyModel (BC-3, BC-6, BC-7, BC-8, BC-9, BC-11, BC-15)
+
+**Contracts:** BC-3, BC-6, BC-7, BC-8, BC-9, BC-11, BC-15
+
+**Pre-step: Interface addition (must compile before tests)**
+
+1. File: `sim/latency_model.go` — add to LatencyModel interface:
+```go
+// PostDecodeFixedOverhead estimates the fixed per-request post-processing overhead (µs).
+// This is the constant overhead at request completion (e.g., response setup, final API processing).
+// Added for trained-roofline alpha model: α₁ = fixed post-decode overhead per request.
+// Existing backends return 0.
+PostDecodeFixedOverhead() int64
+```
+
+2. File: `sim/simulator.go` — in `recordRequestCompletion` (~line 337), change:
+```go
+lat := req.FirstTokenTime + itlSum
+```
+to:
+```go
+lat := req.FirstTokenTime + itlSum + sim.latencyModel.PostDecodeFixedOverhead()
+```
+
+3. File: `sim/latency/latency.go` — add to BlackboxLatencyModel and RooflineLatencyModel:
+```go
+func (m *BlackboxLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }
+func (m *RooflineLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }
+```
+
+4. File: `sim/latency/crossmodel.go` — add:
+```go
+func (m *CrossModelLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }
+```
+
+5. Verify: `go build ./... && go test ./... -count=1` — all existing tests must pass (BC-12).
+
+**Test (failing):**
+
+File: `sim/latency/trained_roofline_test.go` — create with behavioral tests:
+
+```go
+package latency
+
+import (
+	"math"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test helpers ---
+
+// llama7bConfig returns a ModelConfig approximating Llama-2-7b (TP=1).
+func llama7bConfig() sim.ModelConfig {
+	return sim.ModelConfig{
+		NumLayers:       32,
+		HiddenDim:       4096,
+		NumHeads:        32,
+		NumKVHeads:      32,
+		IntermediateDim: 11008,
+		BytesPerParam:   2,
+	}
+}
+
+// mixtral8x7bConfig returns a ModelConfig approximating Mixtral-8x7B (MoE).
+func mixtral8x7bConfig() sim.ModelConfig {
+	return sim.ModelConfig{
+		NumLayers:        32,
+		HiddenDim:        4096,
+		NumHeads:         32,
+		NumKVHeads:       8,
+		IntermediateDim:  14336,
+		NumLocalExperts:  8,
+		NumExpertsPerTok: 2,
+		BytesPerParam:    2,
+	}
+}
+
+// h100HWConfig returns HardwareCalib for H100 SXM.
+func h100HWConfig() sim.HardwareCalib {
+	return sim.HardwareCalib{
+		TFlopsPeak: 989.5,
+		BwPeakTBs:  3.35,
+		MfuPrefill: 0.45,
+		MfuDecode:  0.30,
+		MemoryGiB:  80.0,
+	}
+}
+
+// trainingFittedBetas returns the β₁-β₇ from training/output/fit/coefficients.json.
+var trainingFittedBetas = []float64{
+	0.7726491335309499,  // β₁: prefill roofline correction
+	1.127489556719325,   // β₂: decode roofline correction
+	1.0559901872766853,  // β₃: weight loading correction
+	0.0,                 // β₄: TP communication (zeroed)
+	43.500541908701074,  // β₅: per-layer overhead (µs/layer)
+	48.80613214319187,   // β₆: per-request scheduling (µs/req)
+	0.0,                 // β₇: per-step overhead (zeroed)
+}
+
+// trainingFittedAlphas returns the α₀-α₂ from training/output/fit/coefficients.json.
+var trainingFittedAlphas = []float64{
+	9315.338771116985,   // α₀: API processing overhead
+	1849.5902371340574,  // α₁: post-decode fixed
+	1.7079389122469397,  // α₂: per-output-token
+}
+
+func makePrefillRequest(inputLen int, newTokens int) *sim.Request {
+	req := &sim.Request{
+		InputTokens:   make([]int, inputLen),
+		ProgressIndex: 0,
+		NumNewTokens:  newTokens,
+	}
+	return req
+}
+
+func makeDecodeRequest(inputLen int, outputSoFar int) *sim.Request {
+	req := &sim.Request{
+		InputTokens:   make([]int, inputLen),
+		OutputTokens:  make([]int, outputSoFar),
+		ProgressIndex: int64(inputLen + outputSoFar),
+		NumNewTokens:  1,
+	}
+	return req
+}
+
+// --- BC-6: Clock safety ---
+
+func TestTrainedRoofline_EmptyBatch_ReturnsOne(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs: trainingFittedBetas,
+		alphaCoeffs: trainingFittedAlphas,
+		numLayers: 32, hiddenDim: 4096, numHeads: 32,
+		headDim: 128, dKV: 4096, dFF: 11008,
+		kEff: 1, tp: 1,
+		flopsPeakUs: 989.5e6, bwHbmUs: 3.35e6,
+	}
+	assert.Equal(t, int64(1), model.StepTime(nil))
+	assert.Equal(t, int64(1), model.StepTime([]*sim.Request{}))
+}
+
+// --- BC-3: Step-time formula ---
+
+func TestTrainedRoofline_PrefillOnly_PositiveStepTime(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs: trainingFittedBetas,
+		alphaCoeffs: trainingFittedAlphas,
+		numLayers: 32, hiddenDim: 4096, numHeads: 32,
+		headDim: 128, dKV: 4096, dFF: 11008,
+		kEff: 1, tp: 1,
+		flopsPeakUs: 989.5e6, bwHbmUs: 3.35e6,
+	}
+	batch := []*sim.Request{makePrefillRequest(512, 512)}
+	stepTime := model.StepTime(batch)
+	assert.Greater(t, stepTime, int64(1), "prefill step time should be > 1 µs")
+}
+
+func TestTrainedRoofline_DecodeOnly_PositiveStepTime(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs: trainingFittedBetas,
+		alphaCoeffs: trainingFittedAlphas,
+		numLayers: 32, hiddenDim: 4096, numHeads: 32,
+		headDim: 128, dKV: 4096, dFF: 11008,
+		kEff: 1, tp: 1,
+		flopsPeakUs: 989.5e6, bwHbmUs: 3.35e6,
+	}
+	batch := []*sim.Request{makeDecodeRequest(512, 100)}
+	stepTime := model.StepTime(batch)
+	assert.Greater(t, stepTime, int64(1), "decode step time should be > 1 µs")
+}
+
+// --- BC-7: QueueingTime = α₀ only (API processing overhead) ---
+
+func TestTrainedRoofline_QueueingTime_IsAlpha0(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	// QueueingTime = α₀ (constant, independent of input length)
+	req512 := makePrefillRequest(512, 512)
+	req1024 := makePrefillRequest(1024, 1024)
+	assert.Equal(t, int64(9315), model.QueueingTime(req512))
+	assert.Equal(t, int64(9315), model.QueueingTime(req1024),
+		"QueueingTime must be constant (α₀ only), independent of input length")
+}
+
+// --- BC-8: OutputTokenProcessingTime = α₂ (per-token detokenization) ---
+
+func TestTrainedRoofline_OutputTokenProcessingTime_IsAlpha2(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	assert.Equal(t, int64(1), model.OutputTokenProcessingTime())
+}
+
+// --- BC-15: PostDecodeFixedOverhead = α₁ (fixed per-request post-decode) ---
+
+func TestTrainedRoofline_PostDecodeFixedOverhead_IsAlpha1(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	assert.Equal(t, int64(1850), model.PostDecodeFixedOverhead())
+}
+
+// --- BC-9: MoE-aware weight loading ---
+
+func TestTrainedRoofline_MoE_WeightLoading_UsesEffectiveExperts(t *testing.T) {
+	// For MoE with N=8 experts, k=2 active, batch of 1 token:
+	// n_eff = min(8, max(2, 1*2)) = min(8, 2) = 2
+	// For batch of 10 tokens: n_eff = min(8, max(2, 10*2)) = min(8, 20) = 8
+	denseBetas := []float64{0, 0, 1.0, 0, 0, 0, 0} // only β₃ (weight loading) nonzero
+	alphas := []float64{0, 0, 0}
+
+	modelSmall := &TrainedRooflineLatencyModel{
+		betaCoeffs: denseBetas, alphaCoeffs: alphas,
+		numLayers: 32, hiddenDim: 4096, numHeads: 32,
+		headDim: 128, dKV: 1024, dFF: 14336,
+		kEff: 2, numExperts: 8, isMoE: true, tp: 1,
+		flopsPeakUs: 989.5e6, bwHbmUs: 3.35e6,
+	}
+	modelLarge := &TrainedRooflineLatencyModel{
+		betaCoeffs: denseBetas, alphaCoeffs: alphas,
+		numLayers: 32, hiddenDim: 4096, numHeads: 32,
+		headDim: 128, dKV: 1024, dFF: 14336,
+		kEff: 2, numExperts: 8, isMoE: true, tp: 1,
+		flopsPeakUs: 989.5e6, bwHbmUs: 3.35e6,
+	}
+
+	// 1 decode token → n_eff=2; 10 decode tokens → n_eff=8 (all experts)
+	smallBatch := []*sim.Request{makeDecodeRequest(100, 10)}
+	largeBatch := make([]*sim.Request, 10)
+	for i := range largeBatch {
+		largeBatch[i] = makeDecodeRequest(100, 10)
+	}
+
+	smallTime := modelSmall.StepTime(smallBatch)
+	largeTime := modelLarge.StepTime(largeBatch)
+
+	// Weight loading should increase with more effective experts
+	assert.Greater(t, largeTime, smallTime,
+		"larger batch should load more MoE experts → higher weight loading time")
+}
+
+// --- BC-11: No MFU scaling regression anchor ---
+
+func TestTrainedRoofline_NoMfuScaling_RegressionAnchor(t *testing.T) {
+	// Construct a model where we can hand-compute the expected FLOPs.
+	// Architecture: 1 layer, d=128, H=1, kv_heads=1, d_h=128, d_kv=128, d_ff=1024, TP=1
+	// 1 prefill token, s_i=1 (len(InputTokens)=1), t_i=1 (NumNewTokens=1)
+	//
+	// FLOPs_proj = 1 * 2 * 1 * 128 * (2*128 + 2*128) / 1 = 2 * 128 * 512 = 131072
+	// FLOPs_attn = 1 * 4 * 1 * 1 * (1 + 0.5) * 128 = 768
+	// FLOPs_ffn  = 1 * 1 * 1 * 6 * 128 * 1024 / 1 = 786432
+	// Total = 131072 + 768 + 786432 = 918272 FLOPs
+	// T_pf_compute = 918272 / (1.0e6 FLOP/µs) = 0.918272 µs
+	// bw very high → T_pf_kv ≈ 0 → max(T_pf_compute, T_pf_kv) = 0.918272
+	// β₁=1.0 → step time = 0.918272 → int64 = 0, floored to 1
+	//
+	// If MFU were applied (MfuPrefill=0.45): 918272 / (0.45e6) = 2.040 µs → int64 = 2
+	// Without MFU: int64 result = 1. With MFU: int64 result = 2.
+
+	betas := []float64{1.0, 0, 0, 0, 0, 0, 0} // only β₁ nonzero
+	alphas := []float64{0, 0, 0}
+
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs: betas, alphaCoeffs: alphas,
+		numLayers: 1, hiddenDim: 128, numHeads: 1,
+		headDim: 128, dKV: 128,
+		dFF: 1024, kEff: 1, tp: 1,
+		flopsPeakUs: 1.0e6, // 1 TFLOP/s → easy calculation
+		bwHbmUs: 1e12,      // very high BW → compute-bound
+	}
+
+	req := makePrefillRequest(1, 1)
+	st := model.StepTime([]*sim.Request{req})
+
+	// Without MFU: FLOPs/peak gives ~0.92 µs → floored to 1
+	// With MFU (0.45): FLOPs/(peak*0.45) gives ~2.04 µs → int64 = 2
+	assert.Equal(t, int64(1), st,
+		"step time should be 1 (no MFU scaling); if MFU were applied it would be 2")
+}
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/latency/... -run TestTrainedRoofline -count=1`
+**Expected:** FAIL (TrainedRooflineLatencyModel undefined)
+
+**Implement:**
+
+File: `sim/latency/trained_roofline.go` — create with full implementation.
+
+The struct holds frozen architecture features (computed at construction) and coefficient copies. The 6 basis functions are methods on the struct for access to architecture fields.
+
+Step-time formula:
+```
+StepTime = β₁·max(T_pf_compute, T_pf_kv)
+         + β₂·max(T_dc_compute, T_dc_kv)
+         + β₃·T_weight
+         + β₄·T_tp
+         + β₅·numLayers
+         + β₆·batchSize
+         + β₇
+```
+
+**Struct definition:**
+
+```go
+type TrainedRooflineLatencyModel struct {
+	betaCoeffs  []float64 // [β₁..β₇] from trained_roofline_defaults
+	alphaCoeffs []float64 // [α₀, α₁, α₂]
+
+	// Pre-computed architecture features (frozen at construction)
+	numLayers  int
+	hiddenDim  int     // d (hidden_size)
+	numHeads   int     // H (num_attention_heads)
+	headDim    int     // d_h = d / H
+	dKV        int     // kv_heads * d_h (NOT d; differs for GQA)
+	dFF        int     // intermediate_size (= IntermediateDim, NOT MoEExpertFFNDim)
+	kEff       int     // max(1, NumExpertsPerTok) — FFN FLOPs multiplier
+	numExperts int     // NumLocalExperts (0 for dense)
+	isMoE      bool    // NumLocalExperts > 0
+	tp         int     // tensor parallelism degree
+
+	// Pre-converted hardware specs for per-call efficiency
+	flopsPeakUs float64 // TFlopsPeak × 1e6 → FLOP/µs (divide FLOPs by this → µs)
+	bwHbmUs     float64 // BwPeakTBs × 1e6 → bytes/µs (divide bytes by this → µs)
+}
+```
+
+**Derived field formulas (computed in factory):**
+- `headDim = HiddenDim / NumHeads`
+- `dKV = numKVHeads * headDim` (where numKVHeads defaults to NumHeads if 0)
+- `dFF = IntermediateDim` (NOT MoEExpertFFNDim — matches training's `d_ff = cfg["intermediate_size"]`)
+- `kEff = max(1, NumExpertsPerTok)` (1 for dense models)
+- `flopsPeakUs = TFlopsPeak * 1e6` (989.5 TFLOPS → 989.5e6 FLOP/µs)
+- `bwHbmUs = BwPeakTBs * 1e6` (3.35 TB/s → 3.35e6 bytes/µs)
+
+**Basis function formulas (ported from training/basis_functions.py):**
+
+All use FP16 (2 bytes per element). No MFU scaling (BC-11). **All arithmetic must use float64** throughout to prevent integer overflow for large models (e.g., 70B: `L*2*T_pf*d*(2*d+2*dKV)` can exceed int64 in intermediate products). Cast all int struct fields to float64 before multiplication.
+
+**T_pf_compute** — prefill compute time (µs):
+```
+For each prefill request i: t_i = NumNewTokens, s_i = len(InputTokens)
+T_pf = Σ t_i (total prefill tokens)
+FLOPs_proj = L * 2 * T_pf * d * (2*d + 2*dKV) / TP
+FLOPs_attn = L * Σᵢ 4 * (H/TP) * t_i * (s_i + t_i/2) * d_h    ← PER-REQUEST loop
+FLOPs_ffn  = L * T_pf * kEff * 6 * d * dFF / TP
+result = (FLOPs_proj + FLOPs_attn + FLOPs_ffn) / flopsPeakUs
+```
+
+**T_pf_kv** — prefill KV write bandwidth (µs):
+```
+bytes = L * 2 * (kvHeads/TP) * d_h * T_pf * 2
+result = bytes / bwHbmUs
+```
+Where `kvHeads/TP = dKV / d_h / TP` (integer division, must be exact).
+
+**T_dc_compute** — decode compute time (µs):
+```
+T_dc = number of decode requests (each generates 1 token)
+sum_ctx = Σⱼ req.ProgressIndex    ← context_length maps to ProgressIndex in BLIS
+FLOPs_proj = L * 2 * T_dc * d * (2*d + 2*dKV) / TP
+FLOPs_attn = L * 4 * (H/TP) * sum_ctx * d_h
+FLOPs_ffn  = L * T_dc * kEff * 6 * d * dFF / TP
+result = (FLOPs_proj + FLOPs_attn + FLOPs_ffn) / flopsPeakUs
+```
+
+**T_dc_kv** — decode KV read+write bandwidth (µs):
+```
+bytes = L * 2 * (kvHeads/TP) * d_h * 2 * (sum_ctx + T_dc)
+result = bytes / bwHbmUs
+```
+
+**T_weight** — weight loading time (µs):
+```
+For dense: nEff = 1
+For MoE: B = T_pf + T_dc; nEff = min(numExperts, max(kEff, B*kEff))
+bytes_attn = L * d * (2*d + 2*dKV) * 2 / TP
+bytes_ffn  = L * nEff * 3 * d * dFF * 2 / TP    ← 3 matrices (SwiGLU), NOT mlpMatrixCount()=2
+result = (bytes_attn + bytes_ffn) / bwHbmUs
+```
+
+**T_tp** — TP communication (µs): returns 0.0 always (β₄=0.0, no NVLink data).
+
+**Key implementation notes:**
+- **Empty-batch guard:** `if len(batch) == 0 || batch == nil { return 1 }` — MUST be first line of StepTime. Without this, batch-independent terms (β₃·T_weight + β₅·L) produce ~5.5ms for an empty batch (physically wrong). Matches roofline.go's early return pattern.
+- **Single-pass accumulation:** StepTime iterates batch ONCE, accumulating: `totalPrefillTokens`, `totalDecodeTokens`, `sumCtx` (decode ProgressIndex sum), `prefillAttentionFlops` (per-request sum), and `batchSize = len(batch)`. Then computes each basis function in O(1) from these aggregates. Zero heap allocations — all arithmetic uses stack-local float64 values.
+- `batchSize = len(batch)` — total requests in the step (prefill + decode)
+- Attention `s_i = len(req.InputTokens)` matches training's `entry.prompt_tokens` (total prompt, NOT ProgressIndex). See Deviation 3.
+- Decode `context_length` maps to `req.ProgressIndex` — the canonical position tracker in BLIS (= inputLen + outputSoFar)
+- T_tp returns 0.0 always (no NVLink data; β₄=0.0)
+- `dFF = IntermediateDim` (NOT MoEExpertFFNDim) — matches training pipeline's `d_ff = cfg["intermediate_size"]`
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/latency/... -run TestTrainedRoofline -count=1`
+**Expected:** PASS
+
+**Lint:** `cd .worktrees/trained-roofline-backend && golangci-lint run ./sim/latency/...`
+
+**Commit:** `feat(latency): implement TrainedRooflineLatencyModel with 6 basis functions (BC-3,6,7,8,9,11)`
+
+---
+
+#### Task 3: Wire factory in NewLatencyModel (BC-2, BC-13, BC-14)
+
+**Contracts:** BC-2, BC-13, BC-14
+
+**Test (failing):**
+
+File: `sim/latency/trained_roofline_test.go` — add factory tests:
+
+```go
+// --- BC-2: Factory construction ---
+
+func TestNewLatencyModel_TrainedRoofline_ReturnsModel(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend:     "trained-roofline",
+		ModelConfig: llama7bConfig(),
+		HWConfig:    h100HWConfig(),
+		TP:          1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+
+	// Verify it produces positive step times
+	batch := []*sim.Request{makePrefillRequest(512, 512)}
+	assert.Greater(t, model.StepTime(batch), int64(1))
+}
+
+// --- BC-13: Coefficient length validation ---
+
+func TestNewLatencyModel_TrainedRoofline_TooFewBetas_Error(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs([]float64{1, 2, 3, 4, 5, 6}, trainingFittedAlphas) // only 6 betas
+	hw := sim.ModelHardwareConfig{
+		Backend:     "trained-roofline",
+		ModelConfig: llama7bConfig(),
+		HWConfig:    h100HWConfig(),
+		TP:          1,
+	}
+	_, err := NewLatencyModel(coeffs, hw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "7 elements")
+}
+
+// --- BC-14: Config validation ---
+
+func TestNewLatencyModel_TrainedRoofline_InvalidConfig_Error(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+
+	tests := []struct {
+		name   string
+		modify func(*sim.ModelHardwareConfig)
+		errMsg string
+	}{
+		{"zero TP", func(hw *sim.ModelHardwareConfig) { hw.TP = 0 }, "TP > 0"},
+		{"zero NumLayers", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumLayers = 0 }, "NumLayers > 0"},
+		{"zero NumHeads", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumHeads = 0 }, "NumHeads > 0"},
+		{"zero HiddenDim", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.HiddenDim = 0 }, "HiddenDim > 0"},
+		{"zero TFlopsPeak", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.TFlopsPeak = 0 }, "TFlopsPeak"},
+		{"zero BwPeakTBs", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.BwPeakTBs = 0 }, "BwPeakTBs"},
+		{"zero IntermediateDim", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.IntermediateDim = 0 }, "IntermediateDim > 0"},
+		{"NaN TFlopsPeak", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.TFlopsPeak = math.NaN() }, "TFlopsPeak"},
+		{"Inf BwPeakTBs", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.BwPeakTBs = math.Inf(1) }, "BwPeakTBs"},
+		{"NumKVHeads not divisible by TP", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumKVHeads = 5; hw.TP = 2 }, "divisible"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hw := sim.ModelHardwareConfig{
+				Backend:     "trained-roofline",
+				ModelConfig: llama7bConfig(),
+				HWConfig:    h100HWConfig(),
+				TP:          1,
+			}
+			tc.modify(&hw)
+			_, err := NewLatencyModel(coeffs, hw)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/latency/... -run "TestNewLatencyModel_TrainedRoofline" -count=1`
+**Expected:** FAIL (no "trained-roofline" case in NewLatencyModel)
+
+**Implement:**
+
+File: `sim/latency/latency.go` — add `case "trained-roofline":` to the switch in `NewLatencyModel`:
+
+```go
+case "trained-roofline":
+	if hw.TP <= 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires TP > 0, got %d", hw.TP)
+	}
+	if hw.ModelConfig.NumLayers <= 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires NumLayers > 0, got %d", hw.ModelConfig.NumLayers)
+	}
+	if hw.ModelConfig.NumHeads <= 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires NumHeads > 0, got %d", hw.ModelConfig.NumHeads)
+	}
+	if hw.ModelConfig.HiddenDim <= 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires HiddenDim > 0, got %d", hw.ModelConfig.HiddenDim)
+	}
+	if hw.ModelConfig.NumHeads%hw.TP != 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires NumHeads (%d) divisible by TP (%d)", hw.ModelConfig.NumHeads, hw.TP)
+	}
+	numKVHeads := hw.ModelConfig.NumKVHeads
+	if numKVHeads == 0 {
+		numKVHeads = hw.ModelConfig.NumHeads
+	}
+	if numKVHeads%hw.TP != 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires NumKVHeads (%d) divisible by TP (%d)", numKVHeads, hw.TP)
+	}
+	if invalidPositiveFloat(hw.HWConfig.TFlopsPeak) {
+		return nil, fmt.Errorf("latency model: trained-roofline requires valid TFlopsPeak > 0, got %v", hw.HWConfig.TFlopsPeak)
+	}
+	if invalidPositiveFloat(hw.HWConfig.BwPeakTBs) {
+		return nil, fmt.Errorf("latency model: trained-roofline requires valid BwPeakTBs > 0, got %v", hw.HWConfig.BwPeakTBs)
+	}
+	if hw.ModelConfig.IntermediateDim <= 0 {
+		return nil, fmt.Errorf("latency model: trained-roofline requires IntermediateDim > 0, got %d", hw.ModelConfig.IntermediateDim)
+	}
+	if len(coeffs.BetaCoeffs) < 7 {
+		return nil, fmt.Errorf("latency model: trained-roofline BetaCoeffs requires at least 7 elements, got %d", len(coeffs.BetaCoeffs))
+	}
+	if err := validateCoeffs("BetaCoeffs", coeffs.BetaCoeffs); err != nil {
+		return nil, err
+	}
+	headDim := hw.ModelConfig.HiddenDim / hw.ModelConfig.NumHeads
+	dKV := numKVHeads * headDim
+	dFF := hw.ModelConfig.IntermediateDim
+	kEff := max(1, hw.ModelConfig.NumExpertsPerTok) // matches training: k_eff = max(1, k)
+	return &TrainedRooflineLatencyModel{
+		betaCoeffs:  coeffs.BetaCoeffs,
+		alphaCoeffs: coeffs.AlphaCoeffs,
+		numLayers:   hw.ModelConfig.NumLayers,
+		hiddenDim:   hw.ModelConfig.HiddenDim,
+		numHeads:    hw.ModelConfig.NumHeads,
+		headDim:     headDim,
+		dKV:         dKV,
+		dFF:         dFF,
+		kEff:        kEff,
+		numExperts:  hw.ModelConfig.NumLocalExperts,
+		isMoE:       hw.ModelConfig.NumLocalExperts > 0,
+		tp:          hw.TP,
+		flopsPeakUs: hw.HWConfig.TFlopsPeak * 1e6,
+		bwHbmUs:     hw.HWConfig.BwPeakTBs * 1e6,
+	}, nil
+```
+
+Also add TP divisibility tests to `TestNewLatencyModel_TrainedRoofline_InvalidConfig_Error`:
+```go
+{"NumHeads not divisible by TP", func(hw *sim.ModelHardwareConfig) { hw.TP = 3 }, "divisible"},
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/latency/... -run "TestNewLatencyModel_TrainedRoofline" -count=1`
+**Expected:** PASS
+
+**Lint:** `cd .worktrees/trained-roofline-backend && golangci-lint run ./sim/latency/...`
+
+**Commit:** `feat(latency): wire trained-roofline factory in NewLatencyModel (BC-2,13,14)`
+
+---
+
+#### Task 4: Behavioral monotonicity tests (BC-4, BC-5)
+
+**Contracts:** BC-4, BC-5
+
+**Test:**
+
+File: `sim/latency/trained_roofline_test.go` — add monotonicity tests:
+
+```go
+// --- BC-4: Prefill monotonicity ---
+
+func TestTrainedRoofline_PrefillMonotonicity(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline", ModelConfig: llama7bConfig(),
+		HWConfig: h100HWConfig(), TP: 1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	require.NoError(t, err)
+
+	tokenCounts := []int{64, 128, 256, 512, 1024}
+	var prevTime int64
+	for _, n := range tokenCounts {
+		batch := []*sim.Request{makePrefillRequest(n, n)}
+		st := model.StepTime(batch)
+		assert.GreaterOrEqual(t, st, prevTime,
+			"prefill step time should be non-decreasing with more tokens: %d tokens → %d µs (prev %d µs)", n, st, prevTime)
+		prevTime = st
+	}
+}
+
+// --- BC-5: Decode monotonicity ---
+
+func TestTrainedRoofline_DecodeMonotonicity(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline", ModelConfig: llama7bConfig(),
+		HWConfig: h100HWConfig(), TP: 1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	require.NoError(t, err)
+
+	// More decode requests → higher batch size → more KV reads → longer step
+	var prevTime int64
+	for nReqs := 1; nReqs <= 16; nReqs *= 2 {
+		batch := make([]*sim.Request, nReqs)
+		for i := range batch {
+			batch[i] = makeDecodeRequest(512, 100)
+		}
+		st := model.StepTime(batch)
+		assert.GreaterOrEqual(t, st, prevTime,
+			"decode step time should be non-decreasing with more requests: %d reqs → %d µs (prev %d µs)", nReqs, st, prevTime)
+		prevTime = st
+	}
+}
+```
+
+**Command:** `cd .worktrees/trained-roofline-backend && go test ./sim/latency/... -run "TestTrainedRoofline_.*Monotonicity" -count=1`
+**Expected:** PASS (implementation from Task 2/3)
+
+**Commit:** `test(latency): add monotonicity behavioral tests for trained-roofline (BC-4,5)`
+
+---
+
+#### Task 5: Add defaults + CLI loading (BC-10, BC-12)
+
+**Contracts:** BC-10, BC-12
+
+**Implement:**
+
+1. File: `defaults.yaml` — add `trained_roofline_defaults` section (after `crossmodel_defaults`):
+
+```yaml
+trained_roofline_defaults:
+  # Globally-fitted roofline correction coefficients from training/output/fit/coefficients.json.
+  # Fitted via 3-phase NNLS from 13 experiments (4 models × 3-4 profiles, 137K requests).
+  # β₁-β₄ are dimensionless roofline corrections, β₅ is µs/layer, β₆ is µs/req, β₇ is µs/step.
+  beta_coeffs: [0.7726491335309499, 1.127489556719325, 1.0559901872766853, 0.0, 43.500541908701074, 48.80613214319187, 0.0]
+  # α₀=API processing overhead (µs), α₁=post-decode fixed (µs), α₂=per-output-token detokenization (µs/tok).
+  alpha_coeffs: [9315.338771116985, 1849.5902371340574, 1.7079389122469397]
+```
+
+2. File: `cmd/default_config.go` — add struct and field:
+
+```go
+// TrainedRooflineDefaults holds globally-fitted roofline correction coefficients.
+// These are model-independent: analytical basis functions from config.json scale the coefficients.
+type TrainedRooflineDefaults struct {
+	BetaCoeffs  []float64 `yaml:"beta_coeffs"`
+	AlphaCoeffs []float64 `yaml:"alpha_coeffs"`
+}
+```
+
+Add to Config struct: `TrainedRooflineDefaults *TrainedRooflineDefaults \`yaml:"trained_roofline_defaults,omitempty"\``
+
+3. File: `cmd/root.go` — 4 modification sites:
+
+   **Site A: Trained-roofline loading block (after crossmodel block, ~line 302).** Add a new `if backend == "trained-roofline"` block. Same structure as crossmodel: require `--hardware` and `--tp > 0`, resolve model config, resolve hardware config, load `cfg.TrainedRooflineDefaults` from defaults.yaml using `Flags().Changed()` guards (R18), validate coefficients were loaded (analogous to crossmodel line 297-301):
+   ```go
+   if !cmd.Flags().Changed("beta-coeffs") && (len(betaCoeffs) < 7 || allZeros(betaCoeffs)) {
+       logrus.Fatalf("--latency-model trained-roofline: no trained_roofline_defaults found in %s and no --beta-coeffs provided. "+
+           "Add trained_roofline_defaults to defaults.yaml or provide --beta-coeffs explicitly",
+           defaultsFilePath)
+   }
+   ```
+
+   **Site B: Zero-coefficients safety guard (~line 351).** Add `&& backend != "trained-roofline"` to prevent false-positive fatal error:
+   ```go
+   if backend != "roofline" && backend != "crossmodel" && backend != "trained-roofline" && allZeros(alphaCoeffs) && allZeros(betaCoeffs) {
+   ```
+   Also update the error message at ~line 352-354 to mention `trained-roofline`.
+
+   **Site C: Analytical backends HFConfig parsing (~line 358).** Add `|| backend == "trained-roofline"`:
+   ```go
+   if backend == "roofline" || backend == "crossmodel" || backend == "trained-roofline" {
+   ```
+
+   **Site D: Help text (~line 972).** Update `--latency-model` flag description:
+   ```go
+   "Latency model backend: blackbox (default), roofline, crossmodel, trained-roofline"
+   ```
+
+**Test:** Verify existing backends unchanged (BC-12):
+
+```bash
+cd .worktrees/trained-roofline-backend && go test ./... -count=1
+```
+
+**Expected:** All existing tests PASS (no behavioral change to existing backends).
+
+**Lint:** `cd .worktrees/trained-roofline-backend && golangci-lint run ./...`
+
+**Commit:** `feat(latency): add trained-roofline defaults + CLI loading (BC-10,12)`
+
+---
+
+#### Task 6: Update documentation
+
+**Contracts:** (documentation only)
+
+**Implement:**
+
+1. File: `CLAUDE.md` — update:
+   - Latency Estimation section: change "Three modes" to "Four modes", add trained-roofline as 4th mode with description
+   - File Organization: add `trained_roofline.go` to `sim/latency/` listing
+   - Key Data Flow: update parenthetical to "(alpha/beta, roofline, cross-model, or trained-roofline)"
+
+2. File: `sim/latency/latency.go` — update package doc comment to mention TrainedRooflineLatencyModel
+
+3. File: `sim/config.go` — update `Backend` field comment on `ModelHardwareConfig` (~line 81) to include `"trained-roofline"`
+
+4. File: `docs/guide/latency-models.md` — add "Trained-Roofline Mode" section:
+   - Description: roofline basis functions × learned correction coefficients from real vLLM traces
+   - Usage: `./blis run --model <name> --latency-model trained-roofline --hardware <GPU> --tp <N>`
+   - Update comparison table and mode count
+   - Note: coefficients fitted from 137K requests across 4 architectures (7% MAPE on GPU combined)
+
+5. File: `docs/reference/configuration.md` — update `--latency-model` flag description, add `trained_roofline_defaults` YAML section
+
+6. File: `docs/concepts/core-engine.md` — update "Latency Models" section: change "one of three" to "one of four", add trained-roofline subsection
+
+7. File: `docs/concepts/glossary.md` — update "Latency Model" entry: change "Three modes" to "Four modes"
+
+8. File: `docs/index.md` — update feature bullet to include "trained-roofline"
+
+9. File: `docs/reference/models.md` — mention trained-roofline in "Roofline and Cross-Model Modes" section
+
+**Command:** `cd .worktrees/trained-roofline-backend && go build ./... && go test ./... -count=1`
+**Expected:** PASS
+
+**Commit:** `docs: add trained-roofline to latency model documentation`
+
+---
+
+### H) Test Strategy
+
+| Contract | Task | Test Type | Test Name |
+|----------|------|-----------|-----------|
+| BC-1 | Task 1 | Unit | TestIsValidLatencyBackend (updated) |
+| BC-1 | Task 1 | Unit | TestValidLatencyBackendNames (updated) |
+| BC-2 | Task 3 | Unit | TestNewLatencyModel_TrainedRoofline_ReturnsModel |
+| BC-3 | Task 2 | Unit | TestTrainedRoofline_PrefillOnly_PositiveStepTime |
+| BC-3 | Task 2 | Unit | TestTrainedRoofline_DecodeOnly_PositiveStepTime |
+| BC-4 | Task 4 | Behavioral | TestTrainedRoofline_PrefillMonotonicity |
+| BC-5 | Task 4 | Behavioral | TestTrainedRoofline_DecodeMonotonicity |
+| BC-6 | Task 2 | Unit | TestTrainedRoofline_EmptyBatch_ReturnsOne |
+| BC-7 | Task 2 | Unit | TestTrainedRoofline_QueueingTime_IsAlpha0 |
+| BC-8 | Task 2 | Unit | TestTrainedRoofline_OutputTokenProcessingTime_IsAlpha2 |
+| BC-9 | Task 2 | Behavioral | TestTrainedRoofline_MoE_WeightLoading_UsesEffectiveExperts |
+| BC-11 | Task 2 | Regression | TestTrainedRoofline_NoMfuScaling_RegressionAnchor |
+| BC-12 | Task 5 | Integration | Full test suite passes (no regressions) |
+| BC-13 | Task 3 | Error | TestNewLatencyModel_TrainedRoofline_TooFewBetas_Error |
+| BC-14 | Task 3 | Error | TestNewLatencyModel_TrainedRoofline_InvalidConfig_Error |
+| BC-15 | Task 2 | Unit | TestTrainedRoofline_PostDecodeFixedOverhead_IsAlpha1 |
+
+**Invariant tests:**
+- BC-6 verifies INV-3 (clock monotonicity: StepTime >= 1)
+- BC-4/BC-5 verify physical monotonicity (more work → more time)
+- BC-12 verifies INV-6 (determinism: no regressions in existing backends)
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation | Task |
+|------|-----------|--------|------------|------|
+| Basis function formula mismatch with training pipeline | Medium | High (coefficients invalid) | Regression anchor test + exact formula port from training/basis_functions.py | Task 2 |
+| MFU accidentally applied (double-counting) | Low | High (2-3x step time error) | BC-11 test explicitly checks no MFU | Task 2 |
+| Division by zero in basis functions | Low | High (panic) | Validate TFlopsPeak > 0, BwPeakTBs > 0 at construction (BC-14) | Task 3 |
+| Interface addition (PostDecodeFixedOverhead) | Low | Low (all existing backends return 0; 1-line change to recordRequestCompletion) | Existing backends unaffected (BC-12); trained-roofline returns α₁; verified by BC-15 test | Task 2/3 |
+| defaults.yaml strict parsing (R10) rejects new section | Low | Medium (breaks existing tests) | TrainedRooflineDefaults uses `omitempty` tag | Task 5 |
+| NaN/Inf in coefficients | Low | High (silent garbage) | validateCoeffs called for both alpha and beta | Task 3 |
+
+---
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+**Plan-specific checks:**
+- [x] No unnecessary abstractions — single new struct, one method added to existing LatencyModel interface (PostDecodeFixedOverhead)
+- [x] No feature creep — only trained-roofline backend, no refactoring of existing backends
+- [x] No unexercised flags — all 7 betas and 3 alphas are used
+- [x] No partial implementations — all 4 LatencyModel methods implemented (StepTime, QueueingTime, OutputTokenProcessingTime, PostDecodeFixedOverhead)
+- [x] No breaking changes — existing backends untouched (BC-12)
+- [x] No hidden global state — struct is immutable after construction
+- [x] All new code will pass golangci-lint
+- [x] Shared test helpers used (testify assert/require)
+- [x] CLAUDE.md updated — Task 6
+- [x] No stale references
+- [x] Documentation DRY — CLAUDE.md file tree and latency section updated
+- [x] Deviation log reviewed — 6 deviations (α mapping via PostDecodeFixedOverhead, T_tp=0, prompt_tokens semantics, SwiGLU 3-matrix, IntermediateDim vs MoEExpertFFNDim, chunked prefill overprediction), all justified
+- [x] Each task produces working, testable code
+- [x] Task dependencies correctly ordered (1 → 2 → 3 → 4 → 5 → 6)
+- [x] All contracts mapped to tasks
+- [x] Golden dataset not affected (new backend, no output changes)
+- [x] Construction site audit: validLatencyBackends (1 site, updated in Task 1), Config struct (YAML deserialization, updated in Task 5)
+
+**Antipattern rules:**
+- [x] R1: No silent data loss — all error paths return error
+- [x] R2: No map iteration for ordered output (basis functions use direct computation)
+- [x] R3: All numeric params validated (TP, NumLayers, NumHeads, HiddenDim, TFlopsPeak, BwPeakTBs)
+- [x] R4: Construction site audit completed (validLatencyBackends, Config struct)
+- [x] R5: No resource allocation loops
+- [x] R6: No Fatalf in sim/ — returns error from NewLatencyModel
+- [x] R7: Monotonicity tests alongside value tests
+- [x] R8: validLatencyBackends remains unexported
+- [x] R9: No new YAML pointer types needed
+- [x] R10: Config uses existing KnownFields(true) parsing (omitempty on new field)
+- [x] R11: Division guarded (TFlopsPeak > 0, BwPeakTBs > 0 at construction)
+- [x] R12: No golden dataset changes
+- [x] R13: LatencyModel interface now has 4 implementations (was 3)
+- [x] R14: StepTime computes step time only (no scheduling/metrics concerns)
+- [x] R15: No stale PR references
+- [x] R16: Coefficients loaded from existing LatencyCoeffs (module-scoped config)
+- [x] R17: N/A (no routing signals)
+- [x] R18: CLI uses Flags().Changed() guard (follows crossmodel pattern)
+- [x] R19: No retry loops
+- [x] R20: Empty batch handled (returns 1)
+- [x] R21: No range over mutable slices
+- [x] R22: N/A (no pre-checks)
+- [x] R23: Basis functions internally consistent. **Documented exception:** trained-roofline uses 3-matrix SwiGLU (6·d·d_ff FLOPs, 3·d·d_ff weights) while roofline.go uses 2-matrix (mlpMatrixCount()=2). This is intentional — coefficients were fitted against 3-matrix formulas. Cross-reference comment in implementation code required.
+
+---
+
+## Appendix: File-Level Implementation Details
+
+### File: `sim/latency/trained_roofline.go` (CREATE)
+
+**Purpose:** TrainedRooflineLatencyModel — applies learned correction factors to analytical roofline basis functions.
+
+**Key implementation notes:**
+- StepTime uses single-pass accumulation: one loop classifies prefill/decode and accumulates all aggregate values, then computes 6 basis functions in O(1). Zero heap allocations.
+- Empty-batch guard: `if len(batch) == 0 || batch == nil { return 1 }` — first line of StepTime.
+- Architecture features frozen at construction (headDim, dKV, dFF, kEff, isMoE, etc.)
+- Pre-converted hardware specs: `flopsPeakUs` = TFlopsPeak × 1e6, `bwHbmUs` = BwPeakTBs × 1e6
+- FP16 assumed (2 bytes per element) for all KV/weight calculations — matches training pipeline's `_BYTES_PER_ELEMENT = 2`
+- No MFU scaling (BC-11)
+- T_tp returns 0 (no NVLink data, β₄=0)
+- Cross-reference comment for 3-matrix SwiGLU vs roofline.go's `mlpMatrixCount()=2` (R23 exception)
+
+### File: `sim/latency/latency.go` (MODIFY)
+
+**Purpose:** Add `"trained-roofline"` case to NewLatencyModel switch.
+
+**Changes:**
+- New case between `"crossmodel"` and `"", "blackbox"` cases
+- Validates: TP > 0, NumLayers > 0, NumHeads > 0, HiddenDim > 0, IntermediateDim > 0, TFlopsPeak > 0 (via invalidPositiveFloat — catches NaN/Inf), BwPeakTBs > 0, NumHeads%TP == 0, NumKVHeads%TP == 0
+- Validates: BetaCoeffs >= 7 elements
+- Calls validateCoeffs for both alpha and beta
+- Computes derived features (headDim, dKV, etc.) and constructs TrainedRooflineLatencyModel
+
+### File: `sim/bundle.go` (MODIFY)
+
+**Purpose:** Register "trained-roofline" as valid backend name.
+
+**Changes:** Single line addition to validLatencyBackends map.
+
+### File: `defaults.yaml` (MODIFY)
+
+**Purpose:** Store fitted coefficients from training pipeline.
+
+**Changes:** Add `trained_roofline_defaults` section between `crossmodel_defaults` and `version`.
+
+### File: `cmd/default_config.go` (MODIFY)
+
+**Purpose:** Add YAML deserialization struct for trained-roofline defaults.
+
+**Changes:**
+- Add `TrainedRooflineDefaults` struct (BetaCoeffs, AlphaCoeffs)
+- Add field to Config struct with `yaml:"trained_roofline_defaults,omitempty"` tag
+
+### File: `cmd/root.go` (MODIFY)
+
+**Purpose:** CLI handling for `--latency-model trained-roofline`.
+
+**Changes (4 sites):**
+- **Site A (~line 302):** Add `if backend == "trained-roofline"` loading block with coefficient validation guard
+- **Site B (~line 351):** Add `&& backend != "trained-roofline"` to zero-coefficients safety guard + update error message
+- **Site C (~line 358):** Add `|| backend == "trained-roofline"` to analytical HFConfig parsing block
+- **Site D (~line 972):** Update `--latency-model` help text: `"blackbox (default), roofline, crossmodel, trained-roofline"`
+
+### File: `sim/config.go` (MODIFY)
+
+**Purpose:** Update `Backend` field comment on `ModelHardwareConfig`.
+
+**Changes:** Line ~81: add `"trained-roofline"` to the comment listing valid backend names.
+
+### File: `CLAUDE.md` (MODIFY)
+
+**Purpose:** Document the new backend.
+
+**Changes:**
+- Latency Estimation section: "Four modes" + trained-roofline description
+- File Organization: add `trained_roofline.go` to sim/latency/ listing
+- Key Data Flow parenthetical: add "trained-roofline"
+
+### Files: `docs/guide/latency-models.md`, `docs/reference/configuration.md`, `docs/concepts/core-engine.md`, `docs/concepts/glossary.md`, `docs/index.md`, `docs/reference/models.md` (MODIFY)
+
+**Purpose:** Update all documentation working copies that reference the number of latency backends.
+
+**Changes:** Update mode counts from "three" to "four", add trained-roofline descriptions where appropriate. See Task 6 for per-file details.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -40,7 +40,7 @@ Controls GPU and CPU memory simulation for key-value cache blocks. Maps to `KVCa
 | `--kv-transfer-bandwidth` | float64 | 100.0 | GPU-CPU transfer rate in blocks/tick. Required > 0 when CPU blocks > 0. |
 | `--kv-transfer-base-latency` | int64 | 0 | Fixed per-transfer latency in ticks. |
 
-\* The effective value of `--total-kv-blocks` depends on the latency backend — see [Resolution Process](#resolution-process) for the full priority chain. In blackbox mode, `defaults.yaml` overrides the 1,000,000 CLI default per model (e.g., `llama-3.1-8b/H100/TP=2` uses 132,139 blocks). In roofline or crossmodel mode, the value is auto-calculated from model architecture and GPU memory via `CalculateKVBlocks`, which supersedes the `defaults.yaml` value. Explicit `--total-kv-blocks` always takes precedence.
+\* The effective value of `--total-kv-blocks` depends on the latency backend — see [Resolution Process](#resolution-process) for the full priority chain. In blackbox mode, `defaults.yaml` overrides the 1,000,000 CLI default per model (e.g., `qwen3-14b/H100/TP=1` uses 17,600 blocks). In roofline or crossmodel mode, the value is auto-calculated from model architecture and GPU memory via `CalculateKVBlocks`, which supersedes the `defaults.yaml` value. Explicit `--total-kv-blocks` always takes precedence.
 
 ## Batch Formation
 
@@ -71,10 +71,11 @@ Maps to `ModelHardwareConfig`.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--model` | string | (required) | LLM model name (e.g., `meta-llama/llama-3.1-8b-instruct`). |
+| `--model` | string | (required) | LLM model name (e.g., `qwen/qwen3-14b`). |
 | `--hardware` | string | "" | GPU type (e.g., `H100`, `A100`). If empty, loaded from `defaults.yaml`. |
 | `--tp` | int | 0 | Tensor parallelism degree. If 0, loaded from `defaults.yaml`. |
 | `--vllm-version` | string | "" | vLLM version string. If empty, loaded from `defaults.yaml`. |
+| `--max-model-len` | int64 | 0 | Max total sequence length (input + output) in tokens. 0 = unlimited. Mirrors vLLM's `--max-model-len`. Auto-derived from `max_position_embeddings` in HuggingFace `config.json` for roofline/crossmodel backends. Applies `rope_scaling` factor for types `linear`, `dynamic`, `yarn`, `default`, `mrope`; excludes `su`, `longrope`, `llama3`; skips entirely for `gemma3` models. Capped at KV-feasible maximum. |
 
 ### Roofline Mode
 
@@ -82,7 +83,7 @@ For analytical step time estimation without trained coefficients.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--latency-model` | string | "" | Latency model backend: `blackbox` (default), `roofline`, `crossmodel`. When set to `roofline` or `crossmodel`, auto-fetches HuggingFace config.json and resolves hardware config. Requires `--hardware` and `--tp`. Set `HF_TOKEN` for gated models. |
+| `--latency-model` | string | "" | Latency model backend: `blackbox` (default), `roofline`, `crossmodel`, `trained-roofline`. When set to `roofline`, `crossmodel`, or `trained-roofline`, auto-fetches HuggingFace config.json and resolves hardware config. Requires `--hardware` and `--tp`. Set `HF_TOKEN` for gated models. `trained-roofline` is recommended for new models (7% MAPE GPU step time). |
 | `--model-config-folder` | string | "" | Path to folder containing HuggingFace `config.json`. Overrides `--latency-model` auto-resolution. |
 | `--hardware-config` | string | "" | Path to `hardware_config.json` with GPU specifications. Overrides `--latency-model` auto-resolution. |
 
@@ -373,11 +374,11 @@ The `defaults.yaml` file serves as a model registry and workload preset store:
 ```yaml
 # Section 1: Hardware/TP mappings (keyed by model ID)
 defaults:
-  meta-llama/llama-3.1-8b-instruct:
+  qwen/qwen3-14b:
     GPU: H100
-    tensor_parallelism: 2
-    vllm_version: vllm/vllm-openai:v0.8.4
-    hf_repo: meta-llama/Llama-3.1-8B-Instruct
+    tensor_parallelism: 1
+    vllm_version: vllm/vllm-openai:v0.11.0
+    hf_repo: Qwen/Qwen3-14B
 
 # Section 2: Workload presets
 workloads:
@@ -390,13 +391,13 @@ workloads:
 
 # Section 3: Trained coefficients (keyed by model+GPU+TP)
 models:
-  - id: meta-llama/llama-3.1-8b-instruct
+  - id: qwen/qwen3-14b
     GPU: H100
-    tensor_parallelism: 2
-    vllm_version: vllm/vllm-openai:v0.8.4
-    alpha_coeffs: [1601.35, 3.51, 1805.54]
-    beta_coeffs: [6910.42, 17.67, 2.84]
-    total_kv_blocks: 132139
+    tensor_parallelism: 1
+    vllm_version: vllm/vllm-openai:v0.11.0
+    alpha_coeffs: [8888.09, 0.18, 0.0]
+    beta_coeffs: [13578.19, 39.44, 27.32]
+    total_kv_blocks: 17600
 ```
 
 ### Resolution Process
@@ -423,7 +424,7 @@ When BLIS starts, it resolves latency coefficients and KV block counts through a
 
 1. **Explicit CLI flag** — if `--total-kv-blocks` is set, that value is used regardless of backend
 2. **Auto-calculation** (roofline/crossmodel only) — when `MemoryGiB > 0` in the hardware config, `CalculateKVBlocks` derives the block count from model architecture and GPU memory, superseding the `defaults.yaml` value. Three failure modes: (a) if `MemoryGiB` is missing from `hardware_config.json`, BLIS warns and falls back to the `defaults.yaml` value (layer 3) or hardcoded default (layer 4); (b) if model architecture params cannot be extracted from `config.json`, BLIS exits with an error; (c) if the calculation itself fails (e.g., unsupported activation function), BLIS exits with an error. Only the `MemoryGiB`-missing case is a graceful fallback — other failures are fatal. Auto-calculation currently requires SwiGLU-family activations (`silu`, `swiglu`, `geglu`); models with other activations (e.g., Falcon's `gelu`) should set `--total-kv-blocks` explicitly
-3. **`defaults.yaml`** — per-model block count loaded for the model/GPU/TP combination (e.g., 132,139 for llama-3.1-8b/H100/TP=2). For roofline/crossmodel with `MemoryGiB > 0`, this value is superseded by auto-calculation (layer 2). It remains the effective value only for blackbox mode or when `MemoryGiB` is unavailable in the hardware config
+3. **`defaults.yaml`** — per-model block count loaded for the model/GPU/TP combination (e.g., 17,600 for qwen3-14b/H100/TP=1). For roofline/crossmodel with `MemoryGiB > 0`, this value is superseded by auto-calculation (layer 2). It remains the effective value only for blackbox mode or when `MemoryGiB` is unavailable in the hardware config
 4. **Hardcoded default** — 1,000,000 (CLI flag default, used only when no other source provides a value)
 
 ## Coefficient Calibration
@@ -447,7 +448,7 @@ For environments where live profiling is not feasible, the [Roofline model](../c
 | **KVCacheConfig** | `--total-kv-blocks`, `--block-size-in-tokens`, `--kv-cpu-blocks`, `--kv-offload-threshold`, `--kv-transfer-bandwidth`, `--kv-transfer-base-latency` |
 | **BatchConfig** | `--max-num-running-reqs`, `--max-num-scheduled-tokens`, `--long-prefill-token-threshold` |
 | **LatencyCoeffs** | `--alpha-coeffs`, `--beta-coeffs` |
-| **ModelHardwareConfig** | `--model`, `--hardware`, `--tp`, `--vllm-version`, `--latency-model`, `--model-config-folder`, `--hardware-config` |
+| **ModelHardwareConfig** | `--model`, `--hardware`, `--tp`, `--vllm-version`, `--latency-model`, `--model-config-folder`, `--hardware-config`, `--max-model-len` |
 | **PolicyConfig** | `--scheduler`, `--priority-policy` |
 | **WorkloadConfig** | `--workload`, `--workload-spec`, `--workload-traces-filepath`, `--defaults-filepath`, `--rate`, `--num-requests`, `--prompt-tokens*`, `--output-tokens*`, `--prefix-tokens` |
 | **DeploymentConfig** | `--num-instances`, `--admission-policy`, `--admission-latency`, `--token-bucket-capacity`, `--token-bucket-refill-rate`, `--routing-policy`, `--routing-latency`, `--routing-scorers`, `--snapshot-refresh-interval`, `--trace-level`, `--counterfactual-k` |

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -29,9 +29,11 @@ All models below have pre-trained alpha/beta coefficients in `defaults.yaml` for
 
 Red Hat AI (`redhatai/`) provides FP8, W4A16, and W8A8 quantized variants for many of the above models, including LLaMA 3.1/3.3/4, Mistral Small 3.1, Phi-4, Qwen 2.5, and SmolLM3 3B (FP8 only). See [`defaults.yaml`](https://github.com/inference-sim/inference-sim/blob/main/defaults.yaml) for the full list.
 
-## Roofline and Cross-Model Modes
+## Analytical Modes (Roofline, Cross-Model, Trained-Roofline)
 
-Any model with a HuggingFace `config.json` can use roofline mode (`--latency-model roofline`) or cross-model mode (`--latency-model crossmodel`). Both auto-fetch configs from HuggingFace on first use, caching them in `model_configs/`. Cross-model mode is MoE-aware and uses globally-fitted physics coefficients, making it the preferred choice for MoE models like Mixtral. Tested architectures include Qwen 2.5 1.5B/3B, Qwen 3 14B, LLaMA 2 7B/70B, and Mixtral 8x7B.
+Any model with a HuggingFace `config.json` can use roofline mode (`--latency-model roofline`), cross-model mode (`--latency-model crossmodel`), or trained-roofline mode (`--latency-model trained-roofline`). All three auto-fetch configs from HuggingFace on first use, caching them in `model_configs/`.
+
+**Trained-roofline** (recommended) applies learned correction factors to analytical roofline basis functions — 7% MAPE GPU combined step time across 4 architectures. **Cross-model** uses hand-engineered physics features with globally-fitted coefficients. **Roofline** uses pure analytical estimation (no learned corrections). All three are MoE-aware. Tested architectures include Qwen 2.5 1.5B/3B, Qwen 3 14B, LLaMA 2 7B/70B, Mixtral 8x7B, and CodeLlama 34B.
 
 ## Adding a New Model
 
@@ -46,4 +48,4 @@ To add roofline support:
 2. Place in `model_configs/<model-name>/config.json`
 3. Run with `--latency-model roofline --hardware <GPU> --tp <N>`
 
-Or let BLIS auto-fetch it with `--latency-model roofline`.
+Or let BLIS auto-fetch it with `--latency-model roofline` (or `trained-roofline` for higher accuracy).

--- a/hardware_config.json
+++ b/hardware_config.json
@@ -1,36 +1,24 @@
 {
     "H100": {
-		"TFlopsPeak":        989.5,
-		"BwPeakTBs":         3.35,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.65,
-		"mfuDecode":        0.12,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"TFlopsPeak":  989.5,
+		"BwPeakTBs":   3.35,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	},
 	"A100-SXM": {
-		"TFlopsPeak":        312,
-		"BwPeakTBs":         2.039,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.65,
-		"mfuDecode":        0.12,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"TFlopsPeak":  312,
+		"BwPeakTBs":   2.039,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	},
 	"A100-80": {
-		"_comment":          "Alias for A100-SXM — defaults.yaml uses A100-80 for all A100 model entries (BC-14)",
-		"TFlopsPeak":        312,
-		"BwPeakTBs":         2.039,
-        "BwEffConstant": 0.72,
-		"TOverheadMicros":  500.0,
-		"perLayerOverhead": 20.0,
-		"mfuPrefill":       0.65,
-		"mfuDecode":        0.12,
-		"allReduceLatency": 20.0,
-		"MemoryGiB":        80.0
+		"_comment":    "Alias for A100-SXM — defaults.yaml uses A100-80 for all A100 model entries (BC-14)",
+		"TFlopsPeak":  312,
+		"BwPeakTBs":   2.039,
+		"mfuPrefill":  0.45,
+		"mfuDecode":   0.30,
+		"MemoryGiB":   80.0
 	}
 }

--- a/sim/batch_formation_test.go
+++ b/sim/batch_formation_test.go
@@ -14,7 +14,7 @@ func TestVLLMBatchFormation_ImplementsInterface(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	if bf == nil {
@@ -49,7 +49,7 @@ func TestVLLMBatchFormation_TokenBudgetEnforced(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 50, 0), // tight token budget
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -102,7 +102,7 @@ func TestVLLMBatchFormation_BatchSizeEnforced(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(200, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(2, 10000, 0), // tight batch size limit
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -157,7 +157,7 @@ func TestVLLMBatchFormation_PreemptionReleasesKV(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -223,7 +223,7 @@ func TestVLLMBatchFormation_PreemptionStopsDequeue(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0), // very tight
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -278,7 +278,7 @@ func TestVLLMBatchFormation_CircuitBreaker(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0), // very small
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -323,7 +323,7 @@ func TestVLLMBatchFormation_KVAllocationFailure_StopsDequeue(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(3, 16, 0, 0, 0, 0), // limited KV blocks
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -431,7 +431,7 @@ func TestVLLMBatchFormation_Phase1_EvictedNotRevisited(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(6, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 0, 0}, []float64{100, 1, 0}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
@@ -548,7 +548,7 @@ func TestVLLMBatchFormation_LivelockResolution(t *testing.T) {
 			[]float64{5752.705191348184, 17.25086436834028, 5.999143920128404},   // beta
 			[]float64{232.46191091038054, 1.752360364195244, 3357.4400353290152}, // alpha
 		),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 		PolicyConfig:        NewPolicyConfig("constant", "fcfs"),
 	}
 

--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -62,7 +62,7 @@ var (
 	validRoutingPolicies   = map[string]bool{"": true, "round-robin": true, "least-loaded": true, "weighted": true, "always-busiest": true}
 	validPriorityPolicies  = map[string]bool{"": true, "constant": true, "slo-based": true, "inverted-slo": true}
 	validSchedulers        = map[string]bool{"": true, "fcfs": true, "priority-fcfs": true, "sjf": true, "reverse-priority": true}
-	validLatencyBackends        = map[string]bool{"": true, "blackbox": true, "roofline": true, "crossmodel": true}
+	validLatencyBackends        = map[string]bool{"": true, "blackbox": true, "roofline": true, "crossmodel": true, "trained-roofline": true}
 	validDisaggregationDeciders = map[string]bool{"": true, "never": true, "always": true, "prefix-threshold": true}
 )
 

--- a/sim/bundle_test.go
+++ b/sim/bundle_test.go
@@ -331,6 +331,7 @@ func TestIsValidLatencyBackend(t *testing.T) {
 	assert.True(t, IsValidLatencyBackend("blackbox"))
 	assert.True(t, IsValidLatencyBackend("roofline"))
 	assert.True(t, IsValidLatencyBackend("crossmodel"))
+	assert.True(t, IsValidLatencyBackend("trained-roofline"))
 	assert.False(t, IsValidLatencyBackend("nonexistent"))
 }
 
@@ -339,5 +340,6 @@ func TestValidLatencyBackendNames(t *testing.T) {
 	assert.Contains(t, names, "blackbox")
 	assert.Contains(t, names, "roofline")
 	assert.Contains(t, names, "crossmodel")
+	assert.Contains(t, names, "trained-roofline")
 	assert.NotContains(t, names, "")
 }

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -559,6 +559,7 @@ func (c *ClusterSimulator) aggregateMetrics() *sim.Metrics {
 		merged.PreemptionCount += m.PreemptionCount
 		merged.KVAllocationFailures += m.KVAllocationFailures
 		merged.DroppedUnservable += m.DroppedUnservable
+		merged.LengthCappedRequests += m.LengthCappedRequests
 		merged.CacheHitRate += m.CacheHitRate
 		merged.KVThrashingRate += m.KVThrashingRate
 		merged.StillQueued += m.StillQueued

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -256,7 +256,7 @@ func (e *DisaggregationDecisionEvent) Execute(cs *ClusterSimulator) {
 	prefillSubReq := &sim.Request{
 		ID:          parent.PrefillSubReqID,
 		InputTokens: e.request.InputTokens,
-		// OutputTokens intentionally nil: zero-output request completes at prefill end
+		// No output tokens assigned: zero-output sub-request completes at prefill end
 		State:       sim.StateQueued,
 		ArrivalTime: e.request.ArrivalTime,
 		TenantID:    e.request.TenantID,

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -3,9 +3,11 @@ package cluster
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -21,7 +23,7 @@ func newTestDeploymentConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "", 0),
 		},
 		NumInstances: numInstances,
 	}
@@ -58,7 +60,7 @@ func TestDeploymentConfig_ToSimConfig_ReturnsEmbeddedSimConfig(t *testing.T) {
 			KVCacheConfig:       sim.NewKVCacheConfig(500, 32, 0, 0, 0, 42),
 			BatchConfig:         sim.NewBatchConfig(128, 4096, 512),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1, 2, 3}, []float64{4, 5, 6}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 2, "roofline"),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 2, "roofline", 0),
 			PolicyConfig:        sim.NewPolicyConfig("slo-based", "priority-fcfs"),
 		},
 		NumInstances:    3,
@@ -136,7 +138,7 @@ func TestClusterSimulator_SingleInstance_GoldenEquivalence(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", 0),
 				},
 				NumInstances: 1,
 			}
@@ -186,7 +188,7 @@ func TestClusterSimulator_SingleInstance_GoldenInvariants(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", 0),
 				},
 				NumInstances: 1,
 			}
@@ -1551,4 +1553,119 @@ func TestClusterSimulator_FullStackConservation(t *testing.T) {
 			t.Error("expected some rejections with token-bucket(cap=500,refill=300) at rate=200, got 0")
 		}
 	})
+}
+
+// BC-6: Cluster-mode MaxModelLen drops surface in aggregated metrics with INV-1 conservation.
+// Exercises Guard 1a (input >= MaxModelLen) and Guard 1b (input + budget > MaxModelLen).
+// Differs from TestClusterSimulator_InFlightRequests_DroppedUnservable_Decrements which tests
+// the KV-capacity Guard 2 path.
+func TestClusterSimulator_MaxModelLen_DroppedUnservable(t *testing.T) {
+	const maxModelLen = 200
+
+	config := DeploymentConfig{
+		SimConfig: sim.SimConfig{
+			Horizon:             10_000_000,
+			Seed:                42,
+			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
+			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}), // zero alpha
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", maxModelLen),
+		},
+		NumInstances: 2,
+	}
+
+	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(42))
+	workloadRNG := rng.ForSubsystem(sim.SubsystemWorkload)
+
+	var requests []*sim.Request
+	numFit, numGuard1a, numGuard1b := 0, 0, 0
+
+	// 5 requests that fit (input=50, output=50, no budget → auto-filled to 150, budget check passes)
+	for i := 0; i < 5; i++ {
+		req := &sim.Request{
+			ID:           fmt.Sprintf("fit_%d", i),
+			InputTokens:  sim.GenerateRandomTokenIDs(workloadRNG, 50),
+			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 50),
+			ArrivalTime:  int64(i * 100_000),
+			State:        sim.StateQueued,
+		}
+		requests = append(requests, req)
+		numFit++
+	}
+
+	// 3 requests dropped by Guard 1a (input >= MaxModelLen)
+	for i := 0; i < 3; i++ {
+		req := &sim.Request{
+			ID:           fmt.Sprintf("guard1a_%d", i),
+			InputTokens:  sim.GenerateRandomTokenIDs(workloadRNG, 200), // input == MaxModelLen → dropped
+			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 10),
+			ArrivalTime:  int64((5 + i) * 100_000),
+			State:        sim.StateQueued,
+		}
+		requests = append(requests, req)
+		numGuard1a++
+	}
+
+	// 2 requests dropped by Guard 1b (input + budget > MaxModelLen)
+	for i := 0; i < 2; i++ {
+		req := &sim.Request{
+			ID:           fmt.Sprintf("guard1b_%d", i),
+			InputTokens:  sim.GenerateRandomTokenIDs(workloadRNG, 100),
+			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 50),
+			MaxOutputLen: 150, // 100 + 150 = 250 > MaxModelLen(200)
+			ArrivalTime:  int64((8 + i) * 100_000),
+			State:        sim.StateQueued,
+		}
+		requests = append(requests, req)
+		numGuard1b++
+	}
+
+	totalInjected := numFit + numGuard1a + numGuard1b
+	expectedDropped := numGuard1a + numGuard1b
+
+	cs := NewClusterSimulator(config, requests)
+	mustRun(t, cs)
+
+	agg := cs.AggregatedMetrics()
+
+	// DroppedUnservable matches expected oversized count
+	if agg.DroppedUnservable != expectedDropped {
+		t.Errorf("DroppedUnservable = %d, want %d (Guard1a=%d + Guard1b=%d)",
+			agg.DroppedUnservable, expectedDropped, numGuard1a, numGuard1b)
+	}
+
+	// INV-1 conservation: injected == completed + queued + running + dropped
+	conservation := agg.CompletedRequests + agg.StillQueued + agg.StillRunning + agg.DroppedUnservable
+	if conservation != totalInjected {
+		t.Errorf("INV-1: completed(%d) + queued(%d) + running(%d) + dropped(%d) = %d, want %d",
+			agg.CompletedRequests, agg.StillQueued, agg.StillRunning, agg.DroppedUnservable,
+			conservation, totalInjected)
+	}
+
+	// Post-simulation drain: all requests completed or dropped, nothing in-flight
+	if agg.StillQueued != 0 || agg.StillRunning != 0 {
+		t.Errorf("StillQueued=%d, StillRunning=%d; want both 0 (all should complete within horizon)",
+			agg.StillQueued, agg.StillRunning)
+	}
+
+	// inFlightRequests drains to 0 for each instance (direct access, same package)
+	for _, inst := range cs.instances {
+		instID := string(inst.ID())
+		inflight := cs.inFlightRequests[instID]
+		if inflight != 0 {
+			t.Errorf("inFlightRequests[%s] = %d, want 0 (should drain after completion+drops)", instID, inflight)
+		}
+	}
+
+	// Metrics.Requests map excludes dropped request IDs
+	for _, req := range requests {
+		_, exists := agg.Requests[req.ID]
+		isDropped := strings.HasPrefix(req.ID, "guard1")
+		if exists && isDropped {
+			t.Errorf("Metrics.Requests should NOT contain dropped request %s", req.ID)
+		}
+		if !exists && !isDropped {
+			t.Errorf("Metrics.Requests should contain fit request %s", req.ID)
+		}
+	}
 }

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -86,7 +86,7 @@ func newTestDisaggDeploymentConfig(numInstances, prefill, decode int) Deployment
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "", 0),
 		},
 		NumInstances:            numInstances,
 		PrefillInstances:        prefill,
@@ -332,7 +332,7 @@ func TestDisaggregation_BackwardCompatibility(t *testing.T) {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "", 0),
 		},
 		NumInstances:  4,
 		RoutingPolicy: "round-robin",
@@ -394,7 +394,7 @@ func newTestPrefixThresholdConfig(threshold int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "", 0),
 		},
 		NumInstances:            4,
 		PrefillInstances:        2,
@@ -537,7 +537,7 @@ func TestAllocateTransferredKV_Success(t *testing.T) {
 		KVCacheConfig:       sim.NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 	inst := NewInstanceSimulator("decode_0", cfg)
 
@@ -566,7 +566,7 @@ func TestAllocateTransferredKV_InsufficientCapacity(t *testing.T) {
 		KVCacheConfig:       sim.NewKVCacheConfig(2, 16, 0, 0, 0, 0), // Only 2 blocks
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 	inst := NewInstanceSimulator("decode_0", cfg)
 

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -18,7 +18,7 @@ func newTestSimConfig() sim.SimConfig {
 		KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 }
 
@@ -50,7 +50,7 @@ func TestInstanceSimulator_GoldenDataset_Equivalence(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 				},
 			)
 
@@ -104,7 +104,7 @@ func TestInstanceSimulator_GoldenDataset_Invariants(t *testing.T) {
 					KVCacheConfig:       sim.NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 					BatchConfig:         sim.NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 					LatencyCoeffs:       sim.NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 				},
 			)
 

--- a/sim/cluster/metrics.go
+++ b/sim/cluster/metrics.go
@@ -102,6 +102,7 @@ type RawMetrics struct {
 	HOLBlockingEvents    int
 	RejectedRequests     int
 	DroppedUnservable    int
+	LengthCappedRequests int
 
 	// KV cache metrics (PR12)
 	CacheHitRate    float64
@@ -120,8 +121,9 @@ type RawMetrics struct {
 // E2E differences reflect workload variance, not unfairness.
 func CollectRawMetrics(aggregated *sim.Metrics, perInstance []*sim.Metrics, rejectedRequests int, priorityPolicy string) *RawMetrics {
 	raw := &RawMetrics{
-		RejectedRequests:  rejectedRequests,
-		DroppedUnservable: aggregated.DroppedUnservable,
+		RejectedRequests:     rejectedRequests,
+		DroppedUnservable:    aggregated.DroppedUnservable,
+		LengthCappedRequests: aggregated.LengthCappedRequests,
 	}
 
 	// Latency distributions

--- a/sim/cluster/metrics_substrate_test.go
+++ b/sim/cluster/metrics_substrate_test.go
@@ -25,7 +25,7 @@ func msClusterConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 100000, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{5000, 10, 3}, []float64{1000, 2, 500}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "test-gpu", 1, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "test-gpu", 1, "", 0),
 			PolicyConfig:        sim.NewPolicyConfig("constant", "fcfs"),
 		},
 		NumInstances:    numInstances,

--- a/sim/cluster/prefix_routing_test.go
+++ b/sim/cluster/prefix_routing_test.go
@@ -63,7 +63,7 @@ func baseDeploymentConfig(numInstances int) DeploymentConfig {
 			KVCacheConfig:       sim.NewKVCacheConfig(2000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(64, 65536, 0),
 			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 50, 25}),
-			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "", 0, ""),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "", 0, "", 0),
 		},
 		NumInstances: numInstances,
 		TraceLevel:   "decisions",

--- a/sim/cluster/snapshot_test.go
+++ b/sim/cluster/snapshot_test.go
@@ -15,7 +15,7 @@ func newTestInstance(id InstanceID, totalKVBlocks int64) *InstanceSimulator {
 		KVCacheConfig:       sim.NewKVCacheConfig(totalKVBlocks, 16, 0, 0, 0, 0),
 		BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 	return NewInstanceSimulator(id, cfg)
 }

--- a/sim/config.go
+++ b/sim/config.go
@@ -78,14 +78,18 @@ type ModelHardwareConfig struct {
 	Model       string        // model name (e.g., "meta-llama/llama-3.1-8b-instruct")
 	GPU         string        // GPU type (e.g., "H100")
 	TP          int           // tensor parallelism degree
-	Backend     string        // latency model backend: "" or "blackbox" (default), "roofline", "crossmodel"
+	Backend     string        // latency model backend: "" or "blackbox" (default), "roofline", "crossmodel", "trained-roofline"
+	MaxModelLen int64         // max total sequence length (input + output); 0 = unlimited (mirrors vLLM --max-model-len)
 }
 
 // NewModelHardwareConfig creates a ModelHardwareConfig with all fields explicitly set.
 // This is the canonical constructor — all construction sites must use it (R4).
 // Parameter order matches struct field order.
 func NewModelHardwareConfig(modelConfig ModelConfig, hwConfig HardwareCalib,
-	model, gpu string, tp int, backend string) ModelHardwareConfig {
+	model, gpu string, tp int, backend string, maxModelLen int64) ModelHardwareConfig {
+	if maxModelLen < 0 {
+		panic(fmt.Sprintf("NewModelHardwareConfig: MaxModelLen must be >= 0, got %d", maxModelLen))
+	}
 	return ModelHardwareConfig{
 		ModelConfig: modelConfig,
 		HWConfig:    hwConfig,
@@ -93,6 +97,7 @@ func NewModelHardwareConfig(modelConfig ModelConfig, hwConfig HardwareCalib,
 		GPU:         gpu,
 		TP:          tp,
 		Backend:     backend,
+		MaxModelLen: maxModelLen,
 	}
 }
 

--- a/sim/config_test.go
+++ b/sim/config_test.go
@@ -42,7 +42,7 @@ func TestNewLatencyCoeffs_FieldEquivalence(t *testing.T) {
 func TestNewModelHardwareConfig_FieldEquivalence(t *testing.T) {
 	mc := ModelConfig{NumLayers: 32}
 	hw := HardwareCalib{TFlopsPeak: 1000.0, MemoryGiB: 80.0}
-	got := NewModelHardwareConfig(mc, hw, "llama", "H100", 2, "roofline")
+	got := NewModelHardwareConfig(mc, hw, "llama", "H100", 2, "roofline", 8192)
 	want := ModelHardwareConfig{
 		ModelConfig: mc,
 		HWConfig:    hw,
@@ -50,6 +50,7 @@ func TestNewModelHardwareConfig_FieldEquivalence(t *testing.T) {
 		GPU:         "H100",
 		TP:          2,
 		Backend:     "roofline",
+		MaxModelLen: 8192,
 	}
 	assert.Equal(t, want, got)
 }

--- a/sim/internal/testutil/golden.go
+++ b/sim/internal/testutil/golden.go
@@ -38,7 +38,7 @@ type GoldenTestCase struct {
 	Seed                      int64         `json:"seed"`
 	MaxNumRunningReqs         int64         `json:"max-num-running-reqs"`
 	MaxNumScheduledTokens     int64         `json:"max-num-scheduled-tokens"`
-	MaxModelLen               int           `json:"max-model-len"`
+	MaxModelLen               int64         `json:"max-model-len"`
 	TotalKVBlocks             int64         `json:"total-kv-blocks"`
 	BlockSizeInTokens         int64         `json:"block-size-in-tokens"`
 	LongPrefillTokenThreshold int64         `json:"long-prefill-token-threshold"`

--- a/sim/latency/config.go
+++ b/sim/latency/config.go
@@ -179,21 +179,55 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	// Intermediate dim: Falcon/GLM use "ffn_hidden_size" instead of "intermediate_size".
 	intermediateDim := getIntWithFallbacks("intermediate_size", "ffn_hidden_size")
 
-	// MoE fields: 0 = dense model (zero-value safe)
+	// MoE expert count: extended resolution chain (design D4).
+	// Threshold is > 1: single-expert models (num_local_experts=1) are dense-equivalent.
+	// This matches ExtractKVCapacityParams semantics (R23 code path parity).
 	numLocalExperts := getInt("num_local_experts")
+	if numLocalExperts <= 1 {
+		for _, key := range []string{"num_routed_experts", "n_routed_experts", "num_experts"} {
+			if v := getInt(key); v > 1 {
+				numLocalExperts = v
+				break
+			}
+		}
+	}
 	numExpertsPerTok := getInt("num_experts_per_tok")
 
+	// MoE per-expert FFN dimension (design Section 4.2)
+	// When present and nonzero, takes precedence over general intermediate dim.
+	moeExpertFFNDim := getInt("moe_intermediate_size")
+
+	// Shared expert FFN dimension resolution (design D3, D5)
+	// Priority: explicit shared_expert_intermediate_size > n_shared_experts × per-expert dim
+	var sharedExpertFFNDim int
+	if v := getInt("shared_expert_intermediate_size"); v > 0 {
+		sharedExpertFFNDim = v
+	} else if nShared := getInt("n_shared_experts"); nShared > 0 {
+		// Compute total shared dim from count × per-expert dim
+		perExpert := moeExpertFFNDim
+		if perExpert == 0 {
+			perExpert = intermediateDim // Mixtral convention
+		}
+		sharedExpertFFNDim = nShared * perExpert
+	}
+
+	// Activation function: used by KV capacity for SwiGLU detection (3-matrix weight estimation).
+	// Roofline step time currently uses 2-matrix for all activations (see mlpMatrixCount).
+	hiddenAct := hf.MustGetString("hidden_act", "")
+
 	modelConfig := &sim.ModelConfig{
-		// From HFConfig.Raw
-		NumLayers:        getInt("num_hidden_layers"),
-		HiddenDim:        getInt("hidden_size"),
-		VocabSize:        getInt("vocab_size"),
-		IntermediateDim:  intermediateDim,
-		NumHeads:         numHeads,
-		NumKVHeads:       numKVHeads,
-		BytesPerParam:    float64(bytesPerParam),
-		NumLocalExperts:  numLocalExperts,
-		NumExpertsPerTok: numExpertsPerTok,
+		NumLayers:          getInt("num_hidden_layers"),
+		HiddenDim:          getInt("hidden_size"),
+		VocabSize:          getInt("vocab_size"),
+		IntermediateDim:    intermediateDim,
+		NumHeads:           numHeads,
+		NumKVHeads:         numKVHeads,
+		BytesPerParam:      float64(bytesPerParam),
+		NumLocalExperts:    numLocalExperts,
+		NumExpertsPerTok:   numExpertsPerTok,
+		MoEExpertFFNDim:    moeExpertFFNDim,
+		SharedExpertFFNDim: sharedExpertFFNDim,
+		HiddenAct:          hiddenAct,
 	}
 	return modelConfig, nil
 }
@@ -227,14 +261,40 @@ func ValidateRooflineConfig(mc sim.ModelConfig, hc sim.HardwareCalib) error {
 	if invalidPositiveFloat(hc.BwPeakTBs) {
 		problems = append(problems, fmt.Sprintf("HardwareCalib.BwPeakTBs must be a valid positive number, got %v", hc.BwPeakTBs))
 	}
-	if invalidPositiveFloat(hc.BwEffConstant) {
-		problems = append(problems, fmt.Sprintf("HardwareCalib.BwEffConstant must be a valid positive number, got %v", hc.BwEffConstant))
-	}
 	if invalidPositiveFloat(hc.MfuPrefill) {
 		problems = append(problems, fmt.Sprintf("HardwareCalib.MfuPrefill must be a valid positive number, got %v", hc.MfuPrefill))
 	}
 	if invalidPositiveFloat(hc.MfuDecode) {
 		problems = append(problems, fmt.Sprintf("HardwareCalib.MfuDecode must be a valid positive number, got %v", hc.MfuDecode))
+	}
+
+	// MoE consistency checks (design Section 4.6)
+	if mc.NumLocalExperts < 0 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: NumLocalExperts must be >= 0, got %d", mc.NumLocalExperts))
+	}
+	if mc.NumLocalExperts > 1 && mc.NumExpertsPerTok <= 0 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: NumLocalExperts=%d but active experts per token (NumExpertsPerTok) must be > 0",
+			mc.NumLocalExperts))
+	}
+	if mc.NumExpertsPerTok > mc.NumLocalExperts && mc.NumLocalExperts > 1 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: NumExpertsPerTok (%d) cannot exceed NumLocalExperts (%d)",
+			mc.NumExpertsPerTok, mc.NumLocalExperts))
+	}
+	if mc.NumLocalExperts == 0 && mc.NumExpertsPerTok > 0 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: NumExpertsPerTok=%d but NumLocalExperts=0 (inconsistent)",
+			mc.NumExpertsPerTok))
+	}
+	if mc.MoEExpertFFNDim < 0 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: MoEExpertFFNDim must be >= 0, got %d", mc.MoEExpertFFNDim))
+	}
+	if mc.SharedExpertFFNDim < 0 {
+		problems = append(problems, fmt.Sprintf(
+			"MoE: SharedExpertFFNDim must be >= 0, got %d", mc.SharedExpertFFNDim))
 	}
 
 	// MemoryGiB is optional (0 = no auto-calculation).

--- a/sim/latency/config_test.go
+++ b/sim/latency/config_test.go
@@ -332,7 +332,7 @@ func TestGetModelConfig_StandardFieldsTakePrecedenceOverFallbacks(t *testing.T) 
 }
 
 func TestValidateRooflineConfig_ZeroModelFields_ReturnsError(t *testing.T) {
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
 
 	tests := []struct {
 		name  string
@@ -374,7 +374,7 @@ func TestValidateRooflineConfig_ZeroHardwareFields_ReturnsAllErrors(t *testing.T
 		t.Fatal("expected error for zero hardware fields, got nil")
 	}
 	errMsg := err.Error()
-	for _, field := range []string{"TFlopsPeak", "BwPeakTBs", "BwEffConstant", "MfuPrefill", "MfuDecode"} {
+	for _, field := range []string{"TFlopsPeak", "BwPeakTBs", "MfuPrefill", "MfuDecode"} {
 		if !strings.Contains(errMsg, field) {
 			t.Errorf("error should mention %s, got: %v", field, errMsg)
 		}
@@ -385,12 +385,11 @@ func TestValidateRooflineConfig_NaNInfFields_ReturnsErrors(t *testing.T) {
 	// GIVEN a HardwareCalib with NaN and Inf fields (bypass <= 0 check)
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096}
 	hc := sim.HardwareCalib{
-		TFlopsPeak:    math.NaN(),
-		BwPeakTBs:     math.Inf(1),
-		BwEffConstant: 0.7,
-		MfuPrefill:    0.5,
-		MfuDecode:     math.NaN(),
-		MemoryGiB:     math.Inf(-1),
+		TFlopsPeak: math.NaN(),
+		BwPeakTBs:  math.Inf(1),
+		MfuPrefill: 0.5,
+		MfuDecode:  math.NaN(),
+		MemoryGiB:  math.Inf(-1),
 	}
 
 	// WHEN ValidateRooflineConfig is called
@@ -412,7 +411,7 @@ func TestValidateRooflineConfig_NaNMemoryGiB_ReturnsError(t *testing.T) {
 	// NaN != 0 is true in IEEE 754, so NaN passes the outer guard and must
 	// be caught by the inner math.IsNaN check. This test covers that path.
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: math.NaN()}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: math.NaN()}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 
@@ -428,7 +427,7 @@ func TestValidateRooflineConfig_NegativeMemoryGiB_ReturnsError(t *testing.T) {
 	// A plain negative value (not -Inf) exercises the hc.MemoryGiB < 0 branch,
 	// which is distinct from the math.IsInf path tested by NaNInfFields.
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: -80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: -80.0}
 
 	err := latency.ValidateRooflineConfig(mc, hc)
 
@@ -443,7 +442,7 @@ func TestValidateRooflineConfig_NegativeMemoryGiB_ReturnsError(t *testing.T) {
 func TestValidateRooflineConfig_ValidConfig_ReturnsNil(t *testing.T) {
 	// GIVEN valid ModelConfig and HardwareCalib
 	mc := sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2}
-	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0}
 
 	// WHEN ValidateRooflineConfig is called
 	err := latency.ValidateRooflineConfig(mc, hc)
@@ -459,8 +458,8 @@ func TestNewLatencyModel_RooflineZeroNumHeads_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs(nil, []float64{100, 1, 100})
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 0, NumLayers: 32, HiddenDim: 4096},
-		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
-		"", "", 1, "roofline",
+		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
+		"", "", 1, "roofline", 0,
 	)
 
 	// WHEN NewLatencyModel is called (roofline validation happens here)
@@ -480,8 +479,8 @@ func TestNewLatencyModel_RooflineZeroTP_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs(nil, []float64{100, 1, 100})
 	hw := sim.NewModelHardwareConfig(
 		sim.ModelConfig{NumHeads: 32, NumLayers: 32, HiddenDim: 4096},
-		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, BwEffConstant: 0.7, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
-		"", "", 0, "roofline",
+		sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3, MemoryGiB: 80.0},
+		"", "", 0, "roofline", 0,
 	)
 
 	// WHEN NewLatencyModel is called (roofline validation happens here)
@@ -537,5 +536,206 @@ func TestGetHWConfig_MemoryGiB_ParsedFromRealConfig(t *testing.T) {
 				t.Errorf("expected MemoryGiB=80.0 for %q, got %v", tt.gpu, cfg.MemoryGiB)
 			}
 		})
+	}
+}
+
+// --- MoE config parsing tests (BC-15 through BC-18) ---
+
+func TestGetModelConfig_DeepSeekV3Style_ParsesMoEFields(t *testing.T) {
+	// BC-15, BC-17, BC-18: DeepSeek-V3-style config with explicit per-expert dim,
+	// shared experts, and num_routed_experts field name.
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.json")
+	content := `{
+		"num_hidden_layers": 61,
+		"hidden_size": 7168,
+		"num_attention_heads": 128,
+		"num_key_value_heads": 128,
+		"vocab_size": 129280,
+		"intermediate_size": 18432,
+		"moe_intermediate_size": 2048,
+		"n_shared_experts": 1,
+		"num_routed_experts": 256,
+		"num_experts_per_tok": 8,
+		"torch_dtype": "bfloat16"
+	}`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg, err := latency.GetModelConfig(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// BC-18: num_routed_experts resolved to NumLocalExperts
+	if cfg.NumLocalExperts != 256 {
+		t.Errorf("expected NumLocalExperts=256 from num_routed_experts, got %d", cfg.NumLocalExperts)
+	}
+	// BC-15: moe_intermediate_size → MoEExpertFFNDim
+	if cfg.MoEExpertFFNDim != 2048 {
+		t.Errorf("expected MoEExpertFFNDim=2048, got %d", cfg.MoEExpertFFNDim)
+	}
+	// BC-17: SharedExpertFFNDim = n_shared_experts (1) × per-expert dim (2048) = 2048
+	if cfg.SharedExpertFFNDim != 2048 {
+		t.Errorf("expected SharedExpertFFNDim=2048 (1 shared × 2048 per-expert), got %d", cfg.SharedExpertFFNDim)
+	}
+	if cfg.NumExpertsPerTok != 8 {
+		t.Errorf("expected NumExpertsPerTok=8, got %d", cfg.NumExpertsPerTok)
+	}
+}
+
+func TestGetModelConfig_MixtralStyle_NoPerExpertDim(t *testing.T) {
+	// BC-16: Mixtral-style config — no moe_intermediate_size field.
+	// MoEExpertFFNDim should remain 0 (fallback handled at calculation time).
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.json")
+	content := `{
+		"num_hidden_layers": 32,
+		"hidden_size": 4096,
+		"num_attention_heads": 32,
+		"num_key_value_heads": 8,
+		"vocab_size": 32000,
+		"intermediate_size": 14336,
+		"torch_dtype": "bfloat16",
+		"num_local_experts": 8,
+		"num_experts_per_tok": 2
+	}`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg, err := latency.GetModelConfig(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.MoEExpertFFNDim != 0 {
+		t.Errorf("expected MoEExpertFFNDim=0 for Mixtral (no moe_intermediate_size), got %d", cfg.MoEExpertFFNDim)
+	}
+	if cfg.SharedExpertFFNDim != 0 {
+		t.Errorf("expected SharedExpertFFNDim=0 for Mixtral (no shared experts), got %d", cfg.SharedExpertFFNDim)
+	}
+}
+
+func TestGetModelConfig_Qwen2MoEStyle_SharedExpertDimExplicit(t *testing.T) {
+	// BC-17 variant: Qwen2-MoE has shared_expert_intermediate_size explicitly
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.json")
+	content := `{
+		"num_hidden_layers": 24,
+		"hidden_size": 2048,
+		"num_attention_heads": 16,
+		"num_key_value_heads": 16,
+		"vocab_size": 151936,
+		"intermediate_size": 5632,
+		"moe_intermediate_size": 2560,
+		"shared_expert_intermediate_size": 5632,
+		"torch_dtype": "bfloat16",
+		"num_local_experts": 60,
+		"num_experts_per_tok": 4
+	}`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg, err := latency.GetModelConfig(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.MoEExpertFFNDim != 2560 {
+		t.Errorf("expected MoEExpertFFNDim=2560, got %d", cfg.MoEExpertFFNDim)
+	}
+	// Explicit shared_expert_intermediate_size takes precedence
+	if cfg.SharedExpertFFNDim != 5632 {
+		t.Errorf("expected SharedExpertFFNDim=5632 (explicit field), got %d", cfg.SharedExpertFFNDim)
+	}
+}
+
+// --- MoE validation tests (BC-12, BC-13, BC-14) ---
+
+func TestValidateRooflineConfig_MoE_ExpertsWithoutActive_ReturnsError(t *testing.T) {
+	// BC-12: experts > 0, active = 0
+	mc := sim.ModelConfig{
+		NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+		NumLocalExperts: 8, NumExpertsPerTok: 0,
+	}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
+
+	err := latency.ValidateRooflineConfig(mc, hc)
+	if err == nil {
+		t.Fatal("expected error for experts > 0 with active = 0")
+	}
+	if !strings.Contains(err.Error(), "active") {
+		t.Errorf("expected error mentioning 'active', got: %v", err)
+	}
+}
+
+func TestValidateRooflineConfig_MoE_ActiveExceedsTotal_ReturnsError(t *testing.T) {
+	// BC-13: active > total
+	mc := sim.ModelConfig{
+		NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+		NumLocalExperts: 8, NumExpertsPerTok: 10,
+	}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
+
+	err := latency.ValidateRooflineConfig(mc, hc)
+	if err == nil {
+		t.Fatal("expected error for active > total experts")
+	}
+}
+
+func TestValidateRooflineConfig_MoE_NegativeDimensions_ReturnsError(t *testing.T) {
+	// BC-14: negative MoE dimensions
+	tests := []struct {
+		name string
+		mc   sim.ModelConfig
+	}{
+		{
+			"negative MoEExpertFFNDim",
+			sim.ModelConfig{
+				NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+				NumLocalExperts: 8, NumExpertsPerTok: 2, MoEExpertFFNDim: -1,
+			},
+		},
+		{
+			"negative SharedExpertFFNDim",
+			sim.ModelConfig{
+				NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+				NumLocalExperts: 8, NumExpertsPerTok: 2, SharedExpertFFNDim: -1,
+			},
+		},
+		{
+			"negative NumLocalExperts",
+			sim.ModelConfig{
+				NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+				NumLocalExperts: -1,
+			},
+		},
+	}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := latency.ValidateRooflineConfig(tt.mc, hc)
+			if err == nil {
+				t.Fatal("expected error for negative MoE dimension")
+			}
+		})
+	}
+}
+
+func TestValidateRooflineConfig_MoE_ValidConfig_ReturnsNil(t *testing.T) {
+	mc := sim.ModelConfig{
+		NumHeads: 32, NumLayers: 32, HiddenDim: 4096, BytesPerParam: 2,
+		IntermediateDim: 14336,
+		NumLocalExperts: 8, NumExpertsPerTok: 2,
+	}
+	hc := sim.HardwareCalib{TFlopsPeak: 1000, BwPeakTBs: 3.35, MfuPrefill: 0.5, MfuDecode: 0.3}
+
+	err := latency.ValidateRooflineConfig(mc, hc)
+	if err != nil {
+		t.Errorf("expected nil error for valid MoE config, got: %v", err)
 	}
 }

--- a/sim/latency/crossmodel.go
+++ b/sim/latency/crossmodel.go
@@ -66,3 +66,5 @@ func (m *CrossModelLatencyModel) QueueingTime(req *sim.Request) int64 {
 func (m *CrossModelLatencyModel) OutputTokenProcessingTime() int64 {
 	return int64(m.alphaCoeffs[2])
 }
+
+func (m *CrossModelLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }

--- a/sim/latency/crossmodel_test.go
+++ b/sim/latency/crossmodel_test.go
@@ -160,7 +160,7 @@ func TestNewLatencyModel_CrossModelMode(t *testing.T) {
 		[]float64{116.110, 1226.868, 19.943, 9445.157},
 		[]float64{13732.0, 0.0, 860.6},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	assert.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestNewLatencyModel_CrossModelMode_MoE(t *testing.T) {
 		[]float64{116.110, 1226.868, 19.943, 9445.157},
 		[]float64{13732.0, 0.0, 860.6},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	assert.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestNewLatencyModel_CrossModelMode_MissingNumLayers(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NumLayers")
@@ -219,7 +219,7 @@ func TestNewLatencyModel_CrossModelMode_MissingNumHeads(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NumHeads")
@@ -232,7 +232,7 @@ func TestNewLatencyModel_CrossModelMode_MissingHiddenDim(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HiddenDim")
@@ -245,7 +245,7 @@ func TestNewLatencyModel_CrossModelMode_ZeroTP(t *testing.T) {
 		[]float64{116, 1226, 19, 9445},
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 0, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 0, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "TP")
@@ -258,7 +258,7 @@ func TestNewLatencyModel_CrossModelMode_ShortBeta(t *testing.T) {
 		[]float64{116, 1226, 19}, // only 3, need 4
 		[]float64{13732, 0, 860},
 	)
-	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel")
+	hw := sim.NewModelHardwareConfig(mc, sim.HardwareCalib{}, "", "", 2, "crossmodel", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "4")

--- a/sim/latency/kv_capacity.go
+++ b/sim/latency/kv_capacity.go
@@ -10,22 +10,26 @@ import (
 // KVCapacityParams holds model-architecture parameters that are not part of
 // sim.ModelConfig but are needed for KV block capacity estimation.
 // These come from the HuggingFace config.json (hidden_act, MoE indicators,
-// tie_word_embeddings).
+// tie_word_embeddings, per-expert and shared-expert FFN dims).
 type KVCapacityParams struct {
-	IsMoE             bool
-	NumLocalExperts   int
-	TieWordEmbeddings bool
-	HiddenAct         string
+	IsMoE              bool
+	NumLocalExperts    int
+	TieWordEmbeddings  bool
+	HiddenAct          string
+	MoEExpertFFNDim    int // Per-routed-expert FFN dim; 0 = use IntermediateDim
+	SharedExpertFFNDim int // Total shared-expert FFN dim; 0 = no shared experts
 }
 
 // NewKVCapacityParams creates a KVCapacityParams. Positional arguments ensure
 // that adding a field causes a compiler error at every construction site (R4).
-func NewKVCapacityParams(isMoE bool, numLocalExperts int, tieWordEmbeddings bool, hiddenAct string) KVCapacityParams {
+func NewKVCapacityParams(isMoE bool, numLocalExperts int, tieWordEmbeddings bool, hiddenAct string, moeExpertFFNDim int, sharedExpertFFNDim int) KVCapacityParams {
 	return KVCapacityParams{
-		IsMoE:             isMoE,
-		NumLocalExperts:   numLocalExperts,
-		TieWordEmbeddings: tieWordEmbeddings,
-		HiddenAct:         hiddenAct,
+		IsMoE:              isMoE,
+		NumLocalExperts:    numLocalExperts,
+		TieWordEmbeddings:  tieWordEmbeddings,
+		HiddenAct:          hiddenAct,
+		MoEExpertFFNDim:    moeExpertFFNDim,
+		SharedExpertFFNDim: sharedExpertFFNDim,
 	}
 }
 
@@ -212,17 +216,27 @@ func computeModelWeightBytes(mc sim.ModelConfig, params KVCapacityParams) int64 
 	// O: hidden_dim * hidden_dim
 	attentionPerLayer := hiddenDim*(hiddenDim+2*kvDim) + hiddenDim*hiddenDim
 
-	// MLP per layer: SwiGLU uses 3 matrices (gate, up, down)
-	// gate: hidden_dim * intermediate_dim
-	// up:   hidden_dim * intermediate_dim
-	// down: intermediate_dim * hidden_dim
-	mlpPerLayer := 3 * hiddenDim * intermediateDim
-
-	// MoE: multiply MLP by number of local experts, add router weights.
-	if params.IsMoE && params.NumLocalExperts > 0 {
-		mlpPerLayer *= int64(params.NumLocalExperts)
+	// MLP per layer: SwiGLU uses 3 matrices (gate, up, down) to match capacity_planner.py.
+	// NOTE: roofline step time (mlpMatrixCount in roofline.go) uses 2-matrix convention for
+	// FLOPs/bandwidth — see that function's comment for the calibration rationale.
+	var mlpPerLayer int64
+	if params.IsMoE && params.NumLocalExperts > 1 {
+		// MoE: use per-expert FFN dim for routed experts, add shared and gate
+		expertFFNDim := intermediateDim // Mixtral convention: IntermediateDim IS per-expert
+		if params.MoEExpertFFNDim > 0 {
+			expertFFNDim = int64(params.MoEExpertFFNDim)
+		}
+		// All routed experts (total model weight, not active)
+		mlpPerLayer = 3 * hiddenDim * expertFFNDim * int64(params.NumLocalExperts)
+		// Shared experts
+		if params.SharedExpertFFNDim > 0 {
+			mlpPerLayer += 3 * hiddenDim * int64(params.SharedExpertFFNDim)
+		}
 		// Router weights: num_local_experts * hidden_dim per layer
 		mlpPerLayer += int64(params.NumLocalExperts) * hiddenDim
+	} else {
+		// Dense: gate + up + down
+		mlpPerLayer = 3 * hiddenDim * intermediateDim
 	}
 
 	// Layer norms: 2 per layer (pre-attention + pre-MLP), each = hidden_dim params
@@ -260,8 +274,8 @@ func ExtractKVCapacityParamsFromFile(hfConfigPath string) (KVCapacityParams, err
 
 // ExtractKVCapacityParams extracts KVCapacityParams from a parsed HFConfig.
 // MoE detection: checks num_local_experts > 1, then falls back to
-// n_routed_experts, num_experts. Returns an error if MoE is detected
-// via activation-count fields (n_shared_experts, num_experts_per_tok)
+// num_routed_experts, n_routed_experts, num_experts. Returns an error if MoE
+// is detected via activation-count fields (n_shared_experts, num_experts_per_tok)
 // without a total expert count — weight estimation requires the count.
 func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 	hiddenAct := hf.MustGetString("hidden_act", "")
@@ -271,20 +285,35 @@ func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 	}
 
 	// MoE detection: check multiple field names used by different architectures.
+	// Extended resolution chain (design D4): parity with GetModelConfigFromHF.
+	// Threshold is > 1: single-expert models (num_local_experts=1) are dense-equivalent
+	// and should not enter the MoE weight estimation path.
 	numLocalExperts := hf.MustGetInt("num_local_experts", 0)
-	if numLocalExperts > 1 {
-		return NewKVCapacityParams(true, numLocalExperts, tieWordEmbeddings, hiddenAct), nil
-	}
-
-	// Fallback MoE indicators: fields that represent total expert count can
-	// be used directly as NumLocalExperts. Fields like num_experts_per_tok
-	// represent activation count (e.g., 2 for Mixtral) and only signal MoE
-	// presence — they must NOT be used as the expert multiplier for weights.
-	for _, key := range []string{"n_routed_experts", "num_experts"} {
-		if v := hf.MustGetInt(key, 0); v > 1 {
-			return NewKVCapacityParams(true, v, tieWordEmbeddings, hiddenAct), nil
+	if numLocalExperts <= 1 {
+		for _, key := range []string{"num_routed_experts", "n_routed_experts", "num_experts"} {
+			if v := hf.MustGetInt(key, 0); v > 1 {
+				numLocalExperts = v
+				break
+			}
 		}
 	}
+
+	if numLocalExperts > 1 {
+		// Extract per-expert and shared expert dims for weight estimation
+		moeExpertFFNDim := hf.MustGetInt("moe_intermediate_size", 0)
+		var sharedExpertFFNDim int
+		if v := hf.MustGetInt("shared_expert_intermediate_size", 0); v > 0 {
+			sharedExpertFFNDim = v
+		} else if nShared := hf.MustGetInt("n_shared_experts", 0); nShared > 0 {
+			perExpert := moeExpertFFNDim
+			if perExpert == 0 {
+				perExpert = hf.MustGetInt("intermediate_size", 0)
+			}
+			sharedExpertFFNDim = nShared * perExpert
+		}
+		return NewKVCapacityParams(true, numLocalExperts, tieWordEmbeddings, hiddenAct, moeExpertFFNDim, sharedExpertFFNDim), nil
+	}
+
 	// Activation-count or shared-expert fields: signal MoE but don't provide
 	// a reliable total expert count. Without the total count, weight estimation
 	// would use dense MLP weights — massively underestimating MoE model size.
@@ -297,5 +326,5 @@ func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 		}
 	}
 
-	return NewKVCapacityParams(false, 0, tieWordEmbeddings, hiddenAct), nil
+	return NewKVCapacityParams(false, 0, tieWordEmbeddings, hiddenAct, 0, 0), nil
 }

--- a/sim/latency/kv_capacity_test.go
+++ b/sim/latency/kv_capacity_test.go
@@ -30,19 +30,18 @@ func validDenseModelConfig() sim.ModelConfig {
 // validHWConfig returns an H100-like HardwareCalib with 80 GiB memory.
 func validHWConfig() sim.HardwareCalib {
 	return sim.HardwareCalib{
-		TFlopsPeak:    989.5,
-		BwPeakTBs:     3.35,
-		BwEffConstant: 0.72,
-		MfuPrefill:    0.65,
-		MfuDecode:     0.12,
-		MemoryGiB:     80.0,
+		TFlopsPeak: 989.5,
+		BwPeakTBs:  3.35,
+		MfuPrefill: 0.65,
+		MfuDecode:  0.12,
+		MemoryGiB:  80.0,
 	}
 }
 
 // validDenseKVParams returns KVCapacityParams for a dense (non-MoE) model
 // with SwiGLU activation.
 func validDenseKVParams() latency.KVCapacityParams {
-	return latency.NewKVCapacityParams(false, 0, false, "silu")
+	return latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
 }
 
 // --- Input validation tests ---
@@ -326,7 +325,7 @@ func h100HWConfig() sim.HardwareCalib         { return validHWConfig() }
 func TestCalculateKVBlocks_Llama31_8B_H100_TP2_WithinTolerance(t *testing.T) {
 	mc := llama31_8B_ModelConfig()
 	hc := h100HWConfig()
-	params := latency.NewKVCapacityParams(false, 0, false, "silu")
+	params := latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
 
 	// Empirical baseline from defaults.yaml: Llama-3.1-8B / H100 / TP=2 = 132,139 blocks
 	const empirical int64 = 132139
@@ -350,7 +349,7 @@ func TestCalculateKVBlocks_Llama31_8B_H100_TP2_WithinTolerance(t *testing.T) {
 func TestCalculateKVBlocks_Llama31_8B_H100_TP4_WithinTolerance(t *testing.T) {
 	mc := llama31_8B_ModelConfig()
 	hc := h100HWConfig()
-	params := latency.NewKVCapacityParams(false, 0, false, "silu")
+	params := latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
 
 	// Empirical baseline from defaults.yaml: Llama-3.1-8B / H100 / TP=4 = 559,190 blocks
 	const empirical int64 = 559190
@@ -460,7 +459,7 @@ func TestCalculateKVBlocks_Mixtral_8x7B_H100_TP2_WithinTolerance(t *testing.T) {
 		IntermediateDim: 14336,
 	}
 	hc := h100HWConfig()
-	params := latency.NewKVCapacityParams(true, 8, false, "silu")
+	params := latency.NewKVCapacityParams(true, 8, false, "silu", 0, 0)
 
 	// Empirical baseline from defaults.yaml: Mixtral-8x7B / H100 / TP=2 = 58,377 blocks
 	const empirical int64 = 58377
@@ -493,8 +492,8 @@ func TestCalculateKVBlocks_MoE_UsesHigherActivationConstant(t *testing.T) {
 	}
 	hc := h100HWConfig()
 
-	denseParams := latency.NewKVCapacityParams(false, 0, false, "silu")
-	moeParams := latency.NewKVCapacityParams(true, 8, false, "silu")
+	denseParams := latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
+	moeParams := latency.NewKVCapacityParams(true, 8, false, "silu", 0, 0)
 
 	denseBlocks, err := latency.CalculateKVBlocks(mc, hc, 2, 16, denseParams)
 	if err != nil {
@@ -521,8 +520,8 @@ func TestCalculateKVBlocks_TiedEmbeddings_ProducesMoreBlocks(t *testing.T) {
 	mc := validDenseModelConfig()
 	hc := validHWConfig()
 
-	untiedParams := latency.NewKVCapacityParams(false, 0, false, "silu")
-	tiedParams := latency.NewKVCapacityParams(false, 0, true, "silu")
+	untiedParams := latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
+	tiedParams := latency.NewKVCapacityParams(false, 0, true, "silu", 0, 0)
 
 	untiedBlocks, err := latency.CalculateKVBlocks(mc, hc, 2, 16, untiedParams)
 	if err != nil {
@@ -776,5 +775,161 @@ func TestExtractKVCapacityParams_TiedEmbeddings(t *testing.T) {
 
 	if !params.TieWordEmbeddings {
 		t.Error("expected TieWordEmbeddings=true")
+	}
+}
+
+// --- Task 6: MoE per-expert dim fix tests ---
+
+func TestCalculateKVBlocks_DeepSeekV3_PerExpertDimFix(t *testing.T) {
+	// BC-7 (MOD-ROOF-6): per-expert dim (2048) vs general dim (18432) for DeepSeek-V3.
+	// DeepSeek-V3 is a 671B model — requires FP8 (1 byte/param) and high TP in practice.
+	// Without the fix, using 18432 as per-expert dim overestimates MLP weights by ~9×.
+	mc := sim.ModelConfig{
+		NumLayers:          61,
+		HiddenDim:          7168,
+		NumHeads:           128,
+		NumKVHeads:         128,
+		VocabSize:          129280,
+		BytesPerParam:      1, // FP8 quantization (real-world deployment)
+		IntermediateDim:    18432,
+		NumLocalExperts:    256,
+		NumExpertsPerTok:   8,
+		MoEExpertFFNDim:    2048,
+		SharedExpertFFNDim: 2048,
+	}
+	hc := validHWConfig()
+	hc.MemoryGiB = 80.0
+
+	// With per-expert dim fix: should produce usable blocks on 16×H100
+	// (DeepSeek-V3 at 671B FP8 ≈ 656 GiB — requires TP≥16 on H100-80GB)
+	params := latency.NewKVCapacityParams(true, 256, false, "silu", 2048, 2048)
+	blocks, err := latency.CalculateKVBlocks(mc, hc, 16, 16, params)
+	if err != nil {
+		t.Fatalf("per-expert dim fix should succeed, got error: %v", err)
+	}
+	if blocks <= 0 {
+		t.Errorf("expected positive blocks for DeepSeek-V3 with per-expert dim fix, got %d", blocks)
+	}
+	t.Logf("DeepSeek-V3 H100×16 FP8 with per-expert dim fix: %d blocks", blocks)
+
+	// Without fix (using general intermediate dim as per-expert): should fail or give fewer blocks
+	paramsBuggy := latency.NewKVCapacityParams(true, 256, false, "silu", 0, 0)
+	blocksBuggy, errBuggy := latency.CalculateKVBlocks(mc, hc, 16, 16, paramsBuggy)
+	if errBuggy == nil && blocksBuggy >= blocks {
+		t.Errorf("BC-7: buggy path (using general dim) should give fewer blocks or error: buggy=%d, fixed=%d",
+			blocksBuggy, blocks)
+	}
+	// With the buggy path, 18432 per-expert → 9× MLP weight overestimate → likely budget exceeded
+	if errBuggy != nil {
+		t.Logf("BC-7 confirmed: buggy path (general dim as per-expert) returns error: %v", errBuggy)
+	} else {
+		t.Logf("BC-7 confirmed: buggy path gives fewer blocks: buggy=%d < fixed=%d", blocksBuggy, blocks)
+	}
+}
+
+func TestCalculateKVBlocks_MixtralPublishedParams(t *testing.T) {
+	// BC-9: Mixtral-8x7B published parameter count cross-validation.
+	// Published: 46.7B params. Weight bytes = 46.7B × 2 = ~93.4 GB.
+	mc := sim.ModelConfig{
+		NumLayers:        32,
+		HiddenDim:        4096,
+		NumHeads:         32,
+		NumKVHeads:       8,
+		VocabSize:        32000,
+		BytesPerParam:    2,
+		IntermediateDim:  14336,
+		NumLocalExperts:  8,
+		NumExpertsPerTok: 2,
+	}
+	params := latency.NewKVCapacityParams(true, 8, false, "silu", 0, 0)
+	hc := validHWConfig()
+	hc.MemoryGiB = 80.0
+
+	blocks, err := latency.CalculateKVBlocks(mc, hc, 2, 16, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blocks <= 0 {
+		t.Errorf("expected positive blocks for Mixtral-8x7B, got %d", blocks)
+	}
+	t.Logf("Mixtral-8x7B H100 TP=2 (with MoE params): %d blocks", blocks)
+}
+
+func TestCalculateKVBlocks_Dense_UnchangedWithNewParams(t *testing.T) {
+	// BC-11: dense model unchanged after adding MoE fields to KVCapacityParams
+	mc := validDenseModelConfig()
+	hc := validHWConfig()
+
+	params := latency.NewKVCapacityParams(false, 0, false, "silu", 0, 0)
+	blocks, err := latency.CalculateKVBlocks(mc, hc, 2, 16, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must match the existing Llama-3.1-8B empirical baseline
+	const empirical int64 = 132139
+	const tolerance = 0.10
+	deviation := math.Abs(float64(blocks)-float64(empirical)) / float64(empirical)
+	if deviation > tolerance {
+		t.Errorf("BC-11: dense blocks=%d deviates %.1f%% from empirical %d",
+			blocks, deviation*100, empirical)
+	}
+}
+
+func TestExtractKVCapacityParams_DeepSeekV3_PerExpertDim(t *testing.T) {
+	// BC-18 + KV capacity: num_routed_experts detected, per-expert and shared dims extracted
+	path := writeTempConfigJSON(t, map[string]any{
+		"hidden_act":            "silu",
+		"num_hidden_layers":     61,
+		"hidden_size":           7168,
+		"num_attention_heads":   128,
+		"num_key_value_heads":   128,
+		"intermediate_size":     18432,
+		"moe_intermediate_size": 2048,
+		"n_shared_experts":      1,
+		"num_routed_experts":    256,
+		"num_experts_per_tok":   8,
+		"vocab_size":            129280,
+		"torch_dtype":           "bfloat16",
+	})
+
+	params, err := latency.ExtractKVCapacityParamsFromFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !params.IsMoE {
+		t.Error("expected IsMoE=true for DeepSeek-V3")
+	}
+	if params.NumLocalExperts != 256 {
+		t.Errorf("expected NumLocalExperts=256, got %d", params.NumLocalExperts)
+	}
+	if params.MoEExpertFFNDim != 2048 {
+		t.Errorf("expected MoEExpertFFNDim=2048, got %d", params.MoEExpertFFNDim)
+	}
+	if params.SharedExpertFFNDim != 2048 {
+		t.Errorf("expected SharedExpertFFNDim=2048 (1 shared × 2048 per-expert), got %d", params.SharedExpertFFNDim)
+	}
+}
+
+func TestExtractKVCapacityParams_Qwen2MoE_ExplicitSharedDim(t *testing.T) {
+	// shared_expert_intermediate_size takes precedence over n_shared_experts × per-expert
+	path := writeTempConfigJSON(t, map[string]any{
+		"hidden_act":                       "silu",
+		"num_local_experts":                60,
+		"moe_intermediate_size":            2560,
+		"shared_expert_intermediate_size":  5632,
+	})
+
+	params, err := latency.ExtractKVCapacityParamsFromFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if params.MoEExpertFFNDim != 2560 {
+		t.Errorf("expected MoEExpertFFNDim=2560, got %d", params.MoEExpertFFNDim)
+	}
+	if params.SharedExpertFFNDim != 5632 {
+		t.Errorf("expected SharedExpertFFNDim=5632 (explicit field), got %d", params.SharedExpertFFNDim)
 	}
 }

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -1,8 +1,9 @@
 // Package latency provides latency model implementations for the BLIS simulator.
 // The LatencyModel interface is defined in sim/ (parent package).
 // This package provides BlackboxLatencyModel (alpha/beta regression),
-// RooflineLatencyModel (analytical FLOPs/bandwidth), and
-// CrossModelLatencyModel (physics-informed cross-model step time).
+// RooflineLatencyModel (analytical FLOPs/bandwidth),
+// CrossModelLatencyModel (physics-informed cross-model step time), and
+// TrainedRooflineLatencyModel (roofline basis functions × learned corrections).
 package latency
 
 import (
@@ -51,6 +52,8 @@ func (m *BlackboxLatencyModel) OutputTokenProcessingTime() int64 {
 	return int64(m.alphaCoeffs[2])
 }
 
+func (m *BlackboxLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }
+
 // RooflineLatencyModel estimates latency using analytical FLOPs/bandwidth roofline model.
 // Step time is computed via rooflineStepTime(); overhead estimates use alpha coefficients.
 type RooflineLatencyModel struct {
@@ -91,6 +94,8 @@ func (m *RooflineLatencyModel) QueueingTime(req *sim.Request) int64 {
 func (m *RooflineLatencyModel) OutputTokenProcessingTime() int64 {
 	return int64(m.alphaCoeffs[2])
 }
+
+func (m *RooflineLatencyModel) PostDecodeFixedOverhead() int64 { return 0 }
 
 // validateCoeffs checks for NaN, Inf, or negative values in a coefficient slice.
 func validateCoeffs(name string, coeffs []float64) error {
@@ -176,6 +181,67 @@ func NewLatencyModel(coeffs sim.LatencyCoeffs, hw sim.ModelHardwareConfig) (sim.
 			kvDimScaled: kvDimScaled,
 			isMoE:       isMoE,
 			isTP:        isTP,
+		}, nil
+	case "trained-roofline":
+		// TrainedRooflineLatencyModel: roofline basis functions × learned corrections.
+		// Requires model architecture (config.json) and hardware specs for basis functions.
+		if hw.TP <= 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires TP > 0, got %d", hw.TP)
+		}
+		if hw.ModelConfig.NumLayers <= 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires NumLayers > 0, got %d", hw.ModelConfig.NumLayers)
+		}
+		if hw.ModelConfig.NumHeads <= 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires NumHeads > 0, got %d", hw.ModelConfig.NumHeads)
+		}
+		if hw.ModelConfig.HiddenDim <= 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires HiddenDim > 0, got %d", hw.ModelConfig.HiddenDim)
+		}
+		if hw.ModelConfig.IntermediateDim <= 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires IntermediateDim > 0, got %d", hw.ModelConfig.IntermediateDim)
+		}
+		if hw.ModelConfig.NumHeads%hw.TP != 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires NumHeads (%d) divisible by TP (%d)", hw.ModelConfig.NumHeads, hw.TP)
+		}
+		numKVHeadsTR := hw.ModelConfig.NumKVHeads
+		if numKVHeadsTR == 0 {
+			numKVHeadsTR = hw.ModelConfig.NumHeads // MHA fallback
+		}
+		if numKVHeadsTR%hw.TP != 0 {
+			return nil, fmt.Errorf("latency model: trained-roofline requires NumKVHeads (%d) divisible by TP (%d)", numKVHeadsTR, hw.TP)
+		}
+		if invalidPositiveFloat(hw.HWConfig.TFlopsPeak) {
+			return nil, fmt.Errorf("latency model: trained-roofline requires valid TFlopsPeak > 0, got %v", hw.HWConfig.TFlopsPeak)
+		}
+		if invalidPositiveFloat(hw.HWConfig.BwPeakTBs) {
+			return nil, fmt.Errorf("latency model: trained-roofline requires valid BwPeakTBs > 0, got %v", hw.HWConfig.BwPeakTBs)
+		}
+		if len(coeffs.BetaCoeffs) < 7 {
+			return nil, fmt.Errorf("latency model: trained-roofline BetaCoeffs requires at least 7 elements, got %d", len(coeffs.BetaCoeffs))
+		}
+		if err := validateCoeffs("BetaCoeffs", coeffs.BetaCoeffs); err != nil {
+			return nil, err
+		}
+		headDimTR := hw.ModelConfig.HiddenDim / hw.ModelConfig.NumHeads
+		// Defensive copy of coefficient slices to enforce the "frozen at construction" contract.
+		// This prevents callers from mutating coefficients after construction.
+		betaCopy := append([]float64(nil), coeffs.BetaCoeffs...)
+		alphaCopy := append([]float64(nil), coeffs.AlphaCoeffs...)
+		return &TrainedRooflineLatencyModel{
+			betaCoeffs:  betaCopy,
+			alphaCoeffs: alphaCopy,
+			numLayers:   hw.ModelConfig.NumLayers,
+			hiddenDim:   hw.ModelConfig.HiddenDim,
+			numHeads:    hw.ModelConfig.NumHeads,
+			headDim:     headDimTR,
+			dKV:         numKVHeadsTR * headDimTR,
+			dFF:         hw.ModelConfig.IntermediateDim,
+			kEff:        max(1, hw.ModelConfig.NumExpertsPerTok), // matches training: k_eff = max(1, k)
+			numExperts:  hw.ModelConfig.NumLocalExperts,
+			isMoE:       hw.ModelConfig.NumLocalExperts > 0,
+			tp:          hw.TP,
+			flopsPeakUs: hw.HWConfig.TFlopsPeak * 1e6,
+			bwHbmUs:     hw.HWConfig.BwPeakTBs * 1e6,
 		}, nil
 	case "", "blackbox":
 		// BlackboxLatencyModel indexes betaCoeffs[0..2]; validate upfront.

--- a/sim/latency/latency_test.go
+++ b/sim/latency/latency_test.go
@@ -227,7 +227,7 @@ func TestRooflineLatencyModel_QueueingTime_Positive(t *testing.T) {
 func TestNewLatencyModel_BlackboxMode(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0),
 	}
 
 	model, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -267,7 +267,7 @@ func TestNewLatencyModel_BlackboxMode(t *testing.T) {
 func TestNewLatencyModel_RooflineMode(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs(nil, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(testModelConfig(), testHardwareCalib(), "", "", 2, "roofline"),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(testModelConfig(), testHardwareCalib(), "", "", 2, "roofline", 0),
 	}
 
 	model, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -294,7 +294,7 @@ func TestNewLatencyModel_RooflineMode(t *testing.T) {
 func TestNewLatencyModel_InvalidRoofline(t *testing.T) {
 	cfg := sim.SimConfig{
 		LatencyCoeffs:       sim.NewLatencyCoeffs(nil, []float64{100, 1, 100}),
-		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "roofline"),
+		ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "roofline", 0),
 	}
 
 	_, err := NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
@@ -319,7 +319,7 @@ func TestNewLatencyModel_ShortAlphaCoeffs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, tc.alpha)
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, tc.backend)
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, tc.backend, 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for short AlphaCoeffs, got nil")
@@ -340,7 +340,7 @@ func TestNewLatencyModel_ShortBetaCoeffs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, []float64{100, 1, 100})
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for short BetaCoeffs, got nil")
@@ -352,7 +352,7 @@ func TestNewLatencyModel_ShortBetaCoeffs(t *testing.T) {
 // TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError verifies BC-4: NaN in alpha rejected.
 func TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{5000, 10, 5}, []float64{math.NaN(), 1.0, 100.0})
-	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""))
+	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0))
 	if err == nil {
 		t.Fatal("expected error for NaN AlphaCoeffs, got nil")
 	}
@@ -361,7 +361,7 @@ func TestNewLatencyModel_NaNAlphaCoeffs_ReturnsError(t *testing.T) {
 // TestNewLatencyModel_InfBetaCoeffs_ReturnsError verifies BC-4: Inf in beta rejected.
 func TestNewLatencyModel_InfBetaCoeffs_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{math.Inf(1), 10, 5}, []float64{100, 1.0, 100.0})
-	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, ""))
+	_, err := NewLatencyModel(coeffs, sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0))
 	if err == nil {
 		t.Fatal("expected error for Inf BetaCoeffs, got nil")
 	}
@@ -370,7 +370,7 @@ func TestNewLatencyModel_InfBetaCoeffs_ReturnsError(t *testing.T) {
 // TestNewLatencyModel_UnknownBackend_ReturnsError verifies BC-6: unknown backend → error.
 func TestNewLatencyModel_UnknownBackend_ReturnsError(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{1000, 10, 2}, []float64{500, 1, 100})
-	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "nonexistent")
+	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "nonexistent", 0)
 	_, err := NewLatencyModel(coeffs, hw)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
@@ -394,7 +394,7 @@ func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			coeffs := sim.NewLatencyCoeffs(tc.beta, tc.alpha)
-			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+			hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 			_, err := NewLatencyModel(coeffs, hw)
 			if err == nil {
 				t.Fatal("expected error for negative coefficient")
@@ -412,7 +412,7 @@ func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
 // THEN the return value is >= 1 (livelock protection via R19)
 func TestBlackboxLatencyModel_StepTime_FloorAtOne(t *testing.T) {
 	coeffs := sim.NewLatencyCoeffs([]float64{0, 0, 0}, []float64{0, 0, 0})
-	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "")
+	hw := sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "", "", 0, "", 0)
 	model, err := NewLatencyModel(coeffs, hw)
 	if err != nil {
 		t.Fatalf("NewLatencyModel: %v", err)

--- a/sim/latency/roofline.go
+++ b/sim/latency/roofline.go
@@ -25,7 +25,26 @@ type StepConfig struct {
 	DecodeRequests  []DecodeRequestConfig  `json:"decode_requests"`
 }
 
+// mlpMatrixCount returns the number of MLP weight matrices for bandwidth/FLOPs estimation.
+// Always returns 2 (up+down) to match llm-optimizer's convention: for SwiGLU models,
+// HF intermediate_size is already scaled so that 2 × d × intermediate ≈ 3 × d × (2/3 × 4d).
+// Using 3 with the raw intermediate_size over-predicts for models like Llama2-70B
+// whose intermediate_size exceeds the standard SwiGLU (2/3 × 4d) convention.
+//
+// NOTE: KV capacity (computeModelWeightBytes in kv_capacity.go) intentionally uses 3-matrix
+// SwiGLU to match the capacity_planner.py reference formula. The difference is deliberate:
+// roofline optimizes for step-time accuracy (calibrated to llm-optimizer), while KV capacity
+// optimizes for conservative weight estimation (over-counting weights is safer than OOM).
+func mlpMatrixCount(hiddenAct string) float64 {
+	_ = hiddenAct // reserved for future per-activation tuning
+	return 2
+}
+
 // --- Bento FLOPS Logic ---
+//
+// Precondition: config must pass ValidateRooflineConfig (NumHeads > 0, and when
+// NumLocalExperts > 1, NumExpertsPerTok must be > 0). Violating preconditions
+// produces silently incorrect results (zero MLP FLOPs, +Inf from division).
 func calculateTransformerFlops(config sim.ModelConfig, sequenceLength int64, newTokens int64, includeAttention, includeMLP bool) map[string]float64 {
 	dModel := float64(config.HiddenDim)
 	nLayers := float64(config.NumLayers)
@@ -74,14 +93,24 @@ func calculateTransformerFlops(config sim.ModelConfig, sequenceLength int64, new
 	}
 
 	if includeMLP {
-		// SwiGLU Gating: Gate, Up, and Down (3 matrices)
-		flops["gemm_ops"] += 2 * newT * (3 * dModel * dFF) * nLayers
+		nMat := mlpMatrixCount(config.HiddenAct)
+		dExpert := dFF
+		if config.NumLocalExperts > 1 && config.MoEExpertFFNDim > 0 {
+			dExpert = float64(config.MoEExpertFFNDim)
+		}
+		mlpFlopsPerLayer := 2 * newT * (nMat * dModel * dExpert)
+		if config.NumLocalExperts > 1 {
+			mlpFlopsPerLayer *= float64(config.NumExpertsPerTok)
+		}
+		flops["gemm_ops"] += mlpFlopsPerLayer * nLayers
 	}
 
 	flops["total"] = flops["gemm_ops"] + flops["sram_ops"]
 	return flops
 }
 
+// Precondition: same as calculateTransformerFlops — config must pass
+// ValidateRooflineConfig. NumHeads > 0 required (division at dHead).
 func calculateMemoryAccessBytes(
 	config sim.ModelConfig,
 	sequenceLength int64,
@@ -109,7 +138,20 @@ func calculateMemoryAccessBytes(
 
 	// Weights: Loaded exactly once. (Static)
 	dKV := nKVHeads * dHead
-	weightsPerLayer := dModel*(dModel+2*dKV) + (dModel * dModel) + (3 * dModel * dFF)
+	attnWeightsPerLayer := dModel*(dModel+2*dKV) + (dModel * dModel)
+
+	nMat := mlpMatrixCount(config.HiddenAct)
+	dExpert := dFF
+	if config.NumLocalExperts > 1 && config.MoEExpertFFNDim > 0 {
+		dExpert = float64(config.MoEExpertFFNDim)
+	}
+	mlpWeightsPerLayer := nMat * dModel * dExpert
+	if config.NumLocalExperts > 1 {
+		// MoE: all E expert weights loaded from HBM per step
+		mlpWeightsPerLayer *= float64(config.NumLocalExperts)
+	}
+
+	weightsPerLayer := attnWeightsPerLayer + mlpWeightsPerLayer
 	mem["model_weights"] = weightsPerLayer * nLayers * config.BytesPerParam
 
 	if includeKVCache {
@@ -146,6 +188,15 @@ func calculateMemoryAccessBytes(
 }
 
 // rooflineStepTime computes step latency using the roofline model.
+//
+// Models a single forward pass per step (matching vLLM chunked prefill):
+// all prefill and decode tokens are processed together, weights loaded once.
+// Uses single-crossover roofline: step_time = max(compute_time, memory_time).
+// No bandwidth haircut, no overhead terms.
+//
+// Compute uses phase-specific MFU: prefill tokens at MfuPrefill, decode at MfuDecode,
+// reflecting that prefill is compute-bound (large GEMMs) while decode is memory-bound.
+//
 // Precondition: ValidateRooflineConfig(modelConfig, hwConfig) must return nil
 // and tp must be > 0. Callers must validate before first call.
 func rooflineStepTime(modelConfig sim.ModelConfig, hwConfig sim.HardwareCalib, stepConfig StepConfig, tp int) int64 {
@@ -153,70 +204,42 @@ func rooflineStepTime(modelConfig sim.ModelConfig, hwConfig sim.HardwareCalib, s
 	tpFactor := float64(tp)
 	peakFlops := hwConfig.TFlopsPeak * 1e12
 	peakBW := hwConfig.BwPeakTBs * 1e12
-	effBW := peakBW * hwConfig.BwEffConstant
-	vectorPeak := peakFlops * 0.10 // Non-tensor core ops
 
-	var prefillComputeS, prefillMemoryS float64
-	var decodeComputeS, decodeMemoryS float64
-
-	// 1. PREFILL PHASE (Calculated as a single batched operation)
-	if len(stepConfig.PrefillRequests) > 0 {
-		var pGemmFlops, pVectorFlops, pDynamicBytes float64
-
-		for _, req := range stepConfig.PrefillRequests {
-			numTokens := int64(req.NumNewPrefillTokens)
-
-			f := calculateTransformerFlops(modelConfig, req.ProgressIndex, numTokens, true, true)
-			pGemmFlops += f["gemm_ops"] / tpFactor
-			pVectorFlops += f["sram_ops"] / tpFactor
-
-			m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, numTokens, true)
-			pDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
-		}
-
-		// Prefill Roofline: Weights + KV Cache are loaded once for the whole chunk
-		baseMem := calculateMemoryAccessBytes(modelConfig, 0, 0, false)
-		pWeightBytes := baseMem["model_weights"] / tpFactor
-
-		prefillComputeS = (pGemmFlops / (peakFlops * hwConfig.MfuPrefill)) + (pVectorFlops / vectorPeak)
-		prefillMemoryS = (pWeightBytes + pDynamicBytes) / effBW
+	if len(stepConfig.PrefillRequests) == 0 && len(stepConfig.DecodeRequests) == 0 {
+		return 0
 	}
 
-	// 2. DECODE PHASE (Calculated as a single batched step)
-	if len(stepConfig.DecodeRequests) > 0 {
-		var dGemmFlops, dVectorFlops, dDynamicBytes float64
+	var totalComputeS float64
+	var totalDynamicBytes float64
 
-		for _, req := range stepConfig.DecodeRequests {
-			f := calculateTransformerFlops(modelConfig, req.ProgressIndex, 1, true, true)
-			dGemmFlops += f["gemm_ops"] / tpFactor
-			dVectorFlops += f["sram_ops"] / tpFactor
+	// 1. PREFILL FLOPs + dynamic memory (KV cache, activations)
+	for _, req := range stepConfig.PrefillRequests {
+		numTokens := int64(req.NumNewPrefillTokens)
 
-			m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, 1, true)
-			dDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
-		}
+		f := calculateTransformerFlops(modelConfig, req.ProgressIndex, numTokens, true, true)
+		totalComputeS += f["total"] / tpFactor / (peakFlops * hwConfig.MfuPrefill)
 
-		// Decode Roofline: Every step must reload the weights
-		baseMem := calculateMemoryAccessBytes(modelConfig, 0, 0, false)
-		dWeightBytes := baseMem["model_weights"] / tpFactor
-
-		decodeComputeS = (dGemmFlops / (peakFlops * hwConfig.MfuDecode)) + (dVectorFlops / vectorPeak)
-		decodeMemoryS = (dWeightBytes + dDynamicBytes) / effBW
+		m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, numTokens, true)
+		totalDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
 	}
 
-	// 3. COMBINE AND ADD OVERHEADS
-	// We take the Max (bottleneck) for each phase independently
-	stepHardwareS := math.Max(prefillComputeS, prefillMemoryS) + math.Max(decodeComputeS, decodeMemoryS)
+	// 2. DECODE FLOPs + dynamic memory (KV cache, activations)
+	for _, req := range stepConfig.DecodeRequests {
+		f := calculateTransformerFlops(modelConfig, req.ProgressIndex, 1, true, true)
+		totalComputeS += f["total"] / tpFactor / (peakFlops * hwConfig.MfuDecode)
 
-	// Parallelism & Launch Overheads
-	layerFloorS := (float64(modelConfig.NumLayers) * hwConfig.PerLayerOverhead) / 1e6
-
-	commOverheadS := 0.0
-	if tp > 1 {
-		// TP synchronization happens per layer
-		commOverheadS = (float64(modelConfig.NumLayers) * 2 * hwConfig.AllReduceLatency) / 1e6
+		m := calculateMemoryAccessBytes(modelConfig, req.ProgressIndex, 1, true)
+		totalDynamicBytes += (m["total"] - m["model_weights"]) / tpFactor
 	}
 
-	totalMicros := (stepHardwareS * 1e6) + (layerFloorS * 1e6) + (commOverheadS * 1e6) + hwConfig.TOverheadMicros
+	// 3. WEIGHTS loaded once per step (single forward pass, per Sarathi-Serve/vLLM V1)
+	baseMem := calculateMemoryAccessBytes(modelConfig, 0, 0, false)
+	weightBytes := baseMem["model_weights"] / tpFactor
+
+	totalMemoryS := (weightBytes + totalDynamicBytes) / peakBW
+
+	// 4. ROOFLINE: single crossover
+	totalMicros := math.Max(totalComputeS, totalMemoryS) * 1e6
 
 	return int64(math.Round(totalMicros))
 }

--- a/sim/latency/roofline_test.go
+++ b/sim/latency/roofline_test.go
@@ -183,15 +183,11 @@ func TestCalculateMemoryAccessBytes_Conservation_TotalEqualsSumOfComponents(t *t
 // testHardwareCalib returns an H100-like hardware config for roofline tests.
 func testHardwareCalib() sim.HardwareCalib {
 	return sim.HardwareCalib{
-		TFlopsPeak:       989.0,
-		BwPeakTBs:        3.35,
-		BwEffConstant:    0.7,
-		TOverheadMicros:  50.0,
-		PerLayerOverhead: 5.0,
-		MfuPrefill:       0.55,
-		MfuDecode:        0.30,
-		AllReduceLatency: 10.0,
-		MemoryGiB:        80.0,
+		TFlopsPeak: 989.0,
+		BwPeakTBs:  3.35,
+		MfuPrefill: 0.55,
+		MfuDecode:  0.30,
+		MemoryGiB:  80.0,
 	}
 }
 
@@ -269,16 +265,337 @@ func TestRooflineStepTime_Smoke_ValidInputsProducePositiveFiniteResult(t *testin
 	}
 }
 
-func TestRooflineStepTime_EmptyStep_ReturnsOverheadOnly(t *testing.T) {
-	// Edge case: no requests should still return overhead (non-zero due to TOverheadMicros)
+func TestRooflineStepTime_EmptyStep_ReturnsZero(t *testing.T) {
+	// No requests = no work = 0 µs (no overhead terms in llm-optimizer model)
 	mc := testModelConfig()
 	hc := testHardwareCalib()
 
 	step := StepConfig{} // empty
 	result := rooflineStepTime(mc, hc, step, 1)
 
-	// Should be approximately TOverheadMicros (50) + layer overhead
-	if result <= 0 {
-		t.Errorf("empty step should still have overhead latency, got %d µs", result)
+	if result != 0 {
+		t.Errorf("empty step should return 0 µs, got %d µs", result)
 	}
+}
+
+// --- MoE test helpers ---
+
+// testMixtralConfig returns a Mixtral-8x7B-like MoE config.
+func testMixtralConfig() sim.ModelConfig {
+	return sim.ModelConfig{
+		NumLayers:        32,
+		HiddenDim:        4096,
+		NumHeads:         32,
+		NumKVHeads:       8,
+		VocabSize:        32000,
+		BytesPerParam:    2,
+		IntermediateDim:  14336,
+		NumLocalExperts:  8,
+		NumExpertsPerTok: 2,
+		// MoEExpertFFNDim=0 → use IntermediateDim (Mixtral convention)
+	}
+}
+
+// testDeepSeekV3Config returns a DeepSeek-V3-like MoE config with shared experts.
+func testDeepSeekV3Config() sim.ModelConfig {
+	return sim.ModelConfig{
+		NumLayers:          61,
+		HiddenDim:          7168,
+		NumHeads:           128,
+		NumKVHeads:         128,
+		VocabSize:          129280,
+		BytesPerParam:      2,
+		IntermediateDim:    18432,
+		NumLocalExperts:    256,
+		NumExpertsPerTok:   8,
+		MoEExpertFFNDim:    2048,
+		SharedExpertFFNDim: 2048,
+	}
+}
+
+// --- Task 4: MoE FLOPs tests ---
+
+func TestCalculateTransformerFlops_MoE_TopKScaling(t *testing.T) {
+	// MoE MLP FLOPs scale by top_k (active experts per token)
+	mc := testMixtralConfig() // top_k=2, E=8
+
+	moeFlops := calculateTransformerFlops(mc, 0, 128, false, true)
+
+	dense := mc
+	dense.NumLocalExperts = 0
+	dense.NumExpertsPerTok = 0
+	denseFlops := calculateTransformerFlops(dense, 0, 128, false, true)
+
+	// MoE MLP FLOPs = top_k × dense MLP FLOPs
+	ratio := moeFlops["gemm_ops"] / denseFlops["gemm_ops"]
+	if math.Abs(ratio-float64(mc.NumExpertsPerTok)) > 0.01 {
+		t.Errorf("MoE FLOPs should be %dx dense: moe=%g, dense=%g, ratio=%g",
+			mc.NumExpertsPerTok, moeFlops["gemm_ops"], denseFlops["gemm_ops"], ratio)
+	}
+}
+
+func TestCalculateTransformerFlops_MoE_Conservation(t *testing.T) {
+	// total = gemm_ops + sram_ops for MoE configs
+	configs := []struct {
+		name string
+		mc   sim.ModelConfig
+	}{
+		{"Mixtral", testMixtralConfig()},
+		{"DeepSeek-V3", testDeepSeekV3Config()},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			flops := calculateTransformerFlops(cfg.mc, 512, 64, true, true)
+			sum := flops["gemm_ops"] + flops["sram_ops"]
+			if flops["total"] != sum {
+				t.Errorf("conservation: total (%g) != gemm+sram (%g)", flops["total"], sum)
+			}
+		})
+	}
+}
+
+func TestCalculateTransformerFlops_Dense_UnchangedAfterMoE(t *testing.T) {
+	// BC-10: dense model FLOPs unchanged (regression anchor)
+	mc := testModelConfig()
+
+	flops := calculateTransformerFlops(mc, 512, 64, true, true)
+
+	if flops["total"] <= 0 {
+		t.Fatal("expected positive total FLOPs for dense model")
+	}
+	// Conservation still holds
+	sum := flops["gemm_ops"] + flops["sram_ops"]
+	if flops["total"] != sum {
+		t.Errorf("dense conservation: total (%g) != gemm+sram (%g)", flops["total"], sum)
+	}
+}
+
+// --- Task 5: MoE memory access tests ---
+
+func TestCalculateMemoryAccessBytes_MoE_AllExpertsLoaded(t *testing.T) {
+	// MoE weight bandwidth includes all E experts (all loaded from HBM per step)
+	mc := testMixtralConfig() // E=8
+	moeMem := calculateMemoryAccessBytes(mc, 512, 1, false)
+
+	dense := mc
+	dense.NumLocalExperts = 0
+	dense.NumExpertsPerTok = 0
+	denseMem := calculateMemoryAccessBytes(dense, 512, 1, false)
+
+	// MoE model_weights > dense (attention is same, MLP is E× larger)
+	if moeMem["model_weights"] <= denseMem["model_weights"] {
+		t.Errorf("MoE weights (%g) should exceed dense weights (%g)",
+			moeMem["model_weights"], denseMem["model_weights"])
+	}
+}
+
+func TestCalculateMemoryAccessBytes_MoE_Conservation(t *testing.T) {
+	// total = sum of components
+	mc := testMixtralConfig()
+	mem := calculateMemoryAccessBytes(mc, 512, 64, true)
+
+	keys := make([]string, 0, len(mem))
+	for k := range mem {
+		if k != "total" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var sum float64
+	for _, k := range keys {
+		sum += mem[k]
+	}
+	if math.Abs(mem["total"]-sum) > 1e-6 {
+		t.Errorf("conservation violation: total (%g) != components (%g)", mem["total"], sum)
+	}
+}
+
+func TestCalculateMemoryAccessBytes_Dense_UnchangedAfterMoE(t *testing.T) {
+	// BC-10: dense model memory unchanged (regression anchor)
+	mc := testModelConfig()
+	mem := calculateMemoryAccessBytes(mc, 512, 64, true)
+
+	if mem["model_weights"] <= 0 {
+		t.Fatal("expected positive model_weights for dense config")
+	}
+	keys := make([]string, 0, len(mem))
+	for k := range mem {
+		if k != "total" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var sum float64
+	for _, k := range keys {
+		sum += mem[k]
+	}
+	if mem["total"] != sum {
+		t.Errorf("dense conservation: total (%g) != sum (%g)", mem["total"], sum)
+	}
+}
+
+// --- Task 7: MoE roofline step time smoke tests ---
+
+func TestRooflineStepTime_MoE_Smoke_PositiveFinite(t *testing.T) {
+	// Smoke test: MoE config produces valid step times
+	configs := []struct {
+		name string
+		mc   sim.ModelConfig
+	}{
+		{"Mixtral-8x7B", testMixtralConfig()},
+		{"DeepSeek-V3", testDeepSeekV3Config()},
+	}
+	hc := testHardwareCalib()
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			step := StepConfig{
+				PrefillRequests: []PrefillRequestConfig{
+					{ProgressIndex: 0, NumNewPrefillTokens: 128},
+				},
+				DecodeRequests: []DecodeRequestConfig{
+					{ProgressIndex: 256, NumNewDecodeTokens: 1},
+				},
+			}
+			result := rooflineStepTime(cfg.mc, hc, step, 2)
+			if result <= 0 {
+				t.Errorf("expected positive step time, got %d µs", result)
+			}
+			t.Logf("%s TP=2: %d µs", cfg.name, result)
+		})
+	}
+}
+
+func TestRooflineStepTime_MoE_TPScaling(t *testing.T) {
+	// TP scaling: TP=2 should be less than TP=1 for MoE
+	mc := testMixtralConfig()
+	hc := testHardwareCalib()
+
+	step := StepConfig{
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 512, NumNewDecodeTokens: 1},
+		},
+	}
+
+	tp1 := rooflineStepTime(mc, hc, step, 1)
+	tp2 := rooflineStepTime(mc, hc, step, 2)
+
+	if tp2 >= tp1 {
+		t.Errorf("MoE TP=2 (%d µs) should be less than TP=1 (%d µs)", tp2, tp1)
+	}
+}
+
+func TestRooflineStepTime_SingleCrossover_MemoryBoundDecode(t *testing.T) {
+	// llm-optimizer physics: memory-bound step time = total_bytes / peak_bandwidth
+	// No bandwidth haircut, no overhead terms, single crossover (not dual ceiling).
+	mc := testModelConfig()
+	hc := testHardwareCalib()
+
+	// Single decode request — decode is memory-bound on H100
+	step := StepConfig{
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 512, NumNewDecodeTokens: 1},
+		},
+	}
+	result := rooflineStepTime(mc, hc, step, 1)
+
+	// Compute expected: weights + KV + activations, all at raw peak bandwidth
+	peakBW := hc.BwPeakTBs * 1e12
+	peakFlops := hc.TFlopsPeak * 1e12
+
+	baseMem := calculateMemoryAccessBytes(mc, 0, 0, false)
+	dynamicMem := calculateMemoryAccessBytes(mc, 512, 1, true)
+	totalBytes := baseMem["model_weights"] + (dynamicMem["total"] - dynamicMem["model_weights"])
+
+	flops := calculateTransformerFlops(mc, 512, 1, true, true)
+	totalFlops := flops["total"]
+
+	computeS := totalFlops / (peakFlops * hc.MfuDecode)
+	memoryS := totalBytes / peakBW
+
+	// Decode should be memory-bound (verify assumption)
+	if computeS >= memoryS {
+		t.Skipf("decode is compute-bound with this config, skipping memory-bound test")
+	}
+
+	expectedMicros := int64(math.Round(memoryS * 1e6))
+	if result != expectedMicros {
+		t.Errorf("expected %d µs (total_bytes/peak_bw), got %d µs (delta=%d)",
+			expectedMicros, result, result-expectedMicros)
+	}
+}
+
+func TestRooflineStepTime_MixedBatch_WeightsLoadedOnce(t *testing.T) {
+	// Verify that a mixed batch (prefill + decode) loads weights once,
+	// not once per phase. The memory-bound time for a mixed batch should
+	// equal weights + prefill_dynamic + decode_dynamic, NOT 2×weights + dynamic.
+	mc := testModelConfig()
+	hc := testHardwareCalib()
+
+	// Mixed batch: 1 prefill + 1 decode
+	mixedStep := StepConfig{
+		PrefillRequests: []PrefillRequestConfig{
+			{ProgressIndex: 0, NumNewPrefillTokens: 64},
+		},
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 512, NumNewDecodeTokens: 1},
+		},
+	}
+
+	// Decode-only step with the same decode request
+	decodeOnlyStep := StepConfig{
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 512, NumNewDecodeTokens: 1},
+		},
+	}
+
+	mixed := rooflineStepTime(mc, hc, mixedStep, 1)
+	decodeOnly := rooflineStepTime(mc, hc, decodeOnlyStep, 1)
+
+	// Mixed should be >= decode-only (more work), but if weights were loaded
+	// twice, mixed would be roughly 2× decode-only for memory-bound steps.
+	// With single weight load, the increase should be modest (just extra dynamic bytes).
+	baseMem := calculateMemoryAccessBytes(mc, 0, 0, false)
+	weightBytes := baseMem["model_weights"]
+
+	// The mixed step should NOT double the weight bandwidth.
+	// If it did, the overhead would be approximately weightBytes/peakBW extra.
+	peakBW := hc.BwPeakTBs * 1e12
+	doubleWeightPenaltyMicros := int64(weightBytes / peakBW * 1e6)
+
+	// mixed - decodeOnly should be much less than a full extra weight load
+	overhead := mixed - decodeOnly
+	if overhead >= doubleWeightPenaltyMicros {
+		t.Errorf("mixed batch overhead (%d µs) >= full weight load (%d µs): weights appear loaded twice",
+			overhead, doubleWeightPenaltyMicros)
+	}
+	t.Logf("mixed=%d µs, decodeOnly=%d µs, overhead=%d µs, doubleWeightPenalty=%d µs",
+		mixed, decodeOnly, overhead, doubleWeightPenaltyMicros)
+}
+
+func TestRooflineStepTime_Dense_PositiveAndTPScaling(t *testing.T) {
+	// Dense model: positive step times and TP=2 < TP=1 (invariant, not pinned values)
+	mc := testModelConfig()
+	hc := testHardwareCalib()
+
+	step := StepConfig{
+		PrefillRequests: []PrefillRequestConfig{
+			{ProgressIndex: 0, NumNewPrefillTokens: 128},
+		},
+		DecodeRequests: []DecodeRequestConfig{
+			{ProgressIndex: 256, NumNewDecodeTokens: 1},
+		},
+	}
+
+	tp1 := rooflineStepTime(mc, hc, step, 1)
+	tp2 := rooflineStepTime(mc, hc, step, 2)
+
+	if tp1 <= 0 || tp2 <= 0 {
+		t.Fatalf("expected positive step times: TP=1=%d, TP=2=%d", tp1, tp2)
+	}
+	if tp2 >= tp1 {
+		t.Errorf("TP scaling violated: TP=2=%d >= TP=1=%d", tp2, tp1)
+	}
+	t.Logf("Dense regression: TP=1=%d µs, TP=2=%d µs", tp1, tp2)
 }

--- a/sim/latency/trained_roofline.go
+++ b/sim/latency/trained_roofline.go
@@ -1,0 +1,187 @@
+package latency
+
+import (
+	"math"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/internal/util"
+)
+
+// TrainedRooflineLatencyModel estimates latency using analytical roofline basis functions
+// with learned correction coefficients fitted from real vLLM traces.
+//
+// Step-time formula (from training/DESIGN.md):
+//
+//	β₁·max(T_pf_compute, T_pf_kv) + β₂·max(T_dc_compute, T_dc_kv)
+//	+ β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇
+//
+// Where β₁-β₄ are dimensionless corrections to the roofline model (analytical prior ≈ 1.0),
+// β₅ is µs/layer, β₆ is µs/request, β₇ is µs/step. Basis functions compute µs from model
+// architecture + hardware specs + batch composition.
+//
+// Coefficients are from training/output/fit/coefficients.json, fitted via 3-phase NNLS
+// from 13 experiments across 4 architectures (137K requests, 7% MAPE GPU combined).
+//
+// Key differences from the pure RooflineLatencyModel:
+//   - No MFU scaling: β₁/β₂ ARE the MFU corrections. Applying MfuPrefill/MfuDecode would double-count.
+//   - 3-matrix SwiGLU (6·d·d_ff for FLOPs, 3·d·d_ff for weight bytes), NOT roofline.go's
+//     2-matrix convention (mlpMatrixCount()=2). See R23 documented exception.
+//   - MoE weight loading uses min(N, max(k, B·k)) effective experts, not all N.
+//   - T_tp hardcoded to 0 (β₄=0.0 in current fit; TP communication absorbed into β₅·L).
+//
+// All fields are frozen at construction. StepTime is allocation-free and uses a single
+// O(batch_size) pass over the batch.
+type TrainedRooflineLatencyModel struct {
+	betaCoeffs  []float64 // [β₁..β₇] from trained_roofline_defaults
+	alphaCoeffs []float64 // [α₀, α₁, α₂]
+
+	// Pre-computed architecture features (frozen at construction)
+	numLayers  int
+	hiddenDim  int // d (hidden_size)
+	numHeads   int // H (num_attention_heads)
+	headDim    int // d_h = d / H
+	dKV        int // kv_heads * d_h (NOT d; differs for GQA)
+	dFF        int // intermediate_size (= IntermediateDim, NOT MoEExpertFFNDim)
+	kEff       int // max(1, NumExpertsPerTok) — FFN FLOPs multiplier
+	numExperts int // NumLocalExperts (0 for dense)
+	isMoE      bool
+	tp         int
+
+	// Pre-converted hardware specs (FLOP/µs and bytes/µs) for hot-path efficiency.
+	// flopsPeakUs = TFlopsPeak * 1e6; bwHbmUs = BwPeakTBs * 1e6.
+	flopsPeakUs float64 // FLOP/µs (divide FLOPs by this → µs)
+	bwHbmUs     float64 // bytes/µs (divide bytes by this → µs)
+}
+
+// bytesPerElement is FP16 = 2 bytes, matching training pipeline's _BYTES_PER_ELEMENT = 2.
+const bytesPerElement = 2.0
+
+func (m *TrainedRooflineLatencyModel) StepTime(batch []*sim.Request) int64 {
+	if len(batch) == 0 {
+		return 1
+	}
+
+	// Single-pass accumulation: classify prefill/decode, accumulate all aggregate values.
+	// Zero heap allocations — all arithmetic uses stack-local float64 values.
+	var (
+		totalPrefillTokens float64
+		totalDecodeTokens  float64
+		sumCtx             float64 // Σ ProgressIndex for decode requests
+		prefillAttnFlops   float64 // per-request attention FLOPs sum
+	)
+	batchSize := float64(len(batch))
+	L := float64(m.numLayers)
+	d := float64(m.hiddenDim)
+	dKV := float64(m.dKV)
+	dH := float64(m.headDim)
+	dFF := float64(m.dFF)
+	tp := float64(m.tp)
+	kEff := float64(m.kEff)
+	hPerGPU := float64(m.numHeads) / tp
+
+	for _, req := range batch {
+		if req.ProgressIndex < util.Len64(req.InputTokens) {
+			// Prefill: t_i = NumNewTokens, s_i = len(InputTokens) (total prompt length,
+			// matching training's entry.prompt_tokens — see Deviation 3)
+			ti := float64(req.NumNewTokens)
+			si := float64(len(req.InputTokens))
+			totalPrefillTokens += ti
+			// Per-request attention FLOPs: 4 * (H/TP) * t_i * (s_i + t_i/2) * d_h
+			// Accounts for causal masking: average context length is s_i + t_i/2.
+			prefillAttnFlops += 4 * hPerGPU * ti * (si + ti/2) * dH
+		} else if len(req.OutputTokens) > 0 {
+			// Decode: context_length maps to ProgressIndex in BLIS
+			// (= inputLen + outputSoFar at StepTime call time, before ProgressIndex++)
+			totalDecodeTokens++
+			sumCtx += float64(req.ProgressIndex)
+		}
+	}
+
+	// --- Basis function computation (O(1) from pre-accumulated aggregates) ---
+
+	// T_pf_compute: prefill compute time (µs)
+	// FLOPs_proj = L * 2 * T_pf * d * (2*d + 2*d_kv) / TP
+	// FLOPs_attn = L * prefillAttnFlops (already accumulated per-request above)
+	// FLOPs_ffn  = L * T_pf * k_eff * 6 * d * d_ff / TP
+	var tPfCompute float64
+	if totalPrefillTokens > 0 {
+		flopsProj := L * 2 * totalPrefillTokens * d * (2*d + 2*dKV) / tp
+		flopsAttn := L * prefillAttnFlops
+		flopsFfn := L * totalPrefillTokens * kEff * 6 * d * dFF / tp
+		tPfCompute = (flopsProj + flopsAttn + flopsFfn) / m.flopsPeakUs
+	}
+
+	// T_pf_kv: prefill KV cache write bandwidth (µs)
+	// Bytes = L * 2 * (kv_heads/TP) * d_h * T_pf * 2
+	// Using dKV/TP = (kvHeads * dH) / TP, which is exact (factory validates divisibility).
+	var tPfKv float64
+	if totalPrefillTokens > 0 {
+		bytesPfKv := L * 2 * (dKV / tp) * totalPrefillTokens * bytesPerElement
+		tPfKv = bytesPfKv / m.bwHbmUs
+	}
+
+	// T_dc_compute: decode compute time (µs)
+	// FLOPs_proj = L * 2 * T_dc * d * (2*d + 2*d_kv) / TP
+	// FLOPs_attn = L * 4 * (H/TP) * sum_ctx * d_h   (each decode token attends to its context)
+	// FLOPs_ffn  = L * T_dc * k_eff * 6 * d * d_ff / TP
+	var tDcCompute float64
+	if totalDecodeTokens > 0 {
+		flopsProj := L * 2 * totalDecodeTokens * d * (2*d + 2*dKV) / tp
+		flopsAttn := L * 4 * hPerGPU * sumCtx * dH
+		flopsFfn := L * totalDecodeTokens * kEff * 6 * d * dFF / tp
+		tDcCompute = (flopsProj + flopsAttn + flopsFfn) / m.flopsPeakUs
+	}
+
+	// T_dc_kv: decode KV cache read+write bandwidth (µs)
+	// Bytes = L * 2 * (kv_heads/TP) * d_h * 2 * (sum_ctx + T_dc)
+	var tDcKv float64
+	if totalDecodeTokens > 0 {
+		bytesDcKv := L * 2 * (dKV / tp) * bytesPerElement * (sumCtx + totalDecodeTokens)
+		tDcKv = bytesDcKv / m.bwHbmUs
+	}
+
+	// T_weight: weight loading time (µs)
+	// Dense: nEff = 1. MoE: nEff = min(N, max(k, B*k)) where B = total tokens.
+	// Uses 3-matrix SwiGLU for FFN weights (R23 exception vs roofline.go's mlpMatrixCount()=2).
+	nEff := 1.0
+	if m.isMoE {
+		B := totalPrefillTokens + totalDecodeTokens
+		nEff = math.Min(float64(m.numExperts), math.Max(kEff, B*kEff))
+	}
+	bytesAttn := L * d * (2*d + 2*dKV) * bytesPerElement / tp
+	bytesFfn := L * nEff * 3 * d * dFF * bytesPerElement / tp
+	tWeight := (bytesAttn + bytesFfn) / m.bwHbmUs
+
+	// T_tp: TP communication time (µs) — hardcoded to 0.
+	// β₄=0.0 in current fit; TP communication cost absorbed into β₅·L (H100 NVLink specific).
+	// No NVLink bandwidth data in HardwareCalib. See Deviation 2.
+	tTp := 0.0
+
+	// 7-term step-time formula
+	stepTime := m.betaCoeffs[0]*math.Max(tPfCompute, tPfKv) +
+		m.betaCoeffs[1]*math.Max(tDcCompute, tDcKv) +
+		m.betaCoeffs[2]*tWeight +
+		m.betaCoeffs[3]*tTp +
+		m.betaCoeffs[4]*L +
+		m.betaCoeffs[5]*batchSize +
+		m.betaCoeffs[6]
+
+	return max(1, int64(stepTime))
+}
+
+func (m *TrainedRooflineLatencyModel) QueueingTime(req *sim.Request) int64 {
+	// α₀ = API processing overhead (ARRIVED → QUEUED), constant per-request.
+	// Unlike other backends, this does NOT scale with input length.
+	return int64(m.alphaCoeffs[0])
+}
+
+func (m *TrainedRooflineLatencyModel) OutputTokenProcessingTime() int64 {
+	// α₂ = per-output-token detokenization cost (µs/token).
+	return int64(m.alphaCoeffs[2])
+}
+
+func (m *TrainedRooflineLatencyModel) PostDecodeFixedOverhead() int64 {
+	// α₁ = fixed per-request post-decode overhead (µs).
+	// Added to E2E in recordRequestCompletion, NOT to TTFT.
+	return int64(m.alphaCoeffs[1])
+}

--- a/sim/latency/trained_roofline_test.go
+++ b/sim/latency/trained_roofline_test.go
@@ -1,0 +1,468 @@
+package latency
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Test helpers ---
+
+var trainingFittedBetas = []float64{
+	0.7726491335309499,  // β₁: prefill roofline correction
+	1.127489556719325,   // β₂: decode roofline correction
+	1.0559901872766853,  // β₃: weight loading correction
+	0.0,                 // β₄: TP communication (zeroed)
+	43.500541908701074,  // β₅: per-layer overhead (µs/layer)
+	48.80613214319187,   // β₆: per-request scheduling (µs/req)
+	0.0,                 // β₇: per-step overhead (zeroed)
+}
+
+var trainingFittedAlphas = []float64{
+	9315.338771116985,  // α₀: API processing overhead
+	1849.5902371340574, // α₁: post-decode fixed
+	1.7079389122469397, // α₂: per-output-token
+}
+
+func makePrefillRequest(inputLen int, newTokens int) *sim.Request {
+	return &sim.Request{
+		InputTokens:   make([]int, inputLen),
+		ProgressIndex: 0,
+		NumNewTokens:  newTokens,
+	}
+}
+
+func makeDecodeRequest(inputLen int, outputSoFar int) *sim.Request {
+	return &sim.Request{
+		InputTokens:   make([]int, inputLen),
+		OutputTokens:  make([]int, outputSoFar),
+		ProgressIndex: int64(inputLen + outputSoFar),
+		NumNewTokens:  1,
+	}
+}
+
+// newLlama7bModel constructs a TrainedRooflineLatencyModel for Llama-2-7b / H100 / TP=1.
+func newLlama7bModel() *TrainedRooflineLatencyModel {
+	return &TrainedRooflineLatencyModel{
+		betaCoeffs:  trainingFittedBetas,
+		alphaCoeffs: trainingFittedAlphas,
+		numLayers:   32,
+		hiddenDim:   4096,
+		numHeads:    32,
+		headDim:     128,
+		dKV:         4096, // 32 * 128 (MHA: kv_heads=H)
+		dFF:         11008,
+		kEff:        1,
+		numExperts:  0,
+		isMoE:       false,
+		tp:          1,
+		flopsPeakUs: 989.5e6,
+		bwHbmUs:     3.35e6,
+	}
+}
+
+// --- BC-6: Clock safety ---
+
+func TestTrainedRoofline_EmptyBatch_ReturnsOne(t *testing.T) {
+	model := newLlama7bModel()
+	assert.Equal(t, int64(1), model.StepTime(nil))
+	assert.Equal(t, int64(1), model.StepTime([]*sim.Request{}))
+}
+
+// --- BC-3: Step-time formula produces positive results ---
+
+func TestTrainedRoofline_PrefillOnly_PositiveStepTime(t *testing.T) {
+	model := newLlama7bModel()
+	batch := []*sim.Request{makePrefillRequest(512, 512)}
+	stepTime := model.StepTime(batch)
+	assert.Greater(t, stepTime, int64(1), "prefill step time should be > 1 µs")
+}
+
+func TestTrainedRoofline_DecodeOnly_PositiveStepTime(t *testing.T) {
+	model := newLlama7bModel()
+	batch := []*sim.Request{makeDecodeRequest(512, 100)}
+	stepTime := model.StepTime(batch)
+	assert.Greater(t, stepTime, int64(1), "decode step time should be > 1 µs")
+}
+
+func TestTrainedRoofline_MixedBatch_PositiveStepTime(t *testing.T) {
+	model := newLlama7bModel()
+	batch := []*sim.Request{
+		makePrefillRequest(256, 256),
+		makeDecodeRequest(512, 100),
+	}
+	stepTime := model.StepTime(batch)
+	assert.Greater(t, stepTime, int64(1), "mixed batch step time should be > 1 µs")
+}
+
+// --- BC-7: QueueingTime = α₀ only ---
+
+func TestTrainedRoofline_QueueingTime_IsAlpha0(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	// Constant regardless of input length
+	req512 := makePrefillRequest(512, 512)
+	req1024 := makePrefillRequest(1024, 1024)
+	assert.Equal(t, int64(9315), model.QueueingTime(req512))
+	assert.Equal(t, int64(9315), model.QueueingTime(req1024),
+		"QueueingTime must be constant (α₀ only), independent of input length")
+}
+
+// --- BC-8: OutputTokenProcessingTime = α₂ ---
+
+func TestTrainedRoofline_OutputTokenProcessingTime_IsAlpha2(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	assert.Equal(t, int64(1), model.OutputTokenProcessingTime())
+}
+
+// --- BC-15: PostDecodeFixedOverhead = α₁ ---
+
+func TestTrainedRoofline_PostDecodeFixedOverhead_IsAlpha1(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: []float64{9315.0, 1850.0, 1.71},
+	}
+	assert.Equal(t, int64(1850), model.PostDecodeFixedOverhead())
+}
+
+// --- BC-9: MoE-aware weight loading uses effective experts ---
+
+func TestTrainedRoofline_MoE_WeightLoading_UsesEffectiveExperts(t *testing.T) {
+	// β₃=1.0 (only weight loading nonzero) to isolate the effect.
+	// MoE N=8, k=2: small batch → nEff=2, large batch → nEff=8.
+	denseBetas := []float64{0, 0, 1.0, 0, 0, 0, 0}
+	alphas := []float64{0, 0, 0}
+
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs:  denseBetas,
+		alphaCoeffs: alphas,
+		numLayers:   32,
+		hiddenDim:   4096,
+		numHeads:    32,
+		headDim:     128,
+		dKV:         1024, // 8 * 128 (GQA: kv_heads=8)
+		dFF:         14336,
+		kEff:        2,
+		numExperts:  8,
+		isMoE:       true,
+		tp:          1,
+		flopsPeakUs: 989.5e6,
+		bwHbmUs:     3.35e6,
+	}
+
+	smallBatch := []*sim.Request{makeDecodeRequest(100, 10)}
+	largeBatch := make([]*sim.Request, 10)
+	for i := range largeBatch {
+		largeBatch[i] = makeDecodeRequest(100, 10)
+	}
+
+	smallTime := model.StepTime(smallBatch)
+	largeTime := model.StepTime(largeBatch)
+
+	assert.Greater(t, largeTime, smallTime,
+		"larger batch should load more MoE experts → higher weight loading time")
+}
+
+// --- BC-11: No MFU scaling — regression anchor with hand-computed values ---
+
+func TestTrainedRoofline_NoMfuScaling_RegressionAnchor(t *testing.T) {
+	// Architecture: 1 layer, d=128, H=1, kv_heads=1, d_h=128, d_kv=128, d_ff=1024, TP=1
+	// 1 prefill token, s_i=1, t_i=1.
+	//
+	// Hand-computed FLOPs:
+	// FLOPs_proj = 1 * 2 * 1 * 128 * (256 + 256) / 1 = 131072
+	// FLOPs_attn = 1 * 4 * 1 * 1 * (1 + 0.5) * 128 = 768
+	// FLOPs_ffn  = 1 * 1 * 1 * 6 * 128 * 1024 / 1 = 786432
+	// Total = 918272
+	// T_pf_compute = 918272 / 1e6 = 0.918272 µs
+	// β₁=1.0 → step time = 0.918 → int64 = 0 → floored to 1
+	//
+	// If MFU (0.45) were applied: 918272 / 0.45e6 = 2.04 → int64 = 2
+	betas := []float64{1.0, 0, 0, 0, 0, 0, 0}
+	alphas := []float64{0, 0, 0}
+
+	model := &TrainedRooflineLatencyModel{
+		betaCoeffs:  betas,
+		alphaCoeffs: alphas,
+		numLayers:   1,
+		hiddenDim:   128,
+		numHeads:    1,
+		headDim:     128,
+		dKV:         128,
+		dFF:         1024,
+		kEff:        1,
+		tp:          1,
+		flopsPeakUs: 1.0e6,  // 1 TFLOP/s → easy calculation
+		bwHbmUs:     1e12,   // very high BW → compute-bound
+	}
+
+	req := makePrefillRequest(1, 1)
+	st := model.StepTime([]*sim.Request{req})
+
+	// Without MFU: ~0.92 µs → floored to 1
+	// With MFU (0.45): ~2.04 µs → int64 = 2
+	assert.Equal(t, int64(1), st,
+		"step time should be 1 (no MFU scaling); if MFU were applied it would be 2")
+}
+
+// --- Existing backends: PostDecodeFixedOverhead returns 0 ---
+
+func TestExistingBackends_PostDecodeFixedOverhead_ReturnsZero(t *testing.T) {
+	bb := &BlackboxLatencyModel{
+		betaCoeffs:  []float64{1000, 10, 5},
+		alphaCoeffs: []float64{100, 1, 200},
+	}
+	assert.Equal(t, int64(0), bb.PostDecodeFixedOverhead())
+
+	rf := &RooflineLatencyModel{
+		alphaCoeffs: []float64{100, 1, 200},
+	}
+	assert.Equal(t, int64(0), rf.PostDecodeFixedOverhead())
+
+	cm := &CrossModelLatencyModel{
+		alphaCoeffs: []float64{100, 1, 200},
+	}
+	assert.Equal(t, int64(0), cm.PostDecodeFixedOverhead())
+}
+
+// --- Benchmark: verify zero allocations in hot path ---
+
+func BenchmarkTrainedRoofline_StepTime(b *testing.B) {
+	model := newLlama7bModel()
+	batch := make([]*sim.Request, 8)
+	for i := range batch {
+		if i < 2 {
+			batch[i] = makePrefillRequest(512, 512)
+		} else {
+			batch[i] = makeDecodeRequest(512, 100)
+		}
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = model.StepTime(batch)
+	}
+}
+
+// --- Zero-allocation enforcement test ---
+
+func TestTrainedRoofline_StepTime_ZeroAllocs(t *testing.T) {
+	model := newLlama7bModel()
+	batch := make([]*sim.Request, 8)
+	for i := range batch {
+		if i < 2 {
+			batch[i] = makePrefillRequest(512, 512)
+		} else {
+			batch[i] = makeDecodeRequest(512, 100)
+		}
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = model.StepTime(batch)
+	})
+	assert.Equal(t, float64(0), allocs, "StepTime must be allocation-free on the hot path")
+}
+
+// --- Regression: verify non-negative for degenerate but valid inputs ---
+
+func TestTrainedRoofline_StepTime_NeverNegative(t *testing.T) {
+	model := newLlama7bModel()
+	cases := []struct {
+		name  string
+		batch []*sim.Request
+	}{
+		{"nil", nil},
+		{"empty", []*sim.Request{}},
+		{"single prefill 1 token", []*sim.Request{makePrefillRequest(1, 1)}},
+		{"single decode short context", []*sim.Request{makeDecodeRequest(10, 1)}},
+		{"large batch", func() []*sim.Request {
+			b := make([]*sim.Request, 256)
+			for i := range b {
+				b[i] = makeDecodeRequest(512, 200)
+			}
+			return b
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := model.StepTime(tc.batch)
+			assert.GreaterOrEqual(t, st, int64(1),
+				"StepTime must be >= 1 for all inputs (INV-3)")
+		})
+	}
+}
+
+// --- Verify OutputTokenProcessingTime rounds alpha2 correctly ---
+
+func TestTrainedRoofline_OutputTokenProcessingTime_WithRealCoeffs(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: trainingFittedAlphas,
+	}
+	// α₂ = 1.7079 → int64(1.7079) = 1 (truncation)
+	assert.Equal(t, int64(1), model.OutputTokenProcessingTime())
+}
+
+// --- Verify PostDecodeFixedOverhead with real coefficients ---
+
+func TestTrainedRoofline_PostDecodeFixedOverhead_WithRealCoeffs(t *testing.T) {
+	model := &TrainedRooflineLatencyModel{
+		alphaCoeffs: trainingFittedAlphas,
+	}
+	// α₁ = 1849.5902 → int64(1849.5902) = 1849
+	assert.Equal(t, int64(1849), model.PostDecodeFixedOverhead())
+}
+
+// --- BC-2: Factory construction ---
+
+func TestNewLatencyModel_TrainedRoofline_ReturnsModel(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline",
+		ModelConfig: sim.ModelConfig{
+			NumLayers: 32, HiddenDim: 4096, NumHeads: 32, NumKVHeads: 32,
+			IntermediateDim: 11008, BytesPerParam: 2,
+		},
+		HWConfig: sim.HardwareCalib{TFlopsPeak: 989.5, BwPeakTBs: 3.35, MfuPrefill: 0.45, MfuDecode: 0.30, MemoryGiB: 80.0},
+		TP:      1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	// Verify it produces positive step times
+	batch := []*sim.Request{makePrefillRequest(512, 512)}
+	assert.Greater(t, model.StepTime(batch), int64(1))
+}
+
+// --- BC-13: Coefficient length validation ---
+
+func TestNewLatencyModel_TrainedRoofline_TooFewBetas_Error(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs([]float64{1, 2, 3, 4, 5, 6}, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline",
+		ModelConfig: sim.ModelConfig{
+			NumLayers: 32, HiddenDim: 4096, NumHeads: 32, NumKVHeads: 32,
+			IntermediateDim: 11008, BytesPerParam: 2,
+		},
+		HWConfig: sim.HardwareCalib{TFlopsPeak: 989.5, BwPeakTBs: 3.35, MfuPrefill: 0.45, MfuDecode: 0.30, MemoryGiB: 80.0},
+		TP:      1,
+	}
+	_, err := NewLatencyModel(coeffs, hw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "7 elements")
+}
+
+// --- BC-14: Config validation ---
+
+func TestNewLatencyModel_TrainedRoofline_InvalidConfig_Error(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+
+	baseHW := func() sim.ModelHardwareConfig {
+		return sim.ModelHardwareConfig{
+			Backend: "trained-roofline",
+			ModelConfig: sim.ModelConfig{
+				NumLayers: 32, HiddenDim: 4096, NumHeads: 32, NumKVHeads: 32,
+				IntermediateDim: 11008, BytesPerParam: 2,
+			},
+			HWConfig: sim.HardwareCalib{TFlopsPeak: 989.5, BwPeakTBs: 3.35, MfuPrefill: 0.45, MfuDecode: 0.30, MemoryGiB: 80.0},
+			TP:      1,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		modify func(*sim.ModelHardwareConfig)
+		errMsg string
+	}{
+		{"zero TP", func(hw *sim.ModelHardwareConfig) { hw.TP = 0 }, "TP > 0"},
+		{"zero NumLayers", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumLayers = 0 }, "NumLayers > 0"},
+		{"zero NumHeads", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumHeads = 0 }, "NumHeads > 0"},
+		{"zero HiddenDim", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.HiddenDim = 0 }, "HiddenDim > 0"},
+		{"zero IntermediateDim", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.IntermediateDim = 0 }, "IntermediateDim > 0"},
+		{"zero TFlopsPeak", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.TFlopsPeak = 0 }, "TFlopsPeak"},
+		{"zero BwPeakTBs", func(hw *sim.ModelHardwareConfig) { hw.HWConfig.BwPeakTBs = 0 }, "BwPeakTBs"},
+		{"NumHeads not divisible by TP", func(hw *sim.ModelHardwareConfig) { hw.TP = 3 }, "divisible"},
+		{"NumKVHeads not divisible by TP", func(hw *sim.ModelHardwareConfig) { hw.ModelConfig.NumKVHeads = 5; hw.TP = 2 }, "divisible"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hw := baseHW()
+			tc.modify(&hw)
+			_, err := NewLatencyModel(coeffs, hw)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+// --- BC-4: Prefill monotonicity ---
+
+func TestTrainedRoofline_PrefillMonotonicity(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline",
+		ModelConfig: sim.ModelConfig{
+			NumLayers: 32, HiddenDim: 4096, NumHeads: 32, NumKVHeads: 32,
+			IntermediateDim: 11008, BytesPerParam: 2,
+		},
+		HWConfig: sim.HardwareCalib{TFlopsPeak: 989.5, BwPeakTBs: 3.35, MfuPrefill: 0.45, MfuDecode: 0.30, MemoryGiB: 80.0},
+		TP:      1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	assert.NoError(t, err)
+
+	tokenCounts := []int{64, 128, 256, 512, 1024}
+	var prevTime int64
+	for _, n := range tokenCounts {
+		batch := []*sim.Request{makePrefillRequest(n, n)}
+		st := model.StepTime(batch)
+		assert.GreaterOrEqual(t, st, prevTime,
+			"prefill step time should be non-decreasing: %d tokens -> %d us (prev %d us)", n, st, prevTime)
+		prevTime = st
+	}
+}
+
+// --- BC-5: Decode monotonicity ---
+
+func TestTrainedRoofline_DecodeMonotonicity(t *testing.T) {
+	coeffs := sim.NewLatencyCoeffs(trainingFittedBetas, trainingFittedAlphas)
+	hw := sim.ModelHardwareConfig{
+		Backend: "trained-roofline",
+		ModelConfig: sim.ModelConfig{
+			NumLayers: 32, HiddenDim: 4096, NumHeads: 32, NumKVHeads: 32,
+			IntermediateDim: 11008, BytesPerParam: 2,
+		},
+		HWConfig: sim.HardwareCalib{TFlopsPeak: 989.5, BwPeakTBs: 3.35, MfuPrefill: 0.45, MfuDecode: 0.30, MemoryGiB: 80.0},
+		TP:      1,
+	}
+	model, err := NewLatencyModel(coeffs, hw)
+	assert.NoError(t, err)
+
+	var prevTime int64
+	for nReqs := 1; nReqs <= 16; nReqs *= 2 {
+		batch := make([]*sim.Request, nReqs)
+		for i := range batch {
+			batch[i] = makeDecodeRequest(512, 100)
+		}
+		st := model.StepTime(batch)
+		assert.GreaterOrEqual(t, st, prevTime,
+			"decode step time should be non-decreasing: %d reqs -> %d us (prev %d us)", nReqs, st, prevTime)
+		prevTime = st
+	}
+}
+
+// --- Verify no NaN/Inf propagation for extreme but valid inputs ---
+
+func TestTrainedRoofline_StepTime_LargeContext_NoOverflow(t *testing.T) {
+	model := newLlama7bModel()
+	// Very large context (100K tokens) — tests float64 arithmetic doesn't overflow
+	batch := []*sim.Request{makeDecodeRequest(100000, 50000)}
+	st := model.StepTime(batch)
+	assert.GreaterOrEqual(t, st, int64(1))
+	// Step time should be a reasonable value (not overflowed to 1 from max(1, negative))
+	assert.Greater(t, st, int64(100), "150K context should produce >100 µs step time")
+}

--- a/sim/latency_model.go
+++ b/sim/latency_model.go
@@ -1,8 +1,9 @@
 package sim
 
 // LatencyModel estimates execution times for the DES step loop.
-// Three implementations exist in sim/latency/: BlackboxLatencyModel (alpha/beta regression),
-// RooflineLatencyModel (analytical FLOPs/bandwidth), and CrossModelLatencyModel (physics-informed cross-model).
+// Four implementations exist in sim/latency/: BlackboxLatencyModel (alpha/beta regression),
+// RooflineLatencyModel (analytical FLOPs/bandwidth), CrossModelLatencyModel (physics-informed
+// cross-model), and TrainedRooflineLatencyModel (roofline basis functions × learned corrections).
 // All time estimates are in microseconds (ticks).
 type LatencyModel interface {
 	// StepTime estimates the duration of one batch step given the running batch.
@@ -16,6 +17,13 @@ type LatencyModel interface {
 
 	// OutputTokenProcessingTime estimates per-token post-processing time.
 	OutputTokenProcessingTime() int64
+
+	// PostDecodeFixedOverhead estimates the fixed per-request post-decode overhead (µs).
+	// This is the constant overhead at request completion (e.g., response setup, final API
+	// processing) that is NOT per-token. Added for the trained-roofline alpha model where
+	// α₁ = fixed post-decode overhead per request. Existing backends return 0.
+	// Used by recordRequestCompletion to add to E2E without affecting TTFT.
+	PostDecodeFixedOverhead() int64
 }
 
 // NewLatencyModelFunc is a factory function for creating LatencyModel implementations.

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -28,7 +28,8 @@ type Metrics struct {
 	KVThrashingRate      float64 // KV thrashing rate at finalization (PR12)
 	StillQueued          int     // Requests still in wait queue at sim end
 	StillRunning         int     // Requests still in running batch at sim end
-	DroppedUnservable    int     // Requests dropped because input tokens exceed KV cache capacity (R19)
+	DroppedUnservable    int // Requests dropped at enqueue: negative MaxOutputLen (R3), MaxModelLen violation, or input exceeds KV capacity (R19)
+	LengthCappedRequests int // Requests force-completed by runtime MaxModelLen cap (BC-5 defense-in-depth)
 
 	TTFTSum int64 // Total time-to-first-token sum (in ticks)
 	ITLSum  int64 // Total ITL sum across requests (in ticks)
@@ -77,6 +78,7 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 		KVAllocationFailures: m.KVAllocationFailures,
 		PreemptionCount:      m.PreemptionCount,
 		DroppedUnservable:    m.DroppedUnservable,
+		LengthCappedRequests: m.LengthCappedRequests,
 	}
 
 	if m.CompletedRequests > 0 {

--- a/sim/metrics_substrate_test.go
+++ b/sim/metrics_substrate_test.go
@@ -51,7 +51,7 @@ func msConfig(horizon int64) SimConfig {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 100000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs(msBeta(), msAlpha()),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "test-gpu", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "test-gpu", 1, "", 0),
 		PolicyConfig:        NewPolicyConfig("constant", "fcfs"),
 		WorkloadConfig:      NewWorkloadConfig(),
 	}

--- a/sim/metrics_test.go
+++ b/sim/metrics_test.go
@@ -381,3 +381,30 @@ func TestSaveResults_DroppedUnservable_InJSON(t *testing.T) {
 		t.Errorf("InjectedRequests = %d, want 2 (should include dropped)", output.InjectedRequests)
 	}
 }
+
+// BC-3: LengthCappedRequests appears in JSON output
+func TestSaveResults_LengthCappedRequests_InJSON(t *testing.T) {
+	m := NewMetrics()
+	m.LengthCappedRequests = 3
+	m.CompletedRequests = 3
+	m.SimEndedTime = 1_000_000
+
+	tmpFile := filepath.Join(t.TempDir(), "test_output.json")
+	if err := m.SaveResults("test", 10_000_000, 100, tmpFile); err != nil {
+		t.Fatalf("SaveResults returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var output MetricsOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+
+	if output.LengthCappedRequests != 3 {
+		t.Errorf("LengthCappedRequests in JSON = %d, want 3", output.LengthCappedRequests)
+	}
+}

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -69,6 +69,7 @@ type MetricsOutput struct {
 	KVAllocationFailures    int64            `json:"kv_allocation_failures,omitempty"`
 	PreemptionCount         int64            `json:"preemption_count"`
 	DroppedUnservable       int              `json:"dropped_unservable"`
+	LengthCappedRequests    int              `json:"length_capped_requests"`
 	Requests                []RequestMetrics `json:"requests,omitempty"`
 }
 

--- a/sim/model_hardware_config.go
+++ b/sim/model_hardware_config.go
@@ -4,28 +4,27 @@ package sim
 // Used by the roofline and cross-model latency models for step time estimation.
 // Parsing functions are in sim/latency/config.go.
 type ModelConfig struct {
-	NumLayers        int     `json:"num_hidden_layers"`
-	HiddenDim        int     `json:"hidden_size"`
-	NumHeads         int     `json:"num_attention_heads"`
-	NumKVHeads       int     `json:"num_key_value_heads"`
-	VocabSize        int     `json:"vocab_size"`
-	BytesPerParam    float64 `json:"bytes_per_param"`
-	IntermediateDim  int     `json:"intermediate_size"`
-	NumLocalExperts  int     `json:"num_local_experts"`   // 0 = dense model (MoE: number of experts)
-	NumExpertsPerTok int     `json:"num_experts_per_tok"` // 0 = dense model (MoE: active experts per token; parsed for future iteration, not yet consumed by crossmodel)
+	NumLayers          int     `json:"num_hidden_layers"`
+	HiddenDim          int     `json:"hidden_size"`
+	NumHeads           int     `json:"num_attention_heads"`
+	NumKVHeads         int     `json:"num_key_value_heads"`
+	VocabSize          int     `json:"vocab_size"`
+	BytesPerParam      float64 `json:"bytes_per_param"`
+	IntermediateDim    int     `json:"intermediate_size"`
+	NumLocalExperts    int     `json:"num_local_experts"`               // 0 = dense model (MoE: number of experts)
+	NumExpertsPerTok   int     `json:"num_experts_per_tok"`             // 0 = dense model (MoE: active experts per token)
+	MoEExpertFFNDim    int     `json:"moe_intermediate_size"`           // Per-routed-expert FFN dim; 0 = use IntermediateDim (Mixtral convention)
+	SharedExpertFFNDim int     `json:"shared_expert_intermediate_size"` // Total shared-expert FFN dim; 0 = no shared experts
+	HiddenAct          string  `json:"hidden_act"`                     // Activation function (e.g. "silu", "gelu", "relu"); used by KV capacity (3-matrix SwiGLU detection), reserved for future roofline per-activation tuning
 }
 
 // HardwareCalib holds GPU hardware calibration parameters.
 // Used by the roofline latency model for compute/memory bandwidth estimation.
 // Parsing functions are in sim/latency/config.go.
 type HardwareCalib struct {
-	TFlopsPeak       float64 `json:"TFlopsPeak"`      // Tera (10^12) FLOP/s
-	BwPeakTBs        float64 `json:"BwPeakTBs"`       // in TB/s
-	BwEffConstant    float64 `json:"BwEffConstant"`    // scaling factor to convert Peak BW to Effective BW
-	TOverheadMicros  float64 `json:"TOverheadMicros"`  // Per-step Overheads unaccounted for
-	PerLayerOverhead float64 `json:"perLayerOverhead"`
-	MfuPrefill       float64 `json:"mfuPrefill"`
-	MfuDecode        float64 `json:"mfuDecode"`
-	AllReduceLatency float64 `json:"allReduceLatency"`
-	MemoryGiB        float64 `json:"MemoryGiB"` // GPU memory capacity in GiB
+	TFlopsPeak float64 `json:"TFlopsPeak"` // Tera (10^12) FLOP/s
+	BwPeakTBs  float64 `json:"BwPeakTBs"`  // in TB/s
+	MfuPrefill float64 `json:"mfuPrefill"`
+	MfuDecode  float64 `json:"mfuDecode"`
+	MemoryGiB  float64 `json:"MemoryGiB"` // GPU memory capacity in GiB
 }

--- a/sim/request.go
+++ b/sim/request.go
@@ -30,6 +30,7 @@ type Request struct {
 
 	InputTokens  []int // Prompt tokens
 	OutputTokens []int // Pre-specified output tokens (already known for the simulation)
+	MaxOutputLen int   // Client output budget (vLLM max_tokens); 0 = no budget (input-only check, runtime stop enforces limit)
 
 	State         RequestState // queued, running, completed
 	ProgressIndex int64  // Total number of input tokens processed so far + number of output tokens generated so far

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -76,6 +76,7 @@ type Simulator struct {
 	batchFormation       BatchFormation
 	model                  string
 	gpu                    string
+	maxModelLen            int64 // max total sequence length (0 = unlimited)
 	rng                    *PartitionedRNG // partitioned RNG for deterministic multi-subsystem simulation
 	priorityPolicy         PriorityPolicy
 	scheduler              InstanceScheduler
@@ -100,6 +101,23 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	if cfg.LongPrefillTokenThreshold < 0 {
 		return nil, fmt.Errorf("NewSimulator: LongPrefillTokenThreshold must be >= 0, got %d", cfg.LongPrefillTokenThreshold)
 	}
+	if cfg.MaxModelLen < 0 {
+		return nil, fmt.Errorf("NewSimulator: MaxModelLen must be >= 0, got %d", cfg.MaxModelLen)
+	}
+	if cfg.MaxModelLen > 0 {
+		if cfg.BlockSizeTokens <= 0 {
+			return nil, fmt.Errorf("NewSimulator: BlockSizeTokens must be > 0 when MaxModelLen is set, got %d", cfg.BlockSizeTokens)
+		}
+		// Ceiling division for MaxModelLen → block count (R11).
+		blocksForMaxLen := cfg.MaxModelLen / cfg.BlockSizeTokens
+		if cfg.MaxModelLen%cfg.BlockSizeTokens != 0 {
+			blocksForMaxLen++
+		}
+		if blocksForMaxLen > cfg.TotalKVBlocks {
+			return nil, fmt.Errorf("NewSimulator: KV cache too small for MaxModelLen: need %d blocks (ceil(%d/%d)) but TotalKVBlocks=%d",
+				blocksForMaxLen, cfg.MaxModelLen, cfg.BlockSizeTokens, cfg.TotalKVBlocks)
+		}
+	}
 	batchFormation := NewBatchFormation()
 
 	s := &Simulator{
@@ -119,6 +137,7 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 		batchFormation:            batchFormation,
 		model:                     cfg.Model,
 		gpu:                       cfg.GPU,
+		maxModelLen:               cfg.MaxModelLen,
 		latencyModel:              latencyModel,
 	}
 	s.rng = NewPartitionedRNG(NewSimulationKey(cfg.Seed))
@@ -226,11 +245,68 @@ func (sim *Simulator) CurrentClock() int64 { return sim.Clock }
 func (sim *Simulator) SimHorizon() int64 { return sim.Horizon }
 
 // EnqueueRequest adds a newly arrived request to the waiting queue.
-// Requests whose input tokens require more KV blocks than the total cache
-// capacity are dropped with a warning (R19: livelock protection). This mirrors
-// real vLLM behavior where oversized requests are rejected before entering
-// the engine.
+//
+// Preprocessing: auto-fills MaxOutputLen when the client doesn't set a budget
+// (MaxOutputLen == 0) and maxModelLen > 0. Sets MaxOutputLen = maxModelLen - len(InputTokens),
+// mirroring vLLM's input_processor.py:554 (max_tokens = max_model_len - seq_len).
+// Workload generators normally set MaxOutputLen = len(OutputTokens) (tight budget);
+// this auto-fill is a safety net for requests that bypass generators.
+//
+// Three guards then prevent unservable requests from entering the queue:
+//  0. MaxOutputLen validation (R3): drops requests with negative MaxOutputLen.
+//  1. MaxModelLen guard (when maxModelLen > 0): validates the request fits within
+//     the model's context window. First checks input >= maxModelLen (vLLM uses >=:
+//     input filling the entire context leaves no room for output). Then, when
+//     MaxOutputLen > 0 (client budget), checks input + budget <= maxModelLen.
+//  2. KV capacity guard (defense-in-depth, always active): drops requests whose input
+//     tokens alone require more KV blocks than total cache capacity (R19: livelock protection).
+//
+// All guards mirror real vLLM behavior where oversized requests are rejected
+// before entering the engine. The control plane never peeks at len(OutputTokens) —
+// respecting the oracle knowledge boundary (INV-9, #567).
 func (sim *Simulator) EnqueueRequest(r *Request) {
+	// Auto-fill: if client didn't set a budget, cap at remaining context window.
+	// Mirrors vLLM input_processor.py:554: max_tokens = max_model_len - seq_len.
+	// Only fires when maxModelLen > 0 (unlimited mode has nothing to cap against)
+	// and input fits (Guard 1 handles the input >= maxModelLen rejection).
+	if r.MaxOutputLen == 0 && sim.maxModelLen > 0 && int64(len(r.InputTokens)) < sim.maxModelLen {
+		r.MaxOutputLen = int(sim.maxModelLen) - len(r.InputTokens)
+	}
+
+	// Guard 0: Negative MaxOutputLen check (R3)
+	if r.MaxOutputLen < 0 {
+		logrus.Warnf("dropping request %s: MaxOutputLen %d is negative",
+			r.ID, r.MaxOutputLen)
+		sim.Metrics.DroppedUnservable++
+		delete(sim.Metrics.Requests, r.ID)
+		return
+	}
+
+	// Guard 1: MaxModelLen check (BC-2, BC-3)
+	if sim.maxModelLen > 0 {
+		// vLLM uses >= for the input check (serving.py:1542): input that fills
+		// the entire context window leaves no room for even one output token.
+		if int64(len(r.InputTokens)) >= sim.maxModelLen {
+			logrus.Warnf("dropping request %s: input length %d >= MaxModelLen %d (no room for output)",
+				r.ID, len(r.InputTokens), sim.maxModelLen)
+			sim.Metrics.DroppedUnservable++
+			delete(sim.Metrics.Requests, r.ID)
+			return
+		}
+		if r.MaxOutputLen > 0 {
+			// Client declared a budget: check input + budget fits context window
+			totalSeqLen := int64(len(r.InputTokens)) + int64(r.MaxOutputLen)
+			if totalSeqLen > sim.maxModelLen {
+				logrus.Warnf("dropping request %s: total sequence length %d (input=%d + budget=%d) exceeds MaxModelLen %d",
+					r.ID, totalSeqLen, len(r.InputTokens), r.MaxOutputLen, sim.maxModelLen)
+				sim.Metrics.DroppedUnservable++
+				delete(sim.Metrics.Requests, r.ID)
+				return
+			}
+		}
+	}
+
+	// Guard 2: KV capacity check (defense-in-depth, always active)
 	blocksNeeded := (int64(len(r.InputTokens)) + sim.KVCache.BlockSize() - 1) / sim.KVCache.BlockSize()
 	if blocksNeeded > sim.KVCache.TotalCapacity() {
 		logrus.Warnf("dropping request %s: input requires %d KV blocks but cache has only %d total",
@@ -283,6 +359,13 @@ func (sim *Simulator) recordKVUsageMetrics(stepDuration int64) {
 // recordRequestCompletion records per-request metrics for a completed request.
 // Called after state transitions (req.State, req.ITL, req.FinishedStepIdx)
 // and KV cleanup are done.
+//
+// NOTE: E2E (lat) includes PostDecodeFixedOverhead and OutputTokenProcessingTime, both of
+// which model non-blocking CPU overhead (concurrent with GPU execution). These inflate
+// E2E and RequestCompletionTimes beyond the RequestLeftEvent timestamp by the overhead
+// amount. This is architecturally intentional: real vLLM's post-processing (detokenization,
+// response serialization) is non-blocking but still contributes to client-perceived latency.
+// For trained-roofline, PostDecodeFixedOverhead adds ~1.85ms to E2E; for other backends it's 0.
 func (sim *Simulator) recordRequestCompletion(req *Request) {
 	sim.Metrics.CompletedRequests++
 
@@ -290,12 +373,25 @@ func (sim *Simulator) recordRequestCompletion(req *Request) {
 	for _, v := range req.ITL {
 		itlSum += v
 	}
-	lat := req.FirstTokenTime + itlSum
+	// PostDecodeFixedOverhead: fixed per-request overhead at completion (e.g., response setup).
+	// Only applied to requests that went through a decode phase. Zero-output-token requests
+	// (prefill-only) skip this overhead since they never entered the post-decode path.
+	var postDecodeOverhead int64
+	if len(req.OutputTokens) > 0 {
+		postDecodeOverhead = sim.latencyModel.PostDecodeFixedOverhead()
+	}
+	lat := req.FirstTokenTime + itlSum + postDecodeOverhead
 	sim.Metrics.RequestE2Es[req.ID] = float64(lat)
 	logrus.Debugf("Finished req: ID: %s at time: %d", req.ID, lat+req.ArrivalTime)
 	if len(req.OutputTokens) > 0 {
-		reqTotalOutput := lat - req.FirstTokenTime
-		// TPOT calculation in vLLM excludes the first generated token
+		// Compute average ITL from itlSum directly (not from lat - FirstTokenTime)
+		// to avoid contaminating per-token ITL with the fixed post-decode overhead.
+		reqTotalOutput := itlSum
+		// TPOT calculation in vLLM excludes the first generated token.
+		// NOTE: For length-capped requests (BC-5), this denominator uses the
+		// pre-determined output token count rather than actual decode steps completed.
+		// The resulting average ITL (stored in RequestITLs) will be underestimated.
+		// Acceptable for a defense-in-depth path that should rarely fire.
 		sim.Metrics.RequestITLs[req.ID] = float64(reqTotalOutput) / float64(max(len(req.OutputTokens)-1, 1))
 	} else {
 		sim.Metrics.RequestITLs[req.ID] = 0
@@ -449,6 +545,30 @@ func (sim *Simulator) processCompletions(now, currStepAdvance int64) []*Request 
 			})
 
 			// Record completion metrics
+			sim.recordRequestCompletion(req)
+		} else if sim.maxModelLen > 0 && req.ProgressIndex >= sim.maxModelLen {
+			// BC-5: Runtime length cap — defense-in-depth.
+			// Force-complete any request that has reached MaxModelLen.
+			// This should not fire under normal operation (enqueue guard prevents it),
+			// but protects against unbounded growth if a request bypasses the guard.
+			//
+			// NOTE (R23 exception): Final-token KV allocation is intentionally skipped here.
+			// R23 requires parallel code paths to apply equivalent transformations, but
+			// the normal completion path's AllocateKVBlocks for the last token (to commit
+			// it to the prefix cache) is not useful for a force-terminated request whose
+			// blocks are immediately released. The token at the cap boundary was already
+			// processed by executeBatchStep; the partially-filled last block is not
+			// committed to the prefix cache.
+			logrus.Warnf("[tick %07d] force-completing request %s: ProgressIndex %d >= MaxModelLen %d (length-capped)",
+				now, req.ID, req.ProgressIndex, sim.maxModelLen)
+			sim.Metrics.LengthCappedRequests++
+			req.State = StateCompleted
+			sim.KVCache.ReleaseKVBlocks(req)
+			req.FinishedStepIdx = sim.stepCount
+			sim.Schedule(&RequestLeftEvent{
+				time:    now + currStepAdvance,
+				Request: req,
+			})
 			sim.recordRequestCompletion(req)
 		} else {
 			remaining = append(remaining, req)

--- a/sim/simulator_preempt_test.go
+++ b/sim/simulator_preempt_test.go
@@ -13,7 +13,7 @@ func TestPreempt_EmptyBatch_ReturnsFalse(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(config.TotalKVBlocks, config.BlockSizeTokens)
@@ -67,7 +67,7 @@ func TestPreempt_InsufficientBlocks_EvictsAllThenReturnsFalse(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(2, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 10000, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	bf := NewBatchFormation()
 	kvCache := MustNewKVCacheState(config.TotalKVBlocks, config.BlockSizeTokens)

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -47,7 +47,7 @@ func TestSimulator_GoldenDataset(t *testing.T) {
 				KVCacheConfig:       NewKVCacheConfig(tc.TotalKVBlocks, tc.BlockSizeInTokens, 0, 0, 0, 0),
 				BatchConfig:         NewBatchConfig(tc.MaxNumRunningReqs, tc.MaxNumScheduledTokens, tc.LongPrefillTokenThreshold),
 				LatencyCoeffs:       NewLatencyCoeffs(tc.BetaCoeffs, tc.AlphaCoeffs),
-				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, ""),
+				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, tc.Model, tc.Hardware, tc.TP, "", tc.MaxModelLen),
 			})
 
 			requests := testGenerateRequests(tc.Seed, math.MaxInt64, tc.Rate/1e6,
@@ -158,7 +158,7 @@ func TestSimulator_WorkloadRNG_NotNil(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, "", 0),
 	})
 
 	rng := sim.WorkloadRNG()
@@ -180,7 +180,7 @@ func TestSimulator_DeterministicWorkload(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 0),
 	}
 
 	requests := testGenerateRequests(42, math.MaxInt64, 10.0/1e6, 50,
@@ -225,7 +225,7 @@ func newTestSimConfig() SimConfig {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-model", "H100", 1, "", 0),
 	}
 }
 
@@ -330,7 +330,7 @@ func TestMustNewLatencyModel_NilFunc_Panics(t *testing.T) {
 		}
 	}()
 	coeffs := NewLatencyCoeffs([]float64{1, 2, 3}, []float64{1, 2, 3})
-	hw := NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "")
+	hw := NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0)
 	_, _ = MustNewLatencyModel(coeffs, hw) //nolint:errcheck // expected to panic before returning
 }
 
@@ -344,6 +344,45 @@ func TestNewSimulator_NilLatencyModel_ReturnsError(t *testing.T) {
 	if err.Error() != "NewSimulator: latencyModel must not be nil" {
 		t.Errorf("unexpected error message: %v", err)
 	}
+}
+
+// BC-1: KV cache too small for MaxModelLen → error
+func TestNewSimulator_MaxModelLen_KVTooSmall(t *testing.T) {
+	cfg := newTestSimConfig()
+	// 1024 tokens / 16 block size = 64 blocks needed, but only 50 available
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 1024)
+	cfg.KVCacheConfig = NewKVCacheConfig(50, 16, 0, 0, 0, 0)
+
+	kvStore := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
+	latencyModel, err := MustNewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
+	if err != nil {
+		t.Fatalf("MustNewLatencyModel: %v", err)
+	}
+	_, err = NewSimulator(cfg, kvStore, latencyModel)
+	if err == nil {
+		t.Fatal("expected error when KV cache too small for MaxModelLen")
+	}
+	if !strings.Contains(err.Error(), "KV cache too small for MaxModelLen") {
+		t.Errorf("error should mention KV cache too small, got: %v", err)
+	}
+}
+
+// BC-1: KV cache sufficient for MaxModelLen → no error
+func TestNewSimulator_MaxModelLen_KVSufficient(t *testing.T) {
+	cfg := newTestSimConfig()
+	// 1024 tokens / 16 block size = 64 blocks needed, 100 available
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 1024)
+	cfg.KVCacheConfig = NewKVCacheConfig(100, 16, 0, 0, 0, 0)
+	_ = mustNewSimulator(t, cfg) // should not error
+}
+
+// BC-3: MaxModelLen=0 bypasses the KV check
+func TestNewSimulator_MaxModelLen_Zero_NoValidation(t *testing.T) {
+	cfg := newTestSimConfig()
+	// MaxModelLen=0 (default) — no validation even with small KV cache
+	cfg.ModelHardwareConfig = NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 0)
+	cfg.KVCacheConfig = NewKVCacheConfig(1, 16, 0, 0, 0, 0)
+	_ = mustNewSimulator(t, cfg) // should not error
 }
 
 // TestNewSimulator_NoWorkload_EmptyQueue verifies that a SimConfig with no injected
@@ -526,7 +565,7 @@ func TestSimulator_RequestConservation_InfiniteHorizon_AllRequestsComplete(t *te
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -583,7 +622,7 @@ func TestSimulator_RequestConservation_FiniteHorizon_ThreeTermEquation(t *testin
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation-finite", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-conservation-finite", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -648,7 +687,7 @@ func TestSimulator_Causality_FullChain_ArrivalToCompletion(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-causality", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-causality", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -704,7 +743,7 @@ func TestSimulator_ClockMonotonicity_NeverDecreases(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-monotonicity", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-monotonicity", "H100", 1, "", 0),
 	}
 
 	sim := mustNewSimulator(t, cfg)
@@ -747,7 +786,7 @@ func TestInjectArrival_BeyondHorizon_Warns(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(100, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(10, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{100, 1, 1}, []float64{50, 0.1, 50}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 	sim := mustNewSimulator(t, cfg)
 	req := &Request{
@@ -772,7 +811,7 @@ func TestSimulator_Determinism_ByteIdenticalJSON(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-determinism", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-determinism", "H100", 1, "", 0),
 	}
 
 	// Run 1
@@ -852,7 +891,7 @@ func TestSimulator_KVBlockConservation_PostSimulation_ZeroLeak(t *testing.T) {
 				KVCacheConfig:       NewKVCacheConfig(10000, 16, tt.kvCPUBlocks, 0.8, 100.0, 0),
 				BatchConfig:         NewBatchConfig(256, 2048, 0),
 				LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-kv-conservation", "H100", 1, ""),
+				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-kv-conservation", "H100", 1, "", 0),
 			}
 
 			sim := mustNewSimulator(t, cfg)
@@ -923,7 +962,7 @@ func TestWorkConserving_StepRestartsWhenWaitQNonEmpty(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(1, 2048, 0), // KEY: only one request can run at a time
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-work-conserving", "H100", 1, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test-work-conserving", "H100", 1, "", 0),
 	}
 
 	s := mustNewSimulator(t, cfg)
@@ -1087,6 +1126,502 @@ func TestEnqueueRequest_NormalInput_Enqueued(t *testing.T) {
 	// AND TotalInputTokens must include the request's tokens
 	if sim.Metrics.TotalInputTokens != 100 {
 		t.Errorf("TotalInputTokens = %d, want 100", sim.Metrics.TotalInputTokens)
+	}
+}
+
+// BC-2: Request with explicit budget exceeding MaxModelLen is dropped
+func TestEnqueueRequest_MaxModelLen_Exceeded_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Request: 300 input + 300 budget = 600 > MaxModelLen(512)
+	req := &Request{
+		ID:           "too_long",
+		InputTokens:  make([]int, 300),
+		OutputTokens: make([]int, 300),
+		MaxOutputLen: 300, // client declares output budget
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+	if _, exists := sim.Metrics.Requests[req.ID]; exists {
+		t.Error("dropped request should be removed from Metrics.Requests")
+	}
+}
+
+// BC-3: MaxModelLen=0 falls through to KV check only
+func TestEnqueueRequest_MaxModelLen_Zero_FallsThroughToKV(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 0),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Large request that fits KV (100 tokens, 1000 blocks available) but would fail MaxModelLen if it were set
+	req := &Request{
+		ID:           "large_but_fits_kv",
+		InputTokens:  make([]int, 100),
+		OutputTokens: make([]int, 1000),
+		State:        StateQueued,
+	}
+
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (MaxModelLen=0 should not reject)", sim.WaitQ.Len())
+	}
+}
+
+// BC-4: MaxOutputLen=0 → input-only check (oracle knowledge boundary: control plane
+// never peeks at len(OutputTokens)). Runtime stop enforces output growth limit.
+func TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Case 1: MaxOutputLen=0 → auto-filled to 312 (512-200), input+budget=512 ≤ 512 → enqueued.
+	// Auto-fill sets MaxOutputLen=312 (remaining context). Guard 1 budget check passes (200+312=512).
+	// The control plane still doesn't peek at len(OutputTokens) (INV-9 preserved).
+	reqFits := &Request{
+		ID:           "input_fits_oracle",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 1000), // actual output exceeds context, but control plane can't see this
+		MaxOutputLen: 0,                 // auto-filled to maxModelLen - input = 312
+		State:        StateQueued,
+	}
+	sim.EnqueueRequest(reqFits)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (MaxOutputLen=0 should only check input)", sim.WaitQ.Len())
+	}
+
+	// Case 2: MaxOutputLen=0, input exceeds MaxModelLen → dropped
+	reqInputTooBig := &Request{
+		ID:           "input_too_big",
+		InputTokens:  make([]int, 600), // 600 > 512
+		OutputTokens: make([]int, 10),
+		MaxOutputLen: 0,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[reqInputTooBig.ID] = NewRequestMetrics(reqInputTooBig, 0)
+	sim.EnqueueRequest(reqInputTooBig)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (input exceeds MaxModelLen)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+
+	// Case 3: MaxOutputLen=400 (client budget) → total: 200 + 400 = 600 > 512 → dropped
+	reqBudgetExceeds := &Request{
+		ID:           "budget_exceeds",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 100), // actual output is 100, but client budget says 400
+		MaxOutputLen: 400,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[reqBudgetExceeds.ID] = NewRequestMetrics(reqBudgetExceeds, 0)
+	sim.EnqueueRequest(reqBudgetExceeds)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (budget-exceeded request should be dropped)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 2 {
+		t.Errorf("DroppedUnservable = %d, want 2", sim.Metrics.DroppedUnservable)
+	}
+}
+
+// Boundary test: input == maxModelLen with no budget → dropped (vLLM uses >= at serving.py:1542).
+// A request whose input fills the entire context leaves no room for output.
+func TestEnqueueRequest_InputEqualsMaxModelLen_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// input == MaxModelLen: fills the entire context, no room for output
+	req := &Request{
+		ID:           "exact_boundary",
+		InputTokens:  make([]int, 512), // == MaxModelLen
+		OutputTokens: make([]int, 10),
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0 (input==MaxModelLen should be rejected)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+}
+
+// Boundary test: input + budget == maxModelLen → accepted (exact fit, not exceeded).
+func TestEnqueueRequest_ExactFit_Accepted(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// input=200 + budget=312 = 512 == MaxModelLen → exact fit, should be accepted
+	req := &Request{
+		ID:           "exact_fit",
+		InputTokens:  make([]int, 200),
+		OutputTokens: make([]int, 312),
+		MaxOutputLen: 312,
+		State:        StateQueued,
+	}
+	sim.EnqueueRequest(req)
+	if sim.WaitQ.Len() != 1 {
+		t.Errorf("WaitQ.Len() = %d, want 1 (exact fit should be accepted)", sim.WaitQ.Len())
+	}
+}
+
+// BC-7: Negative MaxOutputLen → warning + dropped
+func TestEnqueueRequest_NegativeMaxOutputLen_Dropped(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{6910, 17.67, 2.84}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 512),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	req := &Request{
+		ID:           "neg_budget",
+		InputTokens:  make([]int, 100),
+		OutputTokens: make([]int, 50),
+		MaxOutputLen: -1,
+		State:        StateQueued,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.EnqueueRequest(req)
+
+	if sim.WaitQ.Len() != 0 {
+		t.Errorf("WaitQ.Len() = %d, want 0 (negative MaxOutputLen should be dropped)", sim.WaitQ.Len())
+	}
+	if sim.Metrics.DroppedUnservable != 1 {
+		t.Errorf("DroppedUnservable = %d, want 1", sim.Metrics.DroppedUnservable)
+	}
+	if _, exists := sim.Metrics.Requests["neg_budget"]; exists {
+		t.Error("Metrics.Requests should not contain dropped request")
+	}
+}
+
+// BC-5: Runtime length cap force-completes request at MaxModelLen boundary.
+// This is a defense-in-depth test: we directly place a request in the running batch
+// with ProgressIndex already at MaxModelLen to simulate bypass of enqueue guard.
+func TestProcessCompletions_RuntimeLengthCap(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 100),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Create a request with ProgressIndex at MaxModelLen boundary (bypassing enqueue guard)
+	req := &Request{
+		ID:           "length_capped",
+		InputTokens:  make([]int, 50),
+		OutputTokens: make([]int, 200), // would normally be longer than MaxModelLen
+		State:        StateRunning,
+		ProgressIndex: 100, // == MaxModelLen → should be force-completed
+		ArrivalTime:  0,
+	}
+	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
+	sim.RunningBatch = &Batch{Requests: []*Request{req}}
+
+	// Simulate processCompletions
+	remaining := sim.processCompletions(1000, 5000)
+
+	// THEN the request is force-completed
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %d, want 0 (length-capped request should be completed)", len(remaining))
+	}
+	if req.State != StateCompleted {
+		t.Errorf("req.State = %s, want completed", req.State)
+	}
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests = %d, want 1", sim.Metrics.CompletedRequests)
+	}
+
+	// BC-2: LengthCappedRequests counter incremented
+	if sim.Metrics.LengthCappedRequests != 1 {
+		t.Errorf("LengthCappedRequests = %d, want 1", sim.Metrics.LengthCappedRequests)
+	}
+
+	// Conservation: no requests lost
+	if sim.WaitQ.Len()+len(remaining)+sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("conservation violated: queued=%d + remaining=%d + completed=%d != 1",
+			sim.WaitQ.Len(), len(remaining), sim.Metrics.CompletedRequests)
+	}
+}
+
+// BC-5: End-to-end runtime length cap via sim.Run()
+// Injects a request that passes the enqueue guard (MaxOutputLen=0 → input-only check)
+// but has OutputTokens exceeding MaxModelLen. The runtime cap in processCompletions
+// should force-complete the request at the MaxModelLen boundary.
+func TestSimulator_RuntimeLengthCap_E2E(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             10_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{6910, 17.67, 2.84}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 100),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// MaxOutputLen=0 → auto-filled to 50 (100-50). Guard 1 budget check: 50+50=100 ≤ 100 → enqueued.
+	// But actual OutputTokens=200 means ProgressIndex will exceed MaxModelLen=100.
+	req := &Request{
+		ID:           "will_be_capped",
+		InputTokens:  GenerateRandomTokenIDs(sim.WorkloadRNG(), 50),
+		OutputTokens: GenerateRandomTokenIDs(sim.WorkloadRNG(), 200),
+		ArrivalTime:  0,
+		State:        StateQueued,
+	}
+	sim.InjectArrival(req)
+
+	sim.Run()
+
+	// Request completes (force-completed at MaxModelLen boundary)
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests = %d, want 1", sim.Metrics.CompletedRequests)
+	}
+	if sim.Metrics.LengthCappedRequests != 1 {
+		t.Errorf("LengthCappedRequests = %d, want 1", sim.Metrics.LengthCappedRequests)
+	}
+	// INV-1: conservation holds
+	total := sim.Metrics.CompletedRequests + sim.Metrics.StillQueued + sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != 1 {
+		t.Errorf("INV-1: completed(%d)+queued(%d)+running(%d)+dropped(%d) = %d, want 1",
+			sim.Metrics.CompletedRequests, sim.Metrics.StillQueued, sim.Metrics.StillRunning, sim.Metrics.DroppedUnservable, total)
+	}
+	// Output was truncated below the full 200
+	if sim.Metrics.TotalOutputTokens >= 200 {
+		t.Errorf("TotalOutputTokens = %d, want < 200 (force-completion should truncate)", sim.Metrics.TotalOutputTokens)
+	}
+	if sim.Metrics.TotalOutputTokens == 0 {
+		t.Error("TotalOutputTokens = 0, want > 0 (some decode work should have happened)")
+	}
+	// Regression anchor: MaxModelLen(100) - input(50) = 50 decode steps
+	if sim.Metrics.TotalOutputTokens != 50 {
+		t.Errorf("TotalOutputTokens = %d, want 50 (regression anchor)", sim.Metrics.TotalOutputTokens)
+	}
+	// KV blocks released
+	if sim.KVCache.UsedBlocks() != 0 {
+		t.Errorf("UsedBlocks = %d, want 0 (KV blocks should be released after force-completion)", sim.KVCache.UsedBlocks())
+	}
+}
+
+// BC-7: INV-1 conservation holds when MaxModelLen drops requests.
+// End-to-end test: inject mix of requests (some exceed budget, some fit),
+// run to completion, verify injected == completed + dropped.
+func TestSimulator_Conservation_WithMaxModelLen_Drops(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             10_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 1, 1}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", 200),
+	}
+	sim := mustNewSimulator(t, cfg)
+	rng := sim.WorkloadRNG()
+
+	// Inject 20 requests: 10 that fit (input=50, output=50, budget=100 → 150 < 200)
+	// and 10 that exceed (input=50, output=50, budget=200 → 250 > 200)
+	numInjected := 0
+	for i := 0; i < 10; i++ {
+		req := &Request{
+			ID:           fmt.Sprintf("fits_%d", i),
+			InputTokens:  GenerateRandomTokenIDs(rng, 50),
+			OutputTokens: GenerateRandomTokenIDs(rng, 50),
+			MaxOutputLen: 100,
+			ArrivalTime:  int64(i * 100000),
+			State:        StateQueued,
+		}
+		sim.InjectArrival(req)
+		numInjected++
+	}
+	for i := 0; i < 10; i++ {
+		req := &Request{
+			ID:           fmt.Sprintf("exceeds_%d", i),
+			InputTokens:  GenerateRandomTokenIDs(rng, 50),
+			OutputTokens: GenerateRandomTokenIDs(rng, 50),
+			MaxOutputLen: 200, // 50 + 200 = 250 > MaxModelLen(200)
+			ArrivalTime:  int64(i * 100000),
+			State:        StateQueued,
+		}
+		sim.InjectArrival(req)
+		numInjected++
+	}
+
+	sim.Run()
+
+	// INV-1: injected == completed + still_queued + still_running + dropped
+	total := sim.Metrics.CompletedRequests + sim.Metrics.StillQueued +
+		sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != numInjected {
+		t.Errorf("INV-1 violation: completed(%d) + queued(%d) + running(%d) + dropped(%d) = %d, want %d",
+			sim.Metrics.CompletedRequests, sim.Metrics.StillQueued,
+			sim.Metrics.StillRunning, sim.Metrics.DroppedUnservable,
+			total, numInjected)
+	}
+
+	// Verify: 10 requests should be dropped, 10 should complete
+	if sim.Metrics.DroppedUnservable != 10 {
+		t.Errorf("DroppedUnservable = %d, want 10", sim.Metrics.DroppedUnservable)
+	}
+	if sim.Metrics.CompletedRequests != 10 {
+		t.Errorf("CompletedRequests = %d, want 10", sim.Metrics.CompletedRequests)
+	}
+}
+
+// BC-1: Negative MaxModelLen rejected by NewSimulator (defense-in-depth for struct literal bypass)
+func TestNewSimulator_NegativeMaxModelLen_Error(t *testing.T) {
+	cfg := newTestSimConfig()
+	cfg.MaxModelLen = -5 // bypass canonical constructor's panic to test NewSimulator validation
+	kvStore := MustNewKVStoreFromConfig(cfg.KVCacheConfig)
+	latencyModel, err := MustNewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
+	if err != nil {
+		t.Fatalf("MustNewLatencyModel: %v", err)
+	}
+	_, err = NewSimulator(cfg, kvStore, latencyModel)
+	if err == nil {
+		t.Fatal("expected error for negative MaxModelLen")
+	}
+	if !strings.Contains(err.Error(), "MaxModelLen") {
+		t.Errorf("error %q should mention MaxModelLen", err.Error())
+	}
+}
+
+// R3: NewModelHardwareConfig panics on negative MaxModelLen
+func TestNewModelHardwareConfig_NegativeMaxModelLen_Panics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for negative MaxModelLen")
+		}
+		msg := fmt.Sprintf("%v", r)
+		if !strings.Contains(msg, "MaxModelLen") {
+			t.Errorf("panic message %q should contain MaxModelLen", msg)
+		}
+	}()
+	NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", -1)
+}
+
+// INV-9: Oracle Knowledge Boundary — control-plane functions must not reference OutputTokens.
+// This is a structural enforcement test: it reads the source files for servability-decision
+// functions and verifies zero references to OutputTokens.
+func TestINV9_OracleKnowledgeBoundary_NoOutputTokensInControlPlane(t *testing.T) {
+	// Control-plane files in sim/ that must not reference OutputTokens.
+	// These files contain no metric-aggregate names like TotalOutputTokens,
+	// so a whole-file scan is safe and maximally conservative.
+	simControlPlaneFiles := []string{
+		"admission.go",
+		"routing.go",
+		"routing_scorers.go",
+		"routing_prefix_scorer.go",
+		"scheduler.go",
+		"priority.go",
+	}
+
+	for _, filename := range simControlPlaneFiles {
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", filename, err)
+		}
+		content := string(data)
+		if strings.Contains(content, "OutputTokens") {
+			t.Errorf("INV-9 violation: %s references OutputTokens — control-plane code must not access oracle output length", filename)
+		}
+	}
+
+	// Cluster control-plane files that handle *Request in the routing pipeline.
+	// These files may contain TotalOutputTokens (metric aggregation, not oracle access),
+	// so we use line-level scanning with TotalOutputTokens exclusion.
+	clusterControlPlaneFiles := []string{
+		"cluster/cluster.go",
+		"cluster/cluster_event.go",
+		"cluster/snapshot.go",
+		"cluster/counterfactual.go",
+	}
+
+	for _, filename := range clusterControlPlaneFiles {
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", filename, err)
+		}
+		for lineNum, line := range strings.Split(string(data), "\n") {
+			// Remove known-safe metric aggregate names, then check for remaining OutputTokens
+			cleaned := strings.ReplaceAll(line, "TotalOutputTokens", "")
+			if strings.Contains(cleaned, "OutputTokens") {
+				t.Errorf("INV-9 violation: %s line %d references OutputTokens — control-plane code must not access oracle output length",
+					filename, lineNum+1)
+			}
+		}
+	}
+
+	// Additionally verify EnqueueRequest specifically (it's in simulator.go, which
+	// also contains execution-engine code that legitimately uses OutputTokens).
+	data, err := os.ReadFile("simulator.go")
+	if err != nil {
+		t.Fatalf("failed to read simulator.go: %v", err)
+	}
+	content := string(data)
+	// Extract EnqueueRequest function body (between "func (sim *Simulator) EnqueueRequest" and the next "func ")
+	startIdx := strings.Index(content, "func (sim *Simulator) EnqueueRequest")
+	if startIdx < 0 {
+		t.Fatal("EnqueueRequest function not found in simulator.go")
+	}
+	endIdx := strings.Index(content[startIdx+1:], "\nfunc ")
+	if endIdx < 0 {
+		t.Fatal("could not find end of EnqueueRequest function")
+	}
+	enqueueBody := content[startIdx : startIdx+1+endIdx]
+	if strings.Contains(enqueueBody, "OutputTokens") {
+		t.Error("INV-9 violation: EnqueueRequest references OutputTokens — enqueue guard must not access oracle output length")
 	}
 }
 
@@ -1322,7 +1857,7 @@ func TestNewSimulator_NonRooflineZeroNumHeads_Succeeds(t *testing.T) {
 		KVCacheConfig:       NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
 		BatchConfig:         NewBatchConfig(256, 2048, 0),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{1, 2, 3}, []float64{1, 2, 3}),
-		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{NumHeads: 0}, HardwareCalib{}, "", "", 0, ""),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{NumHeads: 0}, HardwareCalib{}, "", "", 0, "", 0),
 	}
 
 	// WHEN NewSimulator is called
@@ -1339,5 +1874,150 @@ func TestNewSimulator_NonRooflineZeroNumHeads_Succeeds(t *testing.T) {
 	}
 	if sim == nil {
 		t.Error("expected non-nil simulator")
+	}
+}
+
+// BC-7: Chunked prefill + MaxModelLen — no spurious force-completion.
+// GIVEN LongPrefillTokenThreshold=64, MaxModelLen=500, input=200, output=50
+// WHEN the request undergoes multi-chunk prefill (4 chunks: 64,64,64,8)
+// THEN the request completes normally (peak ProgressIndex=249 < 500),
+//
+//	LengthCappedRequests==0, TTFT recorded, TotalOutputTokens==49.
+func TestSimulator_ChunkedPrefill_MaxModelLen_NoSpuriousCap(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             10_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 64), // LongPrefillTokenThreshold=64
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "", 500),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	req := &Request{
+		ID:           "chunked_prefill",
+		InputTokens:  GenerateRandomTokenIDs(sim.WorkloadRNG(), 200),
+		OutputTokens: GenerateRandomTokenIDs(sim.WorkloadRNG(), 50),
+		ArrivalTime:  0,
+		State:        StateQueued,
+	}
+	sim.InjectArrival(req)
+	sim.Run()
+
+	// Request completes normally (no force-completion)
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests = %d, want 1", sim.Metrics.CompletedRequests)
+	}
+	if sim.Metrics.LengthCappedRequests != 0 {
+		t.Errorf("LengthCappedRequests = %d, want 0 (no spurious force-completion during chunked prefill)", sim.Metrics.LengthCappedRequests)
+	}
+
+	// TTFT recorded — verifies TTFT fires on final prefill chunk (ProgressIndex=200), not intermediate chunks
+	ttft, hasTTFT := sim.Metrics.RequestTTFTs["chunked_prefill"]
+	if !hasTTFT || ttft <= 0 {
+		t.Errorf("TTFT not recorded (hasTTFT=%v, ttft=%v); expected positive TTFT after chunked prefill", hasTTFT, ttft)
+	}
+
+	// TotalOutputTokens: decode runs PI 201→249 = 49 tokens.
+	// Normal completion fires at PI == 200 + max(50,1) - 1 = 249.
+	if sim.Metrics.TotalOutputTokens != 49 {
+		t.Errorf("TotalOutputTokens = %d, want 49 (decode PI 201→249)", sim.Metrics.TotalOutputTokens)
+	}
+
+	// INV-1 conservation
+	total := sim.Metrics.CompletedRequests + sim.Metrics.StillQueued + sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != 1 {
+		t.Errorf("INV-1: completed(%d)+queued(%d)+running(%d)+dropped(%d) = %d, want 1",
+			sim.Metrics.CompletedRequests, sim.Metrics.StillQueued, sim.Metrics.StillRunning, sim.Metrics.DroppedUnservable, total)
+	}
+}
+
+// TestEnqueueRequest_AutoFill_MaxOutputLen verifies the engine-level auto-fill
+// that sets MaxOutputLen = maxModelLen - len(InputTokens) when the client doesn't
+// provide a budget (BC-1..BC-4, BC-8, BC-10).
+func TestEnqueueRequest_AutoFill_MaxOutputLen(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxModelLen    int64
+		inputLen       int
+		initialMOL     int
+		expectedMOL    int
+		expectEnqueued bool
+		desc           string
+	}{
+		{
+			name:           "BC-1: auto-fill when client omits budget",
+			maxModelLen:    1000,
+			inputLen:       200,
+			initialMOL:     0,
+			expectedMOL:    800, // 1000 - 200
+			expectEnqueued: true,
+			desc:           "MaxOutputLen auto-filled to remaining context window",
+		},
+		{
+			name:           "BC-2: no auto-fill when client sets budget",
+			maxModelLen:    1000,
+			inputLen:       200,
+			initialMOL:     300,
+			expectedMOL:    300, // unchanged
+			expectEnqueued: true,
+			desc:           "client-provided MaxOutputLen preserved",
+		},
+		{
+			name:           "BC-3: no auto-fill in unlimited mode",
+			maxModelLen:    0,
+			inputLen:       200,
+			initialMOL:     0,
+			expectedMOL:    0, // unchanged
+			expectEnqueued: true,
+			desc:           "maxModelLen=0 means unlimited, no auto-fill",
+		},
+		{
+			name:           "BC-4: no auto-fill when input exceeds context",
+			maxModelLen:    100,
+			inputLen:       150,
+			initialMOL:     0,
+			expectedMOL:    0, // unchanged (Guard 1 handles rejection)
+			expectEnqueued: false,
+			desc:           "input >= maxModelLen, Guard 1 drops it",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := SimConfig{
+				KVCacheConfig:       NewKVCacheConfig(1000000, 16, 0, 0, 0, 0),
+				BatchConfig:         NewBatchConfig(256, 4096, 0),
+				LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 0, 0}, []float64{0, 0, 0}),
+				ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "", "", 0, "", tc.maxModelLen),
+				Horizon:             1000000,
+				Seed:                42,
+			}
+			s := mustNewSimulator(t, cfg)
+
+			req := &Request{
+				ID:           "test-req",
+				InputTokens:  make([]int, tc.inputLen),
+				OutputTokens: make([]int, 100),
+				MaxOutputLen: tc.initialMOL,
+				State:        StateQueued,
+			}
+
+			s.EnqueueRequest(req)
+
+			if tc.expectEnqueued {
+				if s.WaitQ.Len() != 1 {
+					t.Fatalf("expected request enqueued, WaitQ.Len()=%d", s.WaitQ.Len())
+				}
+				if req.MaxOutputLen != tc.expectedMOL {
+					t.Errorf("MaxOutputLen = %d, want %d (%s)",
+						req.MaxOutputLen, tc.expectedMOL, tc.desc)
+				}
+			} else {
+				if s.WaitQ.Len() != 0 {
+					t.Fatalf("expected request dropped, WaitQ.Len()=%d", s.WaitQ.Len())
+				}
+			}
+		})
 	}
 }

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -263,6 +263,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				ArrivalTime:      currentTime,
 				InputTokens:      inputTokens,
 				OutputTokens:     outputTokens,
+				MaxOutputLen:     len(outputTokens),
 				State:            sim.StateQueued,
 				ScheduledStepIdx: 0,
 				FinishedStepIdx:  0,

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -1149,3 +1149,35 @@ func TestGenerateRequests_ReasoningClient_NoPrefixGroup_Unchanged(t *testing.T) 
 		}
 	}
 }
+
+// BC-5: Generator sets MaxOutputLen = len(OutputTokens) for all requests.
+func TestGenerateRequests_SetsMaxOutputLen(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version:       "2",
+		Seed:          42,
+		Category:      "language",
+		AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID:           "c1",
+			RateFraction: 1.0,
+			Arrival:      ArrivalSpec{Process: "constant"},
+			InputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			OutputDist:   DistSpec{Type: "constant", Params: map[string]float64{"value": 30}},
+		}},
+	}
+
+	requests, err := GenerateRequests(spec, 1_000_000, 42)
+	if err != nil {
+		t.Fatalf("GenerateRequests: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+
+	for i, req := range requests {
+		if req.MaxOutputLen != len(req.OutputTokens) {
+			t.Errorf("request %d: MaxOutputLen=%d, want len(OutputTokens)=%d",
+				i, req.MaxOutputLen, len(req.OutputTokens))
+		}
+	}
+}

--- a/sim/workload/reasoning.go
+++ b/sim/workload/reasoning.go
@@ -66,10 +66,11 @@ func GenerateReasoningRequests(
 		}
 
 		req := &sim.Request{
-			ID:          "", // assigned later
-			ArrivalTime: currentTime,
-			InputTokens: inputTokens,
+			ID:           "", // assigned later
+			ArrivalTime:  currentTime,
+			InputTokens:  inputTokens,
 			OutputTokens: outputTokens,
+			MaxOutputLen: len(outputTokens),
 			State:        sim.StateQueued,
 			TenantID:     tenantID,
 			SLOClass:     sloClass,

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -46,6 +46,7 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 			ArrivalTime:      rec.ArrivalTimeUs,
 			InputTokens:      inputTokens,
 			OutputTokens:     outputTokens,
+			MaxOutputLen:     len(outputTokens),
 			State:            sim.StateQueued,
 			ScheduledStepIdx: 0,
 			FinishedStepIdx:  0,

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -49,6 +49,14 @@ func TestLoadTraceV2Requests_CorrectTokenCounts(t *testing.T) {
 	if requests[1].ArrivalTime != 100000 {
 		t.Errorf("request 1 arrival = %d, want 100000", requests[1].ArrivalTime)
 	}
+
+	// BC-6: MaxOutputLen = len(OutputTokens)
+	if requests[0].MaxOutputLen != len(requests[0].OutputTokens) {
+		t.Errorf("request 0 MaxOutputLen = %d, want %d", requests[0].MaxOutputLen, len(requests[0].OutputTokens))
+	}
+	if requests[1].MaxOutputLen != len(requests[1].OutputTokens) {
+		t.Errorf("request 1 MaxOutputLen = %d, want %d", requests[1].MaxOutputLen, len(requests[1].OutputTokens))
+	}
 }
 
 func TestLoadTraceV2Requests_PrefixGroup_SharedTokens(t *testing.T) {

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -33,7 +33,7 @@ type TraceServerConfig struct {
 	MaxNumSeqs            int     `yaml:"max_num_seqs,omitempty"`
 	BlockSize             int     `yaml:"block_size,omitempty"`
 	GPUMemoryUtilization  float64 `yaml:"gpu_memory_utilization,omitempty"`
-	MaxModelLen           int     `yaml:"max_model_len,omitempty"`
+	MaxModelLen           int64   `yaml:"max_model_len,omitempty"`
 }
 
 // TraceNetworkConfig captures network configuration in trace header.


### PR DESCRIPTION
## Summary

- Merges 11 commits from `main` into `pd`, bringing the PD disaggregation branch up to date
- Resolves 6 merge conflicts preserving both main's new features and pd's disaggregation work
- Fixes `NewModelHardwareConfig` call sites in disaggregation tests to include the new `MaxModelLen` parameter
- Rewrites a comment in `cluster_event.go` to avoid INV-9 structural test false positive

### Commits from main included:
- feat(latency): trained-roofline backend (#616)
- feat(sim): MaxOutputLen population + engine auto-fill (#621)
- fix(sim): MaxModelLen int64, rope_scaling extraction, tests, docs (#606)
- feat(latency): MoE-aware roofline latency (#561)
- feat(sim): MaxModelLen enforcement + MaxOutputLen budget (#579, #587)
- refactor(sim): remove dead HardwareCalib fields (#596)
- docs: switch default example model to Qwen3-14B (#608)
- CI/CD configuration (#600, #601, #607)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages green)
- [x] No remaining conflict markers
- [x] Disaggregation tests updated for `NewModelHardwareConfig` signature change
- [x] INV-9 oracle knowledge boundary test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)