### PR TITLE
fix(sim): guard decode-only batch path for non-PD transparency

### DIFF
--- a/sim/batch_formation.go
+++ b/sim/batch_formation.go
@@ -119,9 +119,12 @@ func (v *VLLMBatchFormation) FormBatch(ctx BatchContext) BatchResult {
 		next := ctx.WaitQ.Peek()
 
 		// Handle decode-only requests (PD disaggregation: KV pre-allocated by transfer).
-		// When ProgressIndex >= inputLen, the request skips prefill and starts in decode phase.
+		// When ProgressIndex > 0 and >= inputLen, the request skips prefill and starts in decode phase.
+		// The ProgressIndex > 0 guard ensures this path only fires for PD decode sub-requests
+		// (where AllocateTransferredKV explicitly set ProgressIndex = inputLen), not for
+		// pathological zero-input requests in non-PD mode (where ProgressIndex is always 0).
 		inputLen := util.Len64(next.InputTokens)
-		if next.ProgressIndex >= inputLen && len(next.OutputTokens) > 0 {
+		if next.ProgressIndex > 0 && next.ProgressIndex >= inputLen && len(next.OutputTokens) > 0 {
 			decodeTokens := int64(1)
 			if ok := ctx.KVCache.AllocateKVBlocks(next, next.ProgressIndex, next.ProgressIndex+decodeTokens, nil); !ok {
 				break


### PR DESCRIPTION
## Summary
- Adds `ProgressIndex > 0` guard to the PD decode-only batch formation path in `VLLMBatchFormation.FormBatch()`, ensuring it only fires for PD decode sub-requests (where `AllocateTransferredKV` explicitly set `ProgressIndex = inputLen > 0`), not for pathological zero-input requests in non-PD mode
- Ensures the `pd` branch is a fully transparent drop-in replacement for existing BLIS users who don't use PD disaggregation

### Context

The PD decode-only path used the condition `ProgressIndex >= inputLen` to detect decode sub-requests with pre-allocated KV. For hypothetical zero-input requests (`len(InputTokens)==0`), this condition is satisfied since `ProgressIndex(0) >= inputLen(0)`, causing non-PD requests to incorrectly take the decode-only path instead of the normal prefill path.

### Full backward compatibility audit

A comprehensive audit of all 37 changed files (~8700 lines) on the `pd` branch confirmed this was the **only** behavioral difference affecting non-PD users. All other PD additions are properly gated:

| Area | Guard mechanism |
|------|----------------|
| CLI flags | All 10 new PD flags default to disabled (`--pd-decider=never`, instances=0) |
| Event pipeline | Bifurcation gated by `cs.poolsConfigured()` (nil when PD disabled) |
| Metrics/JSON output | `PDMetrics` is nil; `printPDMetrics(nil)` is no-op |
| Trace records | PD records never recorded; summary PD fields are 0 |
| Anomaly counters | Extra `DroppedKVAllocations` line gated on `> 0` |
| Core simulator | `EnqueueDecodeSubRequest` only called by PD cluster logic |
| defaults.yaml | No pd-specific changes (all diffs came from main via merge) |

## Test plan
- [x] `go test ./...` passes (all 11 packages)
- [x] `go vet ./...` clean
- [ ] Verify existing non-PD simulation produces identical output on both `main` and `pd` branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)