### PR TITLE
fix(latency): remove stale training/ references from comments

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1743,14 +1743,14 @@ models:
   total_kv_blocks: 1808703
   vllm_version: vllm/vllm-openai:v0.8.4
 crossmodel_defaults:
-  # Globally-fitted physics coefficients from training/ledger.md Iter 3.
+  # Globally-fitted physics coefficients via OLS from 13 vLLM experiments across 4 architectures.
   # These are model-independent: architecture features from config.json scale the coefficients.
   # β₀=per-layer overhead, β₁=KV bandwidth, β₂=MoE dispatch, β₃=TP sync barrier.
   beta_coeffs: [116.110, 1226.868, 19.943, 9445.157]
   # α₀=pre-scheduling fixed overhead, α₁=per-token preprocessing (≈0), α₂=per-output-token processing.
   alpha_coeffs: [13732.0, 0.0, 860.6]
 trained_roofline_defaults:
-  # Globally-fitted roofline correction coefficients from training/output/fit/coefficients.json.
+  # Globally-fitted roofline correction coefficients.
   # Fitted via 3-phase NNLS from 13 experiments (4 models × 3-4 profiles, 137K requests).
   # β₁-β₄ are dimensionless roofline corrections, β₅ is µs/layer, β₆ is µs/req, β₇ is µs/step.
   beta_coeffs: [0.7726491335309499, 1.127489556719325, 1.0559901872766853, 0.0, 43.500541908701074, 48.80613214319187, 0.0]

--- a/docs/plans/fix-576-stale-training-refs-plan.md
+++ b/docs/plans/fix-576-stale-training-refs-plan.md
@@ -1,0 +1,89 @@
+# Fix Stale References to Deleted training/ Files
+
+- **Goal:** Remove dead `training/` path references from production code and config comments.
+- **The problem today:** PR #560 removed the `training/` directory, but 6 comments in `sim/latency/crossmodel.go`, `sim/latency/trained_roofline.go`, and `defaults.yaml` still reference deleted files (`training/ledger.md`, `training/problem.md`, `training/DESIGN.md`, `training/output/fit/coefficients.json`). Contributors following these references hit dead ends.
+- **What this PR adds:**
+  1. Replaces stale `training/` paths with inline coefficient provenance summaries
+  2. Directs readers to `defaults.yaml` as the canonical coefficient source and `git log` for historical derivation
+- **Why this matters:** Eliminates contributor confusion from dead documentation links (R15: stale references).
+- **Architecture:** Comment-only changes in 3 files. No behavioral changes, no new types, no tests needed.
+- **Source:** GitHub issue #576
+- **Closes:** Fixes #576
+- **Tier:** Small (comment updates only, ≤3 files, no behavioral logic changes)
+
+---
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR updates 6 stale comments across 3 files that reference deleted `training/` directory files. Each reference is replaced with a self-contained provenance note: what the coefficients represent, where they live now (`defaults.yaml`), and how to find the original derivation (`git log -- training/`). No code logic changes.
+
+### B) Behavioral Contracts
+
+**BC-1: No stale training/ references in production code**
+- GIVEN the `training/` directory was removed in PR #560
+- WHEN a contributor reads `sim/latency/crossmodel.go`, `sim/latency/trained_roofline.go`, or `defaults.yaml`
+- THEN no comment references a `training/` path
+
+**BC-2: Coefficient provenance is self-contained**
+- GIVEN a contributor reading the crossmodel or trained-roofline source
+- WHEN they want to understand where coefficients come from
+- THEN the comments explain the derivation method and point to `defaults.yaml` + git history
+
+### C) Risks & Mitigations
+
+None — comment-only changes carry zero runtime risk.
+
+### D) Test Strategy
+
+No tests needed. Verification: `grep -r 'training/' sim/latency/ defaults.yaml` returns only `hypotheses/` and `docs/plans/` (archival, not modified).
+
+---
+
+## Part 2: Executable Tasks
+
+### Task 1: Update crossmodel.go comments
+
+**Files:** `sim/latency/crossmodel.go`
+
+1. Line 16: Replace `(from training/ledger.md Iter 3)` with `(globally-fitted via OLS from 13 vLLM experiments; see defaults.yaml crossmodel_defaults)`
+2. Line 51: Replace `See training/ledger.md Iter 3 and training/problem.md Section 2a for the physics rationale.` with `Decode is memory-bandwidth-bound on H100: each token reads accumulated KV from HBM. Prefill KV write cost is absorbed into β₀ where it overlaps with compute.`
+3. Verify: `go build ./sim/latency/...`
+
+### Task 2: Update trained_roofline.go comments
+
+**Files:** `sim/latency/trained_roofline.go`
+
+1. Line 13: Replace `(from training/DESIGN.md)` with `(see defaults.yaml trained_roofline_defaults)`
+2. Line 22: Replace `from training/output/fit/coefficients.json, fitted` with `from defaults.yaml trained_roofline_defaults, fitted`
+3. Verify: `go build ./sim/latency/...`
+
+### Task 3: Update defaults.yaml comments
+
+**Files:** `defaults.yaml`
+
+1. Line 1746: Replace `from training/ledger.md Iter 3` with `globally-fitted via OLS from 13 vLLM experiments across 4 architectures`
+2. Line 1753: Replace `from training/output/fit/coefficients.json` with `fitted via 3-phase NNLS from 13 experiments (4 models, 137K requests)`
+3. Verify: `go build ./...` and `go test ./sim/latency/... -count=1`
+
+### Task 4: Verify no remaining stale references in production code
+
+Run: `grep -rn 'training/' sim/ defaults.yaml --include='*.go' --include='*.yaml'`
+Expected: zero matches.
+
+---
+
+## Appendix
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `sim/latency/crossmodel.go` | 2 comment updates (lines 16, 51) |
+| `sim/latency/trained_roofline.go` | 2 comment updates (lines 13, 22) |
+| `defaults.yaml` | 2 comment updates (lines 1746, 1753) |
+
+### Out of Scope
+
+- `hypotheses/` and `docs/plans/` references are archival (they document the state when `training/` existed) — not modified.

--- a/sim/latency/crossmodel.go
+++ b/sim/latency/crossmodel.go
@@ -13,7 +13,7 @@ import (
 //
 //	β₀·numLayers + β₁·decodeTokens·kvDimScaled + β₂·(prefillTokens+decodeTokens)·isMoE + β₃·isTP
 //
-// Beta coefficients (from training/ledger.md Iter 3):
+// Beta coefficients (globally-fitted via OLS from 13 vLLM experiments; see defaults.yaml crossmodel_defaults):
 //
 //	β₀ = per-layer CUDA kernel dispatch overhead (µs/layer)
 //	β₁ = KV cache bandwidth cost (µs per scaled KV unit)
@@ -48,7 +48,6 @@ func (m *CrossModelLatencyModel) StepTime(batch []*sim.Request) int64 {
 	// β₁ term uses only decode tokens (not prefill) because decode is memory-bandwidth-bound
 	// on H100: each decode token reads its accumulated KV cache from HBM. Prefill KV write
 	// cost is absorbed into β₀ (per-layer term) where it overlaps with compute via GPU pipelining.
-	// See training/ledger.md Iter 3 and training/problem.md Section 2a for the physics rationale.
 	stepTime := m.betaCoeffs[0]*float64(m.numLayers) +
 		m.betaCoeffs[1]*float64(totalDecodeTokens)*m.kvDimScaled +
 		m.betaCoeffs[2]*float64(totalPrefillTokens+totalDecodeTokens)*m.isMoE +

--- a/sim/latency/trained_roofline.go
+++ b/sim/latency/trained_roofline.go
@@ -10,7 +10,7 @@ import (
 // TrainedRooflineLatencyModel estimates latency using analytical roofline basis functions
 // with learned correction coefficients fitted from real vLLM traces.
 //
-// Step-time formula (from training/DESIGN.md):
+// Step-time formula:
 //
 //	β₁·max(T_pf_compute, T_pf_kv) + β₂·max(T_dc_compute, T_dc_kv)
 //	+ β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇
@@ -19,7 +19,7 @@ import (
 // β₅ is µs/layer, β₆ is µs/request, β₇ is µs/step. Basis functions compute µs from model
 // architecture + hardware specs + batch composition.
 //
-// Coefficients are from training/output/fit/coefficients.json, fitted via 3-phase NNLS
+// Coefficients are from defaults.yaml trained_roofline_defaults, fitted via 3-phase NNLS
 // from 13 experiments across 4 architectures (137K requests, 7% MAPE GPU combined).
 //
 // Key differences from the pure RooflineLatencyModel:


### PR DESCRIPTION
## Summary

- Replace 6 dead `training/` file paths in `sim/latency/crossmodel.go`, `sim/latency/trained_roofline.go`, and `defaults.yaml` with self-contained provenance notes
- The `training/` directory was removed in PR #560; these comments were not updated at that time
- Archival references in `hypotheses/` and `docs/plans/` are intentionally left unchanged (they document historical state accurately)

## Behavioral Contracts

**BC-1: No stale training/ references in production code**
- GIVEN the `training/` directory was removed in PR #560
- WHEN a contributor reads `sim/latency/crossmodel.go`, `sim/latency/trained_roofline.go`, or `defaults.yaml`
- THEN no comment references a `training/` path

**BC-2: Coefficient provenance is self-contained**
- GIVEN a contributor reading the crossmodel or trained-roofline source
- WHEN they want to understand where coefficients come from
- THEN the comments explain the derivation method and point to `defaults.yaml`

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./... -count=1` — all 10 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `grep -rn 'training/' sim/latency/ defaults.yaml` — 0 matches

Fixes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)