### PR TITLE
docs(experiments): add staleness caveat for hypothesis findings

### DIFF
--- a/docs/contributing/hypothesis.md
+++ b/docs/contributing/hypothesis.md
@@ -680,6 +680,12 @@ H13 converged in Round 1 (deterministic = pass/fail). H5 converged in Round 3. H
 
 ---
 
+## Staleness Caveat
+
+Experiment findings reflect simulator behavior at the time of execution. Subsequent bug fixes or feature changes may shift quantitative results. Check the PR that introduced the experiment (linked in each FINDINGS.md) and compare against recent changes to the relevant code paths before citing specific numbers.
+
+When prior findings are known to be affected by a later change, an erratum is added to the FINDINGS.md (e.g., H29 erratum after #574). However, there is no automated mechanism to detect all affected findings — treat quantitative results as point-in-time measurements, not permanent truths.
+
 ## References
 
 - Standards: [docs/contributing/standards/experiments.md](standards/experiments.md)

--- a/hypotheses/README.md
+++ b/hypotheses/README.md
@@ -25,6 +25,10 @@ FINDINGS.md files in individual hypothesis directories may reference old file pa
 - `sim/latency_model.go` → `sim/latency/latency.go` (PKG-2, #424)
 - `sim/roofline_step.go` → `sim/latency/roofline.go` (PKG-2, #424)
 
+## Staleness Caveat
+
+Experiment findings reflect simulator behavior at the time of execution. Subsequent bug fixes or feature changes may shift quantitative results (e.g., #502 shifted KV preemption counts, #574 required an H29 erratum). Check the PR that introduced the experiment (linked in each FINDINGS.md) and compare against recent changes to the relevant code paths before citing specific numbers.
+
 ## Validated Hypotheses
 
 | ID | Family | Hypothesis | Status | Key Finding |


### PR DESCRIPTION
## Summary

- Adds a "Staleness Caveat" section to `hypotheses/README.md` and `docs/contributing/hypothesis.md` advising readers that experiment findings are point-in-time measurements
- Replaces the proposed dependency index (#677) with a lighter-weight approach: caveats + the existing erratum pattern (e.g., H29 after #574, H-Cross-Model after #403)

## Rationale

The dependency index proposed in #677 would require ongoing maintenance (40+ findings, code paths shift during refactors like PKG-1/PKG-2), and the index itself would become a staleness liability. The actual risk is low — stale findings don't break the simulator, and the 3 historical cases were all caught and handled via errata without an index.

If findings are later cited in external publications or used as production calibration targets, a CI-based staleness check could be revisited.

Closes #677

## Test plan

- [ ] Verify caveat appears in `hypotheses/README.md` between "Note on File Path References" and "Validated Hypotheses"
- [ ] Verify caveat appears in `docs/contributing/hypothesis.md` before "References"
- [ ] Confirm no other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)