### PR TITLE
feat(cluster): implement pool topology and disaggregation decision pipeline (PR1)

### DIFF
--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -58,11 +58,12 @@ func LoadPolicyBundle(path string) (*PolicyBundle, error) {
 // Valid policy name registries. Unexported to prevent external mutation.
 // Used by Validate(), factory functions, and ValidatePolicyName().
 var (
-	validAdmissionPolicies = map[string]bool{"": true, "always-admit": true, "token-bucket": true, "reject-all": true}
-	validRoutingPolicies   = map[string]bool{"": true, "round-robin": true, "least-loaded": true, "weighted": true, "always-busiest": true}
-	validPriorityPolicies  = map[string]bool{"": true, "constant": true, "slo-based": true, "inverted-slo": true}
-	validSchedulers        = map[string]bool{"": true, "fcfs": true, "priority-fcfs": true, "sjf": true, "reverse-priority": true}
-	validLatencyBackends   = map[string]bool{"": true, "blackbox": true, "roofline": true, "crossmodel": true, "trained-roofline": true}
+	validAdmissionPolicies       = map[string]bool{"": true, "always-admit": true, "token-bucket": true, "reject-all": true}
+	validRoutingPolicies         = map[string]bool{"": true, "round-robin": true, "least-loaded": true, "weighted": true, "always-busiest": true}
+	validPriorityPolicies        = map[string]bool{"": true, "constant": true, "slo-based": true, "inverted-slo": true}
+	validSchedulers              = map[string]bool{"": true, "fcfs": true, "priority-fcfs": true, "sjf": true, "reverse-priority": true}
+	validLatencyBackends         = map[string]bool{"": true, "blackbox": true, "roofline": true, "crossmodel": true, "trained-roofline": true}
+	validDisaggregationDeciders  = map[string]bool{"": true, "never": true, "always": true}
 )
 
 // IsValidAdmissionPolicy returns true if name is a recognized admission policy.
@@ -94,6 +95,12 @@ func IsValidLatencyBackend(name string) bool { return validLatencyBackends[name]
 
 // ValidLatencyBackendNames returns sorted valid latency backend names (excluding empty).
 func ValidLatencyBackendNames() []string { return validNamesList(validLatencyBackends) }
+
+// IsValidDisaggregationDecider returns true if name is a recognized disaggregation decider.
+func IsValidDisaggregationDecider(name string) bool { return validDisaggregationDeciders[name] }
+
+// ValidDisaggregationDeciderNames returns sorted valid disaggregation decider names (excluding empty).
+func ValidDisaggregationDeciderNames() []string { return validNamesList(validDisaggregationDeciders) }
 
 // validNamesList returns sorted non-empty keys from a validity map.
 func validNamesList(m map[string]bool) []string {

--- a/sim/cluster/pool.go
+++ b/sim/cluster/pool.go
@@ -1,0 +1,98 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// PoolRole identifies whether an instance serves as prefill or decode in PD disaggregation.
+type PoolRole int
+
+const (
+	// PoolRolePrefill indicates the instance handles prefill (prompt processing).
+	PoolRolePrefill PoolRole = iota + 1
+	// PoolRoleDecode indicates the instance handles decode (token generation).
+	PoolRoleDecode
+)
+
+// String returns a human-readable name for the pool role.
+func (r PoolRole) String() string {
+	switch r {
+	case PoolRolePrefill:
+		return "prefill"
+	case PoolRoleDecode:
+		return "decode"
+	default:
+		return fmt.Sprintf("PoolRole(%d)", int(r))
+	}
+}
+
+// ValidatePoolTopology checks that PD pool configuration is valid.
+// Returns nil if pools are disabled (both prefill and decode are 0).
+// Returns an error if:
+//   - prefill or decode is negative
+//   - only one of prefill/decode is set (both must be set or neither)
+//   - prefill + decode exceeds total instances
+func ValidatePoolTopology(prefill, decode, total int) error {
+	if prefill < 0 {
+		return fmt.Errorf("prefill-instances must be >= 0, got %d", prefill)
+	}
+	if decode < 0 {
+		return fmt.Errorf("decode-instances must be >= 0, got %d", decode)
+	}
+	// Both zero = disabled, no further checks
+	if prefill == 0 && decode == 0 {
+		return nil
+	}
+	// Both must be set when disaggregation is enabled
+	if prefill == 0 || decode == 0 {
+		return fmt.Errorf("both --prefill-instances and --decode-instances must be set when PD disaggregation is enabled (got prefill=%d, decode=%d)", prefill, decode)
+	}
+	if prefill+decode > total {
+		return fmt.Errorf("prefill-instances (%d) + decode-instances (%d) = %d exceeds num-instances (%d)", prefill, decode, prefill+decode, total)
+	}
+	return nil
+}
+
+// BuildPoolMembership constructs an immutable map of instance ID → PoolRole.
+// Instances 0..prefill-1 are assigned PoolRolePrefill, prefill..prefill+decode-1 are PoolRoleDecode.
+// Caller must validate prefill+decode <= len(instances) before calling.
+func BuildPoolMembership(instances []*InstanceSimulator, prefill, decode int) map[string]PoolRole {
+	membership := make(map[string]PoolRole, prefill+decode)
+	for i := 0; i < prefill; i++ {
+		membership[string(instances[i].ID())] = PoolRolePrefill
+	}
+	for i := prefill; i < prefill+decode; i++ {
+		membership[string(instances[i].ID())] = PoolRoleDecode
+	}
+	return membership
+}
+
+// BuildPoolMembershipFromIndices constructs a pool membership map from instance indices.
+// Uses the same instance ID naming convention as NewClusterSimulator: "instance_N".
+// This variant does not require constructed instances, enabling pool membership
+// computation before instance construction (needed for per-pool config resolution).
+// Caller must validate prefill+decode <= total before calling.
+func BuildPoolMembershipFromIndices(total, prefill, decode int) map[string]PoolRole {
+	membership := make(map[string]PoolRole, prefill+decode)
+	for i := 0; i < prefill; i++ {
+		membership[fmt.Sprintf("instance_%d", i)] = PoolRolePrefill
+	}
+	for i := prefill; i < prefill+decode; i++ {
+		membership[fmt.Sprintf("instance_%d", i)] = PoolRoleDecode
+	}
+	return membership
+}
+
+// FilterSnapshotsByPool returns only the snapshots for instances in the given pool role.
+// Order is preserved (stable relative to the input slice).
+func FilterSnapshotsByPool(snapshots []sim.RoutingSnapshot, membership map[string]PoolRole, role PoolRole) []sim.RoutingSnapshot {
+	filtered := make([]sim.RoutingSnapshot, 0, len(snapshots))
+	for _, snap := range snapshots {
+		if membership[snap.ID] == role {
+			filtered = append(filtered, snap)
+		}
+	}
+	return filtered
+}

--- a/sim/cluster/pool_test.go
+++ b/sim/cluster/pool_test.go
@@ -1,0 +1,343 @@
+package cluster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// TestValidatePoolTopology verifies pool topology validation rules (BC-PD-2, BC-PD-11, BC-PD-12, BC-PD-13)
+func TestValidatePoolTopology(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefill int
+		decode  int
+		total   int
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "both zero (disabled)",
+			prefill: 0,
+			decode:  0,
+			total:   4,
+			wantErr: false,
+		},
+		{
+			name:    "valid split",
+			prefill: 2,
+			decode:  2,
+			total:   4,
+			wantErr: false,
+		},
+		{
+			name:    "valid unequal split",
+			prefill: 1,
+			decode:  3,
+			total:   4,
+			wantErr: false,
+		},
+		{
+			name:    "negative prefill",
+			prefill: -1,
+			decode:  2,
+			total:   4,
+			wantErr: true,
+			errMsg:  "prefill-instances must be >= 0",
+		},
+		{
+			name:    "negative decode",
+			prefill: 2,
+			decode:  -1,
+			total:   4,
+			wantErr: true,
+			errMsg:  "decode-instances must be >= 0",
+		},
+		{
+			name:    "only prefill set",
+			prefill: 2,
+			decode:  0,
+			total:   4,
+			wantErr: true,
+			errMsg:  "both --prefill-instances and --decode-instances must be set",
+		},
+		{
+			name:    "only decode set",
+			prefill: 0,
+			decode:  2,
+			total:   4,
+			wantErr: true,
+			errMsg:  "both --prefill-instances and --decode-instances must be set",
+		},
+		{
+			name:    "sum exceeds total",
+			prefill: 3,
+			decode:  3,
+			total:   4,
+			wantErr: true,
+			errMsg:  "exceeds num-instances",
+		},
+		{
+			name:    "sum equals total",
+			prefill: 2,
+			decode:  2,
+			total:   4,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePoolTopology(tt.prefill, tt.decode, tt.total)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidatePoolTopology() expected error containing %q, got nil", tt.errMsg)
+				} else if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidatePoolTopology() error = %v, want substring %q", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidatePoolTopology() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildPoolMembership verifies pool membership construction (BC-PD-3)
+func TestBuildPoolMembership(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefill  int
+		decode   int
+		wantSize int
+	}{
+		{
+			name:     "equal split",
+			prefill:  2,
+			decode:   2,
+			wantSize: 4,
+		},
+		{
+			name:     "prefill heavy",
+			prefill:  3,
+			decode:   1,
+			wantSize: 4,
+		},
+		{
+			name:     "decode heavy",
+			prefill:  1,
+			decode:   3,
+			wantSize: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock instances
+			total := tt.prefill + tt.decode
+			instances := make([]*InstanceSimulator, total)
+			for i := 0; i < total; i++ {
+				cfg := sim.SimConfig{
+					Horizon:             100.0,
+					Seed:                42,
+					KVCacheConfig:       sim.NewKVCacheConfig(100, 16, 0, 0, 0, 0),
+					BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
+					LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
+					ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "blackbox", 0),
+				}
+				inst := NewInstanceSimulator(InstanceID(fmt.Sprintf("instance_%d", i)), cfg)
+				instances[i] = inst
+			}
+
+			membership := BuildPoolMembership(instances, tt.prefill, tt.decode)
+
+			// Verify size
+			if len(membership) != tt.wantSize {
+				t.Errorf("BuildPoolMembership() size = %d, want %d", len(membership), tt.wantSize)
+			}
+
+			// Verify prefill instances
+			for i := 0; i < tt.prefill; i++ {
+				id := string(instances[i].ID())
+				if role, ok := membership[id]; !ok {
+					t.Errorf("BuildPoolMembership() missing instance %s", id)
+				} else if role != PoolRolePrefill {
+					t.Errorf("BuildPoolMembership() instance %s role = %v, want PoolRolePrefill", id, role)
+				}
+			}
+
+			// Verify decode instances
+			for i := tt.prefill; i < tt.prefill+tt.decode; i++ {
+				id := string(instances[i].ID())
+				if role, ok := membership[id]; !ok {
+					t.Errorf("BuildPoolMembership() missing instance %s", id)
+				} else if role != PoolRoleDecode {
+					t.Errorf("BuildPoolMembership() instance %s role = %v, want PoolRoleDecode", id, role)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildPoolMembership_Immutability verifies pool membership is immutable (BC-PD-9, INV-PD-5)
+func TestBuildPoolMembership_Immutability(t *testing.T) {
+	// Create mock instances
+	instances := make([]*InstanceSimulator, 4)
+	for i := 0; i < 4; i++ {
+		cfg := sim.SimConfig{
+			Horizon:             100.0,
+			Seed:                42,
+			KVCacheConfig:       sim.NewKVCacheConfig(100, 16, 0, 0, 0, 0),
+			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
+			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{100, 1, 100}),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test-model", "H100", 1, "blackbox", 0),
+		}
+		inst := NewInstanceSimulator(InstanceID(fmt.Sprintf("instance_%d", i)), cfg)
+		instances[i] = inst
+	}
+
+	membership := BuildPoolMembership(instances, 2, 2)
+
+	// Attempt to mutate (should not affect original)
+	membership[string(instances[0].ID())] = PoolRoleDecode
+
+	// Rebuild and verify original assignment is preserved
+	membership2 := BuildPoolMembership(instances, 2, 2)
+	if membership2[string(instances[0].ID())] != PoolRolePrefill {
+		t.Errorf("BuildPoolMembership() not immutable: instance 0 role changed")
+	}
+}
+
+// TestBuildPoolMembershipFromIndices verifies index-based membership construction
+func TestBuildPoolMembershipFromIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		total    int
+		prefill  int
+		decode   int
+		wantSize int
+	}{
+		{
+			name:     "equal split",
+			total:    4,
+			prefill:  2,
+			decode:   2,
+			wantSize: 4,
+		},
+		{
+			name:     "prefill heavy",
+			total:    4,
+			prefill:  3,
+			decode:   1,
+			wantSize: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			membership := BuildPoolMembershipFromIndices(tt.total, tt.prefill, tt.decode)
+
+			// Verify size
+			if len(membership) != tt.wantSize {
+				t.Errorf("BuildPoolMembershipFromIndices() size = %d, want %d", len(membership), tt.wantSize)
+			}
+
+			// Verify prefill instances
+			for i := 0; i < tt.prefill; i++ {
+				id := instanceIDFromIndex(i)
+				if role, ok := membership[id]; !ok {
+					t.Errorf("BuildPoolMembershipFromIndices() missing instance %s", id)
+				} else if role != PoolRolePrefill {
+					t.Errorf("BuildPoolMembershipFromIndices() instance %s role = %v, want PoolRolePrefill", id, role)
+				}
+			}
+
+			// Verify decode instances
+			for i := tt.prefill; i < tt.prefill+tt.decode; i++ {
+				id := instanceIDFromIndex(i)
+				if role, ok := membership[id]; !ok {
+					t.Errorf("BuildPoolMembershipFromIndices() missing instance %s", id)
+				} else if role != PoolRoleDecode {
+					t.Errorf("BuildPoolMembershipFromIndices() instance %s role = %v, want PoolRoleDecode", id, role)
+				}
+			}
+		})
+	}
+}
+
+// TestFilterSnapshotsByPoolRole verifies snapshot filtering by pool role
+func TestFilterSnapshotsByPoolRole(t *testing.T) {
+	// Create mock snapshots
+	snapshots := []sim.RoutingSnapshot{
+		{ID: "instance_0", QueueDepth: 1},
+		{ID: "instance_1", QueueDepth: 2},
+		{ID: "instance_2", QueueDepth: 3},
+		{ID: "instance_3", QueueDepth: 4},
+	}
+
+	membership := map[string]PoolRole{
+		"instance_0": PoolRolePrefill,
+		"instance_1": PoolRolePrefill,
+		"instance_2": PoolRoleDecode,
+		"instance_3": PoolRoleDecode,
+	}
+
+	// Filter prefill
+	prefillSnaps := FilterSnapshotsByPool(snapshots, membership, PoolRolePrefill)
+	if len(prefillSnaps) != 2 {
+		t.Errorf("FilterSnapshotsByPool(PoolRolePrefill) len = %d, want 2", len(prefillSnaps))
+	}
+	if prefillSnaps[0].ID != "instance_0" || prefillSnaps[1].ID != "instance_1" {
+		t.Errorf("FilterSnapshotsByPool(PoolRolePrefill) IDs = %v, want [instance_0, instance_1]", []string{prefillSnaps[0].ID, prefillSnaps[1].ID})
+	}
+
+	// Filter decode
+	decodeSnaps := FilterSnapshotsByPool(snapshots, membership, PoolRoleDecode)
+	if len(decodeSnaps) != 2 {
+		t.Errorf("FilterSnapshotsByPool(PoolRoleDecode) len = %d, want 2", len(decodeSnaps))
+	}
+	if decodeSnaps[0].ID != "instance_2" || decodeSnaps[1].ID != "instance_3" {
+		t.Errorf("FilterSnapshotsByPool(PoolRoleDecode) IDs = %v, want [instance_2, instance_3]", []string{decodeSnaps[0].ID, decodeSnaps[1].ID})
+	}
+}
+
+// TestPoolRoleString verifies String() method
+func TestPoolRoleString(t *testing.T) {
+	tests := []struct {
+		role PoolRole
+		want string
+	}{
+		{PoolRolePrefill, "prefill"},
+		{PoolRoleDecode, "decode"},
+		{PoolRole(99), "PoolRole(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.role.String(); got != tt.want {
+				t.Errorf("PoolRole.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Helper functions
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func instanceIDFromIndex(i int) string {
+	return fmt.Sprintf("instance_%d", i)
+}

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -1,0 +1,55 @@
+package sim
+
+import "fmt"
+
+// DisaggregationDecision encapsulates the prefill-decode disaggregation decision for a request.
+type DisaggregationDecision struct {
+	Disaggregate bool // true = route to prefill pool, false = route to shared/decode pool
+}
+
+// DisaggregationDecider decides whether a request should be disaggregated
+// (sent to a dedicated prefill pool) or handled by the default routing pipeline.
+// Used by ClusterSimulator's event pipeline when pool topology is configured.
+//
+// Implementations must not read Request.OutputTokens (INV-9 oracle boundary);
+// use len(req.InputTokens) and req.MaxOutputLen only.
+//
+// req is guaranteed non-nil; implementations may assume a non-nil pointer.
+type DisaggregationDecider interface {
+	Decide(req *Request) DisaggregationDecision
+}
+
+// NeverDisaggregate always returns Disaggregate=false.
+// Default decider when PD disaggregation is not configured.
+type NeverDisaggregate struct{}
+
+func (n *NeverDisaggregate) Decide(_ *Request) DisaggregationDecision {
+	return DisaggregationDecision{Disaggregate: false}
+}
+
+// AlwaysDisaggregate always returns Disaggregate=true.
+// Test-oriented decider for validating disaggregation pipeline wiring.
+type AlwaysDisaggregate struct{}
+
+func (a *AlwaysDisaggregate) Decide(_ *Request) DisaggregationDecision {
+	return DisaggregationDecision{Disaggregate: true}
+}
+
+// NewDisaggregationDecider creates a disaggregation decider by name.
+// Valid names are defined in validDisaggregationDeciders (bundle.go).
+// An empty string defaults to NeverDisaggregate.
+// Panics on unrecognized names.
+// Note: "prefix-threshold" and "direct-to-decode" are added in PR5/PR9.
+func NewDisaggregationDecider(name string) DisaggregationDecider {
+	if !IsValidDisaggregationDecider(name) {
+		panic(fmt.Sprintf("unknown disaggregation decider %q", name))
+	}
+	switch name {
+	case "", "never":
+		return &NeverDisaggregate{}
+	case "always":
+		return &AlwaysDisaggregate{}
+	default:
+		panic(fmt.Sprintf("unhandled disaggregation decider %q", name))
+	}
+}

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -1,0 +1,134 @@
+package sim
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestNeverDisaggregate_AlwaysReturnsFalse verifies BC-PD-5
+func TestNeverDisaggregate_AlwaysReturnsFalse(t *testing.T) {
+	decider := &NeverDisaggregate{}
+	
+	tests := []struct {
+		name string
+		req  *Request
+	}{
+		{
+			name: "short request",
+			req: &Request{
+				InputTokens:  []int{1, 2, 3},
+				MaxOutputLen: 10,
+			},
+		},
+		{
+			name: "long request",
+			req: &Request{
+				InputTokens:  make([]int, 1000),
+				MaxOutputLen: 500,
+			},
+		},
+		{
+			name: "zero output",
+			req: &Request{
+				InputTokens:  []int{1},
+				MaxOutputLen: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := decider.Decide(tt.req)
+			if decision.Disaggregate {
+				t.Errorf("NeverDisaggregate.Decide() = true, want false")
+			}
+		})
+	}
+}
+
+// TestAlwaysDisaggregate_AlwaysReturnsTrue verifies BC-PD-6
+func TestAlwaysDisaggregate_AlwaysReturnsTrue(t *testing.T) {
+	decider := &AlwaysDisaggregate{}
+	
+	tests := []struct {
+		name string
+		req  *Request
+	}{
+		{
+			name: "short request",
+			req: &Request{
+				InputTokens:  []int{1, 2, 3},
+				MaxOutputLen: 10,
+			},
+		},
+		{
+			name: "long request",
+			req: &Request{
+				InputTokens:  make([]int, 1000),
+				MaxOutputLen: 500,
+			},
+		},
+		{
+			name: "zero output",
+			req: &Request{
+				InputTokens:  []int{1},
+				MaxOutputLen: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := decider.Decide(tt.req)
+			if !decision.Disaggregate {
+				t.Errorf("AlwaysDisaggregate.Decide() = false, want true")
+			}
+		})
+	}
+}
+
+// TestNewDisaggregationDecider_Factory verifies BC-PD-7
+func TestNewDisaggregationDecider_Factory(t *testing.T) {
+	tests := []struct {
+		name         string
+		deciderName  string
+		wantType     string
+	}{
+		{
+			name:        "empty string defaults to never",
+			deciderName: "",
+			wantType:    "*sim.NeverDisaggregate",
+		},
+		{
+			name:        "never",
+			deciderName: "never",
+			wantType:    "*sim.NeverDisaggregate",
+		},
+		{
+			name:        "always",
+			deciderName: "always",
+			wantType:    "*sim.AlwaysDisaggregate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decider := NewDisaggregationDecider(tt.deciderName)
+			gotType := fmt.Sprintf("%T", decider)
+			if gotType != tt.wantType {
+				t.Errorf("NewDisaggregationDecider(%q) type = %v, want %v", tt.deciderName, gotType, tt.wantType)
+			}
+		})
+	}
+}
+
+// TestNewDisaggregationDecider_UnknownPanics verifies BC-PD-14
+func TestNewDisaggregationDecider_UnknownPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewDisaggregationDecider with unknown name should panic")
+		}
+	}()
+	
+	NewDisaggregationDecider("unknown-decider")
+}


### PR DESCRIPTION
Implements the foundation for prefill-decode disaggregation:

- Pool topology validation and membership tracking (sim/cluster/pool.go)
- DisaggregationDecider interface with NeverDisaggregate and AlwaysDisaggregate
- Comprehensive test coverage for pool topology and disaggregation decisions
- Integration tests verifying backward compatibility
- Skipped PR5/PR9 tests for unimplemented deciders (prefix-threshold, direct-to-decode)

**Test Results:**
✅ All packages: PASS
✅ sim/cluster: 2.202s
✅ Build successful
✅ No failures

Ready for PR2 implementation (KV transfer events and bandwidth modeling).