### PR TITLE
docs: add missing observe flags, convert inference-perf, and pipeline diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ go build -o blis main.go
 # Run with default model
 ./blis run --model qwen/qwen3-14b
 
+# Run and export workload as TraceV2 (prefix auto-appends .yaml/.csv)
+./blis run --model qwen/qwen3-14b --trace-output traces/run1
+
 # Replay a captured TraceV2 file through the DES
 ./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b
 
@@ -29,12 +32,21 @@ go build -o blis main.go
   --api-format chat --rtt-ms 2.5 --workload-spec workload.yaml \
   --trace-header trace.yaml --trace-data trace.csv
 
+# Observe with rate-mode distribution synthesis and optional flags
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --api-format chat --rate 10 --num-requests 100 \
+  --prompt-tokens 512 --output-tokens 128 --prefix-tokens 64 \
+  --warmup-requests 5 --no-streaming --api-key $API_KEY \
+  --max-concurrency 32 --unconstrained-output \
+  --trace-header trace.yaml --trace-data trace.csv
+
 # Compare real observed latencies against simulator predictions
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json --report calibration.json
 
 # Convert workload formats
 ./blis convert preset --name chatbot --rate 10 --num-requests 100
 ./blis convert servegen --path data/
+./blis convert inference-perf --spec spec.yaml
 ./blis compose --from spec1.yaml --from spec2.yaml
 ```
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -245,3 +245,31 @@ A complete request lifecycle through the cluster pipeline:
 6. **Per-instance processing:** Request follows the single-instance lifecycle (see [Core Engine](core-engine.md))
 7. **Completion/Drop:** InFlightRequests decremented when request completes or is dropped as unservable
 8. **Metrics:** Request metrics (TTFT, E2E, ITL) recorded at instance level, aggregated at cluster level
+
+## Observe / Replay / Calibrate Pipeline
+
+Alongside the DES simulation pipeline described above, BLIS provides an offline validation workflow for comparing simulator predictions against real server behavior. This pipeline has three stages, of which only **Replay** engages the DES event loop. **Observe** is an HTTP workload dispatcher that sends requests to a real inference server and records per-request timing. **Calibrate** is a statistical comparison tool that computes per-metric MAPE, Pearson R, and quality grades.
+
+```mermaid
+flowchart LR
+    WS["WorkloadSpec<br/>or --rate flags"] --> Obs
+    SU["Server URL"] --> Obs
+    Obs["blis observe<br/>(HTTP client)"] --> TV["TraceV2<br/>(YAML + CSV)"]
+
+    TV --> Rep
+    MC["--model + sim flags"] --> Rep
+    Rep["blis replay<br/>(DES engine)"] --> SR["SimResult JSON<br/>(--results-path)"]
+
+    TV --> Cal
+    SR --> Cal
+    Cal["blis calibrate<br/>(statistical comparison)"] --> Rpt["Calibration<br/>Report"]
+
+    style Obs fill:#a5d8ff
+    style Rep fill:#d0bfff
+    style Cal fill:#b2f2bb
+    style TV fill:#fff3e0
+    style SR fill:#fff3e0
+    style Rpt fill:#c8e6c9
+```
+
+For the full pipeline guide with worked examples, see [Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md). For flag details, see [Configuration Reference](../reference/configuration.md).

--- a/docs/plans/docs-720-721-plan.md
+++ b/docs/plans/docs-720-721-plan.md
@@ -1,0 +1,65 @@
+# Documentation: CLAUDE.md gaps + architecture pipeline diagram
+
+**Goal:** Close documentation gaps in CLAUDE.md's Build and Run Commands section and add an observe/replay/calibrate data flow diagram to the architecture page.
+**Source:** [#720](https://github.com/inference-sim/inference-sim/issues/720), [#721](https://github.com/inference-sim/inference-sim/issues/721) (parent: #715).
+**Closes:** Fixes #720, fixes #721.
+
+## Behavioral Contracts
+
+BC-1: CLAUDE.md observe section covers key flags
+- GIVEN the CLAUDE.md Build and Run Commands section
+- WHEN a contributor reads the `blis observe` examples
+- THEN examples demonstrate `--api-key`, `--max-concurrency`, `--warmup-requests`, `--no-streaming`, `--unconstrained-output`, `--rate` mode with distribution flags (`--prompt-tokens`, `--output-tokens`), and `--prefix-tokens`
+
+BC-2: CLAUDE.md convert section covers inference-perf
+- GIVEN the CLAUDE.md Build and Run Commands section
+- WHEN a contributor reads the `blis convert` examples
+- THEN a `convert inference-perf` example is present alongside the existing `preset` and `servegen` examples
+
+BC-3: CLAUDE.md run section covers --trace-output
+- GIVEN the CLAUDE.md Build and Run Commands section
+- WHEN a contributor reads the `blis run` examples
+- THEN a `--trace-output` flag usage example is present
+
+BC-4: Architecture page documents observe/replay/calibrate pipeline
+- GIVEN `docs/concepts/architecture.md`
+- WHEN a reader looks for the real-server observation data flow
+- THEN a section with a mermaid data flow diagram shows observe → replay → calibrate, noting that only replay engages the DES
+
+## Tasks
+
+### Task 1: Update CLAUDE.md Build and Run Commands (BC-1, BC-2, BC-3)
+
+**Files:** modify `CLAUDE.md`
+
+**Impl:**
+In the `## Build and Run Commands` bash block:
+1. Add a second `blis run` example with `--trace-output <prefix>` (note: takes a prefix, not a file path — auto-appends `.yaml`/`.csv`; keep existing minimal example intact)
+2. Add a third `blis observe` example showing `--rate` mode with key distribution flags (`--rate`, `--num-requests`, `--prompt-tokens`, `--output-tokens`, `--prefix-tokens`) and optional flags (`--warmup-requests`, `--no-streaming`, `--api-key`, `--max-concurrency`, `--unconstrained-output`)
+3. Add `blis convert inference-perf --spec spec.yaml` example after the existing convert examples
+
+**Verify:** Read CLAUDE.md and confirm all flags from BC-1/BC-2/BC-3 appear.
+**Lint:** N/A (markdown only)
+**Commit:** `docs(claude-md): add missing observe flags, convert inference-perf, trace-output (BC-1, BC-2, BC-3)`
+
+### Task 2: Add observe/replay/calibrate section to architecture.md (BC-4)
+
+**Files:** modify `docs/concepts/architecture.md`
+
+**Impl:**
+Add a new `## Observe / Replay / Calibrate Pipeline` section at the end of the file (after `## Online Routing Pipeline Walkthrough`). This is an offline validation workflow, not a DES internal — placing it after all DES content avoids interrupting the cluster simulation flow. Include:
+1. Brief prose (3-5 sentences) describing the three stages, clarifying that only Replay engages the DES event loop; Observe is an HTTP client and Calibrate is statistical comparison
+2. A mermaid flowchart showing dual inputs: WorkloadSpec + ServerURL → Observe → TraceV2; TraceV2 + `--model` + sim flags → Replay (DES) → SimResult JSON (`--results-path`); TraceV2 + SimResult JSON → Calibrate → Report
+3. Cross-reference to the pipeline guide ([Observe / Replay / Calibrate](../guide/observe-replay-calibrate.md)) and the flag reference ([Configuration Reference](../reference/configuration.md))
+
+**Verify:** Read architecture.md and confirm the new section exists with mermaid diagram.
+**Lint:** N/A (markdown only)
+**Commit:** `docs(architecture): add observe/replay/calibrate data flow diagram (BC-4)`
+
+## Sanity Checklist
+
+- [ ] R4 (canonical constructors): N/A — no code changes
+- [ ] R10 (strict YAML): N/A — no code changes
+- [ ] Source-of-truth map: CLAUDE.md is itself a working copy — changes here don't require syncing elsewhere. Architecture.md is not in the source-of-truth map.
+- [ ] No behavioral code changes — docs only
+- [ ] Verify flag names against `cmd/observe_cmd.go`, `cmd/root.go`, `cmd/convert.go` before writing examples


### PR DESCRIPTION
## Summary

- Add `--trace-output` run example, rate-mode observe example with distribution/auth/concurrency flags, and `convert inference-perf` example to CLAUDE.md
- Add observe/replay/calibrate mermaid pipeline diagram to architecture.md with cross-references to guide and config reference pages

## Behavioral Contracts

**BC-1:** CLAUDE.md observe examples demonstrate `--api-key`, `--max-concurrency`, `--warmup-requests`, `--no-streaming`, `--unconstrained-output`, `--rate` mode with `--prompt-tokens`/`--output-tokens`, and `--prefix-tokens`

**BC-2:** `convert inference-perf --spec` example present alongside existing `preset` and `servegen` examples

**BC-3:** `--trace-output` flag usage example present for `blis run`

**BC-4:** Architecture page has observe/replay/calibrate mermaid diagram noting only Replay engages the DES

## Test plan

- [ ] Verify all flag names match `cmd/observe_cmd.go`, `cmd/root.go`, `cmd/convert.go`
- [ ] Verify cross-references resolve: `docs/guide/observe-replay-calibrate.md`, `docs/reference/configuration.md`
- [ ] Verify mermaid diagram renders in MkDocs

## Discovered Issues

- #732 — stale "Recent work" paragraph in CLAUDE.md
- #733 — inaccurate event ordering description in architecture.md

Fixes #720, fixes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)