### PR TITLE
docs: fix stale INV count — update INV-9 → INV-11 in 3 files

### DIFF
--- a/.claude/skills/convergence-review/design-prompts.md
+++ b/.claude/skills/convergence-review/design-prompts.md
@@ -85,7 +85,7 @@ DESIGN DOCUMENT:
 YOUR FOCUS: Module Contract Completeness (design guidelines Section 4.3)
 - Does every new or modified module have all 6 contract aspects?
   (observes / controls / owns / invariants / events / extension friction)
-- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-9)?
+- Are invariants named (INV-N) and cross-referenced with existing invariants (INV-1 through INV-11)?
 - Is the extension friction count specified and within reference targets (Section 4.5)?
 - Are behavioral contracts testable? Could someone write a GIVEN/WHEN/THEN test from the contract alone?
 - Are failure modes specified? What happens under overload, misconfiguration, degenerate inputs?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,7 +372,7 @@ Follow `docs/contributing/hypothesis.md` for the full process (Steps 0-10). Key 
 |---|---|---|
 | `CLAUDE.md` | Code architecture, file organization, CLI flags, compact rule/invariant tables | Always — authoritative for current codebase state |
 | `docs/contributing/standards/rules.md` | 23 antipattern rules with evidence, checks, enforcement | When reviewing or writing code |
-| `docs/contributing/standards/invariants.md` | 9 system invariants (INV-1 through INV-9) with verification strategies | When touching request lifecycle, KV cache, or metrics |
+| `docs/contributing/standards/invariants.md` | 11 system invariants (INV-1 through INV-11) with verification strategies | When touching request lifecycle, KV cache, or metrics |
 | `docs/contributing/standards/experiments.md` | Experiment taxonomy, rigor requirements, findings classification | When running hypothesis experiments |
 | `docs/contributing/pr-workflow.md` | End-to-end PR lifecycle (worktree → plan → review → implement → audit → PR) | Before starting any PR |
 | `docs/concepts/` | System architecture, core engine, concepts glossary, roofline estimation | When learning how BLIS works before contributing |

--- a/docs/concepts/core-engine.md
+++ b/docs/concepts/core-engine.md
@@ -2,7 +2,7 @@
 
 This page describes BLIS's single-instance discrete event simulation engine. For multi-instance cluster orchestration, see [Cluster Architecture](architecture.md).
 
-> **Canonical sources:** System invariants (INV-1 through INV-9) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
+> **Canonical sources:** System invariants (INV-1 through INV-11) are defined in [`docs/contributing/standards/invariants.md`](../contributing/standards/invariants.md). If invariant descriptions here diverge, `invariants.md` is authoritative.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- INV-10 (Session causality) and INV-11 (Session completeness) landed in #648 but three files were never updated
- Three one-line fixes: `INV-9` → `INV-11` (and count `9` → `11` in CONTRIBUTING.md)

## Files changed

| File | Line | Fix |
|------|------|-----|
| `CONTRIBUTING.md` | 380 | `9 system invariants (INV-1 through INV-9)` → `11 system invariants (INV-1 through INV-11)` |
| `docs/concepts/core-engine.md` | 5 | `INV-1 through INV-9` → `INV-1 through INV-11` |
| `.claude/skills/convergence-review/design-prompts.md` | 88 | `INV-1 through INV-9` → `INV-1 through INV-11` |

## Already correct (no changes needed)

`CLAUDE.md`, `docs/contributing/index.md`, `docs/contributing/standards/principles.md`, and `docs/contributing/standards/invariants.md` all already say INV-11.

## Test plan

- [x] `go test ./...` — all passing (docs-only change)
- [x] No remaining `INV-1 through INV-9` count claims outside archived plan docs

Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)