### PR TITLE
docs(claude-md): extract reference sections to dedicated docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ For new features that introduce module boundaries or modify the architecture, a 
 
 ### Code Review Standards
 
-During PR reviews, check all Antipattern Prevention rules (1-23) below. Pay special attention to rules 8-10 (exported mutable maps, YAML pointer types, strict YAML parsing) which are easy to miss in new code. Always run `go test ./...` and lint after fixes.
+During PR reviews, check all Antipattern Prevention rules (R1-R23) in [`docs/contributing/standards/rules.md`](docs/contributing/standards/rules.md). Pay special attention to rules 8-10 (exported mutable maps, YAML pointer types, strict YAML parsing) which are easy to miss in new code. Always run `go test ./...` and lint after fixes.
 
 ### Key Invariants to Maintain
 
@@ -126,34 +126,7 @@ Full details: see [`docs/contributing/standards/principles.md`](docs/contributin
 
 > **Canonical source:** [`docs/contributing/standards/rules.md`](docs/contributing/standards/rules.md). If this section diverges, rules.md is authoritative.
 
-23 rules, each tracing to a real bug. Full details (evidence, checks, enforcement): see [`docs/contributing/standards/rules.md`](docs/contributing/standards/rules.md).
-
-| # | Rule | One-sentence summary |
-|---|------|---------------------|
-| R1 | No silent data loss | Every error path must return error, panic, or increment counter — never silently drop data |
-| R2 | Sort map keys | Map iteration feeding float sums or output ordering must sort keys first (determinism) |
-| R3 | Validate numeric parameters | Every numeric parameter validated — CLI flags AND library constructors |
-| R4 | Construction site audit | Adding a struct field? Grep for ALL literal construction sites, update every one |
-| R5 | Transactional mutation | Resource-allocating loops must rollback on mid-loop failure |
-| R6 | No Fatalf in library | `sim/` never terminates the process — return errors to callers |
-| R7 | Invariant tests | Every golden test needs a companion invariant test verifying a system law |
-| R8 | No exported maps | Validation maps unexported; expose via `IsValid*()` accessors |
-| R9 | YAML pointer types | Use `*float64` when zero is a valid user value |
-| R10 | Strict YAML parsing | `yaml.KnownFields(true)` — typos must cause errors |
-| R11 | Guard division | Runtime-derived denominators must be checked for zero |
-| R12 | Golden regeneration | Regenerate and document golden dataset when output changes |
-| R13 | Multi-impl interfaces | New interfaces must work for >=2 backends |
-| R14 | Single-module methods | No method spans scheduling + latency + metrics — extract concerns |
-| R15 | Stale PR references | Grep for `planned for PR N` after completing PR N |
-| R16 | Config by module | Group config parameters by module, not monolithic structs |
-| R17 | Signal freshness | Document which routing signals are synchronously fresh vs stale |
-| R18 | CLI flag precedence | defaults.yaml must not silently override user-provided CLI flags |
-| R19 | Livelock protection | Unbounded retry/requeue loops must have circuit breakers |
-| R20 | Degenerate detector inputs | Anomaly detectors must handle empty, skewed, or zero inputs explicitly |
-| R21 | No range over mutable slices | Go `range` captures slice header at entry — use index-based iteration when slice can shrink |
-| R22 | Pre-check consistency | Capacity pre-checks must not be stricter than the actual operation they guard |
-| R23 | Code path parity | Parallel code paths producing same output must apply equivalent transformations |
-
+23 rules (R1-R23), each tracing to a real bug. See [`docs/contributing/standards/rules.md`](docs/contributing/standards/rules.md) for the full table with evidence, checks, and enforcement locations.
 
 ### Current Implementation Focus
 
@@ -200,190 +173,15 @@ When asked to update the macro implementation plan, directly edit the document. 
 
 ## File Organization
 
-The simulator uses a discrete-event architecture with a min-heap event queue.
-
-```
-inference-sim/
-├── .github/workflows/         # CI configuration (build, lint, test)
-├── main.go                    # CLI entry point (Cobra)
-├── cmd/
-│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model, --max-model-len, --trace-output)
-│   ├── replay.go              # `blis replay` command: replays TraceV2 file through DES; flags: --trace-header, --trace-data (required), all sim config flags shared via registerSimConfigFlags(); --results-path writes []workload.SimResult (integer request_id, ttft_us/e2e_us in µs); SimResult type lives in sim/workload/calibrate.go
-│   ├── calibrate.go           # `blis calibrate` command: compares real observed latencies (TraceV2 from blis observe) against sim predictions ([]SimResult JSON from blis replay --results-path); flags: --trace-header, --trace-data, --sim-results, --report (required), --warmup-requests (default: from header, sentinel -1), --network-rtt-us (default: from header, sentinel -1), --network-bandwidth-mbps; writes CalibrationReport JSON with MAPE/PearsonR/percentiles per metric
-│   ├── observe.go             # Real mode HTTP client (OpenAI-compatible, streaming + non-streaming)
-│   ├── convert.go             # `blis convert` subcommands (servegen, preset, inference-perf)
-│   ├── compose.go             # `blis compose` for merging v2 specs
-│   ├── hfconfig.go            # HuggingFace config resolution chain (--latency-model auto-fetch, caching)
-│   └── default_config.go      # defaults.yaml loading (includes GetHFRepo for HF repo name mapping)
-├── sim/                       # Core single-instance simulator
-│   ├── config.go              # Module-scoped sub-config types (KVCacheConfig, BatchConfig, LatencyCoeffs, ModelHardwareConfig, PolicyConfig, WorkloadConfig) — composed into SimConfig via embedding (R16)
-│   ├── doc.go                 # Package reading guide: start with request.go, event.go, simulator.go
-│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor (validates MaxModelLen vs KV capacity), event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, EnqueueRequest (MaxModelLen + KV capacity guards), processCompletions (proactive MaxModelLen cap at maxModelLen-1 boundary), observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
-│   ├── admission.go           # AdmissionPolicy interface (accepts *RouterState), AlwaysAdmit, TokenBucket, RejectAll, NewAdmissionPolicy factory
-│   ├── routing.go             # RoutingPolicy interface (accepts *RouterState), RoutingSnapshot (with EffectiveLoad() for canonical load calculation), RoutingDecision (with Priority hint), RoundRobin, LeastLoaded, WeightedScoring (composable scorer pipeline), AlwaysBusiest templates, NewRoutingPolicy factory
-│   ├── routing_scorers.go     # ScorerConfig, scorer implementations (queue-depth, kv-utilization, load-balance), ParseScorerConfigs, IsValidScorer, DefaultScorerConfigs, newScorerWithObserver factory
-│   ├── routing_prefix_scorer.go # Prefix-affinity scorer + observer (proportional prefix matching)
-│   ├── prefix_cache_index.go  # PrefixCacheIndex: per-instance LRU of hierarchical block hashes
-│   ├── priority.go            # PriorityPolicy interface with ConstantPriority, SLOBasedPriority, and InvertedSLO templates, NewPriorityPolicy factory
-│   ├── scheduler.go           # InstanceScheduler interface with FCFSScheduler, PriorityFCFSScheduler, SJFScheduler, and ReversePriority templates, NewScheduler factory
-│   ├── latency_model.go       # LatencyModel interface (3 methods), NewLatencyModelFunc registration variable, MustNewLatencyModel nil-guarded wrapper
-│   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
-│   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
-│   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft, Timeout) with (timestamp, priority, seqID) ordering
-│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted, StateTimedOut), Request lifecycle and state machine, Deadline field for client timeout, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.), MaxOutputLen (client output budget for enqueue guard)
-│   ├── kv_store.go            # KVStore interface (12 methods: +SetClock, +ConsumePendingTransferLatency, +MirrorToCPU), NewKVStoreFromConfig registration variable, MustNewKVCacheState/MustNewKVStoreFromConfig nil-guarded wrappers
-│   ├── batch.go               # Batch struct
-│   ├── batch_formation.go     # BatchFormation interface, BatchContext/BatchResult types, VLLMBatchFormation (FCFS + chunked-prefill + preemption), NewBatchFormation() factory
-│   ├── queue.go               # FIFO wait queue
-│   ├── metrics.go             # TTFT, TPOT, E2E collection and SaveResults()
-│   ├── metrics_utils.go       # Percentile/mean calculation, MetricsOutput JSON struct, NewRequestMetrics canonical constructor
-│   ├── rng.go                 # PartitionedRNG for deterministic multi-subsystem simulation
-│   ├── model_hardware_config.go # ModelConfig, HardwareCalib structs (config types stay in sim/); HardwareCalib includes MemoryGiB (used by KV capacity auto-calculation in roofline/crossmodel modes). Note: MaxModelLen is int64 (aligned with ProgressIndex, TotalKVBlocks, BlockSizeTokens).
-│   └── internal/              # Shared internal packages
-│       ├── hash/              # Block-level hashing for prefix cache
-│       ├── testutil/          # Shared test infrastructure (golden dataset loading)
-│       └── util/              # General utility functions
-├── sim/kv/                    # KV cache implementations (PKG-1)
-│   ├── cache.go               # KVCacheState (single-tier GPU)
-│   ├── tiered.go              # TieredKVCache (GPU+CPU mirror/reload, vLLM v1 model)
-│   └── register.go            # NewKVStore factory + init()-based registration into sim/
-├── sim/latency/               # Latency model implementations (PKG-2)
-│   ├── latency.go             # RooflineLatencyModel (default, analytical FLOPs/bandwidth), BlackboxLatencyModel (alpha/beta regression), CrossModelLatencyModel (physics-informed cross-model), NewLatencyModel(LatencyCoeffs, ModelHardwareConfig) factory
-│   ├── trained_roofline.go    # TrainedRooflineLatencyModel: roofline basis functions × learned corrections (7β + 3α from training pipeline)
-│   ├── crossmodel.go          # CrossModelLatencyModel: physics-informed step time from architecture features (MoE-aware)
-│   ├── roofline.go            # rooflineStepTime(), calculateTransformerFlops(), calculateMemoryAccessBytes(), StepConfig/PrefillRequestConfig/DecodeRequestConfig types
-│   ├── kv_capacity.go         # CalculateKVBlocks: auto-derive total KV cache blocks from model architecture + GPU memory; KVCapacityParams, ExtractKVCapacityParams, computeModelWeightBytes
-│   ├── config.go              # HFConfig, GetHWConfig(), GetModelConfig(), ValidateRooflineConfig(), parseHWConfig(), ParseHFConfig()
-│   └── register.go            # init()-based registration of NewLatencyModelFunc into sim/
-├── sim/cluster/               # Multi-replica cluster simulation
-│   ├── instance.go            # InstanceSimulator wraps sim.Simulator via NewInstanceSimulator(id, SimConfig) with run-once guard; delegates to Simulator observation methods (QueueDepth(), BatchSize(), etc.)
-│   ├── cluster.go             # ClusterSimulator orchestrates N instances with shared-clock event loop, online routing pipeline, and metrics aggregation; Run() returns error
-│   ├── cluster_event.go       # ClusterArrivalEvent, AdmissionDecisionEvent, RoutingDecisionEvent
-│   ├── counterfactual.go      # computeCounterfactual() for top-k candidate ranking and regret computation
-│   ├── snapshot.go            # CachedSnapshotProvider (returns sim.RoutingSnapshot), ObservabilityConfig
-│   ├── metrics.go             # RawMetrics, Distribution, FitnessResult, CollectRawMetrics (accepts priorityPolicy), ComputeFitness (returns (FitnessResult, error)), anomaly detection, ParseFitnessWeights with NaN/Inf validation, per-SLO-class metrics, JainFairnessIndex
-│   ├── deployment.go          # DeploymentConfig embeds sim.SimConfig + cluster-only fields; ToSimConfig() returns the embedded config
-│   └── evaluation.go          # EvaluationResult wrapper (RawMetrics + FitnessResult + trace + summary)
-├── sim/workload/              # ServeGen-informed workload generation (PR10)
-│   ├── spec.go                # WorkloadSpec v2, ClientSpec (with Model field), ArrivalSpec, DistSpec, YAML loading, v1→v2 auto-upgrade (UpgradeV1ToV2), IsValidSLOClass accessor
-│   ├── arrival.go             # ArrivalSampler: Poisson, Gamma (Marsaglia-Tsang), Weibull (bisection), Constant (fixed-interval)
-│   ├── distribution.go        # LengthSampler: Gaussian, Exponential, ParetoLogNormal, EmpiricalPDF, Constant
-│   ├── client.go              # Rate normalization, prefix group management
-│   ├── generator.go           # GenerateRequests pipeline with client decomposition
-│   ├── servegen.go            # Native ServeGen data file loading (chunk-*-trace.csv + dataset.json)
-│   ├── tracev2.go             # Trace v2 format (YAML header + CSV data)
-│   ├── replay.go              # Trace v2 → sim.Request with synthetic token IDs
-│   ├── calibrate.go           # CalibrationReport, PrepareCalibrationPairs, MAPE/Pearson r
-│   ├── multimodal.go          # Multimodal token generation (text+image+audio+video)
-│   ├── reasoning.go           # Reasoning multi-turn with context accumulation
-│   ├── session.go             # SessionManager: closed-loop session tracking, follow-up round generation on completion
-│   ├── network.go             # Client-perspective latency (RTT + bandwidth)
-│   ├── inference_perf.go      # inference-perf format: InferencePerfSpec, expansion, validation
-│   ├── scenarios.go           # Built-in presets (bursty, unfair, prefix-heavy, mixed-slo)
-│   ├── convert.go             # Format converters: ConvertServeGen, ConvertPreset, ComposeSpecs
-│   ├── cohort.go              # CohortSpec expansion: diurnal, spike, drain patterns → lifecycle windows
-│   └── synthesis.go           # Flag-to-spec synthesis: SynthesizeFromDistribution, SynthesizeFromPreset
-├── sim/trace/                 # Decision trace recording (PR13)
-│   ├── trace.go               # TraceLevel, TraceConfig, SimulationTrace, NewSimulationTrace, recording methods
-│   ├── record.go              # AdmissionRecord, RoutingRecord, CandidateScore (pure data types, no sim/ dependency)
-│   └── summary.go             # TraceSummary, Summarize()
-├── model_configs/             # Auto-fetched HuggingFace config.json files (gitignored)
-├── defaults.yaml              # Pre-trained coefficients, default GPU/TP/vLLM mappings, workload presets
-├── hardware_config.json       # GPU specifications
-├── examples/                  # Example configuration files
-├── hypotheses/                # Hypothesis experiment artifacts (run.sh, analyze.py, FINDINGS.md)
-├── testdata/goldendataset.json # Golden dataset for regression tests
-├── docs/
-│   ├── getting-started/       # New user onboarding
-│   │   ├── index.md           # What is BLIS?
-│   │   ├── installation.md    # Build from source
-│   │   ├── quickstart.md      # First simulation
-│   │   └── tutorial.md        # Capacity planning walkthrough
-│   ├── guide/                 # Task-oriented user guides
-│   │   ├── index.md           # Guide overview
-│   │   ├── routing.md         # Routing policies
-│   │   ├── admission.md       # Admission control
-│   │   ├── scheduling.md      # Scheduling & priority
-│   │   ├── latency-models.md  # Latency models (roofline + blackbox)
-│   │   ├── kv-cache.md        # KV cache & memory management
-│   │   ├── workloads.md       # Workload specifications
-│   │   ├── cluster.md         # Cluster simulation
-│   │   ├── results.md         # Metrics & results
-│   │   ├── experimentation.md # Hypothesis-driven experimentation
-│   │   └── skills-and-plugins.md # Claude Code skills & plugins
-│   ├── concepts/              # Architecture and design documentation
-│   │   ├── index.md           # Concepts overview
-│   │   ├── glossary.md        # Concepts glossary
-│   │   ├── architecture.md    # Cluster architecture
-│   │   ├── core-engine.md     # Core DES engine
-│   │   └── roofline.md        # Roofline step time estimation
-│   ├── reference/             # Configuration and model reference
-│   │   ├── index.md           # Reference overview
-│   │   ├── configuration.md   # Configuration reference
-│   │   ├── models.md          # Supported models catalog
-│   │   └── workload-spec.md   # Workload spec YAML schema
-│   ├── methodology/           # Research methodology documentation
-│   │   ├── index.md           # Methodology overview
-│   │   ├── strategy-evolution.md # Strategy Evolution methodology guide
-│   │   ├── hypothesis-bundles.md # Hypothesis bundle examples and writing guide
-│   │   └── principles.md     # Discovered principles catalog (30 principles)
-│   ├── contributing/          # Contributor documentation
-│   │   ├── index.md           # Contributing landing page
-│   │   ├── extension-recipes.md # Step-by-step extension guides
-│   │   ├── pr-workflow.md     # PR development workflow
-│   │   ├── design-process.md  # Design document process
-│   │   ├── macro-planning.md  # Macro-level planning process
-│   │   ├── hypothesis.md      # Hypothesis experiment process
-│   │   ├── convergence.md     # Universal Convergence Protocol
-│   │   ├── standards/         # Canonical rules, invariants, principles, experiment standards
-│   │   └── templates/         # Artifact templates + agent prompts
-│   │       ├── design-guidelines.md  # DES foundations, module architecture
-│   │       ├── macro-plan.md         # Multi-PR template (human-readable)
-│   │       ├── macro-plan-prompt.md  # Agent preamble for macro planning
-│   │       ├── micro-plan.md         # Single-PR template (human-readable)
-│   │       ├── micro-plan-prompt.md  # Agent preamble for writing-plans skill
-│   │       └── hypothesis.md         # Experiment FINDINGS.md template
-│   └── plans/                 # Active implementation plans (excluded from MkDocs)
-│       └── archive/           # Completed design docs (architectural reference)
-├── CONTRIBUTING.md            # Contributor guide (references docs/contributing/standards/)
-└── mkdocs.yml                 # MkDocs Material site configuration
-```
+For the full annotated file tree, see [`docs/reference/project-structure.md`](docs/reference/project-structure.md).
 
 ### Latency Estimation
 
-Four modes, selected by `latency.NewLatencyModel()` factory (in `sim/latency/`) based on `--latency-model` flag:
-
-1. **Roofline mode** (default): Analytical FLOPs/bandwidth estimation via `sim/latency/roofline.go`
-   - Requires HuggingFace `config.json` in `model_configs/`
-   - Requires `hardware_config.json` with GPU specs (including `MemoryGiB` for KV capacity auto-calculation)
-   - **KV capacity auto-calculation**: When an analytical backend (`roofline` or `crossmodel`) is active and `--total-kv-blocks` is not explicitly set, `CalculateKVBlocks()` (in `sim/latency/kv_capacity.go`) derives the block count from model architecture + GPU memory, matching the llm-d-benchmark `capacity_planner.py` reference formula. Supports dense and MoE models.
-   - **`--latency-model roofline`**: Auto-resolves both configs — checks `model_configs/` first, fetches from HuggingFace on miss (creating `model_configs/` and writing into it), and uses bundled `hardware_config.json`. Simplifies usage to: `./blis run --model <name> --hardware <GPU> --tp <N>`
-
-2. **Blackbox mode**: Uses trained alpha/beta coefficients from `defaults.yaml`
-   - Alpha coefficients: queueing time estimation
-   - Beta coefficients: step time estimation based on batch features
-
-3. **Cross-model mode**: Physics-informed estimation via `sim/latency/crossmodel.go`
-   - Uses 7 globally-fitted coefficients — 4 beta (per-layer overhead, KV bandwidth, MoE dispatch, TP sync) + 3 alpha (pre-scheduling, per-token preprocessing, output processing) — from `crossmodel_defaults` in `defaults.yaml`
-   - Derives architecture features from HuggingFace `config.json` (layer count, KV heads, head dimension, MoE expert count, TP degree)
-   - MoE-aware: correctly models sparse activation patterns (unlike roofline which overestimates ~4x for MoE)
-   - **`--latency-model crossmodel`**: Same auto-fetch chain as roofline. Usage: `./blis run --model <name> --latency-model crossmodel --hardware <GPU> --tp <N>`
-
-4. **Trained-roofline mode**: Roofline basis functions × learned correction coefficients via `sim/latency/trained_roofline.go`
-   - Uses 10 globally-fitted coefficients — 7 beta (prefill/decode roofline corrections, weight loading, TP communication, per-layer overhead, per-request scheduling, per-step overhead) + 3 alpha (API processing, post-decode fixed, per-output-token) — from `trained_roofline_defaults` in `defaults.yaml`
-   - Computes 6 analytical basis functions from HuggingFace `config.json` and hardware specs, applies learned β corrections
-   - Achieves 7% MAPE on GPU combined step time (test split) across 4 architectures (137K real vLLM requests)
-   - Key difference from pure roofline: no MFU scaling (β₁/β₂ ARE the corrections); 3-matrix SwiGLU (not roofline's 2-matrix)
-   - **`--latency-model trained-roofline`**: Same auto-fetch chain as roofline/crossmodel. Usage: `./blis run --model <name> --latency-model trained-roofline --hardware <GPU> --tp <N>`
+Four latency model modes (roofline, blackbox, cross-model, trained-roofline), selected via `--latency-model` flag. See [`docs/guide/latency-models.md`](docs/guide/latency-models.md) for details on each mode, configuration, and auto-fetch behavior.
 
 ### Key Data Flow
 
-```
-Request Arrival → Admission → Routing → WaitQueue → Batch Formation → Step Execution → Completion
-                                            ↓              ↓
-                                      KV Allocation   Latency Estimation (roofline, alpha/beta, cross-model, or trained-roofline)
-```
-Note: Admission and Routing steps apply in cluster mode (multi-instance). Single-instance mode skips directly to WaitQueue.
+Request processing pipeline: Arrival → Admission → Routing → WaitQueue → Batch Formation → Step Execution → Completion. Admission and Routing apply in cluster mode only; single-instance skips directly to WaitQueue. See [`docs/concepts/architecture.md`](docs/concepts/architecture.md) for the full diagram.
 
 ## Project Governance Documents
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -40,7 +40,7 @@ See [CONTRIBUTING.md](https://github.com/inference-sim/inference-sim/blob/main/C
 | Document | Covers |
 |----------|--------|
 | [Antipattern Rules (R1-R23)](standards/rules.md) | 23 rules, each tracing to a real bug |
-| [System Invariants (INV-1-8)](standards/invariants.md) | Properties that must always hold |
+| [System Invariants (INV-1-INV-11)](standards/invariants.md) | Properties that must always hold |
 | [Engineering Principles](standards/principles.md) | Separation of concerns, interface design, BDD/TDD |
 | [Experiment Standards](standards/experiments.md) | Hypothesis families, rigor requirements |
 

--- a/docs/contributing/standards/principles.md
+++ b/docs/contributing/standards/principles.md
@@ -89,13 +89,13 @@ Every piece of documentation lives in exactly one canonical location. Other file
 
 | Content | Canonical Source | Working Copies |
 |---------|-----------------|----------------|
-| Antipattern rules (R1-R23) | `docs/contributing/standards/rules.md` | CLAUDE.md (table), CONTRIBUTING.md (checklist), `.github/PULL_REQUEST_TEMPLATE.md` (PR checklist), `docs/contributing/templates/micro-plan-prompt.md` (Phase 8 checklist), `docs/contributing/templates/micro-plan.md` (Phase 8 checklist), `docs/contributing/index.md` (landing page table), `docs/guide/skills-and-plugins.md` (rules count) |
-| System invariants (INV-1–INV-8) | `docs/contributing/standards/invariants.md` | CLAUDE.md (summary), `docs/concepts/core-engine.md` (formulas), `docs/concepts/architecture.md` (signal freshness) |
+| Antipattern rules (R1-R23) | `docs/contributing/standards/rules.md` | CLAUDE.md (pointer), CONTRIBUTING.md (checklist), `.github/PULL_REQUEST_TEMPLATE.md` (PR checklist), `docs/contributing/templates/micro-plan-prompt.md` (Phase 8 checklist), `docs/contributing/templates/micro-plan.md` (Phase 8 checklist), `docs/contributing/index.md` (landing page table), `docs/guide/skills-and-plugins.md` (rules count) |
+| System invariants (INV-1–INV-11) | `docs/contributing/standards/invariants.md` | CLAUDE.md (summary), `docs/concepts/core-engine.md` (formulas), `docs/concepts/architecture.md` (signal freshness) |
 | Engineering principles | `docs/contributing/standards/principles.md` | CLAUDE.md (summary) |
 | Extension recipes (policies, scorers, KV tiers) | `docs/contributing/extension-recipes.md` | — |
 | Design process | `docs/contributing/design-process.md` | CONTRIBUTING.md (summary) |
 | Macro-plan process | `docs/contributing/macro-planning.md` | CONTRIBUTING.md (summary) |
-| File organization and architecture | CLAUDE.md (File Organization tree) | README.md (Project Structure tree) |
+| File organization and architecture | `docs/reference/project-structure.md` | CLAUDE.md (pointer), README.md (Project Structure tree) |
 | Hypothesis catalog and specifications | `docs/plans/research.md` | — |
 | Experiment status and coverage | `hypotheses/README.md` | — |
 | Experiment standards | `docs/contributing/standards/experiments.md` | — (note: review protocol subsection references `docs/contributing/convergence.md` as canonical) |

--- a/docs/plans/669-slim-claude-md-plan.md
+++ b/docs/plans/669-slim-claude-md-plan.md
@@ -1,0 +1,154 @@
+# Slim CLAUDE.md Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce CLAUDE.md from ~416 lines to ~210 lines by extracting reference material to dedicated docs, replacing each section with a 1-2 line pointer.
+
+**The problem today:** CLAUDE.md is loaded into every Claude Code session's context window. ~210 lines are reference material (File Organization tree, Latency Estimation details, Antipattern Prevention table, Key Data Flow diagram) that is rarely needed during a given task. Every session pays this context tax.
+
+**What this PR adds:**
+1. Replaces the File Organization tree (~150 lines) with a pointer to a new `docs/reference/project-structure.md`
+2. Replaces the Latency Estimation section (~26 lines) with a pointer to the existing `docs/guide/latency-models.md`
+3. Replaces the Antipattern Prevention table (~25 lines) with a pointer to the canonical `docs/contributing/standards/rules.md`
+4. Replaces the Key Data Flow diagram (~8 lines) with a pointer to the existing `docs/concepts/architecture.md`
+
+**Why this matters:** Reduces always-loaded context by ~200 lines per session, freeing token budget for actual task work. No information is lost — just moved from always-loaded to read-on-demand.
+
+**Architecture:** Pure documentation change. CLAUDE.md is edited in place. One new file (`docs/reference/project-structure.md`) is created. The source-of-truth map in `docs/contributing/standards/principles.md` is updated to reflect the new canonical location of the file organization tree. MkDocs nav in `mkdocs.yml` is updated to include the new page.
+
+**Source:** GitHub issue #669
+
+**Closes:** Fixes #669
+
+---
+
+## Part 1: Design
+
+### A. Behavioral Contracts
+
+**BC-1: File Organization pointer replacement**
+- GIVEN CLAUDE.md contains the File Organization tree (lines 201-350)
+- WHEN the tree is replaced with a pointer
+- THEN CLAUDE.md contains a 2-line pointer to `docs/reference/project-structure.md` and the full tree exists in that file
+
+**BC-2: Latency Estimation pointer replacement**
+- GIVEN CLAUDE.md contains the Latency Estimation section (lines 352-377)
+- WHEN the section is replaced with a pointer
+- THEN CLAUDE.md contains a 1-line pointer to `docs/guide/latency-models.md` with a note about the four modes
+
+**BC-3: Antipattern Prevention table replacement**
+- GIVEN CLAUDE.md contains the full R1-R23 table (lines 125-155)
+- WHEN the table is replaced with a pointer
+- THEN CLAUDE.md retains the canonical source header and pointer but removes the duplicated table. The "Code Review Standards" section (line 89) no longer says "below" and instead references `docs/contributing/standards/rules.md` directly
+
+**BC-4: Key Data Flow pointer replacement**
+- GIVEN CLAUDE.md contains the Key Data Flow diagram (lines 379-386)
+- WHEN the diagram is replaced with a pointer
+- THEN CLAUDE.md contains a 1-line pointer to `docs/concepts/architecture.md`
+
+**BC-5: Source-of-truth map consistency**
+- GIVEN the source-of-truth map tracks CLAUDE.md as canonical for file organization (line 98 of `docs/contributing/standards/principles.md`)
+- WHEN the tree moves to `docs/reference/project-structure.md`
+- THEN the map row changes canonical source from `CLAUDE.md (File Organization tree)` to `docs/reference/project-structure.md`, and working copies become `CLAUDE.md (pointer), README.md (Project Structure tree)`
+
+**BC-6: MkDocs navigation**
+- GIVEN the new file `docs/reference/project-structure.md` exists
+- WHEN the MkDocs site is built
+- THEN the project structure page appears under the Reference section in navigation
+
+### B. Component Interaction
+
+No code components involved. Only documentation files.
+
+### C. Risk Assessment
+
+- **Low risk**: Pure documentation movement. No code changes. No test changes.
+- **MkDocs build risk**: New page must be in nav or it will be orphaned. Mitigated by updating mkdocs.yml.
+
+### D. Deviation Log
+
+- Issue suggests moving tree to `docs/reference/project-structure.md` or inline in `docs/reference/configuration.md`. Chose dedicated file for clarity.
+- Issue says "Move Latency Estimation section to `docs/reference/latency-models.md`". Since `docs/guide/latency-models.md` already exists with comprehensive coverage of all 4 modes, the pointer targets the existing file instead of creating a new reference file.
+- Issue says "Replace the Key Data Flow with a one-line pointer" without specifying target. Chose `docs/concepts/architecture.md` since it covers the request processing pipeline.
+- README.md line 147 says "see CLAUDE.md" for the authoritative file organization. After this PR, the canonical source moves to `docs/reference/project-structure.md`. Updating README.md is deferred — it was not in the issue scope and the README's Project Structure tree remains a valid (if not authoritative) working copy.
+
+### E. Test Strategy
+
+No tests needed — documentation-only change. Verification via line count and content presence checks.
+
+---
+
+## Part 2: Tasks
+
+### Task 1: Create `docs/reference/project-structure.md` with the File Organization tree
+
+**Test (verification):**
+```bash
+# Verify file exists and contains the tree
+test -f docs/reference/project-structure.md && grep -c "inference-sim/" docs/reference/project-structure.md
+# Expected: file exists, grep count > 0
+```
+
+**Implementation:**
+1. Create `docs/reference/project-structure.md` with the full File Organization tree content from CLAUDE.md (lines 201-350), using title "# Project Structure" and preserving the existing intro sentence
+2. Update `mkdocs.yml` to add the new page under the Reference section nav with label "Project Structure: reference/project-structure.md"
+3. Fix stale `mkdocs.yml` nav labels while editing: "Antipattern Rules (R1-R20)" → "Antipattern Rules (R1-R23)", "System Invariants (INV-1-8)" → "System Invariants (INV-1-INV-11)"
+
+**Commit:** `docs(reference): add project-structure.md with file organization tree`
+
+---
+
+### Task 2: Replace CLAUDE.md sections with pointers
+
+**Test (verification):**
+```bash
+# Verify CLAUDE.md line count is reduced
+wc -l CLAUDE.md
+# Expected: ~210 lines (down from 416)
+
+# Verify pointers exist
+grep -c "docs/reference/project-structure.md" CLAUDE.md
+grep -c "docs/guide/latency-models.md" CLAUDE.md
+grep -c "docs/contributing/standards/rules.md" CLAUDE.md
+grep -c "docs/concepts/architecture.md" CLAUDE.md
+# Expected: each returns >= 1
+```
+
+**Implementation:**
+1. Replace the File Organization section (lines 201-350) with a 2-line pointer
+2. Replace the Latency Estimation section (lines 352-377) with a 2-line pointer
+3. Replace the Key Data Flow section (lines 379-386) with a 1-line pointer
+4. Replace the Antipattern Prevention table (lines 131-155) with a 1-line pointer, keeping the canonical source header
+5. Update the "Code Review Standards" section (line 89) to reference `docs/contributing/standards/rules.md` instead of "below"
+
+**Commit:** `docs(claude-md): replace 4 reference sections with pointers (~200 lines removed)`
+
+---
+
+### Task 3: Update source-of-truth map
+
+**Test (verification):**
+```bash
+# Verify map entry updated
+grep "project-structure" docs/contributing/standards/principles.md
+# Expected: new canonical location appears
+```
+
+**Implementation:**
+1. In `docs/contributing/standards/principles.md` line 98, update the "File organization and architecture" row: canonical source from `CLAUDE.md (File Organization tree)` → `docs/reference/project-structure.md`; working copies from `README.md (Project Structure tree)` → `CLAUDE.md (pointer), README.md (Project Structure tree)`
+2. Fix stale invariant count in same file line 93: `System invariants (INV-1–INV-8)` → `System invariants (INV-1–INV-11)`
+
+**Commit:** `docs(standards): update source-of-truth map for project structure relocation`
+
+---
+
+## Part 3: Appendix
+
+### J. Files Modified
+
+| File | Action | Description |
+|------|--------|-------------|
+| `CLAUDE.md` | Edit | Replace 4 sections with pointers (~200 lines removed) |
+| `docs/reference/project-structure.md` | Create | New file with File Organization tree |
+| `mkdocs.yml` | Edit | Add project-structure.md to Reference nav; fix stale R1-R20→R1-R23 and INV-1-8→INV-1-11 labels |
+| `docs/contributing/standards/principles.md` | Edit | Update source-of-truth map entry + fix stale INV-1-8→INV-1-11 count |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,6 +4,7 @@ Lookup documentation for BLIS configuration, supported models, and workload spec
 
 | Page | Description |
 |------|-------------|
+| [Project Structure](project-structure.md) | Annotated file tree with per-file module descriptions |
 | [Configuration](configuration.md) | All CLI flags, configuration precedence, defaults.yaml behavior |
 | [Supported Models](models.md) | Model compatibility, blackbox coefficient catalog, validated architectures |
 | [Workload Spec Schema](workload-spec.md) | Complete YAML schema for multi-client workload specifications |

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -1,0 +1,151 @@
+# Project Structure
+
+The simulator uses a discrete-event architecture with a min-heap event queue.
+
+```
+inference-sim/
+├── .github/workflows/         # CI configuration (build, lint, test)
+├── main.go                    # CLI entry point (Cobra)
+├── cmd/
+│   ├── root.go                # CLI commands and flags (--num-instances, --policy-config, --routing-scorers, --workload-spec, --trace-level, --fitness-weights, --kv-cpu-blocks, --kv-offload-threshold, --kv-transfer-bandwidth, --kv-transfer-base-latency, --snapshot-refresh-interval, --latency-model, --max-model-len, --trace-output)
+│   ├── replay.go              # `blis replay` command: replays TraceV2 file through DES; flags: --trace-header, --trace-data (required), all sim config flags shared via registerSimConfigFlags(); --results-path writes []workload.SimResult (integer request_id, ttft_us/e2e_us in µs); SimResult type lives in sim/workload/calibrate.go
+│   ├── calibrate.go           # `blis calibrate` command: compares real observed latencies (TraceV2 from blis observe) against sim predictions ([]SimResult JSON from blis replay --results-path); flags: --trace-header, --trace-data, --sim-results, --report (required), --warmup-requests (default: from header, sentinel -1), --network-rtt-us (default: from header, sentinel -1), --network-bandwidth-mbps; writes CalibrationReport JSON with MAPE/PearsonR/percentiles per metric
+│   ├── observe.go             # Real mode HTTP client (OpenAI-compatible, streaming + non-streaming)
+│   ├── convert.go             # `blis convert` subcommands (servegen, preset, inference-perf)
+│   ├── compose.go             # `blis compose` for merging v2 specs
+│   ├── hfconfig.go            # HuggingFace config resolution chain (--latency-model auto-fetch, caching)
+│   └── default_config.go      # defaults.yaml loading (includes GetHFRepo for HF repo name mapping)
+├── sim/                       # Core single-instance simulator
+│   ├── config.go              # Module-scoped sub-config types (KVCacheConfig, BatchConfig, LatencyCoeffs, ModelHardwareConfig, PolicyConfig, WorkloadConfig) — composed into SimConfig via embedding (R16)
+│   ├── doc.go                 # Package reading guide: start with request.go, event.go, simulator.go
+│   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor (validates MaxModelLen vs KV capacity), event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, EnqueueRequest (MaxModelLen + KV capacity guards), processCompletions (proactive MaxModelLen cap at maxModelLen-1 boundary), observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
+│   ├── admission.go           # AdmissionPolicy interface (accepts *RouterState), AlwaysAdmit, TokenBucket, RejectAll, NewAdmissionPolicy factory
+│   ├── routing.go             # RoutingPolicy interface (accepts *RouterState), RoutingSnapshot (with EffectiveLoad() for canonical load calculation), RoutingDecision (with Priority hint), RoundRobin, LeastLoaded, WeightedScoring (composable scorer pipeline), AlwaysBusiest templates, NewRoutingPolicy factory
+│   ├── routing_scorers.go     # ScorerConfig, scorer implementations (queue-depth, kv-utilization, load-balance), ParseScorerConfigs, IsValidScorer, DefaultScorerConfigs, newScorerWithObserver factory
+│   ├── routing_prefix_scorer.go # Prefix-affinity scorer + observer (proportional prefix matching)
+│   ├── prefix_cache_index.go  # PrefixCacheIndex: per-instance LRU of hierarchical block hashes
+│   ├── priority.go            # PriorityPolicy interface with ConstantPriority, SLOBasedPriority, and InvertedSLO templates, NewPriorityPolicy factory
+│   ├── scheduler.go           # InstanceScheduler interface with FCFSScheduler, PriorityFCFSScheduler, SJFScheduler, and ReversePriority templates, NewScheduler factory
+│   ├── latency_model.go       # LatencyModel interface (3 methods), NewLatencyModelFunc registration variable, MustNewLatencyModel nil-guarded wrapper
+│   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
+│   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
+│   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft, Timeout) with (timestamp, priority, seqID) ordering
+│   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted, StateTimedOut), Request lifecycle and state machine, Deadline field for client timeout, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.), MaxOutputLen (client output budget for enqueue guard)
+│   ├── kv_store.go            # KVStore interface (12 methods: +SetClock, +ConsumePendingTransferLatency, +MirrorToCPU), NewKVStoreFromConfig registration variable, MustNewKVCacheState/MustNewKVStoreFromConfig nil-guarded wrappers
+│   ├── batch.go               # Batch struct
+│   ├── batch_formation.go     # BatchFormation interface, BatchContext/BatchResult types, VLLMBatchFormation (FCFS + chunked-prefill + preemption), NewBatchFormation() factory
+│   ├── queue.go               # FIFO wait queue
+│   ├── metrics.go             # TTFT, TPOT, E2E collection and SaveResults()
+│   ├── metrics_utils.go       # Percentile/mean calculation, MetricsOutput JSON struct, NewRequestMetrics canonical constructor
+│   ├── rng.go                 # PartitionedRNG for deterministic multi-subsystem simulation
+│   ├── model_hardware_config.go # ModelConfig, HardwareCalib structs (config types stay in sim/); HardwareCalib includes MemoryGiB (used by KV capacity auto-calculation in roofline/crossmodel modes). Note: MaxModelLen is int64 (aligned with ProgressIndex, TotalKVBlocks, BlockSizeTokens).
+│   └── internal/              # Shared internal packages
+│       ├── hash/              # Block-level hashing for prefix cache
+│       ├── testutil/          # Shared test infrastructure (golden dataset loading)
+│       └── util/              # General utility functions
+├── sim/kv/                    # KV cache implementations (PKG-1)
+│   ├── cache.go               # KVCacheState (single-tier GPU)
+│   ├── tiered.go              # TieredKVCache (GPU+CPU mirror/reload, vLLM v1 model)
+│   └── register.go            # NewKVStore factory + init()-based registration into sim/
+├── sim/latency/               # Latency model implementations (PKG-2)
+│   ├── latency.go             # RooflineLatencyModel (default, analytical FLOPs/bandwidth), BlackboxLatencyModel (alpha/beta regression), CrossModelLatencyModel (physics-informed cross-model), NewLatencyModel(LatencyCoeffs, ModelHardwareConfig) factory
+│   ├── trained_roofline.go    # TrainedRooflineLatencyModel: roofline basis functions × learned corrections (7β + 3α from training pipeline)
+│   ├── crossmodel.go          # CrossModelLatencyModel: physics-informed step time from architecture features (MoE-aware)
+│   ├── roofline.go            # rooflineStepTime(), calculateTransformerFlops(), calculateMemoryAccessBytes(), StepConfig/PrefillRequestConfig/DecodeRequestConfig types
+│   ├── kv_capacity.go         # CalculateKVBlocks: auto-derive total KV cache blocks from model architecture + GPU memory; KVCapacityParams, ExtractKVCapacityParams, computeModelWeightBytes
+│   ├── config.go              # HFConfig, GetHWConfig(), GetModelConfig(), ValidateRooflineConfig(), parseHWConfig(), ParseHFConfig()
+│   └── register.go            # init()-based registration of NewLatencyModelFunc into sim/
+├── sim/cluster/               # Multi-replica cluster simulation
+│   ├── instance.go            # InstanceSimulator wraps sim.Simulator via NewInstanceSimulator(id, SimConfig) with run-once guard; delegates to Simulator observation methods (QueueDepth(), BatchSize(), etc.)
+│   ├── cluster.go             # ClusterSimulator orchestrates N instances with shared-clock event loop, online routing pipeline, and metrics aggregation; Run() returns error
+│   ├── cluster_event.go       # ClusterArrivalEvent, AdmissionDecisionEvent, RoutingDecisionEvent
+│   ├── counterfactual.go      # computeCounterfactual() for top-k candidate ranking and regret computation
+│   ├── snapshot.go            # CachedSnapshotProvider (returns sim.RoutingSnapshot), ObservabilityConfig
+│   ├── metrics.go             # RawMetrics, Distribution, FitnessResult, CollectRawMetrics (accepts priorityPolicy), ComputeFitness (returns (FitnessResult, error)), anomaly detection, ParseFitnessWeights with NaN/Inf validation, per-SLO-class metrics, JainFairnessIndex
+│   ├── deployment.go          # DeploymentConfig embeds sim.SimConfig + cluster-only fields; ToSimConfig() returns the embedded config
+│   └── evaluation.go          # EvaluationResult wrapper (RawMetrics + FitnessResult + trace + summary)
+├── sim/workload/              # ServeGen-informed workload generation
+│   ├── spec.go                # WorkloadSpec v2, ClientSpec (with Model field), ArrivalSpec, DistSpec, YAML loading, v1→v2 auto-upgrade (UpgradeV1ToV2), IsValidSLOClass accessor
+│   ├── arrival.go             # ArrivalSampler: Poisson, Gamma (Marsaglia-Tsang), Weibull (bisection), Constant (fixed-interval)
+│   ├── distribution.go        # LengthSampler: Gaussian, Exponential, ParetoLogNormal, EmpiricalPDF, Constant
+│   ├── client.go              # Rate normalization, prefix group management
+│   ├── generator.go           # GenerateRequests pipeline with client decomposition
+│   ├── servegen.go            # Native ServeGen data file loading (chunk-*-trace.csv + dataset.json)
+│   ├── tracev2.go             # Trace v2 format (YAML header + CSV data)
+│   ├── replay.go              # Trace v2 → sim.Request with synthetic token IDs
+│   ├── calibrate.go           # CalibrationReport, PrepareCalibrationPairs, MAPE/Pearson r
+│   ├── multimodal.go          # Multimodal token generation (text+image+audio+video)
+│   ├── reasoning.go           # Reasoning multi-turn with context accumulation
+│   ├── session.go             # SessionManager: closed-loop session tracking, follow-up round generation on completion
+│   ├── network.go             # Client-perspective latency (RTT + bandwidth)
+│   ├── inference_perf.go      # inference-perf format: InferencePerfSpec, expansion, validation
+│   ├── scenarios.go           # Built-in presets (bursty, unfair, prefix-heavy, mixed-slo)
+│   ├── convert.go             # Format converters: ConvertServeGen, ConvertPreset, ComposeSpecs
+│   ├── cohort.go              # CohortSpec expansion: diurnal, spike, drain patterns → lifecycle windows
+│   └── synthesis.go           # Flag-to-spec synthesis: SynthesizeFromDistribution, SynthesizeFromPreset
+├── sim/trace/                 # Decision trace recording
+│   ├── trace.go               # TraceLevel, TraceConfig, SimulationTrace, NewSimulationTrace, recording methods
+│   ├── record.go              # AdmissionRecord, RoutingRecord, CandidateScore (pure data types, no sim/ dependency)
+│   └── summary.go             # TraceSummary, Summarize()
+├── model_configs/             # Auto-fetched HuggingFace config.json files (gitignored)
+├── defaults.yaml              # Pre-trained coefficients, default GPU/TP/vLLM mappings, workload presets
+├── hardware_config.json       # GPU specifications
+├── examples/                  # Example configuration files
+├── hypotheses/                # Hypothesis experiment artifacts (run.sh, analyze.py, FINDINGS.md)
+├── testdata/goldendataset.json # Golden dataset for regression tests
+├── docs/
+│   ├── getting-started/       # New user onboarding
+│   │   ├── index.md           # What is BLIS?
+│   │   ├── installation.md    # Build from source
+│   │   ├── quickstart.md      # First simulation
+│   │   └── tutorial.md        # Capacity planning walkthrough
+│   ├── guide/                 # Task-oriented user guides
+│   │   ├── index.md           # Guide overview
+│   │   ├── routing.md         # Routing policies
+│   │   ├── admission.md       # Admission control
+│   │   ├── scheduling.md      # Scheduling & priority
+│   │   ├── latency-models.md  # Latency models (roofline + blackbox)
+│   │   ├── kv-cache.md        # KV cache & memory management
+│   │   ├── workloads.md       # Workload specifications
+│   │   ├── cluster.md         # Cluster simulation
+│   │   ├── results.md         # Metrics & results
+│   │   ├── experimentation.md # Hypothesis-driven experimentation
+│   │   └── skills-and-plugins.md # Claude Code skills & plugins
+│   ├── concepts/              # Architecture and design documentation
+│   │   ├── index.md           # Concepts overview
+│   │   ├── glossary.md        # Concepts glossary
+│   │   ├── architecture.md    # Cluster architecture
+│   │   ├── core-engine.md     # Core DES engine
+│   │   └── roofline.md        # Roofline step time estimation
+│   ├── reference/             # Configuration and model reference
+│   │   ├── index.md           # Reference overview
+│   │   ├── project-structure.md # Project file organization (this file)
+│   │   ├── configuration.md   # Configuration reference
+│   │   ├── models.md          # Supported models catalog
+│   │   └── workload-spec.md   # Workload spec YAML schema
+│   ├── methodology/           # Research methodology documentation
+│   │   ├── index.md           # Methodology overview
+│   │   ├── strategy-evolution.md # Strategy Evolution methodology guide
+│   │   ├── hypothesis-bundles.md # Hypothesis bundle examples and writing guide
+│   │   └── principles.md     # Discovered principles catalog (30 principles)
+│   ├── contributing/          # Contributor documentation
+│   │   ├── index.md           # Contributing landing page
+│   │   ├── extension-recipes.md # Step-by-step extension guides
+│   │   ├── pr-workflow.md     # PR development workflow
+│   │   ├── design-process.md  # Design document process
+│   │   ├── macro-planning.md  # Macro-level planning process
+│   │   ├── hypothesis.md      # Hypothesis experiment process
+│   │   ├── convergence.md     # Universal Convergence Protocol
+│   │   ├── standards/         # Canonical rules, invariants, principles, experiment standards
+│   │   └── templates/         # Artifact templates + agent prompts
+│   │       ├── design-guidelines.md  # DES foundations, module architecture
+│   │       ├── macro-plan.md         # Multi-PR template (human-readable)
+│   │       ├── macro-plan-prompt.md  # Agent preamble for macro planning
+│   │       ├── micro-plan.md         # Single-PR template (human-readable)
+│   │       ├── micro-plan-prompt.md  # Agent preamble for writing-plans skill
+│   │       └── hypothesis.md         # Experiment FINDINGS.md template
+│   └── plans/                 # Active implementation plans (excluded from MkDocs)
+│       └── archive/           # Completed design docs (architectural reference)
+├── CONTRIBUTING.md            # Contributor guide (references docs/contributing/standards/)
+└── mkdocs.yml                 # MkDocs Material site configuration
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Skills & Plugins: guide/skills-and-plugins.md
   - Reference:
       - reference/index.md
+      - Project Structure: reference/project-structure.md
       - Configuration: reference/configuration.md
       - Supported Models: reference/models.md
       - Workload Spec Schema: reference/workload-spec.md
@@ -121,8 +122,8 @@ nav:
       - Hypothesis Experiments: contributing/hypothesis.md
       - Convergence Protocol: contributing/convergence.md
       - Standards:
-          - "Antipattern Rules (R1-R20)": contributing/standards/rules.md
-          - "System Invariants (INV-1-8)": contributing/standards/invariants.md
+          - "Antipattern Rules (R1-R23)": contributing/standards/rules.md
+          - "System Invariants (INV-1-INV-11)": contributing/standards/invariants.md
           - Engineering Principles: contributing/standards/principles.md
           - Experiment Standards: contributing/standards/experiments.md
       - Templates:


### PR DESCRIPTION
## Summary

- Extract ~200 lines of reference material from CLAUDE.md to read-on-demand locations
- CLAUDE.md reduced from 416 → 214 lines (48% reduction in always-loaded context)
- No information lost — moved to dedicated docs with pointer references

## Changes

| File | Action | Description |
|------|--------|-------------|
| `CLAUDE.md` | Edit | Replace 4 verbose sections with 1-2 line pointers |
| `docs/reference/project-structure.md` | Create | Full annotated file organization tree |
| `mkdocs.yml` | Edit | Add project-structure.md to Reference nav; fix stale R1-R20→R1-R23 and INV-1-8→INV-1-11 labels |
| `docs/contributing/standards/principles.md` | Edit | Update source-of-truth map + fix stale INV count |
| `docs/plans/669-slim-claude-md-plan.md` | Create | Implementation plan |

## Sections Extracted

1. **File Organization tree** (~150 lines) → `docs/reference/project-structure.md`
2. **Latency Estimation** (~26 lines) → pointer to `docs/guide/latency-models.md`
3. **Antipattern Prevention table** (~25 lines) → pointer to `docs/contributing/standards/rules.md`
4. **Key Data Flow diagram** (~8 lines) → pointer to `docs/concepts/architecture.md`

## Bonus Fixes

- mkdocs.yml: "Antipattern Rules (R1-R20)" → "Antipattern Rules (R1-R23)"
- mkdocs.yml: "System Invariants (INV-1-8)" → "System Invariants (INV-1-INV-11)"
- principles.md: Source-of-truth map invariant count INV-1-8 → INV-1-11
- principles.md: Antipattern rules working copy CLAUDE.md (table) → CLAUDE.md (pointer)

## Discovered Issues

- #702: CLAUDE.md invariants working copy missing INV-10 and INV-11

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)