### PR TITLE
docs(glossary): add observe/replay/calibrate pipeline entries

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -24,6 +24,10 @@ Three regression coefficients `[beta0, beta1, beta2]` that predict GPU step time
 
 The unit of KV cache allocation. Each block holds a fixed number of tokens (default: 16). Requests are allocated blocks proportional to their token count. Blocks are reference-counted and can be shared across requests via prefix caching. See [Core Engine: KV Cache](core-engine.md#kv-cache-management).
 
+### Calibration Report
+
+The JSON output of `blis calibrate` comparing real observed latencies against simulator predictions. Contains per-request TTFT and E2E deltas, aggregate error metrics (MAPE, Pearson correlation, percentile comparisons), bias assessment, and a quality rating. See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md#blis-calibrate).
+
 ### Chunked Prefill
 
 A vLLM optimization where long prefill sequences are split into chunks that fit within the per-step token budget (`max-num-scheduled-tokens`). Controlled by `--long-prefill-token-threshold`. See [Core Engine: Batch Formation](core-engine.md#batch-formation).
@@ -43,6 +47,10 @@ The token generation phase where the model produces output tokens one at a time 
 ### Discrete Event Simulation (DES)
 
 A simulation paradigm where the system state changes only at discrete event times. BLIS maintains a priority queue of timestamped events and advances the simulation clock by jumping between events, rather than stepping through fixed time intervals. See [Core Engine: Event Queue](core-engine.md#event-queue).
+
+### Distribution Synthesis
+
+The `--rate` mode of `blis observe` that generates workload from statistical distributions (prompt/output token counts, arrival rate) instead of a workload spec YAML file. Useful for quick single-client experiments without crafting a full workload specification. See [Observe / Replay / Calibrate: Distribution Synthesis Flags](../guide/observe-replay-calibrate.md#distribution-synthesis-flags).
 
 ### E2E (End-to-End Latency)
 
@@ -75,6 +83,10 @@ The component that predicts GPU execution time for a batch step. Four modes: *Ro
 ### MaxModelLen
 
 Maximum total sequence length (input + output) for a single request, in tokens. Mirrors vLLM's `--max-model-len`. When set (> 0), requests whose input alone fills the context window (`input >= MaxModelLen`) or whose input + output budget exceeds it are dropped before entering the wait queue. A three-part proactive cap matches vLLM `scheduler.py:773-774`: FormBatch clamps token scheduling to `maxModelLen - 1 - ProgressIndex`, executeBatchStep skips decode when 0 tokens allocated, and processCompletions force-completes at the `maxModelLen - 1` boundary. Output per length-capped request: `maxModelLen - 1 - inputLen`. Set to 0 for unlimited. Auto-derived from `max_position_embeddings` in roofline/crossmodel modes, with `rope_scaling` factor application and KV-feasible capping. See [Configuration Reference](../reference/configuration.md#simulation-control).
+
+### Observe / Replay / Calibrate Pipeline
+
+The end-to-end workflow of `blis observe` → `blis replay` → `blis calibrate` for validating simulator accuracy against real inference servers. Each stage is independently useful: observe collects latency baselines, replay tests simulator behavior on real traces, and calibrate compares results. See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md).
 
 ### Oracle Knowledge Boundary (INV-9)
 
@@ -140,14 +152,22 @@ The fundamental time unit in BLIS, representing one microsecond. All timestamps,
 
 An extension of the KV cache with GPU and CPU tiers. When GPU utilization exceeds a threshold, blocks are offloaded to CPU memory. On cache miss, blocks can be reloaded from CPU with a transfer latency penalty. See [Core Engine: KV Cache](core-engine.md#kv-cache-management).
 
+### TraceV2
+
+The trace format used by the observe/replay/calibrate pipeline, consisting of two files: a header YAML file (recording model, server config, and observation metadata) and a data CSV file (recording per-request timing: arrival time, TTFT, E2E latency, token counts). See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md).
+
 ### TTFT (Time To First Token)
 
 Time from request arrival to completion of the prefill phase (first output token ready). Includes queueing delay, prefill step times, and output processing overhead (alpha2). A key latency SLO metric for interactive applications. See [Core Engine: Metrics](core-engine.md#metrics).
 
-### Workload Specification
+### Warmup Requests
 
-A YAML file (`--workload-spec`) defining multi-client workloads with per-client arrival distributions, token length distributions, prefix groups, and SLO classes. Supports `poisson`, `gamma`, `weibull`, and `constant` arrival processes and `gaussian`, `exponential`, `pareto_lognormal`, `constant`, and `empirical` token distributions. See [Configuration Reference](../reference/configuration.md#workload-modes).
+Initial requests dispatched by `blis observe` that are excluded from trace output (`--warmup-requests N`). Warmup requests allow the server to populate its KV cache and reach steady-state scheduling before measurement begins, avoiding cold-start artifacts in the recorded trace. See [Observe / Replay / Calibrate: blis observe](../guide/observe-replay-calibrate.md#blis-observe).
 
 ### Work-Conserving
 
 The property that the simulator never idles while requests are waiting. After every step completion, if the wait queue is non-empty, a new `StepEvent` is scheduled immediately (INV-8). See [Core Engine: Event Queue](core-engine.md#event-queue).
+
+### Workload Specification
+
+A YAML file (`--workload-spec`) defining multi-client workloads with per-client arrival distributions, token length distributions, prefix groups, and SLO classes. Supports `poisson`, `gamma`, `weibull`, and `constant` arrival processes and `gaussian`, `exponential`, `pareto_lognormal`, `constant`, and `empirical` token distributions. See [Configuration Reference](../reference/configuration.md#workload-modes).

--- a/docs/plans/719-glossary-entries-plan.md
+++ b/docs/plans/719-glossary-entries-plan.md
@@ -1,0 +1,79 @@
+# 719: Add Glossary Entries for Observe/Replay/Calibrate Pipeline
+
+**Goal:** Add 5 glossary entries to `docs/concepts/glossary.md` for concepts introduced by the observe/replay/calibrate pipeline. Also fix pre-existing alphabetical ordering issue (Work-Conserving vs Workload Specification).
+
+**Source:** [GitHub Issue #719](https://github.com/inference-sim/inference-sim/issues/719), child of #715.
+
+**Closes:** #719
+
+**Tier:** Small (docs-only, 1 file, no behavioral changes)
+
+**No clarifications needed** — the source document is unambiguous and complete.
+
+---
+
+## Behavioral Contracts
+
+**BC-1: Alphabetical ordering preserved**
+GIVEN the existing glossary has entries in mostly alphabetical order (with one pre-existing violation: "Workload Specification" before "Work-Conserving")
+WHEN 5 new entries are added and the pre-existing order is fixed
+THEN all entries (existing + new) are in strict alphabetical order
+
+**BC-2: Cross-references to pipeline guide**
+GIVEN each new entry describes a pipeline concept
+WHEN the entry is rendered
+THEN it contains a markdown link to the pipeline guide page (`../guide/observe-replay-calibrate.md` or a section anchor within it)
+
+**BC-3: Terminology consistency**
+GIVEN the pipeline guide uses specific terminology (TraceV2, distribution synthesis, warmup requests)
+WHEN the glossary defines these terms
+THEN the definitions are consistent with the guide's usage (no contradictions)
+
+---
+
+## Tasks
+
+### Task 1: Add 5 glossary entries in alphabetical order and fix existing order
+
+1. **Edit** `docs/concepts/glossary.md` to add these entries at their correct alphabetical positions:
+   - **Calibration Report** — between "Block (KV Block)" and "Chunked Prefill" ("Cal" < "Ch")
+
+     > The JSON output of `blis calibrate` comparing real observed latencies against simulator predictions. Contains per-request TTFT and E2E deltas, aggregate error metrics (MAPE, Pearson correlation, percentile comparisons), bias assessment, and a quality rating. See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md#blis-calibrate).
+
+   - **Distribution Synthesis** — between "Discrete Event Simulation (DES)" and "E2E (End-to-End Latency)" ("Disc" < "Dist")
+
+     > The `--rate` mode of `blis observe` that generates workload from statistical distributions (prompt/output token counts, arrival rate) instead of a workload spec YAML file. Useful for quick single-client experiments without crafting a full workload specification. See [Observe / Replay / Calibrate: Distribution Synthesis Flags](../guide/observe-replay-calibrate.md#distribution-synthesis-flags).
+
+   - **Observe/Replay/Calibrate Pipeline** — between "MaxModelLen" and "Oracle Knowledge Boundary (INV-9)" ("Ob" < "Or")
+
+     > The end-to-end workflow of `blis observe` → `blis replay` → `blis calibrate` for validating simulator accuracy against real inference servers. Each stage is independently useful: observe collects latency baselines, replay tests simulator behavior on real traces, and calibrate compares results. See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md).
+
+   - **TraceV2** — between "Tiered KV Cache" and "TTFT (Time To First Token)" ("Ti" < "Tr" < "TT")
+
+     > The trace format used by the observe/replay/calibrate pipeline, consisting of two files: a header YAML file (recording model, server config, and observation metadata) and a data CSV file (recording per-request timing: arrival time, TTFT, E2E latency, token counts). See [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md).
+
+   - **Warmup Requests** — between "TTFT (Time To First Token)" and "Work-Conserving" ("War" < "Wor")
+
+     > Initial requests dispatched by `blis observe` that are excluded from trace output (`--warmup-requests N`). Warmup requests allow the server to populate its KV cache and reach steady-state scheduling before measurement begins, avoiding cold-start artifacts in the recorded trace. See [Observe / Replay / Calibrate: blis observe](../guide/observe-replay-calibrate.md#blis-observe).
+
+2. **Fix pre-existing order:** Swap "Work-Conserving" (currently line 151) before "Workload Specification" (currently line 147). "Work-C" < "Workl" in lexicographic order.
+
+3. Each entry follows the existing format: `### Term` heading, 1–3 sentence description, `See [link text](relative-path).` cross-reference.
+
+4. **Verify** alphabetical order by scanning all `###` headings in sequence.
+
+5. **Verify** MkDocs build (or link check) — no broken links.
+
+6. **Commit.**
+
+---
+
+## Sanity Checklist
+
+- [ ] All 5 entries present
+- [ ] Pre-existing order fixed (Work-Conserving before Workload Specification)
+- [ ] Alphabetical order preserved across entire file
+- [ ] Each entry cross-references the pipeline guide
+- [ ] No broken markdown links
+- [ ] Definitions consistent with `docs/guide/observe-replay-calibrate.md`
+- [ ] No unrelated changes


### PR DESCRIPTION
## Summary

- Add 5 glossary entries for observe/replay/calibrate pipeline concepts: **Calibration Report**, **Distribution Synthesis**, **Observe Pipeline**, **TraceV2**, **Warmup Requests**
- Fix pre-existing alphabetical order violation: swap Work-Conserving before Workload Specification
- All entries cross-reference the pipeline guide (`docs/guide/observe-replay-calibrate.md`)

## Behavioral Contracts

**BC-1: Alphabetical ordering preserved**
GIVEN the existing glossary had entries in mostly alphabetical order (with one pre-existing violation)
WHEN 5 new entries are added and the pre-existing order is fixed
THEN all 42 entries are in strict alphabetical order — verified via `sort -f` diff

**BC-2: Cross-references to pipeline guide**
GIVEN each new entry describes a pipeline concept
WHEN the entry is rendered
THEN it contains a markdown link to `../guide/observe-replay-calibrate.md` or a section anchor within it

**BC-3: Terminology consistency**
GIVEN the pipeline guide uses specific terminology
WHEN the glossary defines these terms
THEN the definitions are consistent with the guide's usage

## Testing

- `go build ./...` — passes
- `go test ./... -count=1` — all 10 packages pass
- Alphabetical order verified via `sort -f` comparison (zero diff)
- Cross-reference link targets verified (all exist)

Fixes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)