### PR TITLE
Enable claude on fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,7 +4,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  statuses: write
   id-token: write
 
 on:
@@ -16,12 +15,45 @@ on:
     types: [opened, assigned]
 
 jobs:
-  claude:
+  check-permissions:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check invoker permissions
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor
+              });
+              const allowed = ['admin', 'write', 'maintain'].includes(data.permission);
+              core.setOutput('allowed', allowed ? 'true' : 'false');
+              if (!allowed) {
+                core.info(`User ${context.actor} has '${data.permission}' permission — skipping.`);
+              }
+            } catch (e) {
+              core.setOutput('allowed', 'false');
+              core.info(`User ${context.actor} is not a collaborator — skipping.`);
+            }
+
+  claude:
+    needs: check-permissions
+    if: needs.check-permissions.outputs.allowed == 'true'
     runs-on: [self-hosted]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
 
     steps:
       - name: Resolve PR head for fork PRs
@@ -35,10 +67,21 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            const headRepo = pr.head.repo ? pr.head.repo.full_name : `${context.repo.owner}/${context.repo.repo}`;
+            if (!pr.head.repo) {
+              core.setFailed('Source fork repository has been deleted; cannot check out PR head.');
+              return;
+            }
             core.setOutput('pr_head_sha', pr.head.sha);
-            core.setOutput('pr_head_repo', headRepo);
-            core.info(`PR #${context.issue.number}: head_repo=${headRepo}, head_sha=${pr.head.sha}`);
+            core.setOutput('pr_head_repo', pr.head.repo.full_name);
+            core.info(`PR #${context.issue.number}: head_repo=${pr.head.repo.full_name}, head_sha=${pr.head.sha}`);
+
+      - name: Validate PR info
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        run: |
+          if [ -z "${{ steps.pr-info.outputs.pr_head_sha }}" ]; then
+            echo "::error::pr-info step failed to resolve PR head SHA"
+            exit 1
+          fi
 
       - uses: actions/checkout@v4
         with:
@@ -65,6 +108,9 @@ jobs:
     needs: claude
     if: always() && github.event_name == 'issue_comment' && github.event.issue.pull_request
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
 
     steps:
       - name: Resolve PR head SHA
@@ -72,32 +118,44 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput('pr_head_sha', pr.head.sha);
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              core.setOutput('pr_head_sha', pr.head.sha);
+            } catch (err) {
+              core.setFailed(`Failed to resolve PR head SHA: ${err.message}`);
+            }
 
       - name: Report commit status
+        if: steps.pr-info.outcome == 'success'
         uses: actions/github-script@v7
+        env:
+          CLAUDE_RESULT: ${{ needs.claude.result }}
+          PR_HEAD_SHA: ${{ steps.pr-info.outputs.pr_head_sha }}
         with:
           script: |
-            const result = '${{ needs.claude.result }}';
+            const result = process.env.CLAUDE_RESULT;
+            const sha = process.env.PR_HEAD_SHA;
             const stateMap = {
               success: 'success',
               failure: 'failure',
               cancelled: 'error',
               skipped: 'pending'
             };
-            const state = stateMap[result] || 'error';
+            const state = stateMap[result];
+            if (!state) {
+              core.warning(`Unknown job result '${result}', mapping to 'error'`);
+            }
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ steps.pr-info.outputs.pr_head_sha }}',
-              state: state,
+              sha: sha,
+              state: state || 'error',
               target_url: runUrl,
               description: `Claude Code: ${result}`,
               context: 'Claude Code Action (comment trigger)'


### PR DESCRIPTION
Fix Claude Code workflow to correctly check out fork PR code by resolving the PR's head SHA/repo, add a write-permission guard to prevent unauthorized `@claude` invocations, and report commit status back to fork PRs so check results are visible, includes permission gates so owner write/maintainer/admin can invoke `@claude`