### PR TITLE
docs(config): add observe/replay/calibrate/convert/compose flag reference

### DIFF
--- a/docs/plans/717-docs-config-flags-plan.md
+++ b/docs/plans/717-docs-config-flags-plan.md
@@ -1,0 +1,124 @@
+# docs: expand configuration.md with observe/replay/calibrate flags — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add reference documentation for `blis observe`, `blis replay`, `blis calibrate`, `blis convert`, and `blis compose` CLI flags to the configuration reference page.
+**Source:** GitHub issue #717 (child of #715 documentation umbrella)
+**Closes:** Fixes #717
+
+## Behavioral Contracts
+
+BC-1: Observe flags documented
+- GIVEN a user reads `docs/reference/configuration.md`
+- WHEN they look for `blis observe` flags
+- THEN they find all 27 flags organized into Required, Workload Input, Optional, and Distribution Synthesis groups, each with name, type, default, and description
+
+BC-2: Replay flags documented
+- GIVEN a user reads `docs/reference/configuration.md`
+- WHEN they look for `blis replay` flags
+- THEN they find the shared sim-config flags (via cross-reference to existing sections) plus replay-specific flags (`--trace-header`, `--trace-data`), with a note that `--results-path` writes `[]SimResult` JSON (not `MetricsOutput` JSON as in `blis run`)
+
+BC-3: Calibrate flags documented
+- GIVEN a user reads `docs/reference/configuration.md`
+- WHEN they look for `blis calibrate` flags
+- THEN they find all 7 flags with name, type, default, and description
+
+BC-4: Convert and compose flags documented
+- GIVEN a user reads `docs/reference/configuration.md`
+- WHEN they look for `blis convert` and `blis compose` flags
+- THEN they find flags for each convert subcommand (preset, servegen, infperf) and the compose command
+
+## Tasks
+
+### Task 1: Add observe command flags section (BC-1)
+
+**Files:** modify `docs/reference/configuration.md`
+
+**Impl:**
+
+Add after the existing `## CLI Flag Summary by Sub-Config` section (end of file), a new top-level section `## blis observe` with four flag tables:
+
+- **Required** (4 flags): `--server-url`, `--model`, `--trace-header`, `--trace-data`
+- **Workload Input** (2 flags): `--workload-spec`, `--rate`
+- **Optional** (7 flags): `--api-key`, `--server-type`, `--max-concurrency`, `--warmup-requests`, `--no-streaming`, `--seed`, `--horizon`, `--num-requests`
+- **Distribution Synthesis** (14 flags): `--prompt-tokens` through `--prefix-tokens`, `--api-format`, `--unconstrained-output`, `--rtt-ms`
+
+Source: `cmd/observe_cmd.go:87-122`
+
+**Verify:** `mkdocs build` (if available) or visual inspection of markdown table formatting
+**Commit:** `docs(config): add blis observe flags (BC-1)`
+
+### Task 2: Add replay command flags section (BC-2)
+
+**Files:** modify `docs/reference/configuration.md`
+
+**Impl:**
+
+Add `## blis replay` section after the observe section. Note that replay shares all sim-config flags with `blis run` (via `registerSimConfigFlags`) and adds two trace-specific flags. Include:
+
+- Prose noting shared flags with cross-reference to existing sections
+- **Replay-specific** table (2 flags): `--trace-header`, `--trace-data`
+- A callout noting the `--results-path` semantic difference: `blis run` writes `MetricsOutput` JSON; `blis replay` writes `[]SimResult` JSON (request_id, ttft_us, e2e_us, input_tokens, output_tokens) for `blis calibrate` consumption.
+
+Source: `cmd/replay.go:701-708`
+
+**Verify:** Visual inspection of markdown
+**Commit:** `docs(config): add blis replay flags (BC-2)`
+
+### Task 3: Add calibrate command flags section (BC-3)
+
+**Files:** modify `docs/reference/configuration.md`
+
+**Impl:**
+
+Add `## blis calibrate` section with a single table of 7 flags:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--trace-header` | string | "" | Path to TraceV2 header YAML file (from blis observe; required) |
+| `--trace-data` | string | "" | Path to TraceV2 data CSV file (from blis observe; required) |
+| `--sim-results` | string | "" | Path to SimResult JSON file (from blis replay --results-path; required) |
+| `--report` | string | "" | Path to write calibration report JSON (required) |
+| `--warmup-requests` | int | -1 | Number of initial requests to exclude (default: from trace header warm_up_requests; pass 0 to include all) |
+| `--network-rtt-us` | int64 | -1 | Network RTT in microseconds added to sim-side latencies (default: from trace header network.measured_rtt_ms) |
+| `--network-bandwidth-mbps` | float64 | 0 | Network bandwidth in Mbps for upload/download delay calculation (0 = no delay) |
+
+Source: `cmd/calibrate.go:156-164`
+
+**Verify:** Visual inspection of markdown
+**Commit:** `docs(config): add blis calibrate flags (BC-3)`
+
+### Task 4: Add convert and compose command flags section (BC-4)
+
+**Files:** modify `docs/reference/configuration.md`
+
+**Impl:**
+
+Add `## blis convert` section with subsections for each subcommand:
+
+- **`blis convert preset`**: `--name`, `--rate`, `--num-requests`, `--defaults-filepath`
+- **`blis convert servegen`**: `--path`
+- **`blis convert infperf`**: `--spec`
+
+Add `## blis compose` section:
+- `--from` (string array, repeatable): Path to v2 WorkloadSpec YAML file
+
+Source: `cmd/convert.go:118-127`, `cmd/compose.go:39`
+
+**Verify:** Visual inspection of markdown
+**Commit:** `docs(config): add blis convert and compose flags (BC-4)`
+
+## Sanity Checklist
+
+- [x] No unnecessary abstractions
+- [x] No feature creep beyond PR scope
+- [x] No unexercised flags or interfaces
+- [x] No partial implementations
+- [x] No breaking changes
+- [x] No hidden global state impact
+- [x] CLAUDE.md: no update needed (no new files/packages, no new CLI flags, no file organization changes)
+- [x] No stale references
+- [x] Documentation DRY: this PR does not modify any canonical source in the source-of-truth map
+- [x] Deviation log: No deviations — issue #717 asked to "consider" convert/compose; we include them (ADDITION: minimal effort, completes the reference page)
+- [x] Task dependencies correctly ordered (independent sections, order is logical not required)
+- [x] All contracts mapped to tasks

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -383,3 +383,138 @@ For environments where live profiling is not feasible, the [Roofline model](../c
 | **WorkloadConfig** | `--workload`, `--workload-spec`, `--defaults-filepath`, `--rate`, `--num-requests`, `--prompt-tokens*`, `--output-tokens*`, `--prefix-tokens` |
 | **DeploymentConfig** | `--num-instances`, `--admission-policy`, `--admission-latency`, `--token-bucket-capacity`, `--token-bucket-refill-rate`, `--routing-policy`, `--routing-latency`, `--routing-scorers`, `--snapshot-refresh-interval`, `--trace-level`, `--counterfactual-k` |
 | **Top-level** | `--seed`, `--horizon`, `--log`, `--results-path`, `--policy-config`, `--fitness-weights`, `--summarize-trace` |
+
+---
+
+## blis observe
+
+Dispatches a workload to a real inference server and records request-level timing into TraceV2 files for later replay and calibration.
+
+### Required
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--server-url` | string | "" | Inference server URL (required). |
+| `--model` | string | "" | Model name for API requests (required). |
+| `--trace-header` | string | "" | Output path for TraceV2 header YAML (required). |
+| `--trace-data` | string | "" | Output path for TraceV2 data CSV (required). |
+
+### Workload Input
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--workload-spec` | string | "" | Path to WorkloadSpec YAML (alternative to `--rate` + distribution flags). |
+| `--rate` | float64 | 0 | Requests per second for distribution synthesis. |
+
+### Optional
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api-key` | string | "" | Bearer token for server authentication. |
+| `--server-type` | string | "vllm" | Server type (`vllm`, `tgi`, etc.). |
+| `--max-concurrency` | int | 256 | Maximum simultaneous in-flight requests. |
+| `--warmup-requests` | int | 0 | Number of initial requests to exclude from trace. |
+| `--no-streaming` | bool | false | Disable streaming (use non-streaming HTTP). |
+| `--seed` | int64 | 42 | RNG seed for workload generation. |
+| `--horizon` | int64 | 0 | Observation horizon in microseconds (0 = from spec or unlimited). |
+| `--num-requests` | int | 0 | Maximum requests to generate (0 = from spec or unlimited). |
+
+### Distribution Synthesis
+
+Used when `--rate` is set instead of `--workload-spec`. Same flag names as `blis run` but with different defaults tuned for observe workloads.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--prompt-tokens` | int | 512 | Average prompt token count. |
+| `--prompt-tokens-stdev` | int | 50 | Prompt token standard deviation. |
+| `--prompt-tokens-min` | int | 1 | Minimum prompt tokens. |
+| `--prompt-tokens-max` | int | 2048 | Maximum prompt tokens. |
+| `--output-tokens` | int | 512 | Average output token count. |
+| `--output-tokens-stdev` | int | 50 | Output token standard deviation. |
+| `--output-tokens-min` | int | 1 | Minimum output tokens. |
+| `--output-tokens-max` | int | 2048 | Maximum output tokens. |
+| `--prefix-tokens` | int | 0 | Shared prefix token count. |
+| `--api-format` | string | "completions" | API format: `completions` (`/v1/completions`) or `chat` (`/v1/chat/completions`). |
+| `--unconstrained-output` | bool | false | Do not set `max_tokens` (let server decide output length). |
+| `--rtt-ms` | float64 | 0 | Measured network round-trip time in milliseconds (recorded in trace header for calibrate). |
+
+---
+
+## blis replay
+
+Replays a captured TraceV2 file through the discrete-event simulator. Replay reuses the full simulation engine, so it accepts the same sim-config flags as `blis run` — see the sections above for [Simulation Control](#simulation-control), [KV Cache Configuration](#kv-cache-configuration), [Batch Formation](#batch-formation), [Latency Model](#latency-model), [Cluster Configuration](#cluster-configuration), [Admission Policy](#admission-policy), [Routing Policy](#routing-policy), [Scheduling and Priority](#scheduling-and-priority), [Decision Tracing](#decision-tracing), and [Fitness Evaluation](#fitness-evaluation).
+
+### Replay-Specific Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--trace-header` | string | "" | Path to TraceV2 header YAML file (required). |
+| `--trace-data` | string | "" | Path to TraceV2 data CSV file (required). |
+
+### `--results-path` Semantic Difference
+
+The `--results-path` flag is shared with `blis run` but writes a different schema:
+
+| Command | Schema | Contents |
+|---------|--------|----------|
+| `blis run` | `MetricsOutput` JSON | Full simulation metrics (aggregated statistics, per-request details, fitness scores). |
+| `blis replay` | `[]SimResult` JSON | Per-request array with fields: `request_id`, `ttft_us`, `e2e_us`, `input_tokens`, `output_tokens`. Designed for `blis calibrate` consumption. |
+
+---
+
+## blis calibrate
+
+Compares real observed latencies (from `blis observe`) against simulator predictions (from `blis replay`) and produces a calibration report with per-metric MAPE, Pearson R, and quality grades.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--trace-header` | string | "" | Path to TraceV2 header YAML file (from `blis observe`; required). |
+| `--trace-data` | string | "" | Path to TraceV2 data CSV file (from `blis observe`; required). |
+| `--sim-results` | string | "" | Path to SimResult JSON file (from `blis replay --results-path`; required). |
+| `--report` | string | "" | Path to write calibration report JSON (required). |
+| `--warmup-requests` | int | -1 | Number of initial requests to exclude. Default: from trace header `warm_up_requests`; pass 0 to include all. |
+| `--network-rtt-us` | int64 | -1 | Network RTT in microseconds added to sim-side latencies. Default: from trace header `network.measured_rtt_ms`. |
+| `--network-bandwidth-mbps` | float64 | 0 | Network bandwidth in Mbps for upload/download delay calculation (0 = no delay). |
+
+---
+
+## blis convert
+
+Converts external workload formats into BLIS WorkloadSpec v2 YAML. Three subcommands are available.
+
+### `blis convert preset`
+
+Generates a WorkloadSpec from a named preset in `defaults.yaml`.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--name` | string | "" | Preset name (e.g., `chatbot`, `summarization`, `contentgen`, `multidoc`). |
+| `--rate` | float64 | 1.0 | Request rate in requests/second. |
+| `--num-requests` | int | 100 | Number of requests. |
+| `--defaults-filepath` | string | "defaults.yaml" | Path to `defaults.yaml`. |
+
+### `blis convert servegen`
+
+Converts a ServeGen data directory into WorkloadSpec format.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--path` | string | "" | Path to ServeGen data directory. |
+
+### `blis convert infperf`
+
+Converts an inference-perf YAML specification into WorkloadSpec format.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--spec` | string | "" | Path to inference-perf YAML spec. |
+
+---
+
+## blis compose
+
+Merges multiple WorkloadSpec v2 YAML files into a single combined specification.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--from` | string (repeatable) | (none) | Path to v2 WorkloadSpec YAML file. Can be repeated to merge multiple specs. |


### PR DESCRIPTION
## Summary

- Add `blis observe` flag reference (26 flags in 4 groups: required, workload input, optional, distribution synthesis)
- Add `blis replay` flag reference (2 unique flags + cross-reference to shared sim-config sections, with `--results-path` semantic difference callout)
- Add `blis calibrate` flag reference (7 flags)
- Add `blis convert` flag reference (3 subcommands: preset, servegen, infperf)
- Add `blis compose` flag reference (1 repeatable flag)

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify MkDocs build passes (CI `docs.yml` workflow)
- [ ] Spot-check flag defaults against `cmd/observe_cmd.go`, `cmd/replay.go`, `cmd/calibrate.go`

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)