### PR TITLE
feat(workload): add normalized exponential arrival sampler (#845)

### DIFF
--- a/docs/plans/pr845-normalized-exponential-simple-plan.md
+++ b/docs/plans/pr845-normalized-exponential-simple-plan.md
@@ -39,18 +39,20 @@ THEN sum(intervals) ≈ 600,000,000 µs (within count microseconds for rounding)
 **BC-2: Request Generation Guarantees**
 ```gherkin
 GIVEN a client with CustomSampler=NormalizedExponentialSampler(count=3000, duration=600s)
-WHEN workload is generated
+WHEN workload is generated with horizon >= duration
 THEN exactly 3000 requests are generated for that client
   AND all 3000 requests arrive within the duration window
+NOTE: If horizon < duration, some requests may be dropped by the horizon guard
 ```
 
-**BC-3: Inference-Perf Auto-Application**
+**BC-3: Inference-Perf Auto-Application (Single-Stage)**
 ```gherkin
-GIVEN an InferencePerfSpec with any stages
+GIVEN an InferencePerfSpec with a single stage
 WHEN expanded to WorkloadSpec
 THEN all clients use NormalizedExponentialSampler via CustomSampler field
-  AND count is set from (stage.Rate * stage.Duration / numClients)
+  AND count is set from ceil(stage.Rate * stage.Duration / numClients)
   AND duration is set from stage.Duration in microseconds
+NOTE: Multi-stage workloads continue to use Poisson arrival for now
 ```
 
 ### C. Component Interaction

--- a/docs/plans/pr845-normalized-exponential-simple-plan.md
+++ b/docs/plans/pr845-normalized-exponential-simple-plan.md
@@ -45,14 +45,44 @@ THEN exactly 3000 requests are generated for that client
 NOTE: If horizon < duration, some requests may be dropped by the horizon guard
 ```
 
-**BC-3: Inference-Perf Auto-Application (Single-Stage)**
+**BC-3: Inference-Perf Auto-Application (Single-Stage Only)**
 ```gherkin
-GIVEN an InferencePerfSpec with a single stage
+GIVEN an InferencePerfSpec with a single stage AND no multi-turn
 WHEN expanded to WorkloadSpec
-THEN all clients use NormalizedExponentialSampler via CustomSampler field
+THEN all clients use NormalizedExponentialSampler via CustomSamplerFactory
   AND count is set from ceil(stage.Rate * stage.Duration / numClients)
   AND duration is set from stage.Duration in microseconds
-NOTE: Multi-stage workloads continue to use Poisson arrival for now
+NOTE: Multi-stage workloads continue to use Poisson arrival (see BC-4)
+NOTE: Multi-turn workloads continue to use Poisson arrival (see BC-5)
+```
+
+**BC-4: Multi-Stage Asymmetry (Architectural Constraint)**
+```gherkin
+GIVEN an InferencePerfSpec with multiple stages
+WHEN expanded to WorkloadSpec
+THEN all clients use Poisson arrival (not NormalizedExponentialSampler)
+RATIONALE: Multi-stage workloads use per-stage client cohorts with lifecycle windows.
+  Each cohort is active only during its stage's window. NormalizedExponentialSampler
+  pre-generates N intervals spanning the FULL duration, but multi-stage clients are
+  only active for a SUBSET of that duration (their stage's window). This mismatch
+  would waste intervals or require complex windowing logic. Poisson generates
+  intervals incrementally during the active window, matching the architecture.
+FUTURE WORK: Per-stage NormalizedExponentialSampler construction (each stage gets
+  its own sampler with count/duration scoped to that stage).
+```
+
+**BC-5: Multi-Turn Asymmetry (Session Start Time Only)**
+```gherkin
+GIVEN an InferencePerfSpec with multi-turn enabled
+WHEN expanded to WorkloadSpec
+THEN all clients use Poisson arrival for session start times
+RATIONALE: Multi-turn workloads with SingleSession=true use ONE arrival sample
+  for the session start time. The rounds within the session are spaced by
+  ThinkTimeUs (not sampled IATs). NormalizedExponentialSampler pre-generates N
+  intervals, but only the first would be used — wasting N-1 intervals.
+  Poisson generates the session start time on-demand without waste.
+NOTE: The rounds within each session still occur at exact ThinkTimeUs intervals,
+  maintaining inference-perf's round-robin cycling semantics.
 ```
 
 ### C. Component Interaction

--- a/docs/plans/pr845-normalized-exponential-simple-plan.md
+++ b/docs/plans/pr845-normalized-exponential-simple-plan.md
@@ -87,12 +87,17 @@ NOTE: The rounds within each session still occur at exact ThinkTimeUs intervals,
 
 ### C. Component Interaction
 
-**Generator Loop (add CustomSampler check):**
+**Generator Loop (CustomSamplerFactory pattern with sub-RNG isolation):**
 ```go
-// generator.go:~115 (new code):
+// generator.go:~114 (post-refactor):
 var arrivalSampler ArrivalSampler
-if client.CustomSampler != nil {
-    arrivalSampler = client.CustomSampler
+if client.CustomSamplerFactory != nil {
+    // Derive sub-RNG for factory with single entropy draw from clientRNG.
+    // This isolates the sampler's N-draw RNG consumption from downstream
+    // content sampling, keeping input/output distributions stable.
+    subSeed := clientRNG.Int63()
+    subRNG := newRandFromSeed(subSeed)
+    arrivalSampler = client.CustomSamplerFactory(subRNG)
 } else {
     arrivalSampler = NewArrivalSampler(client.Arrival, ratePerMicrosecond)
 }
@@ -100,7 +105,7 @@ if client.CustomSampler != nil {
 // Rest of loop unchanged:
 for currentTime < horizon {
     iat := arrivalSampler.SampleIAT(clientRNG)
-    if iat == 0 { break }  // Exhausted sampler signals stop
+    if iat == 0 { break }  // Stateful sampler exhausted (e.g., NormalizedExponentialSampler)
     currentTime += iat
     if currentTime >= horizon { break }
     // generate request...

--- a/docs/plans/pr845-normalized-exponential-simple-plan.md
+++ b/docs/plans/pr845-normalized-exponential-simple-plan.md
@@ -1,0 +1,302 @@
+# Implementation Plan: Normalized Exponential Arrival Sampler (Ultra-Simplified)
+
+**PR Number:** #845
+**Goal:** Add normalized exponential arrival sampler for inference-perf fidelity
+**Source:** GitHub issue #845
+**Closes:** Fixes #845
+**Tier:** Small (3 files, ~80 LOC total)
+
+---
+
+## Part 1: Design Validation
+
+### A. Executive Summary
+
+This PR adds support for inference-perf's "normalized exponential" arrival pattern, eliminating systematic 2% duration bias in training data.
+
+**Problem:** inference-perf generates exactly N requests spanning exactly T seconds by normalizing exponential samples. BLIS uses Poisson which stops at horizon, generating ~2% fewer requests.
+
+**Solution:** Direct port of inference-perf's algorithm (~15 lines of Python → ~25 lines of Go), bypassing the factory pattern entirely:
+1. Add `CustomSampler` field to `ClientSpec` (programmatic use only)
+2. Implement `NormalizedExponentialSampler` (no factory registration)
+3. Construct directly in `ExpandInferencePerfSpec`
+
+**Files modified:** 3 files (spec.go, arrival.go, inference_perf.go)
+**Lines changed:** ~50 LOC production + ~30 LOC tests = ~80 LOC total
+
+**Key simplification:** No factory changes, no YAML changes, no sentinel overflow, no signature changes.
+
+### B. Behavioral Contracts
+
+**BC-1: Normalized Distribution**
+```gherkin
+GIVEN a sampler with count=3000, duration=600s (600M µs), rate=5/s
+WHEN all 3000 intervals are generated
+THEN sum(intervals) ≈ 600,000,000 µs (within count microseconds for rounding)
+  AND exactly 3000 intervals are returned
+```
+
+**BC-2: Request Generation Guarantees**
+```gherkin
+GIVEN a client with CustomSampler=NormalizedExponentialSampler(count=3000, duration=600s)
+WHEN workload is generated
+THEN exactly 3000 requests are generated for that client
+  AND all 3000 requests arrive within the duration window
+```
+
+**BC-3: Inference-Perf Auto-Application**
+```gherkin
+GIVEN an InferencePerfSpec with any stages
+WHEN expanded to WorkloadSpec
+THEN all clients use NormalizedExponentialSampler via CustomSampler field
+  AND count is set from (stage.Rate * stage.Duration / numClients)
+  AND duration is set from stage.Duration in microseconds
+```
+
+### C. Component Interaction
+
+**Generator Loop (add CustomSampler check):**
+```go
+// generator.go:~115 (new code):
+var arrivalSampler ArrivalSampler
+if client.CustomSampler != nil {
+    arrivalSampler = client.CustomSampler
+} else {
+    arrivalSampler = NewArrivalSampler(client.Arrival, ratePerMicrosecond)
+}
+
+// Rest of loop unchanged:
+for currentTime < horizon {
+    iat := arrivalSampler.SampleIAT(clientRNG)
+    if iat == 0 { break }  // Exhausted sampler signals stop
+    currentTime += iat
+    if currentTime >= horizon { break }
+    // generate request...
+}
+```
+
+**Sampler Design (direct port from inference-perf):**
+1. Constructor takes `rng`, `count`, `durationUs`
+2. Generate N exponential samples (float64)
+3. Normalize so sum equals duration (float64 arithmetic)
+4. Convert to int64 microseconds, floor each to >= 1
+5. SampleIAT() returns intervals sequentially
+6. Returns 0 when exhausted (signals loop to break)
+
+### D. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Memory for large N | 8N bytes for int64 intervals. For N=10K: 80KB. Reasonable for training workloads. |
+| RNG determinism | Pass clientRNG from generator. RNG consumed in constructor (all N draws), not incrementally like Poisson. This changes downstream RNG stream - acceptable, documented. |
+| Zero IAT from truncation | Floor all intervals to >= 1 after int64 conversion. |
+| Float64 precision | Follows inference-perf. Sum may differ from target by ~N microseconds due to rounding. Acceptable. |
+
+### E. Direct Port from inference-perf
+
+**inference-perf (Python):**
+```python
+intervals = self._rand.exponential(1 / self._rate, num_requests)
+total_interval_time = np.sum(intervals)
+scale_factor = self._duration / total_interval_time
+normalized_intervals = intervals * scale_factor
+```
+
+**BLIS (Go equivalent):**
+```go
+raw := make([]float64, count)
+for i := range raw {
+    raw[i] = rng.ExpFloat64() / rate
+}
+sum := 0.0
+for _, v := range raw { sum += v }
+scaleFactor := float64(durationUs) / sum
+intervals := make([]int64, count)
+for i, v := range raw {
+    iat := int64(v * scaleFactor)
+    if iat < 1 { iat = 1 }  // Floor to minimum 1µs
+    intervals[i] = iat
+}
+```
+
+---
+
+## Part 2: Implementation Tasks
+
+### Task 1: Add CustomSampler field to ClientSpec
+- **Test:** `TestClientSpec_CustomSampler` — Verify non-nil CustomSampler is used in generation, nil falls back to factory
+- **Code:** Add field to `ClientSpec` in spec.go:
+```go
+type ClientSpec struct {
+    // ... existing fields
+    Arrival       ArrivalSpec
+    // CustomSampler allows programmatic injection of arrival samplers
+    // (bypassing the factory). Used by inference-perf expansion.
+    // Not exposed in YAML (yaml:"-" tag).
+    CustomSampler ArrivalSampler `yaml:"-"`
+}
+```
+- **Code:** Update generator.go:~115 to check CustomSampler:
+```go
+var arrivalSampler ArrivalSampler
+if client.CustomSampler != nil {
+    arrivalSampler = client.CustomSampler
+} else {
+    arrivalSampler = NewArrivalSampler(client.Arrival, ratePerMicrosecond)
+}
+```
+- **Verification:** `go test ./sim/workload -run TestClientSpec_CustomSampler -v`
+- **Commit:** `feat(workload): add CustomSampler field to ClientSpec (BC-2)`
+
+### Task 2: Implement NormalizedExponentialSampler
+- **Test:** `TestNormalizedExponentialSampler_Normalized` — Create sampler (count=600, duration=60s, rate=10/s). Sample all 600 IATs. Verify: (1) count==600, (2) sum within 600µs of 60,000,000µs, (3) all IATs >= 1, (4) final SampleIAT returns 0.
+- **Test:** `TestNormalizedExponentialSampler_Deterministic` — Two samplers with same seed produce identical intervals.
+- **Code:** Add sampler to arrival.go:
+```go
+// NormalizedExponentialSampler generates exactly N inter-arrival times
+// that sum to exactly the target duration. Direct port of inference-perf's
+// normalized exponential algorithm.
+type NormalizedExponentialSampler struct {
+    intervals []int64
+    index     int
+}
+
+// NewNormalizedExponentialSampler creates a sampler that pre-generates
+// count intervals normalized to sum to durationUs microseconds.
+// rate is requests per microsecond (used for distribution shape only).
+func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int64) *NormalizedExponentialSampler {
+    if count <= 0 {
+        panic(fmt.Sprintf("NormalizedExponentialSampler: count must be positive, got %d", count))
+    }
+    if durationUs <= 0 {
+        panic(fmt.Sprintf("NormalizedExponentialSampler: duration must be positive, got %d", durationUs))
+    }
+
+    // Generate exponential samples (float64)
+    rate := float64(count) / float64(durationUs)  // Requests per microsecond
+    raw := make([]float64, count)
+    for i := range raw {
+        raw[i] = rng.ExpFloat64() / rate
+    }
+
+    // Normalize to sum exactly to duration (float64 arithmetic)
+    sum := 0.0
+    for _, v := range raw {
+        sum += v
+    }
+    scaleFactor := float64(durationUs) / sum
+
+    // Convert to int64 microseconds with floor to >= 1
+    intervals := make([]int64, count)
+    for i, v := range raw {
+        iat := int64(v * scaleFactor)
+        if iat < 1 {
+            iat = 1
+        }
+        intervals[i] = iat
+    }
+
+    return &NormalizedExponentialSampler{intervals: intervals}
+}
+
+// SampleIAT returns pre-generated intervals sequentially.
+// Returns 0 when exhausted (signals caller to stop).
+func (s *NormalizedExponentialSampler) SampleIAT(_ *rand.Rand) int64 {
+    if s.index >= len(s.intervals) {
+        return 0  // Exhausted
+    }
+    iat := s.intervals[s.index]
+    s.index++
+    return iat
+}
+```
+- **Verification:** `go test ./sim/workload -run TestNormalizedExponentialSampler -v`
+- **Commit:** `feat(workload): implement NormalizedExponentialSampler (BC-1)`
+
+### Task 3: Integrate into inference-perf
+- **Test:** `TestExpandInferencePerfSpec_UsesNormalizedExponential` — Expand spec with stage (rate=5, duration=600). Verify: (1) clients have non-nil CustomSampler, (2) sampler type is NormalizedExponentialSampler, (3) count matches expected per-client count.
+- **Code:** Modify `ExpandInferencePerfSpec()` in inference_perf.go:
+  - Single-stage path (~line 119-132): Create sampler and assign to CustomSampler
+  - Multi-stage path (~line 163-168): Same for each stage's clients
+  - Compute total stage requests: `totalStageRequests := int64(math.Round(stage.Rate * float64(stage.Duration)))`
+  - Compute per-client count: `perClientCount := totalStageRequests / int64(numClientsPerStage)` with remainder distribution
+  - Compute per-client duration: `stageDurationUs := stage.Duration * 1_000_000` (microseconds)
+  - Create sampler: `sampler := workload.NewNormalizedExponentialSampler(clientRNG, perClientCount, stageDurationUs)`
+  - Assign to ClientSpec: `CustomSampler: sampler`
+- **Code:** For remainder distribution, first `remainder` clients get `perClientCount+1`, rest get `perClientCount`
+- **Verification:** `go test ./sim/workload -run TestExpandInferencePerfSpec_UsesNormalizedExponential -v`
+- **Commit:** `feat(workload): use NormalizedExponentialSampler for inference-perf stages (BC-3)`
+
+### Task 4: Update generator to handle zero IAT as stop signal
+- **Test:** `TestGenerateRequests_StopsOnZeroIAT` — Create client with mock sampler that returns 3 non-zero IATs then 0. Verify exactly 3 requests generated.
+- **Code:** In generator.go:~252, after `iat := arrivalSampler.SampleIAT(clientRNG)`, add:
+```go
+if iat == 0 {
+    break  // Sampler exhausted
+}
+```
+- **Verification:** `go test ./sim/workload -run TestGenerateRequests_StopsOnZeroIAT -v`
+- **Commit:** `feat(workload): handle zero IAT as sampler exhaustion signal (BC-2)`
+
+---
+
+## Part 3: Acceptance Checklist
+
+- [ ] Task 1: CustomSampler field test passes
+- [ ] Task 2: Normalization test passes (sum within count µs)
+- [ ] Task 2: Determinism test passes
+- [ ] Task 3: Inference-perf integration test passes
+- [ ] Task 4: Zero IAT stop signal test passes
+- [ ] All tests pass: `go test ./sim/workload/... -count=1`
+- [ ] Lint passes: `golangci-lint run ./sim/workload/...`
+- [ ] Build passes: `go build ./...`
+
+---
+
+## Appendix: Why This Is Simpler
+
+### Eliminated Complexity
+
+**vs. Previous Plan:**
+- ❌ No factory signature change (was: 10+ call site updates)
+- ❌ No YAML validation updates (was: 2 validation functions)
+- ❌ No error return from factory (was: error handling at all call sites)
+- ❌ No RNG parameter to factory (was: threading RNG through factory)
+- ❌ No `math.MaxInt64` sentinel (was: int64 overflow infinite loop bug)
+- ❌ No Count/Duration fields on ArrivalSpec (was: cross-field validation)
+
+**What Remains:**
+- ✅ CustomSampler field (1 field, 3 lines)
+- ✅ NormalizedExponentialSampler (50 lines)
+- ✅ Direct construction in inference_perf.go (10 lines)
+- ✅ Zero IAT check in generator (1 line)
+
+### File Impact Summary
+
+| File | Changes | LOC |
+|------|---------|-----|
+| sim/workload/spec.go | Add CustomSampler field + comment | +4 |
+| sim/workload/arrival.go | Add NormalizedExponentialSampler (~50 lines with validation) | +50 |
+| sim/workload/generator.go | CustomSampler check + zero IAT break | +6 |
+| sim/workload/inference_perf.go | Construct and assign sampler | +15 |
+| sim/workload/*_test.go | 4 new tests | +30 |
+| **TOTAL** | | **~105 LOC** |
+
+Note: Slightly higher than initial 80 LOC estimate due to Task 4 (zero IAT handling), but still far simpler than the 140 LOC factory-based approach.
+
+---
+
+## Deviation Log
+
+**From original plan:**
+1. **SIMPLIFICATION:** Bypass factory pattern entirely. Original plan modified factory signature and all call sites. New plan uses CustomSampler field.
+2. **SIMPLIFICATION:** Use 0 as exhaustion signal instead of `math.MaxInt64` sentinel. Eliminates overflow bug.
+3. **SIMPLIFICATION:** No YAML exposure. CustomSampler is programmatic only, not a YAML feature.
+4. **SIMPLIFICATION:** Direct RNG threading. Pass clientRNG to constructor, no factory parameter.
+
+**From inference-perf source:**
+- Go requires explicit loops vs NumPy vectorization
+- Floor all intervals to >= 1µs (Go specific, inference-perf uses float seconds)
+- Return 0 when exhausted (Go sentinel convention)
+
+All complexity from the factory-based approach has been **eliminated**.

--- a/sim/workload/arrival.go
+++ b/sim/workload/arrival.go
@@ -10,8 +10,9 @@ import (
 // ArrivalSampler generates inter-arrival times for a client.
 type ArrivalSampler interface {
 	// SampleIAT returns the next inter-arrival time in microseconds.
-	// Returns >= 1 for active samplers.
-	// Returns 0 to signal exhaustion for stateful samplers (e.g., NormalizedExponentialSampler).
+	// Returns >= 1 for stateless samplers (Poisson, Gamma, Weibull, Constant).
+	// Returns 0 to signal exhaustion for stateful samplers (only NormalizedExponentialSampler).
+	// Callers MUST check for 0 and stop generation when encountered.
 	SampleIAT(rng *rand.Rand) int64
 }
 

--- a/sim/workload/arrival.go
+++ b/sim/workload/arrival.go
@@ -173,6 +173,10 @@ func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int
 		// Defensive: should never happen with ExpFloat64, but guard division by zero
 		panic("NormalizedExponentialSampler: sum of raw samples is zero")
 	}
+	if math.IsInf(sum, 0) {
+		// Defensive: catch overflow from extreme inputs (e.g., very small rate with large ExpFloat64 samples)
+		panic("NormalizedExponentialSampler: sum overflow to infinity; inputs may be extreme")
+	}
 	scaleFactor := float64(durationUs) / sum
 
 	// Convert to int64 microseconds with floor to >= 1

--- a/sim/workload/arrival.go
+++ b/sim/workload/arrival.go
@@ -10,7 +10,8 @@ import (
 // ArrivalSampler generates inter-arrival times for a client.
 type ArrivalSampler interface {
 	// SampleIAT returns the next inter-arrival time in microseconds.
-	// Always returns a positive value (>= 1).
+	// Returns >= 1 for active samplers.
+	// Returns 0 to signal exhaustion for stateful samplers (e.g., NormalizedExponentialSampler).
 	SampleIAT(rng *rand.Rand) int64
 }
 
@@ -135,12 +136,22 @@ type NormalizedExponentialSampler struct {
 //
 // The rate parameter only affects the distribution shape; normalization
 // ensures the sum equals durationUs regardless of rate.
+//
+// NOTE: Flooring each IAT to >= 1 means the actual sum may slightly exceed
+// durationUs. This matches inference-perf behavior and is acceptable for
+// workload generation (exact count matters more than exact duration).
 func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int64) *NormalizedExponentialSampler {
 	if count <= 0 {
 		panic("NormalizedExponentialSampler: count must be positive")
 	}
 	if durationUs <= 0 {
 		panic("NormalizedExponentialSampler: duration must be positive")
+	}
+	if count > 10_000_000 {
+		panic("NormalizedExponentialSampler: count exceeds safety limit (10M)")
+	}
+	if durationUs < count {
+		panic("NormalizedExponentialSampler: durationUs < count produces degenerate distribution")
 	}
 
 	// Generate exponential samples (float64)
@@ -150,10 +161,17 @@ func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int
 		raw[i] = rng.ExpFloat64() / rate
 	}
 
-	// Normalize to sum exactly to duration (float64 arithmetic)
+	// Normalize to sum exactly to duration (float64 arithmetic).
+	// Normalization is necessary because exponential samples have high variance;
+	// without normalization, the actual sum would deviate significantly from
+	// the target duration, violating the inference-perf contract.
 	sum := 0.0
 	for _, v := range raw {
 		sum += v
+	}
+	if sum == 0 {
+		// Defensive: should never happen with ExpFloat64, but guard division by zero
+		panic("NormalizedExponentialSampler: sum of raw samples is zero")
 	}
 	scaleFactor := float64(durationUs) / sum
 
@@ -172,6 +190,10 @@ func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int
 
 // SampleIAT returns pre-generated intervals sequentially.
 // Returns 0 when exhausted (signals caller to stop).
+//
+// This is the only ArrivalSampler implementation that returns 0.
+// Callers using CustomSampler must handle zero-IAT as exhaustion signal.
+// See generator.go lines 147, 204 for zero-IAT guards.
 func (s *NormalizedExponentialSampler) SampleIAT(_ *rand.Rand) int64 {
 	if s.index >= len(s.intervals) {
 		return 0 // Exhausted

--- a/sim/workload/arrival.go
+++ b/sim/workload/arrival.go
@@ -112,6 +112,75 @@ func (s *ConstantArrivalSampler) SampleIAT(_ *rand.Rand) int64 {
 	return s.iatMicros
 }
 
+// NormalizedExponentialSampler generates exactly N inter-arrival times
+// that sum to exactly the target duration. Direct port of inference-perf's
+// normalized exponential algorithm.
+//
+// Unlike other samplers which generate IATs incrementally, this sampler
+// pre-generates all N intervals in the constructor, normalizing them so their
+// sum equals the target duration exactly. This matches the behavior of
+// inference-perf's ConstantLoadTimer.
+type NormalizedExponentialSampler struct {
+	intervals []int64
+	index     int
+}
+
+// NewNormalizedExponentialSampler creates a sampler that pre-generates
+// count intervals normalized to sum to durationUs microseconds.
+//
+// Algorithm (direct port from inference-perf load_timer.py):
+// 1. Generate count exponential samples with mean IAT = 1/rate
+// 2. Normalize samples so their sum equals durationUs exactly
+// 3. Convert to int64 microseconds, floor each to >= 1
+//
+// The rate parameter only affects the distribution shape; normalization
+// ensures the sum equals durationUs regardless of rate.
+func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int64) *NormalizedExponentialSampler {
+	if count <= 0 {
+		panic("NormalizedExponentialSampler: count must be positive")
+	}
+	if durationUs <= 0 {
+		panic("NormalizedExponentialSampler: duration must be positive")
+	}
+
+	// Generate exponential samples (float64)
+	rate := float64(count) / float64(durationUs) // Requests per microsecond
+	raw := make([]float64, count)
+	for i := range raw {
+		raw[i] = rng.ExpFloat64() / rate
+	}
+
+	// Normalize to sum exactly to duration (float64 arithmetic)
+	sum := 0.0
+	for _, v := range raw {
+		sum += v
+	}
+	scaleFactor := float64(durationUs) / sum
+
+	// Convert to int64 microseconds with floor to >= 1
+	intervals := make([]int64, count)
+	for i, v := range raw {
+		iat := int64(v * scaleFactor)
+		if iat < 1 {
+			iat = 1
+		}
+		intervals[i] = iat
+	}
+
+	return &NormalizedExponentialSampler{intervals: intervals}
+}
+
+// SampleIAT returns pre-generated intervals sequentially.
+// Returns 0 when exhausted (signals caller to stop).
+func (s *NormalizedExponentialSampler) SampleIAT(_ *rand.Rand) int64 {
+	if s.index >= len(s.intervals) {
+		return 0 // Exhausted
+	}
+	iat := s.intervals[s.index]
+	s.index++
+	return iat
+}
+
 // NewArrivalSampler creates an ArrivalSampler from a spec and rate.
 // ratePerMicrosecond is the client's request rate in requests/microsecond.
 func NewArrivalSampler(spec ArrivalSpec, ratePerMicrosecond float64) ArrivalSampler {

--- a/sim/workload/arrival.go
+++ b/sim/workload/arrival.go
@@ -137,9 +137,10 @@ type NormalizedExponentialSampler struct {
 // The rate parameter only affects the distribution shape; normalization
 // ensures the sum equals durationUs regardless of rate.
 //
-// NOTE: Flooring each IAT to >= 1 means the actual sum may slightly exceed
-// durationUs. This matches inference-perf behavior and is acceptable for
-// workload generation (exact count matters more than exact duration).
+// NOTE: Truncating float64 to int64 means the actual sum may be slightly less
+// than durationUs (by at most count microseconds). The floor-to-1 clamp only
+// affects intervals when normalized values fall below 1µs, which is prevented
+// by the durationUs >= count validation. This matches inference-perf behavior.
 func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int64) *NormalizedExponentialSampler {
 	if count <= 0 {
 		panic("NormalizedExponentialSampler: count must be positive")
@@ -196,8 +197,8 @@ func NewNormalizedExponentialSampler(rng *rand.Rand, count int64, durationUs int
 // Returns 0 when exhausted (signals caller to stop).
 //
 // This is the only ArrivalSampler implementation that returns 0.
-// Callers using CustomSampler must handle zero-IAT as exhaustion signal.
-// See generator.go lines 147, 204 for zero-IAT guards.
+// Callers using CustomSampler must handle zero-IAT as exhaustion signal;
+// see GenerateRequests for the zero-IAT guard pattern in all request generation loops.
 func (s *NormalizedExponentialSampler) SampleIAT(_ *rand.Rand) int64 {
 	if s.index >= len(s.intervals) {
 		return 0 // Exhausted

--- a/sim/workload/arrival_test.go
+++ b/sim/workload/arrival_test.go
@@ -280,7 +280,7 @@ func TestNormalizedExponentialSampler_EdgeCases(t *testing.T) {
 
 		// WHEN all intervals sampled
 		var sum int64
-		var allAtLeastOne bool = true
+		allAtLeastOne := true
 		for i := int64(0); i < count; i++ {
 			iat := sampler.SampleIAT(nil)
 			if iat < 1 {

--- a/sim/workload/arrival_test.go
+++ b/sim/workload/arrival_test.go
@@ -267,3 +267,90 @@ func TestNormalizedExponentialSampler_Deterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizedExponentialSampler_EdgeCases tests edge cases and validation.
+func TestNormalizedExponentialSampler_EdgeCases(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	t.Run("MinimalDuration", func(t *testing.T) {
+		// GIVEN durationUs == count (mean IAT = 1µs, minimum possible per-interval)
+		count := int64(1000)
+		durationUs := int64(1000)
+		sampler := NewNormalizedExponentialSampler(rng, count, durationUs)
+
+		// WHEN all intervals sampled
+		var sum int64
+		var allAtLeastOne bool = true
+		for i := int64(0); i < count; i++ {
+			iat := sampler.SampleIAT(nil)
+			if iat < 1 {
+				allAtLeastOne = false
+				t.Errorf("iat[%d] = %d, want >= 1", i, iat)
+			}
+			sum += iat
+		}
+
+		// THEN all IATs >= 1
+		if !allAtLeastOne {
+			t.Error("some IATs < 1")
+		}
+
+		// AND sum ≈ durationUs (within tolerance for flooring)
+		// Due to flooring to >= 1, the sum may exceed durationUs by up to count microseconds
+		if sum < durationUs || sum > durationUs+count {
+			t.Errorf("sum = %d, want in range [%d, %d]", sum, durationUs, durationUs+count)
+		}
+	})
+
+	t.Run("LargeCount", func(t *testing.T) {
+		// GIVEN a large count (1M requests)
+		count := int64(1_000_000)
+		durationUs := int64(3600_000_000) // 1 hour
+		sampler := NewNormalizedExponentialSampler(rng, count, durationUs)
+
+		// WHEN first few intervals sampled
+		iat1 := sampler.SampleIAT(nil)
+		iat2 := sampler.SampleIAT(nil)
+
+		// THEN all IATs >= 1
+		if iat1 < 1 || iat2 < 1 {
+			t.Errorf("IATs: %d, %d; want >= 1", iat1, iat2)
+		}
+	})
+
+	t.Run("PanicOnInvalidCount", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for count <= 0")
+			}
+		}()
+		NewNormalizedExponentialSampler(rng, 0, 1000)
+	})
+
+	t.Run("PanicOnInvalidDuration", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for durationUs <= 0")
+			}
+		}()
+		NewNormalizedExponentialSampler(rng, 100, 0)
+	})
+
+	t.Run("PanicOnExcessiveCount", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for count > 10M")
+			}
+		}()
+		NewNormalizedExponentialSampler(rng, 10_000_001, 3600_000_000)
+	})
+
+	t.Run("PanicOnDegenerateDistribution", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for durationUs < count")
+			}
+		}()
+		NewNormalizedExponentialSampler(rng, 1000, 999)
+	})
+}

--- a/sim/workload/arrival_test.go
+++ b/sim/workload/arrival_test.go
@@ -187,3 +187,83 @@ func TestConstantArrivalSampler_MinimumOneUs(t *testing.T) {
 		t.Errorf("SampleIAT = %d, want >= 1", iat)
 	}
 }
+
+// TestNormalizedExponentialSampler_Normalized verifies BC-1:
+// Sampler generates exactly count intervals with sum ≈ duration.
+func TestNormalizedExponentialSampler_Normalized(t *testing.T) {
+	// GIVEN a sampler with count=600, duration=60s (60M µs)
+	rng := rand.New(rand.NewSource(42))
+	count := int64(600)
+	durationUs := int64(60_000_000) // 60 seconds
+	sampler := NewNormalizedExponentialSampler(rng, count, durationUs)
+
+	// WHEN all 600 IATs are sampled
+	intervals := make([]int64, 0, count)
+	for {
+		iat := sampler.SampleIAT(nil) // RNG not used after construction
+		if iat == 0 {
+			break // Exhausted
+		}
+		intervals = append(intervals, iat)
+	}
+
+	// THEN exactly 600 intervals returned
+	if int64(len(intervals)) != count {
+		t.Fatalf("count = %d, want %d", len(intervals), count)
+	}
+
+	// AND sum ≈ 60,000,000 µs (within count microseconds for rounding)
+	sum := int64(0)
+	for _, iat := range intervals {
+		sum += iat
+	}
+	tolerance := count // At most 1µs error per interval from flooring
+	if sum < durationUs-tolerance || sum > durationUs+tolerance {
+		t.Errorf("sum = %d µs, want ≈ %d µs (within %d µs)", sum, durationUs, tolerance)
+	}
+
+	// AND all IATs >= 1
+	for i, iat := range intervals {
+		if iat < 1 {
+			t.Errorf("intervals[%d] = %d, want >= 1", i, iat)
+			break
+		}
+	}
+
+	// AND final SampleIAT returns 0 (exhausted)
+	finalIAT := sampler.SampleIAT(nil)
+	if finalIAT != 0 {
+		t.Errorf("SampleIAT after exhaustion = %d, want 0", finalIAT)
+	}
+}
+
+// TestNormalizedExponentialSampler_Deterministic verifies that same seed
+// produces identical intervals (INV-6: determinism).
+func TestNormalizedExponentialSampler_Deterministic(t *testing.T) {
+	// GIVEN two samplers with same seed, count, duration
+	seed := int64(42)
+	count := int64(100)
+	durationUs := int64(10_000_000) // 10 seconds
+
+	rng1 := rand.New(rand.NewSource(seed))
+	sampler1 := NewNormalizedExponentialSampler(rng1, count, durationUs)
+
+	rng2 := rand.New(rand.NewSource(seed))
+	sampler2 := NewNormalizedExponentialSampler(rng2, count, durationUs)
+
+	// WHEN all intervals are sampled from each
+	intervals1 := make([]int64, count)
+	intervals2 := make([]int64, count)
+	for i := int64(0); i < count; i++ {
+		intervals1[i] = sampler1.SampleIAT(nil)
+		intervals2[i] = sampler2.SampleIAT(nil)
+	}
+
+	// THEN intervals are byte-identical
+	for i := range intervals1 {
+		if intervals1[i] != intervals2[i] {
+			t.Errorf("interval[%d]: sampler1=%d, sampler2=%d (want identical)", i, intervals1[i], intervals2[i])
+			break
+		}
+	}
+}

--- a/sim/workload/cohort_test.go
+++ b/sim/workload/cohort_test.go
@@ -569,11 +569,11 @@ func TestCohortClientSpecFieldParity(t *testing.T) {
 	// Fields on ClientSpec that are intentionally absent from CohortSpec.
 	// ID: generated per member by ExpandCohorts.
 	// Lifecycle: synthesized from Diurnal/Spike/Drain by ExpandCohorts.
-	// CustomSampler: programmatic-only field, not exposed in YAML.
+	// CustomSamplerFactory: programmatic-only field, not exposed in YAML.
 	excluded := map[string]bool{
-		"ID":            true,
-		"Lifecycle":     true,
-		"CustomSampler": true,
+		"ID":                   true,
+		"Lifecycle":            true,
+		"CustomSamplerFactory": true,
 	}
 
 	for i := 0; i < clientType.NumField(); i++ {

--- a/sim/workload/cohort_test.go
+++ b/sim/workload/cohort_test.go
@@ -569,9 +569,11 @@ func TestCohortClientSpecFieldParity(t *testing.T) {
 	// Fields on ClientSpec that are intentionally absent from CohortSpec.
 	// ID: generated per member by ExpandCohorts.
 	// Lifecycle: synthesized from Diurnal/Spike/Drain by ExpandCohorts.
+	// CustomSampler: programmatic-only field, not exposed in YAML.
 	excluded := map[string]bool{
-		"ID":        true,
-		"Lifecycle": true,
+		"ID":            true,
+		"Lifecycle":     true,
+		"CustomSampler": true,
 	}
 
 	for i := 0; i < clientType.NumField(); i++ {

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -112,7 +112,12 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 		clientRNG := newRandFromSeed(clientSeed)
 
 		// Create samplers
-		arrivalSampler := NewArrivalSampler(client.Arrival, clientRate)
+		var arrivalSampler ArrivalSampler
+		if client.CustomSampler != nil {
+			arrivalSampler = client.CustomSampler
+		} else {
+			arrivalSampler = NewArrivalSampler(client.Arrival, clientRate)
+		}
 		inputSampler, err := NewLengthSampler(client.InputDist)
 		if err != nil {
 			return nil, fmt.Errorf("client %q input distribution: %w", client.ID, err)
@@ -250,6 +255,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 			}
 
 			iat := arrivalSampler.SampleIAT(clientRNG)
+			if iat == 0 {
+				break // Sampler exhausted
+			}
 			currentTime += iat
 			if currentTime >= horizon {
 				break

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -142,6 +142,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				// filter rounds against horizon. Models inference-perf's behavior
 				// where each client is one persistent session cycling through rounds.
 				iat := arrivalSampler.SampleIAT(clientRNG)
+				if iat == 0 {
+					continue // Sampler exhausted; skip this client
+				}
 				startTime := iat
 				// For clients with lifecycle windows, offset into the first window.
 				// The IAT sample provides staggering within the window.
@@ -199,6 +202,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 					break
 				}
 				iat := arrivalSampler.SampleIAT(clientRNG)
+				if iat == 0 {
+					break // Sampler exhausted; stop generating sessions for this client
+				}
 				currentTime += iat
 				if currentTime >= horizon {
 					break

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -113,8 +113,13 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 
 		// Create samplers
 		var arrivalSampler ArrivalSampler
-		if client.CustomSampler != nil {
-			arrivalSampler = client.CustomSampler
+		if client.CustomSamplerFactory != nil {
+			// Derive sub-RNG for factory with single entropy draw from clientRNG.
+			// This isolates the sampler's N-draw RNG consumption (for N pre-generated intervals)
+			// from downstream content sampling, keeping input/output distributions stable.
+			subSeed := clientRNG.Int63()
+			subRNG := newRandFromSeed(subSeed)
+			arrivalSampler = client.CustomSamplerFactory(subRNG)
 		} else {
 			arrivalSampler = NewArrivalSampler(client.Arrival, clientRate)
 		}
@@ -143,7 +148,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				// where each client is one persistent session cycling through rounds.
 				iat := arrivalSampler.SampleIAT(clientRNG)
 				if iat == 0 {
-					continue // Sampler exhausted; skip this client
+					// Stateful sampler exhausted (e.g., NormalizedExponentialSampler).
+					// Stateless samplers (Poisson, Gamma, etc.) never return 0.
+					continue
 				}
 				startTime := iat
 				// For clients with lifecycle windows, offset into the first window.
@@ -203,7 +210,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				}
 				iat := arrivalSampler.SampleIAT(clientRNG)
 				if iat == 0 {
-					break // Sampler exhausted; stop generating sessions for this client
+					// Stateful sampler exhausted (e.g., NormalizedExponentialSampler).
+					// Stateless samplers (Poisson, Gamma, etc.) never return 0.
+					break
 				}
 				currentTime += iat
 				if currentTime >= horizon {
@@ -262,7 +271,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 
 			iat := arrivalSampler.SampleIAT(clientRNG)
 			if iat == 0 {
-				break // Sampler exhausted
+				// Stateful sampler exhausted (e.g., NormalizedExponentialSampler).
+				// Stateless samplers (Poisson, Gamma, etc.) never return 0.
+				break
 			}
 			currentTime += iat
 			if currentTime >= horizon {

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -1640,5 +1641,61 @@ func TestGenerateRequests_MutualExclusion_CohortsWithInferencePerf_Allowed(t *te
 	}
 	if len(reqs) == 0 {
 		t.Error("expected requests from Cohorts + InferencePerf composition")
+	}
+}
+
+// mockSampler returns fixed intervals for testing CustomSampler
+type mockSampler struct {
+	intervals []int64
+	index     int
+}
+
+func (m *mockSampler) SampleIAT(_ *rand.Rand) int64 {
+	if m.index >= len(m.intervals) {
+		return 0 // Exhausted
+	}
+	iat := m.intervals[m.index]
+	m.index++
+	return iat
+}
+
+func TestClientSpec_CustomSampler(t *testing.T) {
+	// Create a mock sampler that returns 3 fixed intervals
+	mock := &mockSampler{intervals: []int64{100000, 200000, 300000}} // 100ms, 200ms, 300ms
+
+	spec := &WorkloadSpec{
+		Version:       "1",
+		Seed:          42,
+		Category:      "language",
+		AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID:            "c1",
+			TenantID:      "t1",
+			SLOClass:      "batch",
+			RateFraction:  1.0,
+			Arrival:       ArrivalSpec{Process: "poisson"}, // Will be ignored
+			CustomSampler: mock,                            // This will be used instead
+			InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
+			OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
+		}},
+	}
+	horizon := int64(1e9) // 1000 seconds (large enough for all 3 requests)
+
+	requests, err := GenerateRequests(spec, horizon, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should generate exactly 3 requests (mock returns 3 intervals then 0)
+	if len(requests) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(requests))
+	}
+
+	// Verify arrival times match mock intervals (cumulative)
+	expectedTimes := []int64{100000, 300000, 600000} // 100ms, 300ms (100+200), 600ms (100+200+300)
+	for i, req := range requests {
+		if req.ArrivalTime != expectedTimes[i] {
+			t.Errorf("request %d: ArrivalTime = %d, want %d", i, req.ArrivalTime, expectedTimes[i])
+		}
 	}
 }

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -1644,7 +1644,7 @@ func TestGenerateRequests_MutualExclusion_CohortsWithInferencePerf_Allowed(t *te
 	}
 }
 
-// mockSampler returns fixed intervals for testing CustomSampler
+// mockSampler returns fixed intervals for testing CustomSamplerFactory
 type mockSampler struct {
 	intervals []int64
 	index     int
@@ -1660,8 +1660,10 @@ func (m *mockSampler) SampleIAT(_ *rand.Rand) int64 {
 }
 
 func TestClientSpec_CustomSampler(t *testing.T) {
-	// Create a mock sampler that returns 3 fixed intervals
-	mock := &mockSampler{intervals: []int64{100000, 200000, 300000}} // 100ms, 200ms, 300ms
+	// Create a factory that returns a fresh mock sampler on each call
+	factory := func(_ *rand.Rand) ArrivalSampler {
+		return &mockSampler{intervals: []int64{100000, 200000, 300000}} // 100ms, 200ms, 300ms
+	}
 
 	spec := &WorkloadSpec{
 		Version:       "1",
@@ -1669,14 +1671,14 @@ func TestClientSpec_CustomSampler(t *testing.T) {
 		Category:      "language",
 		AggregateRate: 10.0,
 		Clients: []ClientSpec{{
-			ID:            "c1",
-			TenantID:      "t1",
-			SLOClass:      "batch",
-			RateFraction:  1.0,
-			Arrival:       ArrivalSpec{Process: "poisson"}, // Will be ignored
-			CustomSampler: mock,                            // This will be used instead
-			InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
-			OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
+			ID:                   "c1",
+			TenantID:             "t1",
+			SLOClass:             "batch",
+			RateFraction:         1.0,
+			Arrival:              ArrivalSpec{Process: "poisson"}, // Will be ignored
+			CustomSamplerFactory: factory,                         // This will be used instead
+			InputDist:            DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
+			OutputDist:           DistSpec{Type: "constant", Params: map[string]float64{"value": 10}},
 		}},
 	}
 	horizon := int64(1e9) // 1000 seconds (large enough for all 3 requests)
@@ -1704,8 +1706,10 @@ func TestClientSpec_CustomSampler(t *testing.T) {
 // exhaustion signal from stateful samplers (e.g., NormalizedExponentialSampler).
 func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
 	t.Run("SingleSessionReasoning", func(t *testing.T) {
-		// GIVEN a client with CustomSampler that returns 0 immediately (exhausted)
-		exhaustedSampler := &mockSampler{intervals: []int64{0}}
+		// GIVEN a client with CustomSamplerFactory that returns 0 immediately (exhausted)
+		factory := func(_ *rand.Rand) ArrivalSampler {
+			return &mockSampler{intervals: []int64{0}}
+		}
 		spec := &WorkloadSpec{
 			Version:       "1",
 			Seed:          42,
@@ -1713,13 +1717,13 @@ func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
 			AggregateRate: 10.0,
 			Clients: []ClientSpec{
 				{
-					ID:            "client-1",
-					TenantID:      "t1",
-					SLOClass:      "batch",
-					RateFraction:  1.0,
-					CustomSampler: exhaustedSampler,
-					InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
-					OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+					ID:                   "client-1",
+					TenantID:             "t1",
+					SLOClass:             "batch",
+					RateFraction:         1.0,
+					CustomSamplerFactory: factory,
+					InputDist:            DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+					OutputDist:           DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
 					Reasoning: &ReasoningSpec{
 						MultiTurn: &MultiTurnSpec{
 							MaxRounds:     5,
@@ -1745,8 +1749,10 @@ func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
 	})
 
 	t.Run("MultiSessionReasoning", func(t *testing.T) {
-		// GIVEN a client with CustomSampler that returns 2 IATs then exhausts
-		exhaustedSampler := &mockSampler{intervals: []int64{100_000, 200_000, 0}}
+		// GIVEN a client with CustomSamplerFactory that returns 2 IATs then exhausts
+		factory := func(_ *rand.Rand) ArrivalSampler {
+			return &mockSampler{intervals: []int64{100_000, 200_000, 0}}
+		}
 		spec := &WorkloadSpec{
 			Version:       "1",
 			Seed:          42,
@@ -1754,13 +1760,13 @@ func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
 			AggregateRate: 10.0,
 			Clients: []ClientSpec{
 				{
-					ID:            "client-1",
-					TenantID:      "t1",
-					SLOClass:      "batch",
-					RateFraction:  1.0,
-					CustomSampler: exhaustedSampler,
-					InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
-					OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+					ID:                   "client-1",
+					TenantID:             "t1",
+					SLOClass:             "batch",
+					RateFraction:         1.0,
+					CustomSamplerFactory: factory,
+					InputDist:            DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+					OutputDist:           DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
 					Reasoning: &ReasoningSpec{
 						MultiTurn: &MultiTurnSpec{
 							MaxRounds:     3,
@@ -1787,10 +1793,12 @@ func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
 	})
 }
 
-// TestCustomSampler_ReasoningIntegration tests CustomSampler with reasoning clients.
+// TestCustomSampler_ReasoningIntegration tests CustomSamplerFactory with reasoning clients.
 func TestCustomSampler_ReasoningIntegration(t *testing.T) {
-	// GIVEN a client with CustomSampler and reasoning enabled
-	sampler := &mockSampler{intervals: []int64{100_000, 200_000, 300_000}}
+	// GIVEN a client with CustomSamplerFactory and reasoning enabled
+	factory := func(_ *rand.Rand) ArrivalSampler {
+		return &mockSampler{intervals: []int64{100_000, 200_000, 300_000}}
+	}
 	spec := &WorkloadSpec{
 		Version:       "1",
 		Seed:          42,
@@ -1798,13 +1806,13 @@ func TestCustomSampler_ReasoningIntegration(t *testing.T) {
 		AggregateRate: 10.0,
 		Clients: []ClientSpec{
 			{
-				ID:            "client-1",
-				TenantID:      "t1",
-				SLOClass:      "batch",
-				RateFraction:  1.0,
-				CustomSampler: sampler,
-				InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 128}},
-				OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 64}},
+				ID:                   "client-1",
+				TenantID:             "t1",
+				SLOClass:             "batch",
+				RateFraction:         1.0,
+				CustomSamplerFactory: factory,
+				InputDist:            DistSpec{Type: "constant", Params: map[string]float64{"value": 128}},
+				OutputDist:           DistSpec{Type: "constant", Params: map[string]float64{"value": 64}},
 				Reasoning: &ReasoningSpec{
 					MultiTurn: &MultiTurnSpec{
 						MaxRounds:     2,

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -1699,3 +1699,145 @@ func TestClientSpec_CustomSampler(t *testing.T) {
 		}
 	}
 }
+
+// TestCustomSampler_ZeroIATExhaustion tests that generator handles zero-IAT
+// exhaustion signal from stateful samplers (e.g., NormalizedExponentialSampler).
+func TestCustomSampler_ZeroIATExhaustion(t *testing.T) {
+	t.Run("SingleSessionReasoning", func(t *testing.T) {
+		// GIVEN a client with CustomSampler that returns 0 immediately (exhausted)
+		exhaustedSampler := &mockSampler{intervals: []int64{0}}
+		spec := &WorkloadSpec{
+			Version:       "1",
+			Seed:          42,
+			Category:      "language",
+			AggregateRate: 10.0,
+			Clients: []ClientSpec{
+				{
+					ID:            "client-1",
+					TenantID:      "t1",
+					SLOClass:      "batch",
+					RateFraction:  1.0,
+					CustomSampler: exhaustedSampler,
+					InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+					OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+					Reasoning: &ReasoningSpec{
+						MultiTurn: &MultiTurnSpec{
+							MaxRounds:     5,
+							ThinkTimeUs:   100_000, // 100ms
+							SingleSession: true,
+						},
+					},
+				},
+			},
+		}
+		horizon := int64(3600_000_000) // 1 hour
+
+		// WHEN requests are generated
+		requests, err := GenerateRequests(spec, horizon, 0)
+
+		// THEN no error, and zero requests generated (sampler exhausted before first arrival)
+		if err != nil {
+			t.Fatalf("GenerateRequests failed: %v", err)
+		}
+		if len(requests) != 0 {
+			t.Errorf("expected 0 requests (exhausted sampler), got %d", len(requests))
+		}
+	})
+
+	t.Run("MultiSessionReasoning", func(t *testing.T) {
+		// GIVEN a client with CustomSampler that returns 2 IATs then exhausts
+		exhaustedSampler := &mockSampler{intervals: []int64{100_000, 200_000, 0}}
+		spec := &WorkloadSpec{
+			Version:       "1",
+			Seed:          42,
+			Category:      "language",
+			AggregateRate: 10.0,
+			Clients: []ClientSpec{
+				{
+					ID:            "client-1",
+					TenantID:      "t1",
+					SLOClass:      "batch",
+					RateFraction:  1.0,
+					CustomSampler: exhaustedSampler,
+					InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+					OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+					Reasoning: &ReasoningSpec{
+						MultiTurn: &MultiTurnSpec{
+							MaxRounds:     3,
+							ThinkTimeUs:   50_000, // 50ms
+							SingleSession: false,
+						},
+					},
+				},
+			},
+		}
+		horizon := int64(3600_000_000) // 1 hour
+
+		// WHEN requests are generated
+		requests, err := GenerateRequests(spec, horizon, 0)
+
+		// THEN no error, and exactly 2 sessions generated (3 rounds each = 6 requests)
+		if err != nil {
+			t.Fatalf("GenerateRequests failed: %v", err)
+		}
+		expectedRequests := 2 * 3 // 2 sessions * 3 rounds each
+		if len(requests) != expectedRequests {
+			t.Errorf("expected %d requests, got %d", expectedRequests, len(requests))
+		}
+	})
+}
+
+// TestCustomSampler_ReasoningIntegration tests CustomSampler with reasoning clients.
+func TestCustomSampler_ReasoningIntegration(t *testing.T) {
+	// GIVEN a client with CustomSampler and reasoning enabled
+	sampler := &mockSampler{intervals: []int64{100_000, 200_000, 300_000}}
+	spec := &WorkloadSpec{
+		Version:       "1",
+		Seed:          42,
+		Category:      "language",
+		AggregateRate: 10.0,
+		Clients: []ClientSpec{
+			{
+				ID:            "client-1",
+				TenantID:      "t1",
+				SLOClass:      "batch",
+				RateFraction:  1.0,
+				CustomSampler: sampler,
+				InputDist:     DistSpec{Type: "constant", Params: map[string]float64{"value": 128}},
+				OutputDist:    DistSpec{Type: "constant", Params: map[string]float64{"value": 64}},
+				Reasoning: &ReasoningSpec{
+					MultiTurn: &MultiTurnSpec{
+						MaxRounds:     2,
+						ThinkTimeUs:   10_000, // 10ms
+						SingleSession: false,
+					},
+				},
+			},
+		},
+	}
+	horizon := int64(3600_000_000)
+
+	// WHEN requests are generated
+	requests, err := GenerateRequests(spec, horizon, 0)
+
+	// THEN no error, and 3 sessions * 2 rounds = 6 requests
+	if err != nil {
+		t.Fatalf("GenerateRequests failed: %v", err)
+	}
+	expectedRequests := 3 * 2
+	if len(requests) != expectedRequests {
+		t.Errorf("expected %d requests, got %d", expectedRequests, len(requests))
+	}
+
+	// AND each session's rounds are spaced by ThinkTimeUs
+	// (We can't verify exact spacing here since CompletionTime is set by the simulator,
+	// so we just verify that round2.ArrivalTime > round1.ArrivalTime)
+	for i := 0; i < 3; i++ { // 3 sessions
+		round1 := requests[i*2]
+		round2 := requests[i*2+1]
+		if round2.ArrivalTime <= round1.ArrivalTime {
+			t.Errorf("session %d: round2 arrival (%d) should be after round1 arrival (%d)",
+				i, round2.ArrivalTime, round1.ArrivalTime)
+		}
+	}
+}

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -165,30 +165,30 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 				return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
 			}
 
-			// Use a base RNG to derive per-client seeds (avoids sequential offset correlation)
-			baseRNG := rand.New(rand.NewSource(seed))
+			// Create factory closure that captures requestsPerClient and durationUs.
+			// Each GenerateRequests call will invoke this factory with a sub-RNG,
+			// producing a fresh sampler instance (workload reusability).
+			factory := func(rng *rand.Rand) ArrivalSampler {
+				return NewNormalizedExponentialSampler(rng, requestsPerClient, durationUs)
+			}
 
 			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 				prefixGroup := fmt.Sprintf("prompt-%d", p)
 				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 					clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
-					// Derive client-specific seed from base RNG for proper isolation
-					clientSeed := baseRNG.Int63()
-					clientRNG := rand.New(rand.NewSource(clientSeed))
-					sampler := NewNormalizedExponentialSampler(clientRNG, requestsPerClient, durationUs)
 
 					clients = append(clients, ClientSpec{
-						ID:            clientID,
-						TenantID:      prefixGroup,
-						SLOClass:      "batch",
-						RateFraction:  rateFraction,
-						Arrival:       ArrivalSpec{Process: "poisson"}, // Fallback for diagnostics/serialization
-						CustomSampler: sampler,
-						InputDist:     inputDist,
-						OutputDist:    outputDist,
-						PrefixGroup:   prefixGroup,
-						PrefixLength:  sp.SystemPromptLen,
-						Reasoning:     reasoning,
+						ID:                   clientID,
+						TenantID:             prefixGroup,
+						SLOClass:             "batch",
+						RateFraction:         rateFraction,
+						Arrival:              ArrivalSpec{Process: "poisson"}, // Fallback for diagnostics/serialization
+						CustomSamplerFactory: factory,
+						InputDist:            inputDist,
+						OutputDist:           outputDist,
+						PrefixGroup:          prefixGroup,
+						PrefixLength:         sp.SystemPromptLen,
+						Reasoning:            reasoning,
 					})
 				}
 			}

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -201,6 +201,14 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 		// Math: aggregateRate = sum(stageRates), rateFraction = stageRate/numClientsPerStage.
 		// After normalization, each client's rate = stageRate/numClientsPerStage.
 		// During a stage, N*M clients are active → total rate = stageRate.
+		//
+		// NOTE: Multi-stage workloads use Poisson (not NormalizedExponentialSampler).
+		// Rationale: NormalizedExponentialSampler pre-generates intervals spanning the
+		// full workload duration, but per-stage clients are only active during their
+		// stage's window (a subset of the full duration). This mismatch would waste
+		// intervals or require complex windowing. Poisson generates incrementally
+		// during the active window, matching the per-stage lifecycle architecture.
+		// See BC-4 in plan for full details.
 		windows := stagesToWindows(spec.Stages)
 
 		for _, stage := range spec.Stages {

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -115,53 +115,82 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 			reasoning = computeReasoningSpec(stage.Rate, stage.Duration, numClientsPerStage)
 		}
 
-		// Each client gets exactly ceil(stageRate * duration / numClients) requests
-		// over the stage duration, using normalized exponential distribution.
-		// NOTE: math.Ceil means total requests may exceed stage.Rate * stage.Duration
-		// by up to numClients-1. This matches inference-perf behavior.
-		requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
-		durationUs := stage.Duration * 1_000_000 // seconds to microseconds
+		// For multi-turn (reasoning) workloads, use Poisson arrival for session start time.
+		// The rounds within each session are spaced by ThinkTimeUs (not sampled IATs).
+		// NormalizedExponentialSampler only applies to non-reasoning (language) workloads
+		// where each request is independent (not part of a multi-round session).
+		if sp.EnableMultiTurnChat {
+			// Multi-turn: use Poisson, rounds controlled by MaxRounds + ThinkTimeUs
+			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
+				prefixGroup := fmt.Sprintf("prompt-%d", p)
+				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
+					clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
+					clients = append(clients, ClientSpec{
+						ID:           clientID,
+						TenantID:     prefixGroup,
+						SLOClass:     "batch",
+						RateFraction: rateFraction,
+						Arrival:      ArrivalSpec{Process: "poisson"},
+						InputDist:    inputDist,
+						OutputDist:   outputDist,
+						PrefixGroup:  prefixGroup,
+						PrefixLength: sp.SystemPromptLen,
+						Reasoning:    reasoning,
+					})
+				}
+			}
+		} else {
+			// Single-request (language) workload: use NormalizedExponentialSampler
+			// Each client gets exactly ceil(stageRate * duration / numClients) requests
+			// over the stage duration, using normalized exponential distribution.
+			// NOTE: math.Ceil means total requests may exceed stage.Rate * stage.Duration
+			// by up to numClients-1. This matches inference-perf behavior.
+			requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
+			durationUs := stage.Duration * 1_000_000 // seconds to microseconds
 
-		// Validate sampler parameters before construction (prevent panic on user input)
-		if requestsPerClient <= 0 {
-			return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
-		}
-		if requestsPerClient > 10_000_000 {
-			return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)
-		}
-		if durationUs < requestsPerClient {
-			return nil, fmt.Errorf("inference_perf: durationUs (%d) < requestsPerClient (%d) produces degenerate distribution", durationUs, requestsPerClient)
-		}
+			// Validate sampler parameters before construction (prevent panic on user input)
+			if requestsPerClient <= 0 {
+				return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
+			}
+			if requestsPerClient > 10_000_000 {
+				return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)
+			}
+			if durationUs < requestsPerClient {
+				return nil, fmt.Errorf("inference_perf: durationUs (%d) < requestsPerClient (%d) produces degenerate distribution", durationUs, requestsPerClient)
+			}
 
-		// Defensive: prevent integer overflow in seed calculation (cast before multiply)
-		totalClients := int64(sp.NumUniqueSystemPrompts) * int64(sp.NumUsersPerSystemPrompt)
-		if totalClients > 1_000_000 {
-			return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
-		}
+			// Defensive: prevent integer overflow in seed calculation (cast before multiply)
+			totalClients := int64(sp.NumUniqueSystemPrompts) * int64(sp.NumUsersPerSystemPrompt)
+			if totalClients > 1_000_000 {
+				return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
+			}
 
-		for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
-			prefixGroup := fmt.Sprintf("prompt-%d", p)
-			for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
-				clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
-				// Derive client-specific RNG from seed, prompt, and user index
-				clientOffset := int64(p*sp.NumUsersPerSystemPrompt + u)
-				clientSeed := seed + clientOffset
-				clientRNG := rand.New(rand.NewSource(clientSeed))
-				sampler := NewNormalizedExponentialSampler(clientRNG, requestsPerClient, durationUs)
+			// Use a base RNG to derive per-client seeds (avoids sequential offset correlation)
+			baseRNG := rand.New(rand.NewSource(seed))
 
-				clients = append(clients, ClientSpec{
-					ID:            clientID,
-					TenantID:      prefixGroup,
-					SLOClass:      "batch",
-					RateFraction:  rateFraction,
-					CustomSampler: sampler,
-				Arrival:       ArrivalSpec{Process: "poisson"}, // Fallback for diagnostics/serialization
-					InputDist:     inputDist,
-					OutputDist:    outputDist,
-					PrefixGroup:   prefixGroup,
-					PrefixLength:  sp.SystemPromptLen,
-					Reasoning:     reasoning,
-				})
+			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
+				prefixGroup := fmt.Sprintf("prompt-%d", p)
+				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
+					clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
+					// Derive client-specific seed from base RNG for proper isolation
+					clientSeed := baseRNG.Int63()
+					clientRNG := rand.New(rand.NewSource(clientSeed))
+					sampler := NewNormalizedExponentialSampler(clientRNG, requestsPerClient, durationUs)
+
+					clients = append(clients, ClientSpec{
+						ID:            clientID,
+						TenantID:      prefixGroup,
+						SLOClass:      "batch",
+						RateFraction:  rateFraction,
+						Arrival:       ArrivalSpec{Process: "poisson"}, // Fallback for diagnostics/serialization
+						CustomSampler: sampler,
+						InputDist:     inputDist,
+						OutputDist:    outputDist,
+						PrefixGroup:   prefixGroup,
+						PrefixLength:  sp.SystemPromptLen,
+						Reasoning:     reasoning,
+					})
+				}
 			}
 		}
 	} else {

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -117,13 +117,24 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 		// Each client gets exactly ceil(stageRate * duration / numClients) requests
 		// over the stage duration, using normalized exponential distribution.
-		// NOTE: Math.Ceil means total requests may exceed stage.Rate * stage.Duration
+		// NOTE: math.Ceil means total requests may exceed stage.Rate * stage.Duration
 		// by up to numClients-1. This matches inference-perf behavior.
 		requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
 		durationUs := stage.Duration * 1_000_000 // seconds to microseconds
 
-		// Defensive: prevent integer overflow in seed calculation
-		totalClients := int64(sp.NumUniqueSystemPrompts * sp.NumUsersPerSystemPrompt)
+		// Validate sampler parameters before construction (prevent panic on user input)
+		if requestsPerClient <= 0 {
+			return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
+		}
+		if requestsPerClient > 10_000_000 {
+			return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)
+		}
+		if durationUs < requestsPerClient {
+			return nil, fmt.Errorf("inference_perf: durationUs (%d) < requestsPerClient (%d) produces degenerate distribution", durationUs, requestsPerClient)
+		}
+
+		// Defensive: prevent integer overflow in seed calculation (cast before multiply)
+		totalClients := int64(sp.NumUniqueSystemPrompts) * int64(sp.NumUsersPerSystemPrompt)
 		if totalClients > 1_000_000 {
 			return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
 		}
@@ -144,6 +155,7 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 					SLOClass:      "batch",
 					RateFraction:  rateFraction,
 					CustomSampler: sampler,
+				Arrival:       ArrivalSpec{Process: "poisson"}, // Fallback for diagnostics/serialization
 					InputDist:     inputDist,
 					OutputDist:    outputDist,
 					PrefixGroup:   prefixGroup,

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -103,7 +103,8 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 	if len(spec.Stages) == 1 {
 		// Single stage: no lifecycle windows needed.
-		// Use normalized exponential arrival for inference-perf parity.
+		// Use NormalizedExponentialSampler for inference-perf parity:
+		// each client pre-generates N intervals that sum exactly to stage duration.
 		stage := spec.Stages[0]
 		aggregateRate = stage.Rate
 		rateFraction := 1.0 / float64(numClientsPerStage)
@@ -116,15 +117,24 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 		// Each client gets exactly ceil(stageRate * duration / numClients) requests
 		// over the stage duration, using normalized exponential distribution.
+		// NOTE: Math.Ceil means total requests may exceed stage.Rate * stage.Duration
+		// by up to numClients-1. This matches inference-perf behavior.
 		requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
 		durationUs := stage.Duration * 1_000_000 // seconds to microseconds
+
+		// Defensive: prevent integer overflow in seed calculation
+		totalClients := int64(sp.NumUniqueSystemPrompts * sp.NumUsersPerSystemPrompt)
+		if totalClients > 1_000_000 {
+			return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
+		}
 
 		for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 			prefixGroup := fmt.Sprintf("prompt-%d", p)
 			for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 				clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
 				// Derive client-specific RNG from seed, prompt, and user index
-				clientSeed := seed + int64(p*sp.NumUsersPerSystemPrompt+u)
+				clientOffset := int64(p*sp.NumUsersPerSystemPrompt + u)
+				clientSeed := seed + clientOffset
 				clientRNG := rand.New(rand.NewSource(clientSeed))
 				sampler := NewNormalizedExponentialSampler(clientRNG, requestsPerClient, durationUs)
 

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"fmt"
 	"math"
+	"math/rand"
 )
 
 // InferencePerfSpec defines an inference-perf style workload using a compact
@@ -102,6 +103,7 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 	if len(spec.Stages) == 1 {
 		// Single stage: no lifecycle windows needed.
+		// Use normalized exponential arrival for inference-perf parity.
 		stage := spec.Stages[0]
 		aggregateRate = stage.Rate
 		rateFraction := 1.0 / float64(numClientsPerStage)
@@ -112,21 +114,31 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 			reasoning = computeReasoningSpec(stage.Rate, stage.Duration, numClientsPerStage)
 		}
 
+		// Each client gets exactly ceil(stageRate * duration / numClients) requests
+		// over the stage duration, using normalized exponential distribution.
+		requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
+		durationUs := stage.Duration * 1_000_000 // seconds to microseconds
+
 		for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 			prefixGroup := fmt.Sprintf("prompt-%d", p)
 			for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 				clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
+				// Derive client-specific RNG from seed, prompt, and user index
+				clientSeed := seed + int64(p*sp.NumUsersPerSystemPrompt+u)
+				clientRNG := rand.New(rand.NewSource(clientSeed))
+				sampler := NewNormalizedExponentialSampler(clientRNG, requestsPerClient, durationUs)
+
 				clients = append(clients, ClientSpec{
-					ID:           clientID,
-					TenantID:     prefixGroup,
-					SLOClass:     "batch",
-					RateFraction: rateFraction,
-					Arrival:      ArrivalSpec{Process: "poisson"},
-					InputDist:    inputDist,
-					OutputDist:   outputDist,
-					PrefixGroup:  prefixGroup,
-					PrefixLength: sp.SystemPromptLen,
-					Reasoning:    reasoning,
+					ID:            clientID,
+					TenantID:      prefixGroup,
+					SLOClass:      "batch",
+					RateFraction:  rateFraction,
+					CustomSampler: sampler,
+					InputDist:     inputDist,
+					OutputDist:    outputDist,
+					PrefixGroup:   prefixGroup,
+					PrefixLength:  sp.SystemPromptLen,
+					Reasoning:     reasoning,
 				})
 			}
 		}

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -848,7 +848,7 @@ inference_perf:
 
 func TestInferencePerfExpansion_EquivalentToManual(t *testing.T) {
 	// Acceptance criterion: two expansions with same seed produce identical results.
-	// With CustomSampler (stateful), we need fresh expansions for each run.
+	// CustomSamplerFactory ensures fresh sampler instances for each GenerateRequests call.
 
 	ipSpec := &InferencePerfSpec{
 		Stages: []StageSpec{
@@ -1479,7 +1479,7 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedDeterministic(t *testing.
 
 func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
 	// BC-4: Multi-stage expansion still uses Poisson arrival (for now).
-	// Verify that clients have Arrival field set (not CustomSampler).
+	// Verify that clients have Arrival field set (not CustomSamplerFactory).
 	ipSpec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 8.0, Duration: 10},
@@ -1505,8 +1505,8 @@ func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
 		if client.Arrival.Process != "poisson" {
 			t.Errorf("client %d: arrival process = %q, want poisson", i, client.Arrival.Process)
 		}
-		if client.CustomSampler != nil {
-			t.Errorf("client %d: CustomSampler should be nil (using Poisson)", i)
+		if client.CustomSamplerFactory != nil {
+			t.Errorf("client %d: CustomSamplerFactory should be nil (using Poisson)", i)
 		}
 	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1,6 +1,8 @@
 package workload
 
 import (
+	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1465,5 +1467,72 @@ func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
 		if client.CustomSampler != nil {
 			t.Errorf("client %d: CustomSampler should be nil (using Poisson)", i)
 		}
+	}
+}
+
+func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T) {
+	// Invariant test: sum(per_client_requests) == total expected requests
+	// Tests the conservation law that requestsPerClient allocation sums correctly.
+	cases := []struct {
+		rate       float64
+		duration   int64
+		numPrompts int
+		numUsers   int
+	}{
+		{rate: 10.0, duration: 60, numPrompts: 3, numUsers: 2},  // 600 total / 6 clients = 100 each
+		{rate: 10.0, duration: 61, numPrompts: 2, numUsers: 2},  // 610 total / 4 clients = ceil(152.5)=153 each
+		{rate: 5.0, duration: 100, numPrompts: 1, numUsers: 7},  // 500 total / 7 clients
+		{rate: 100.0, duration: 10, numPrompts: 10, numUsers: 3}, // 1000 total / 30 clients
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("rate=%.0f_dur=%d_clients=%dx%d", tc.rate, tc.duration, tc.numPrompts, tc.numUsers), func(t *testing.T) {
+			ipSpec := &InferencePerfSpec{
+				Stages: []StageSpec{
+					{Rate: tc.rate, Duration: tc.duration},
+				},
+				SharedPrefix: &SharedPrefixSpec{
+					NumUniqueSystemPrompts:  tc.numPrompts,
+					NumUsersPerSystemPrompt: tc.numUsers,
+					SystemPromptLen:         10,
+					QuestionLen:             10,
+					OutputLen:               10,
+				},
+			}
+			expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+			if err != nil {
+				t.Fatalf("expansion error: %v", err)
+			}
+
+			horizon := tc.duration * 1_000_000
+			requests, err := GenerateRequests(expanded, horizon, 0)
+			if err != nil {
+				t.Fatalf("generation error: %v", err)
+			}
+
+			// Count requests per client ID
+			perClientCounts := make(map[string]int)
+			for _, req := range requests {
+				perClientCounts[req.ClientID]++
+			}
+
+			// Expected: each client gets ceil(rate * duration / numClients) requests
+			numClients := tc.numPrompts * tc.numUsers
+			expectedPerClient := int(math.Ceil(tc.rate * float64(tc.duration) / float64(numClients)))
+
+			// Verify each client got exactly expectedPerClient requests
+			for clientID, count := range perClientCounts {
+				if count != expectedPerClient {
+					t.Errorf("client %s: got %d requests, want %d", clientID, count, expectedPerClient)
+				}
+			}
+
+			// Verify sum equals numClients * expectedPerClient (conservation)
+			expectedTotal := numClients * expectedPerClient
+			if len(requests) != expectedTotal {
+				t.Errorf("total requests = %d, want %d (conservation: %d clients * %d each)",
+					len(requests), expectedTotal, numClients, expectedPerClient)
+			}
+		})
 	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -845,10 +845,9 @@ inference_perf:
 // --- Equivalence tests (Task 7) ---
 
 func TestInferencePerfExpansion_EquivalentToManual(t *testing.T) {
-	// Acceptance criterion: shorthand and manual expansion produce identical requests.
-	// Build equivalent specs and compare generated request sequences.
+	// Acceptance criterion: two expansions with same seed produce identical results.
+	// With CustomSampler (stateful), we need fresh expansions for each run.
 
-	// Shorthand spec
 	ipSpec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 10.0, Duration: 10},
@@ -861,36 +860,31 @@ func TestInferencePerfExpansion_EquivalentToManual(t *testing.T) {
 			OutputLen:               50,
 		},
 	}
-	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	horizon := int64(10_000_000) // 10 seconds
+
+	// First expansion and generation
+	expanded1, err := ExpandInferencePerfSpec(ipSpec, 42)
 	if err != nil {
 		t.Fatalf("expansion error: %v", err)
 	}
-
-	// Manual spec: construct the same clients explicitly
-	manual := &WorkloadSpec{
-		Version:       expanded.Version,
-		Seed:          expanded.Seed,
-		Category:      expanded.Category,
-		AggregateRate: expanded.AggregateRate,
-		Clients:       expanded.Clients, // use the expanded clients directly
-	}
-
-	horizon := int64(10_000_000) // 10 seconds
-
-	// Generate from expanded
-	r1, err1 := GenerateRequests(expanded, horizon, 0)
+	r1, err1 := GenerateRequests(expanded1, horizon, 0)
 	if err1 != nil {
-		t.Fatalf("expanded generation error: %v", err1)
+		t.Fatalf("generation error: %v", err1)
 	}
 
-	// Generate from manual (same clients)
-	r2, err2 := GenerateRequests(manual, horizon, 0)
+	// Second expansion with same seed (fresh samplers)
+	expanded2, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	r2, err2 := GenerateRequests(expanded2, horizon, 0)
 	if err2 != nil {
-		t.Fatalf("manual generation error: %v", err2)
+		t.Fatalf("generation error: %v", err2)
 	}
 
+	// Verify identical output
 	if len(r1) != len(r2) {
-		t.Fatalf("different request counts: expanded=%d, manual=%d", len(r1), len(r2))
+		t.Fatalf("different request counts: %d vs %d", len(r1), len(r2))
 	}
 
 	for i := range r1 {
@@ -1343,6 +1337,133 @@ func TestGenerateRequests_InferencePerfSpec_MultiTurnMultiStage_Integration(t *t
 		if ratio < 0.3 || ratio > 0.7 {
 			t.Errorf("stage ratio = %.3f (s0=%d, s1=%d), want ~0.5 (±0.2)",
 				ratio, stage0Count, stage1Count)
+		}
+	}
+}
+
+// --- NormalizedExponentialSampler integration tests (Task 3) ---
+
+func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T) {
+	// BC-2: Single-stage expansion uses normalized exponential and produces
+	// exactly ceil(rate*duration/numClients) requests per client, summing to
+	// the stage duration.
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 10.0, Duration: 60}, // 10 req/s for 60s = 600 total requests
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  3,
+			NumUsersPerSystemPrompt: 2,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	// 3*2 = 6 clients, each should get ceil(600/6) = 100 requests
+	horizon := int64(60_000_000) // 60 seconds in µs
+	requests, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+	// Total requests should be exactly 600
+	if len(requests) != 600 {
+		t.Errorf("request count = %d, want 600", len(requests))
+	}
+	// Verify all arrivals are within the stage duration
+	for i, req := range requests {
+		if req.ArrivalTime < 0 || req.ArrivalTime >= horizon {
+			t.Errorf("request %d: arrival time %d µs outside [0, %d) µs",
+				i, req.ArrivalTime, horizon)
+		}
+	}
+}
+
+func TestExpandInferencePerfSpec_SingleStage_NormalizedDeterministic(t *testing.T) {
+	// BC-3: Same seed produces byte-identical expansion.
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 10.0, Duration: 10},
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  2,
+			NumUsersPerSystemPrompt: 2,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+		},
+	}
+	horizon := int64(10_000_000) // 10 seconds in µs
+
+	// First run
+	expanded1, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	r1, err := GenerateRequests(expanded1, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+
+	// Second run with same seed
+	expanded2, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	r2, err := GenerateRequests(expanded2, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+
+	// Verify identical output
+	if len(r1) != len(r2) {
+		t.Fatalf("different request counts: %d vs %d", len(r1), len(r2))
+	}
+	for i := range r1 {
+		if r1[i].ArrivalTime != r2[i].ArrivalTime {
+			t.Errorf("request %d: arrival %d vs %d", i, r1[i].ArrivalTime, r2[i].ArrivalTime)
+			break
+		}
+		if r1[i].ID != r2[i].ID {
+			t.Errorf("request %d: ID %q vs %q", i, r1[i].ID, r2[i].ID)
+			break
+		}
+	}
+}
+
+func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
+	// BC-4: Multi-stage expansion still uses Poisson arrival (for now).
+	// Verify that clients have Arrival field set (not CustomSampler).
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 8.0, Duration: 10},
+			{Rate: 20.0, Duration: 10},
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  1,
+			NumUsersPerSystemPrompt: 1,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	// 2 stages × 1 client each = 2 clients
+	if len(expanded.Clients) != 2 {
+		t.Fatalf("client count = %d, want 2", len(expanded.Clients))
+	}
+	for i, client := range expanded.Clients {
+		if client.Arrival.Process != "poisson" {
+			t.Errorf("client %d: arrival process = %q, want poisson", i, client.Arrival.Process)
+		}
+		if client.CustomSampler != nil {
+			t.Errorf("client %d: CustomSampler should be nil (using Poisson)", i)
 		}
 	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1545,7 +1545,9 @@ func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T)
 				t.Fatalf("expansion error: %v", err)
 			}
 
-			horizon := tc.duration * 1_000_000
+			// Horizon = 2× duration: ensures sampler exhaustion (not horizon) stops generation.
+			// With horizon == duration, sampler and horizon guard race, creating test fragility.
+			horizon := tc.duration * 2_000_000
 			requests, err := GenerateRequests(expanded, horizon, 0)
 			if err != nil {
 				t.Fatalf("generation error: %v", err)
@@ -1575,5 +1577,84 @@ func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T)
 					len(requests), expectedTotal, numClients, expectedPerClient)
 			}
 		})
+	}
+}
+
+// TestExpandInferencePerfSpec_WorkloadReusability verifies that factory pattern
+// enables calling GenerateRequests multiple times on the same WorkloadSpec.
+// This is the primary architectural validation for CustomSamplerFactory.
+func TestExpandInferencePerfSpec_WorkloadReusability(t *testing.T) {
+	// GIVEN a WorkloadSpec with NormalizedExponentialSampler (via factory)
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 10.0, Duration: 30}, // 300 requests total
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  2,
+			NumUsersPerSystemPrompt: 3, // 6 clients × 50 requests/client = 300 total
+			SystemPromptLen:         10,
+			QuestionLen:             100,
+			OutputLen:               50,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+
+	horizon := int64(60_000_000) // 60s (2× duration)
+
+	// WHEN GenerateRequests is called twice with the same WorkloadSpec
+	requests1, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("first generation error: %v", err)
+	}
+
+	requests2, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("second generation error: %v", err)
+	}
+
+	// THEN both runs produce identical request counts
+	if len(requests1) != len(requests2) {
+		t.Fatalf("request count mismatch: run1=%d, run2=%d", len(requests1), len(requests2))
+	}
+
+	// AND identical per-client distributions
+	perClient1 := make(map[string]int)
+	perClient2 := make(map[string]int)
+	for _, req := range requests1 {
+		perClient1[req.ClientID]++
+	}
+	for _, req := range requests2 {
+		perClient2[req.ClientID]++
+	}
+
+	if len(perClient1) != len(perClient2) {
+		t.Fatalf("client count mismatch: run1=%d clients, run2=%d clients",
+			len(perClient1), len(perClient2))
+	}
+
+	for clientID, count1 := range perClient1 {
+		count2, ok := perClient2[clientID]
+		if !ok {
+			t.Errorf("client %s missing in run2", clientID)
+			continue
+		}
+		if count1 != count2 {
+			t.Errorf("client %s: run1=%d requests, run2=%d requests", clientID, count1, count2)
+		}
+	}
+
+	// AND identical arrival times (deterministic from seed)
+	for i := range requests1 {
+		if requests1[i].ArrivalTime != requests2[i].ArrivalTime {
+			t.Errorf("request %d: arrival time mismatch: run1=%d, run2=%d",
+				i, requests1[i].ArrivalTime, requests2[i].ArrivalTime)
+			if i >= 5 {
+				t.Logf("... (stopping after 5 mismatches)")
+				break
+			}
+		}
 	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1366,7 +1366,8 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T)
 		t.Fatalf("expansion error: %v", err)
 	}
 	// 3*2 = 6 clients, each should get ceil(600/6) = 100 requests
-	horizon := int64(60_000_000) // 60 seconds in µs
+	// Horizon = 2× duration: ensures sampler exhaustion (not horizon) stops generation.
+	horizon := int64(120_000_000) // 120 seconds in µs (2× stage duration)
 	requests, err := GenerateRequests(expanded, horizon, 0)
 	if err != nil {
 		t.Fatalf("generation error: %v", err)
@@ -1375,11 +1376,12 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T)
 	if len(requests) != 600 {
 		t.Errorf("request count = %d, want 600", len(requests))
 	}
-	// Verify all arrivals are within the stage duration
+	// Verify all arrivals are within the stage duration (not the inflated horizon)
+	stageDurationUs := int64(60_000_000)
 	for i, req := range requests {
-		if req.ArrivalTime < 0 || req.ArrivalTime >= horizon {
+		if req.ArrivalTime < 0 || req.ArrivalTime >= stageDurationUs {
 			t.Errorf("request %d: arrival time %d µs outside [0, %d) µs",
-				i, req.ArrivalTime, horizon)
+				i, req.ArrivalTime, stageDurationUs)
 		}
 	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1384,6 +1384,47 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T)
 	}
 }
 
+func TestExpandInferencePerfSpec_SingleStage_ExactCountWithLargeHorizon(t *testing.T) {
+	// Verify that sampler (not horizon) limits request count.
+	// With horizon >> durationUs, all N intervals should be consumed.
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 10.0, Duration: 60}, // 10 req/s for 60s = 600 total requests
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  3,
+			NumUsersPerSystemPrompt: 2,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+
+	// Set horizon to 2x the stage duration to ensure sampler exhaustion, not horizon, limits requests
+	horizon := int64(120_000_000) // 120 seconds (2x the 60s stage duration)
+	requests, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+
+	// Should get exactly 600 requests (sampler-limited, not horizon-limited)
+	if len(requests) != 600 {
+		t.Errorf("request count = %d, want 600 (sampler should limit, not horizon)", len(requests))
+	}
+
+	// All requests should arrive well before the 120s horizon
+	for i, req := range requests {
+		if req.ArrivalTime >= int64(60_000_000) {
+			t.Errorf("request %d: arrival %d µs >= stage duration 60s; sampler should limit to stage duration",
+				i, req.ArrivalTime)
+		}
+	}
+}
+
 func TestExpandInferencePerfSpec_SingleStage_NormalizedDeterministic(t *testing.T) {
 	// BC-3: Same seed produces byte-identical expansion.
 	ipSpec := &InferencePerfSpec{

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -251,13 +251,16 @@ func validateClient(c *ClientSpec, idx int) error {
 	if err := validateFinitePositive(prefix+".rate_fraction", c.RateFraction); err != nil {
 		return err
 	}
-	if !validArrivalProcesses[c.Arrival.Process] {
-		return fmt.Errorf("%s: unknown arrival process %q; valid: poisson, gamma, weibull, constant", prefix, c.Arrival.Process)
-	}
-	if c.Arrival.Process == "weibull" && c.Arrival.CV != nil {
-		cv := *c.Arrival.CV
-		if cv < 0.01 || cv > 10.4 {
-			return fmt.Errorf("%s: weibull CV must be in [0.01, 10.4], got %f", prefix, cv)
+	// CustomSampler bypasses arrival process validation (programmatic injection)
+	if c.CustomSampler == nil {
+		if !validArrivalProcesses[c.Arrival.Process] {
+			return fmt.Errorf("%s: unknown arrival process %q; valid: poisson, gamma, weibull, constant", prefix, c.Arrival.Process)
+		}
+		if c.Arrival.Process == "weibull" && c.Arrival.CV != nil {
+			cv := *c.Arrival.CV
+			if cv < 0.01 || cv > 10.4 {
+				return fmt.Errorf("%s: weibull CV must be in [0.01, 10.4], got %f", prefix, cv)
+			}
 		}
 	}
 	if c.Arrival.CV != nil {

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/rand"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -118,17 +119,22 @@ type ClientSpec struct {
 	Reasoning    *ReasoningSpec  `yaml:"reasoning,omitempty"`
 	Timeout      *int64          `yaml:"timeout,omitempty"`      // Per-request timeout in µs. nil = default (300s). 0 = no timeout. (R9: pointer for zero-value)
 	ClosedLoop   *bool           `yaml:"closed_loop,omitempty"`  // nil = default (true for reasoning/multi-turn). false = open-loop (all rounds pre-generated).
-	// CustomSampler allows programmatic injection of arrival samplers,
+	// CustomSamplerFactory allows programmatic injection of arrival sampler factories,
 	// bypassing the factory-based construction from Arrival.Process.
 	//
 	// Use cases:
 	// - inference-perf expansion: NormalizedExponentialSampler for exact count control
 	// - Programmatic workload generation with custom distributions
 	//
-	// When CustomSampler is set, Arrival.Process validation is skipped.
+	// The factory receives a sub-RNG derived from clientRNG with a single entropy draw,
+	// isolating the sampler's RNG consumption from downstream content sampling.
+	// This ensures input/output token distributions remain stable regardless of request count.
+	//
+	// When CustomSamplerFactory is set, Arrival.Process validation is skipped.
+	// The factory is called once per GenerateRequests invocation, ensuring workload reusability.
 	// Callers MUST handle zero-IAT as exhaustion signal if the sampler is stateful.
 	// Not exposed in YAML (yaml:"-" tag).
-	CustomSampler ArrivalSampler `yaml:"-"`
+	CustomSamplerFactory func(*rand.Rand) ArrivalSampler `yaml:"-"`
 }
 
 // ArrivalSpec configures the inter-arrival time process.
@@ -258,8 +264,8 @@ func validateClient(c *ClientSpec, idx int) error {
 	if err := validateFinitePositive(prefix+".rate_fraction", c.RateFraction); err != nil {
 		return err
 	}
-	// CustomSampler bypasses arrival process validation (programmatic injection)
-	if c.CustomSampler == nil {
+	// CustomSamplerFactory bypasses arrival process validation (programmatic injection)
+	if c.CustomSamplerFactory == nil {
 		if !validArrivalProcesses[c.Arrival.Process] {
 			return fmt.Errorf("%s: unknown arrival process %q; valid: poisson, gamma, weibull, constant", prefix, c.Arrival.Process)
 		}

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -118,6 +118,10 @@ type ClientSpec struct {
 	Reasoning    *ReasoningSpec  `yaml:"reasoning,omitempty"`
 	Timeout      *int64          `yaml:"timeout,omitempty"`      // Per-request timeout in µs. nil = default (300s). 0 = no timeout. (R9: pointer for zero-value)
 	ClosedLoop   *bool           `yaml:"closed_loop,omitempty"`  // nil = default (true for reasoning/multi-turn). false = open-loop (all rounds pre-generated).
+	// CustomSampler allows programmatic injection of arrival samplers
+	// (bypassing the factory). Used by inference-perf expansion.
+	// Not exposed in YAML (yaml:"-" tag).
+	CustomSampler ArrivalSampler `yaml:"-"`
 }
 
 // ArrivalSpec configures the inter-arrival time process.

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -118,8 +118,15 @@ type ClientSpec struct {
 	Reasoning    *ReasoningSpec  `yaml:"reasoning,omitempty"`
 	Timeout      *int64          `yaml:"timeout,omitempty"`      // Per-request timeout in µs. nil = default (300s). 0 = no timeout. (R9: pointer for zero-value)
 	ClosedLoop   *bool           `yaml:"closed_loop,omitempty"`  // nil = default (true for reasoning/multi-turn). false = open-loop (all rounds pre-generated).
-	// CustomSampler allows programmatic injection of arrival samplers
-	// (bypassing the factory). Used by inference-perf expansion.
+	// CustomSampler allows programmatic injection of arrival samplers,
+	// bypassing the factory-based construction from Arrival.Process.
+	//
+	// Use cases:
+	// - inference-perf expansion: NormalizedExponentialSampler for exact count control
+	// - Programmatic workload generation with custom distributions
+	//
+	// When CustomSampler is set, Arrival.Process validation is skipped.
+	// Callers MUST handle zero-IAT as exhaustion signal if the sampler is stateful.
 	// Not exposed in YAML (yaml:"-" tag).
 	CustomSampler ArrivalSampler `yaml:"-"`
 }


### PR DESCRIPTION
## Summary

Adds support for inference-perf's "normalized exponential" arrival pattern, eliminating systematic 2% duration bias in training data.

**Problem:** inference-perf generates exactly N requests spanning exactly T seconds by normalizing exponential samples. BLIS uses Poisson which stops at horizon, generating ~2% fewer requests.

**Solution:** Direct port of inference-perf's algorithm (~15 lines of Python → ~25 lines of Go):
1. Add `CustomSampler` field to `ClientSpec` (programmatic use only)  
2. Implement `NormalizedExponentialSampler` with zero-IAT exhaustion signal
3. Construct directly in `ExpandInferencePerfSpec` for single-stage workloads

## Implementation

- **Modified files:** 6 (spec.go, arrival.go, inference_perf.go, generator.go, arrival_test.go, generator_test.go)
- **Lines changed:** ~280 LOC (production + tests)
- **Tests:** All passing (`go test ./... -count=1`)

### Key Changes

1. **Interface contract update:** `ArrivalSampler.SampleIAT()` now allows 0 return value to signal exhaustion for stateful samplers
2. **Validation guards:** count limits, degenerate distribution checks, division-by-zero guards
3. **Zero-IAT guards:** Both reasoning paths in generator.go handle exhaustion signal
4. **Comprehensive tests:** Edge cases (minimal duration, large count), panic validation, zero-IAT exhaustion, reasoning integration

## Commits

1. `bc4d814` - docs(plan): ultra-simplified normalized exponential approach
2. `ed14f1c` - feat(workload): add CustomSampler field and zero IAT stop signal (BC-2)
3. `e74c893` - feat(workload): add NormalizedExponentialSampler (T2)
4. `d9215ca` - feat(workload): integrate NormalizedExponentialSampler into inference-perf (T3)
5. `b71e04e` - fix(workload): address Round 1 convergence review findings

## Review Status

**Convergence review in progress:** Round 2 active (2 CRITICAL + 36 IMPORTANT findings being addressed)

## References

- Closes #845
- Plan: `docs/plans/pr845-normalized-exponential-simple-plan.md`
- Parent branch: `main` (excludes training branch commits as requested)