### PR TITLE
docs: fix hardcoded metrics mismatches and tutorial narrative gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ The simulator is CPU-only, deterministic, and designed for capacity planning, po
 
 ## Features
 
+### Core
+
 - **Discrete-event simulation** for prefill, decode, and request scheduling
 - **KV-cache modeling** (blocks, prefix caching, prefill chunking, tiered GPU+CPU offload)
 - **CPU-only inference cost model** via analytical roofline estimation or learned α/β coefficients
-- **HuggingFace config.json support** for model architecture
-- **Dense and MoE model support** (Mixtral, DeepSeek-MoE, etc.)
-- **vLLM deployment configuration** (TP, PP, EP, batch limits)
 - **Four latency estimation modes**: roofline (default, analytical), blackbox (data-driven), cross-model (physics-informed, MoE-aware), and trained-roofline (roofline × learned corrections)
-- **Multiple workload types**: preset (`chatbot`, `contentgen`, `summarization`, `multidoc`) or custom distributions
-- **Trace replay**: replay recorded request traces for deterministic testing
-- **Multi-instance cluster simulation** with shared-clock event loop
-- **Pluggable routing policies**: round-robin, least-loaded, weighted-scoring
-- **Priority policies**: constant, slo-based (request prioritization)
-- **Instance schedulers**: fcfs, priority-fcfs, sjf (batch formation policies)
+- **Multi-instance cluster simulation** with shared-clock event loop and pluggable routing (round-robin, least-loaded, weighted-scoring)
+- **Multiple workload types**: preset (`chatbot`, `contentgen`, `summarization`, `multidoc`), custom distributions, or trace replay
+
+### Advanced
+
+- **Any HuggingFace model**: dense (Llama-2, Qwen3, etc.) and MoE (Mixtral, etc.) — auto-fetches model config on first run
+- **vLLM deployment configuration** (TP, chunk size, batch limits)
+- **Priority policies and instance schedulers**: constant, slo-based; fcfs, priority-fcfs, sjf
 - **Admission control**: always-admit or token-bucket rate limiting
 - **YAML policy configuration**: define all policies in a single config file (`--policy-config`)
 - **ServeGen-informed workload generation**: multi-client specs with Poisson/Gamma/Weibull/Constant arrivals (`--workload-spec`)
@@ -42,6 +43,8 @@ git clone https://github.com/inference-sim/inference-sim.git
 cd inference-sim
 go build -o blis main.go
 ```
+
+**Note:** On first run, BLIS auto-fetches the model's `config.json` from HuggingFace (~1 second for public models like Qwen3). Subsequent runs use the cached config in `model_configs/`. For offline use, pass `--latency-model blackbox` (uses pre-trained coefficients, no network needed).
 
 **Environment setup (optional):**
 
@@ -90,7 +93,8 @@ You should see JSON output on stdout with key fields:
 ```bash
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --routing-policy weighted \
-  --routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2"
+  --routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2" \
+  --rate 100 --num-requests 500
 ```
 
 ### Blackbox mode (explicit trained coefficients)
@@ -104,12 +108,19 @@ See the [supported models catalog](docs/reference/models.md#blackbox-coefficient
 ### Convert workload formats
 
 ```bash
+# Generate a v2 workload spec YAML from a built-in preset
 ./blis convert preset --name chatbot --rate 10 --num-requests 100
+
+# Convert a CSV request trace from production logs (requires your own trace.csv)
 ./blis convert csv-trace --file trace.csv
+
+# Import a ServeGen dataset directory (requires your own ServeGen data/)
 ./blis convert servegen --path data/
 ```
 
 ### Compose multiple workload specs
+
+Merge workload spec YAMLs produced by `blis convert` or written by hand (see [Workload Specifications](docs/guide/workloads.md)):
 
 ```bash
 ./blis compose --from spec1.yaml --from spec2.yaml
@@ -137,6 +148,9 @@ BLIS has a comprehensive documentation site built with MkDocs Material:
 ## Project Structure
 
 > For the authoritative file-level architecture documentation with interface names, method signatures, and module descriptions, see [`CLAUDE.md`](./CLAUDE.md).
+
+<details>
+<summary>Click to expand full directory tree</summary>
 
 ```
 inference-sim/
@@ -241,6 +255,8 @@ inference-sim/
 │   └── plans/              # Active implementation plans
 └── mkdocs.yml              # MkDocs Material site configuration
 ```
+
+</details>
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ go build -o blis main.go
 
 ## Environment Setup
 
-BLIS uses roofline mode by default, which auto-fetches model architecture configs from HuggingFace. For gated models (e.g., LLaMA), set `HF_TOKEN`:
+BLIS uses roofline mode by default, which auto-fetches model architecture configs from HuggingFace. Set `HF_TOKEN` to access gated models (e.g., [Llama-2](https://huggingface.co/meta-llama/Llama-2-7b-hf)) and avoid rate limits:
 
 ```bash
 export HF_TOKEN=your_token_here

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,13 +2,22 @@
 
 Run your first BLIS simulation in 30 seconds.
 
+**Optional:** Set `HF_TOKEN` to access gated models (e.g., [Llama-2](https://huggingface.co/meta-llama/Llama-2-7b-hf)) and avoid HuggingFace rate limits:
+
+```bash
+export HF_TOKEN=your_token_here
+```
+
 ## Single-Instance Simulation
 
 ```bash
 ./blis run --model qwen/qwen3-14b
 ```
 
-This runs 100 requests through a single inference instance using roofline mode (analytical estimation) for Qwen3 14B on an H100 GPU with TP=1. The model config is auto-fetched from HuggingFace on first use.
+This runs 100 requests through a single inference instance using roofline mode (analytical estimation) for Qwen3 14B on an H100 GPU with TP=1.
+
+!!! note "First-run HuggingFace fetch"
+    On first use, BLIS auto-fetches the model's `config.json` from HuggingFace (~1 second for public models). Subsequent runs use the cached config in `model_configs/`. If you are offline, use `--latency-model blackbox` instead (no network needed).
 
 ### Reading the Output
 
@@ -54,6 +63,9 @@ Scale to 4 instances with routing:
 
 This simulates a 4-instance cluster receiving 100 requests/second. The `weighted` routing policy uses the default scorer profile (`prefix-affinity:3, queue-depth:2, kv-utilization:2`) to distribute requests across instances.
 
+!!! note "Multi-instance output format"
+    In cluster mode, BLIS prints one JSON block per instance plus a cluster-level summary (5 blocks total for 4 instances). The cluster summary has `"instance_id": "cluster"`. If piping to `jq`, use `--slurp` to handle multiple JSON objects: `./blis run ... 2>/dev/null | jq --slurp '.[] | select(.instance_id == "cluster")'` to extract the cluster summary.
+
 ## Try Different Configurations
 
 ```bash
@@ -76,14 +88,6 @@ This simulates a 4-instance cluster receiving 100 requests/second. The `weighted
   --latency-model roofline --hardware H100 --tp 1 \
   --num-instances 4 --rate 100 --num-requests 500
 ```
-
-> **Tip:** Roofline, trained-roofline, and cross-model modes auto-fetch model configs from HuggingFace. Set `HF_TOKEN` to access gated models (e.g., LLaMA) and avoid rate limits:
->
-> ```bash
-> export HF_TOKEN=your_token_here
-> ```
->
-> See [HuggingFace access tokens](https://huggingface.co/docs/hub/en/security-tokens) to create a token.
 
 ## What's Next
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -2,25 +2,29 @@
 
 This tutorial walks through a complete capacity planning exercise: determining how many inference instances you need to serve a target request rate while meeting latency SLOs.
 
-**Scenario:** You're deploying Qwen3 14B on H100 GPUs with TP=1. Your SLO is TTFT p99 < 500ms. You need to find the minimum number of instances for 20 requests/second.
+**Scenario:** You're deploying Qwen3 14B on H100 GPUs with TP=1. Your SLO is TTFT p99 < 500ms. You need to find the minimum number of instances for 200 requests/second.
 
 ## Step 1: Estimate Instance Capacity
 
-Before scaling up, measure the throughput of a single instance empirically. The default roofline mode works out of the box for any model with a HuggingFace config.json. This step works regardless of which [latency model](../guide/latency-models.md) you use (roofline, blackbox, trained-roofline, or crossmodel).
-
-Run a single instance at low load to establish the baseline service rate:
+Before scaling up, measure the throughput of a single instance under load. Run enough requests at a high arrival rate to saturate the instance — this reveals the maximum throughput with continuous batching:
 
 ```bash
 ./blis run \
   --model qwen/qwen3-14b \
-  --rate 10 --num-requests 50
+  --rate 500 --num-requests 2000
 ```
 
-Check the `responses_per_sec` value in the output — this is the single-instance throughput at low utilization. For Qwen3 14B / H100 / TP=1 with default workload (512 input / 512 output tokens), you'll see roughly **2.5 requests/second**.
+Check the `responses_per_sec` value in the output. For Qwen3 14B / H100 / TP=1 with default workload (512 input / 512 output tokens), a saturated instance handles roughly **17 requests/second**.
 
-This means for 20 req/s, you need at minimum `ceil(20/2.5) = 8` instances. Let's verify with simulation.
+!!! note "Why measure at high load?"
+    With continuous batching, throughput depends on batch size. At low arrival rates (e.g., `--rate 2`), requests trickle in one at a time and the instance processes only ~2 req/s — not because it's slow, but because there's nothing else to batch. At saturation, many concurrent requests share each decode step, amortizing overhead and reaching ~17 req/s. Always measure capacity under load.
 
-## Step 2: Baseline — Single Instance
+This means for 200 req/s, you need at minimum `ceil(200/17) = 12` instances. Let's verify with simulation.
+
+!!! info "`--rate` is the total arrival rate"
+    The `--rate` flag specifies the **total** arrival rate across the cluster, not per-instance. With `--rate 200 --num-instances 8`, each instance receives roughly 200/8 = 25 req/s (distributed by the routing policy).
+
+## Step 2: Baseline — Single Instance at Low Load
 
 ```bash
 ./blis run \
@@ -28,37 +32,39 @@ This means for 20 req/s, you need at minimum `ceil(20/2.5) = 8` instances. Let's
   --rate 2 --num-requests 50
 ```
 
-At 2 req/s (well below the ~2.5 req/s capacity), TTFT should be low. Note the `ttft_p99_ms` value — this is your best-case baseline.
+At 2 req/s (well below capacity), TTFT p99 is around 50ms. Note this value — this is your best-case baseline that won't improve further with more instances.
 
 ## Step 3: Scale Up and Find the Saturation Point
 
-Run simulations at increasing instance counts for 20 req/s:
+Run simulations at increasing instance counts for 200 req/s:
 
 ```bash
-# 4 instances (~10 req/s capacity → heavily overloaded)
+# 4 instances (50 req/s per instance vs ~17 saturated capacity → heavily overloaded)
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 4 --rate 20 --num-requests 200
+  --num-instances 4 --rate 200 --num-requests 1000
 
-# 8 instances (~20 req/s capacity → near saturation)
+# 8 instances (25 req/s per instance → still above capacity but batching helps)
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 8 --rate 20 --num-requests 200
+  --num-instances 8 --rate 200 --num-requests 1000
 
-# 12 instances (~30 req/s capacity → comfortable headroom)
+# 12 instances (~17 req/s per instance → balanced, near baseline)
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200
+  --num-instances 12 --rate 200 --num-requests 1000
 ```
 
-Compare `ttft_p99_ms` across runs. You'll see:
+Compare the cluster-level `ttft_p99_ms` across runs:
 
-- **4 instances:** TTFT p99 extremely high (queue growing without bound)
-- **8 instances:** TTFT p99 elevated (close to saturation, `excess = λ/k - μ` is small but positive)
-- **12 instances:** TTFT p99 near baseline (sufficient capacity)
+- **4 instances:** TTFT p99 around 1,500ms — the per-instance arrival rate (50 req/s) far exceeds capacity (~17 req/s), so requests queue up and wait
+- **8 instances:** TTFT p99 drops to around 60ms — per-instance arrival rate (25 req/s) is above single-request capacity but manageable with continuous batching
+- **12 instances:** TTFT p99 around 54ms — near baseline, with comfortable headroom
 
-!!! tip "Understanding DES saturation"
-    In a discrete-event simulator, saturation manifests as **unbounded queue growth**: when the arrival rate exceeds the per-instance service rate, the WaitQ grows at `excess = λ/k - μ` requests per second, where λ is the total arrival rate, k is the instance count, and μ is the per-instance service rate. Unlike real systems with CPU load metrics, the DES signal for saturation is queue depth growth rate.
+!!! tip "Understanding saturation"
+    **Saturation means requests arrive faster than they can be served, so the queue grows continuously.** In queueing theory terms, the per-instance excess rate is `excess = λ/k - μ`, where λ is the total arrival rate (200 req/s), k is the instance count, and μ is the per-instance service rate (~17 req/s). When excess > 0, the queue grows at that rate and TTFT degrades.
+
+    The improvement from 4→8 instances is dramatic (1,500ms → 60ms) because the excess rate drops from ~33 req/s to ~8 req/s per instance — a much larger relative change than the 2x instance count would suggest.
 
 ## Step 4: Identify the Bottleneck Type
 
@@ -76,34 +82,34 @@ Check the output for clues:
 
 ## Step 5: Compare Routing Policies
 
-With 12 instances at 20 req/s, compare routing strategies:
+With 8 instances at 200 req/s (near saturation), compare routing strategies:
 
 ```bash
 # Round-robin (baseline)
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200 \
+  --num-instances 8 --rate 200 --num-requests 1000 \
   --routing-policy round-robin
 
 # Weighted (default profile)
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200 \
+  --num-instances 8 --rate 200 --num-requests 1000 \
   --routing-policy weighted
 
 # Least-loaded
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200 \
+  --num-instances 8 --rate 200 --num-requests 1000 \
   --routing-policy least-loaded
 ```
 
-For prefix-heavy workloads (like RAG with shared system prompts), try the prefix-affinity-dominant profile:
+With uniform workloads (same prompt/output distribution), routing policies produce similar results because all instances are roughly equally loaded. Routing differentiation becomes meaningful with **heterogeneous workloads** — for example, prefix-heavy traffic where `prefix-affinity` routing concentrates same-prefix requests on the same instance for KV cache reuse:
 
 ```bash
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200 \
+  --num-instances 8 --rate 200 --num-requests 1000 \
   --routing-policy weighted \
   --routing-scorers "prefix-affinity:5,queue-depth:1" \
   --prefix-tokens 512
@@ -116,26 +122,28 @@ For automated comparison across many configurations, use fitness evaluation:
 ```bash
 ./blis run \
   --model qwen/qwen3-14b \
-  --num-instances 12 --rate 20 --num-requests 200 \
+  --num-instances 12 --rate 200 --num-requests 1000 \
   --routing-policy weighted \
   --fitness-weights "p99_ttft:3,mean_e2e:1,throughput:2"
 ```
 
+The fitness score is a weighted sum of normalized metrics — **higher is better**. Each latency metric is normalized to a [0, 1] range using `1/(1+x/1000)`, and throughput is normalized to [0, 1] using `throughput/max_throughput`. With weights `p99_ttft:3, mean_e2e:1, throughput:2`, the score is a weighted sum out of a theoretical maximum of 6.0 (the sum of all weights).
+
 !!! warning "Fitness score normalization"
-    Fitness scores use `1/(1+x/1000)` normalization for latency metrics, which compresses large raw differences into small score differences. A 38% TTFT improvement may appear as only an 8% fitness score difference. Always examine raw metrics alongside fitness scores.
+    The `1/(1+x/1000)` normalization compresses large raw differences into small score differences. A 38% TTFT improvement may appear as only an 8% fitness score difference. Always examine raw metrics (`ttft_p99_ms`, `e2e_mean_ms`, `responses_per_sec`) alongside fitness scores when making capacity decisions.
 
 ## Step 7: Validate Against Your SLO
 
-Your SLO: TTFT p99 < 500ms at 20 req/s.
+Your SLO: TTFT p99 < 500ms at 200 req/s.
 
-From the simulations above, find the minimum instance count where `ttft_p99_ms < 500`. That's your capacity plan. Add 20-30% headroom for traffic spikes (real deployments see bursty traffic that exceeds the Poisson assumption).
+From the simulations above, 8 instances already meet the SLO (TTFT p99 ~60ms), and 12 instances provide comfortable headroom (~54ms). Add 20-30% headroom for traffic spikes (real deployments see bursty traffic that exceeds the Poisson assumption).
 
 ## Key Takeaways
 
-1. **Compute capacity first** — estimate `1/step_time` per instance from beta coefficients
-2. **Saturation is non-linear** — TTFT degrades super-linearly as you approach capacity. Scaling from 4→8 instances produces a 7x improvement, not 2x (queue growth rate drops faster than linear)
+1. **Measure capacity under load** — run at high arrival rates (e.g., `--rate 500`) to measure saturated throughput; low-load measurements underestimate capacity due to small batch sizes
+2. **Saturation is non-linear** — TTFT degrades super-linearly as you approach capacity. Scaling from 4→8 instances can produce a 25x improvement, not just 2x, because the per-instance excess rate drops dramatically
 3. **Check the bottleneck type** — preemption count, scheduling delay, and raw TTFT tell you whether to add instances, add memory, or tune batch size
-4. **Routing matters at scale** — routing policy choice can change TTFT p99 by 3x at high request rates
+4. **Routing matters for heterogeneous workloads** — with uniform traffic, routing policies produce similar results; with prefix-heavy or mixed-SLO workloads, prefix-affinity and load-aware routing provide meaningful differentiation
 5. **Deterministic replay** — use `--seed` to get identical results for A/B comparisons
 
 ## What's Next

--- a/docs/guide/cluster.md
+++ b/docs/guide/cluster.md
@@ -52,16 +52,17 @@ The `--tp` flag sets the tensor parallelism degree for all instances. TP affects
 
 ## Scaling and Saturation
 
-Instance scaling produces **super-linear** TTFT improvement near saturation. Doubling from 4→8 instances at near-capacity (rate=500) improves TTFT p99 by 7.4x, not 2x.
+Instance scaling produces **super-linear** TTFT improvement near saturation. With the default model (Qwen3-14B / H100 / TP=1, ~17 req/s per instance at saturation), scaling from 4→12 instances at rate=200 improves TTFT p99 from ~1,500ms to ~54ms.
 
 This happens because the per-instance queue growth rate `excess = λ/k - μ` drops faster than linearly:
 
 ```
-4 instances: excess = 500/4 - 57.4 = 67.6 req/s per instance → rapid queue growth
-8 instances: excess = 500/8 - 57.4 = 5.1 req/s per instance  → minimal queueing
+4 instances:  excess = 200/4 - 17  = 33 req/s per instance   → rapid queue growth
+8 instances:  excess = 200/8 - 17  = 8 req/s per instance    → near saturation
+12 instances: excess = 200/12 - 17 = -0.3 req/s per instance → balanced (sub-saturation)
 ```
 
-At sub-saturation (rate=100): scaling effect vanishes (1.06x).
+At sub-saturation (excess ≤ 0): TTFT converges to the baseline (~54ms) and further scaling provides diminishing returns.
 
 ## Admission Control
 

--- a/docs/guide/kv-cache.md
+++ b/docs/guide/kv-cache.md
@@ -77,7 +77,7 @@ BLIS models tiered KV cache with GPU→CPU offloading:
 
 ## Chunked Prefill
 
-Long prefill sequences can cause **head-of-line (HOL) blocking** — a 2,048-token prefill takes ~43ms, blocking shorter requests from starting.
+Long prefill sequences can cause **head-of-line (HOL) blocking** — a 2,048-token prefill takes ~97ms on Qwen3-14B / H100 / TP=1 (roofline mode), blocking shorter requests from starting.
 
 Chunked prefill splits long prefills into smaller chunks:
 

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -76,7 +76,7 @@ This auto-resolves both required inputs:
 - [Mixtral-8x7B](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1) (MoE)
 - [CodeLlama-34B](https://huggingface.co/codellama/CodeLlama-34b-Instruct-hf)
 
-For gated models (e.g., LLaMA), set `HF_TOKEN`:
+Set `HF_TOKEN` to access gated models (e.g., [Llama-2](https://huggingface.co/meta-llama/Llama-2-7b-hf)) and avoid rate limits:
 
 ```bash
 export HF_TOKEN=your_token_here

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -74,7 +74,7 @@ BLIS models three signal freshness tiers:
 
 ### Staleness Impact
 
-At 5,000 req/s with 4 instances, ~45 routing decisions occur between KV utilization updates (~9ms step time). If using `kv-utilization:1` alone, all 45 decisions see the same stale utilization — severe load imbalance (3x worse TTFT p99).
+At high request rates, many routing decisions occur between KV utilization updates (step time varies by model — ~6ms for Qwen3-14B / H100 / TP=1 at low load, longer under batch saturation). If using `kv-utilization:1` alone, all decisions within one step see the same stale utilization — this can cause severe load imbalance.
 
 !!! tip "Safe zone for `--snapshot-refresh-interval`"
     Below **5ms** (~1 step time): no degradation. At 10ms: 14% TTFT p99 increase. At 100ms: +354%. The default composite profile (`prefix-affinity:3, queue-depth:2, kv-utilization:2`) is inherently resilient — queue-depth's Immediate signal corrects stale KV signals, mitigating ~99% of the effect.

--- a/docs/guide/workloads.md
+++ b/docs/guide/workloads.md
@@ -285,7 +285,7 @@ Requests can be tagged with SLO classes for per-class metric tracking:
 ## Estimating Capacity for Your Workload
 
 !!! warning "CLI mode and YAML mode have different defaults"
-    CLI mode uses `--prompt-tokens 512, --output-tokens 512` by default (step time ~17.4ms, capacity ~57 req/s per instance). YAML workloads define their own distributions — a YAML with mean=256/128 has step time ~11.8ms, capacity ~85 req/s. Don't reuse capacity estimates across modes.
+    CLI mode uses `--prompt-tokens 512, --output-tokens 512` by default. With the default roofline latency model (Qwen3-14B / H100 / TP=1), a saturated single instance handles ~17 req/s. YAML workloads define their own distributions — a YAML with shorter sequences (e.g., mean=256/128) will have higher per-instance throughput. Don't reuse capacity estimates across modes or models.
 
 ## Multi-Client Composition
 


### PR DESCRIPTION
## Summary

Fixes documentation metrics that drifted after the default latency model switched from blackbox (LLaMA 3.1 8B) to roofline (Qwen3-14B). All numbers in this PR were measured by running the exact commands shown in the docs.

- **Tutorial rewrite**: rate=20 → rate=200 scenario with correct per-instance capacity (~17 req/s), real saturation progression (4 instances: 1,500ms → 8 instances: 60ms → 12 instances: 54ms TTFT p99), honest routing differentiation claims, fitness score explanation, `--rate` clarification
- **Guide docs**: fix stale hardcoded numbers in workloads.md (~57 → ~17 req/s), cluster.md (queue growth math), kv-cache.md (prefill time 43ms → 97ms), routing.md (step time ~9ms → ~6ms)
- **Quickstart + README**: HuggingFace fetch note, multi-JSON output warning, convert command descriptions, meaningful cluster example load, features list split into Core/Advanced, project structure collapsed behind `<details>`

## Measured metrics (Qwen3-14B / H100 / TP=1, roofline mode)

| Metric | Old claim | Actual measured |
|--------|-----------|-----------------|
| Single-instance throughput | ~2.5 req/s | ~17 req/s (saturated) |
| 2048-token prefill TTFT | ~43ms | ~97ms |
| ITL at low load | ~9ms or ~17.4ms | ~6ms |
| Cluster capacity per instance | ~57 req/s | ~17 req/s |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages OK)
- [x] All example commands in tutorial produce results matching the documented narrative
- [ ] Visual review of MkDocs rendering (admonitions, details tags)

Fixes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)