### PR TITLE
fix(sim): guard processCompletions against ProgressIndex overshoot in PD mode

### DIFF
--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -1187,3 +1187,40 @@ func TestDisaggregation_MaxModelLen_DropsOversizedRequests(t *testing.T) {
 			metrics.CompletedRequests, metrics.StillQueued, metrics.StillRunning, metrics.DroppedUnservable, injected)
 	}
 }
+
+// TestPDDisagg_OneOutputToken_NoPanic is a regression test for the off-by-one
+// bug in processCompletions that caused an index-out-of-range panic when a
+// disaggregated request had exactly 1 output token.
+//
+// Root cause: completion check used == instead of >=. In PD mode, the decode
+// sub-request enters with ProgressIndex == inputLen; after one decode step
+// ProgressIndex becomes inputLen+1, which failed the == check and allowed a
+// second decode step to call AllocateKVBlocks with out-of-bounds index.
+func TestPDDisagg_OneOutputToken_NoPanic(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+
+	input := make([]int, 20)
+	for i := range input {
+		input[i] = i + 1
+	}
+	output := []int{42} // exactly 1 output token
+
+	requests := []*sim.Request{
+		{
+			ID:           "req-1output",
+			ArrivalTime:  0,
+			InputTokens:  input,
+			OutputTokens: output,
+			State:        sim.StateQueued,
+		},
+	}
+
+	cs := NewClusterSimulator(config, requests)
+	mustRun(t, cs) // must not panic
+
+	metrics := cs.AggregatedMetrics()
+	// The request must complete — not hang or get dropped.
+	if metrics.CompletedRequests == 0 {
+		t.Errorf("expected completed requests > 0, got %d (request did not complete)", metrics.CompletedRequests)
+	}
+}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -520,14 +520,17 @@ func (sim *Simulator) processCompletions(now, currStepAdvance int64) []*Request 
 	remaining := []*Request{}
 	for _, req := range sim.RunningBatch.Requests {
 		// in cases where there are 0 output tokens, set it to 1 manually to avoid errors
-		if req.ProgressIndex == util.Len64(req.InputTokens)+max(util.Len64(req.OutputTokens), 1)-1 {
+		if req.ProgressIndex >= util.Len64(req.InputTokens)+max(util.Len64(req.OutputTokens), 1)-1 {
 			// State transitions
 			req.State = StateCompleted
 			// Zero-output requests complete at prefill end with no decode phase.
 			// The final-token KV allocation only applies to requests that have
-			// output tokens. ITL is NOT appended here — executeBatchStep already
-			// recorded it for this decode step (fix for #524 phantom ITL entry).
-			if len(req.OutputTokens) > 0 {
+			// output tokens AND whose ProgressIndex still points to a valid
+			// output token. In PD disaggregation mode, a 1-output-token request
+			// has its only decode token allocated by FormBatch Phase 2; after
+			// executeBatchStep increments ProgressIndex past the last valid index,
+			// there is no remaining token to allocate here.
+			if len(req.OutputTokens) > 0 && req.ProgressIndex < util.Len64(req.InputTokens)+util.Len64(req.OutputTokens) {
 				ok := sim.KVCache.AllocateKVBlocks(req, req.ProgressIndex, req.ProgressIndex+1, []int64{})
 				if !ok {
 					logrus.Errorf("[tick %07d] KV allocation failed for completing request %s (request will still complete) — this indicates a cache accounting bug", now, req.ID)


### PR DESCRIPTION
## Summary

- **Root cause:** In PD disaggregation, a decode sub-request with 1 output token enters with `ProgressIndex == inputLen`. After one decode step, `ProgressIndex` becomes `inputLen+1`, overshooting the `==` completion check. This allowed a second erroneous decode step that panicked in `AllocateKVBlocks` with `index out of range [1]`.
- **Fix 1:** Change completion check from `==` to `>=` in `processCompletions` (`sim/simulator.go`) to catch overshoot.
- **Fix 2:** Add bounds guard on final-token `AllocateKVBlocks` call to prevent OOB access.
- **Regression test:** `TestPDDisagg_OneOutputToken_NoPanic` in `sim/cluster/disaggregation_test.go` — exercises a 2-prefill + 2-decode disaggregated cluster with 1-output-token requests.

## Test plan

- [x] `go test ./sim/... -run TestPDDisagg_OneOutputToken_NoPanic -v` — PASS
- [x] `go test ./...` — all packages pass, no regressions
- [ ] `golangci-lint run ./...` — runs in CI

## Files changed

- `sim/simulator.go:520-535` — completion check `>=` + bounds guard
- `sim/cluster/disaggregation_test.go:1189-1226` — regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)