### PR TITLE
docs(pr-workflow): add Step 1.5 Source Document Audit

### DIFF
--- a/docs/contributing/pr-workflow.md
+++ b/docs/contributing/pr-workflow.md
@@ -1,6 +1,6 @@
 # PR Development Workflow
 
-**Status:** Active (v4.0 — updated 2026-02-27)
+**Status:** Active (v4.1 — updated 2026-03-17)
 
 This document describes the complete workflow for implementing a PR from any source: a macro plan section, GitHub issues, a design document, or a feature request. The same steps apply whether you use Claude Code or standard git tools.
 
@@ -11,6 +11,7 @@ This document describes the complete workflow for implementing a PR from any sou
 ```mermaid
 flowchart TD
     S1["Step 1: Create Isolated Workspace"]
+    S15["Step 1.5: Source Document Audit"]
     S2["Step 2: Write Implementation Plan"]
     S25["Step 2.5: Review the Plan<br/>(10 perspectives → convergence)"]
     S3["Step 3: Human Review<br/>(Approve plan)"]
@@ -19,7 +20,7 @@ flowchart TD
     S475["Step 4.75: Pre-Commit Self-Audit<br/>(Critical thinking — no agent)"]
     S5["Step 5: Commit, Push, Create PR"]
 
-    S1 --> S2 --> S25 --> S3 --> S4 --> S45 --> S475 --> S5
+    S1 --> S15 --> S2 --> S25 --> S3 --> S4 --> S45 --> S475 --> S5
     S25 -->|convergence<br/>rounds| S25
     S45 -->|convergence<br/>rounds| S45
 
@@ -59,6 +60,22 @@ All remaining steps happen in the worktree.
 
 !!! tip "Automation"
     `/superpowers:using-git-worktrees pr<N>-<feature-name>` creates the worktree and switches your shell into it. Optional pre-cleanup: `/commit-commands:clean_gone` removes stale branches. See [Skills & Plugins](../guide/skills-and-plugins.md).
+
+---
+
+### Step 1.5: Audit the Source Document
+
+Before writing the plan, scan the source document (design doc, macro plan section, GitHub issue, or feature request) for:
+
+1. **Ambiguous requirements** — flag and resolve with the document author before planning
+2. **Contradictions with existing invariants or standards** — check against `standards/invariants.md` and `standards/rules.md`
+3. **Missing information needed for planning** — which extension type? which invariants affected? which construction sites?
+
+**Output:** A list of resolved clarifications, appended to the micro plan's Deviation Log with reason `CLARIFICATION`.
+
+> **CLARIFICATION vs CORRECTION:** Use `CLARIFICATION` when the source was ambiguous or incomplete and you chose an interpretation. Use `CORRECTION` when the source was factually wrong about existing code or behavior.
+
+If the source document is unambiguous and complete, skip this step — but note in the plan that no clarifications were needed.
 
 ---
 
@@ -407,7 +424,7 @@ Not all PRs need the same level of review. Use these objective criteria:
 | **Large** | >10 files, OR new interfaces/modules, OR architecture changes | Full two-stage (pre-pass + convergence) | Full two-stage (pre-pass + convergence) | Full (all 10 dimensions) |
 
 **Rules:**
-- **Steps 1, 2, 3, 4, 5 are always required** — worktree, plan, human review, execution, and commit apply to all tiers.
+- **Steps 1, 1.5, 2, 3, 4, 5 are always required** — worktree, source audit, plan, human review, execution, and commit apply to all tiers.
 - **Self-audit is always full** — the 10-dimension critical thinking check catches substance bugs that no automated review can. It costs 5 minutes and has caught 3+ real bugs in every PR where it was applied.
 - **When in doubt, tier up** — if you're unsure whether a change is Small or Medium, use Medium.
 - **Human reviewer can override** — if the human reviewer at Step 3 believes the tier is wrong, they can request a different tier.
@@ -422,13 +439,14 @@ Not all PRs need the same level of review. Use these objective criteria:
 A typical PR from a macro plan section:
 
 1. **Create worktree:** `git worktree add .worktrees/pr8-routing -b pr8-routing && cd .worktrees/pr8-routing`
-2. **Write plan:** Follow [micro-plan template](templates/micro-plan.md), save to `docs/plans/pr8-routing-plan.md`
-3. **Review plan:** Run all 10 perspectives (Stage 1 pre-pass, then Stage 2 convergence). Fix issues, re-run until converged.
-4. **Human review:** Read plan — contracts, tasks, appendix. Approve to proceed.
-5. **Implement:** Execute TDD tasks: test → fail → implement → pass → lint → commit.
-6. **Review code:** Same two-stage review as plan. Fix issues, re-run until converged. Run verification gate.
-7. **Self-audit:** Think through all 10 dimensions. Fix issues.
-8. **Commit + PR:** Push branch, create PR with closing keywords.
+2. **Audit source:** Scan source document for ambiguities, contradictions, missing info. Record clarifications.
+3. **Write plan:** Follow [micro-plan template](templates/micro-plan.md), save to `docs/plans/pr8-routing-plan.md`
+4. **Review plan:** Run all 10 perspectives (Stage 1 pre-pass, then Stage 2 convergence). Fix issues, re-run until converged.
+5. **Human review:** Read plan — contracts, tasks, appendix. Approve to proceed.
+6. **Implement:** Execute TDD tasks: test → fail → implement → pass → lint → commit.
+7. **Review code:** Same two-stage review as plan. Fix issues, re-run until converged. Run verification gate.
+8. **Self-audit:** Think through all 10 dimensions. Fix issues.
+9. **Commit + PR:** Push branch, create PR with closing keywords.
 
 The workflow is the same regardless of source (macro plan, design doc, GitHub issues). Only the source document passed to the planning step differs.
 
@@ -522,5 +540,6 @@ When to use: When Step 2.5 or Step 4.5 hits context limits. Not needed for most 
 **v2.9 (2026-02-20):** Convergence re-run protocol for both Step 2.5 and Step 4.5.
 **v3.0 (2026-02-23):** Multi-perspective rounds replace sequential passes. External LLM review removed. Convergence redefined as property of a clean round.
 **v4.0 (2026-02-27):** Human-first rewrite (#464). Steps describe human actions; skills in admonition callouts. Manual path is primary; automation is additive. Templates split into human-readable format descriptions + agent prompt companions.
+**v4.1 (2026-03-17):** Added Step 1.5 (Source Document Audit) between Steps 1 and 2 — structured pre-audit of source documents for ambiguities, contradictions, and missing information before planning begins. Added `CLARIFICATION` as a Deviation Log reason (#664).
 
 </details>

--- a/docs/contributing/templates/micro-plan-prompt.md
+++ b/docs/contributing/templates/micro-plan-prompt.md
@@ -253,6 +253,7 @@ For each difference:
 |-------------|-----------------|--------|
 
 Categories of deviation:
+- CLARIFICATION: Ambiguity in source document resolved during Step 1.5 audit
 - SIMPLIFICATION: Source specified more than needed at this stage
 - CORRECTION: Source was wrong about existing code or behavior
 - DEFERRAL: Feature moved to a later PR (explain why)

--- a/docs/contributing/templates/micro-plan.md
+++ b/docs/contributing/templates/micro-plan.md
@@ -148,7 +148,7 @@ Table comparing the micro plan against the source document:
 
 | Source Says | Micro Plan Does | Reason |
 |-------------|-----------------|--------|
-| ... | ... | SIMPLIFICATION / CORRECTION / DEFERRAL / ADDITION / SCOPE_CHANGE |
+| ... | ... | CLARIFICATION / SIMPLIFICATION / CORRECTION / DEFERRAL / ADDITION / SCOPE_CHANGE |
 
 ### E) Review Guide
 

--- a/docs/plans/664-source-doc-audit-plan.md
+++ b/docs/plans/664-source-doc-audit-plan.md
@@ -1,0 +1,218 @@
+# Source Document Audit Step — Implementation Plan
+
+**Goal:** Add Step 1.5 (Source Document Audit) to the PR workflow so ambiguities in source documents are resolved before planning begins.
+**Source:** [GitHub issue #664](https://github.com/inference-sim/inference-sim/issues/664)
+**Closes:** Fixes #664
+
+## Behavioral Contracts
+
+BC-1: Step 1.5 Exists in Workflow
+- GIVEN a reader opens `docs/contributing/pr-workflow.md`
+- WHEN they read the Step-by-Step Process section
+- THEN they see Step 1.5 (Source Document Audit) between Step 1 (Create Isolated Workspace) and Step 2 (Write Implementation Plan), describing three named audit checks — (1) ambiguous requirements, (2) contradictions with existing invariants or standards, (3) missing information needed for planning — and specifying `CLARIFICATION` deviation log entries as output
+
+BC-2: Mermaid Flowchart Shows Step 1.5
+- GIVEN a reader views the Overview flowchart in `pr-workflow.md`
+- WHEN the Mermaid diagram renders
+- THEN Step 1.5 appears between S1 and S2 in the flow, with the label "Step 1.5: Source Document Audit"
+
+BC-3: CLARIFICATION Is a Valid Deviation Log Reason
+- GIVEN a contributor writes a micro plan deviation log
+- WHEN they need to record a clarification resolved during the source document audit
+- THEN the micro-plan template (both human and agent-prompt versions) lists `CLARIFICATION` as a valid reason alongside `SIMPLIFICATION / CORRECTION / DEFERRAL / ADDITION / SCOPE_CHANGE`
+
+BC-4: Example Walkthrough Includes Step 1.5
+- GIVEN a reader follows the Example Walkthrough section
+- WHEN they read the numbered steps
+- THEN Step 1.5 (audit source document) appears between workspace creation and plan writing
+
+BC-5: Workflow Version Updated
+- GIVEN the workflow has been modified
+- WHEN a reader checks the version header
+- THEN the version is incremented and the date is updated
+
+## Part 1: Design Validation
+
+### A) Executive Summary
+
+This PR adds a new lightweight step (1.5) to the PR workflow that requires contributors to audit their source document for ambiguities, contradictions, and missing information before writing a micro plan. The output is a list of resolved clarifications recorded in the deviation log. This is a docs-only change affecting three files: the PR workflow, the micro-plan template, and the micro-plan agent prompt.
+
+### B) Behavioral Contracts
+
+See above.
+
+### C) Component Interaction
+
+No code components. Three documentation files:
+
+```
+pr-workflow.md ──references──> micro-plan.md (Deviation Log section)
+                                  │
+                              micro-plan-prompt.md (agent companion)
+```
+
+The workflow references the deviation log format defined in the template. Both the human template and agent prompt must list the same valid reasons.
+
+### D) Deviation Log
+
+| Source Says | Micro Plan Does | Reason |
+|-------------|-----------------|--------|
+| "Update CLAUDE.md working copy of the PR workflow summary if needed" | No CLAUDE.md change needed — the PR Workflow section only says "follow docs/contributing/pr-workflow.md" without enumerating steps | SIMPLIFICATION |
+| (not mentioned in issue) | Also updates `micro-plan-prompt.md` (agent companion) to add `CLARIFICATION` — ensures human template and agent prompt stay in sync | ADDITION |
+
+### E) Review Guide
+
+- **Scrutinize:** The Mermaid flowchart syntax (easy to break). The exact wording of Step 1.5 — is it actionable without being overly prescriptive?
+- **Safe to skim:** Version bump, example walkthrough update (mechanical).
+- **Known debt:** None.
+
+## Part 2: Executable Implementation
+
+### F) Implementation Overview
+
+Files to modify:
+- `docs/contributing/pr-workflow.md` — add Step 1.5, update Mermaid, update Example Walkthrough, bump version
+- `docs/contributing/templates/micro-plan.md` — add `CLARIFICATION` to Deviation Log reasons
+- `docs/contributing/templates/micro-plan-prompt.md` — add `CLARIFICATION` to Deviation Log reasons
+
+### G) Task Breakdown
+
+#### Task 1: Add Step 1.5 to pr-workflow.md (BC-1, BC-2, BC-4, BC-5)
+
+**Files:** modify `docs/contributing/pr-workflow.md`
+
+**Changes:**
+
+1. Update the Mermaid flowchart (BC-2). Change line 22 from:
+   ```
+   S1 --> S2 --> S25 --> S3 --> S4 --> S45 --> S475 --> S5
+   ```
+   to:
+   ```
+   S1 --> S15 --> S2 --> S25 --> S3 --> S4 --> S45 --> S475 --> S5
+   ```
+   Add the node definition after S1's definition (after line 13):
+   ```
+   S15["Step 1.5: Source Document Audit"]
+   ```
+
+2. Add Step 1.5 section after Step 1's `---` separator (BC-1):
+   ```markdown
+   ### Step 1.5: Audit the Source Document
+
+   Before writing the plan, scan the source document (design doc, macro plan section, GitHub issue, or feature request) for:
+
+   1. **Ambiguous requirements** — flag and resolve with the document author before planning
+   2. **Contradictions with existing invariants or standards** — check against `standards/invariants.md` and `standards/rules.md`
+   3. **Missing information needed for planning** — which extension type? which invariants affected? which construction sites?
+
+   **Output:** A list of resolved clarifications, appended to the micro plan's Deviation Log with reason `CLARIFICATION`.
+
+   > **CLARIFICATION vs CORRECTION:** Use `CLARIFICATION` when the source was ambiguous or incomplete and you chose an interpretation. Use `CORRECTION` when the source was factually wrong about existing code or behavior.
+
+   If the source document is unambiguous and complete, skip this step — but note in the plan that no clarifications were needed.
+   ```
+
+3. Update the Example Walkthrough to insert step 1.5 (BC-4):
+   - After "Create worktree:" add: "**Audit source:** Scan source document for ambiguities, contradictions, missing info. Record clarifications."
+   - Renumber remaining steps.
+
+4. Bump version to v4.1 and update date (BC-5).
+
+5. Update the PR Size Tiers "Rules" bullet (line 410) from:
+   `Steps 1, 2, 3, 4, 5 are always required`
+   to:
+   `Steps 1, 1.5, 2, 3, 4, 5 are always required`
+   Update the full line from:
+   `- **Steps 1, 2, 3, 4, 5 are always required** — worktree, plan, human review, execution, and commit apply to all tiers.`
+   to:
+   `- **Steps 1, 1.5, 2, 3, 4, 5 are always required** — worktree, source audit, plan, human review, execution, and commit apply to all tiers.`
+
+6. Verify the "Key insights" section (lines 32-37) still reads correctly. No update needed — Step 1.5 is a sub-step of the planning phase, not a new quality assurance stage. The two key insights (worktree isolation, three-stage QA) remain accurate.
+
+7. Add a changelog entry to the Appendix: Workflow Evolution (after the v4.0 entry, before `</details>`):
+   ```
+   **v4.1 (2026-03-17):** Added Step 1.5 (Source Document Audit) between Steps 1 and 2 — structured pre-audit of source documents for ambiguities, contradictions, and missing information before planning begins. Added `CLARIFICATION` as a Deviation Log reason (#664).
+   ```
+
+**Verify:** Visual inspection — Mermaid renders, step numbering is correct.
+**Lint:** N/A (markdown only)
+**Commit:** `docs(pr-workflow): add Step 1.5 Source Document Audit (BC-1, BC-2, BC-4, BC-5)`
+
+#### Task 2: Add CLARIFICATION to micro-plan.md (BC-3)
+
+**Files:** modify `docs/contributing/templates/micro-plan.md`
+
+**Changes:**
+
+1. In the Deviation Log table (Part 1, Section D), update the Reason column:
+   - From: `SIMPLIFICATION / CORRECTION / DEFERRAL / ADDITION / SCOPE_CHANGE`
+   - To: `CLARIFICATION / SIMPLIFICATION / CORRECTION / DEFERRAL / ADDITION / SCOPE_CHANGE`
+
+**Verify:** Visual inspection.
+**Lint:** N/A (markdown only)
+**Commit:** `docs(micro-plan): add CLARIFICATION as valid Deviation Log reason (BC-3)`
+
+#### Task 3: Add CLARIFICATION to micro-plan-prompt.md (BC-3)
+
+**Files:** modify `docs/contributing/templates/micro-plan-prompt.md`
+
+**Changes:**
+
+1. In the deviation log reasons list (lines 255-260), add a new bullet as the **first entry** (after line 255 "Categories of deviation:", before line 256 "SIMPLIFICATION"):
+   ```
+   - CLARIFICATION: Ambiguity in source document resolved during Step 1.5 audit
+   ```
+   This is consistent with Task 2 which places CLARIFICATION first in the reason list.
+   Line 535 (`Deviation log reviewed`) does not enumerate reasons — no change needed there.
+
+**Verify:** Visual inspection.
+**Lint:** N/A (markdown only)
+**Commit:** `docs(micro-plan-prompt): add CLARIFICATION as valid Deviation Log reason (BC-3)`
+
+### H) Test Strategy
+
+No code tests. Verification is by visual inspection that:
+- Mermaid flowchart renders with the new node
+- Step 1.5 appears in correct position
+- CLARIFICATION appears in both template files
+- Example walkthrough includes the new step
+
+### I) Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Mermaid syntax error breaks flowchart | Medium | Medium | Careful editing of flowchart, verify renders |
+| Step numbering confusion (1.5 vs integer steps) | Low | Low | Issue explicitly requests "Step 1.5"; consistent with existing "Step 2.5", "Step 4.5" pattern |
+
+## Part 3: Quality Assurance
+
+### J) Sanity Checklist
+
+- [x] No unnecessary abstractions
+- [x] No feature creep beyond PR scope
+- [x] No unexercised flags or interfaces
+- [x] No partial implementations
+- [x] No breaking changes
+- [x] CLAUDE.md — no update needed (PR Workflow section just references the file)
+- [x] Documentation DRY — both micro-plan.md and micro-plan-prompt.md updated for CLARIFICATION
+- [x] Deviation log reviewed — one SIMPLIFICATION, one ADDITION
+
+---
+
+## Appendix: File-Level Implementation Details
+
+**File: `docs/contributing/pr-workflow.md`**
+
+- **Purpose:** Main PR workflow document. Add Step 1.5, update Mermaid, update Size Tiers rules, update Example Walkthrough, bump version, add changelog.
+- **Key edits:** Lines 3 (version), 13-14 (Mermaid node), 22 (Mermaid chain), 63-64 (new Step 1.5 section insertion point), 410 (Size Tiers rules), 424-431 (Example Walkthrough renumbering), 524 (changelog entry).
+
+**File: `docs/contributing/templates/micro-plan.md`**
+
+- **Purpose:** Human-readable micro-plan template. Add CLARIFICATION to Deviation Log reason list.
+- **Key edits:** Line 151 (Deviation Log table Reason column).
+
+**File: `docs/contributing/templates/micro-plan-prompt.md`**
+
+- **Purpose:** Agent prompt companion for micro-plan generation. Add CLARIFICATION to deviation log reasons.
+- **Key edits:** After line 258 (add new bullet for CLARIFICATION reason).


### PR DESCRIPTION
## Summary

- Add **Step 1.5 (Source Document Audit)** between Steps 1 and 2 in the PR workflow
- Add `CLARIFICATION` as a Deviation Log reason in both micro-plan template and agent prompt
- Update Mermaid flowchart, Example Walkthrough, PR Size Tiers rules, and changelog

## Behavioral Contracts

**BC-1:** Step 1.5 exists with three named audit checks (ambiguous requirements, contradictions with invariants/standards, missing information) and specifies CLARIFICATION deviation log output.

**BC-2:** Mermaid flowchart shows S15 node between S1 and S2.

**BC-3:** CLARIFICATION listed as valid Deviation Log reason in both `micro-plan.md` and `micro-plan-prompt.md`.

**BC-4:** Example Walkthrough includes the audit step between workspace creation and plan writing.

**BC-5:** Workflow version bumped to v4.1.

## Test Plan

- [ ] Mermaid flowchart renders correctly with S15 node
- [ ] Step 1.5 section appears between Step 1 and Step 2
- [ ] CLARIFICATION appears in micro-plan.md Deviation Log table
- [ ] CLARIFICATION appears as first bullet in micro-plan-prompt.md deviation categories
- [ ] Example Walkthrough has 9 steps (was 8) with "Audit source" at position 2
- [ ] PR Size Tiers rules say "Steps 1, 1.5, 2, 3, 4, 5 are always required"
- [ ] Changelog entry for v4.1 present in Workflow Evolution appendix

Fixes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)