### PR TITLE
feat(latency): iter24 decode split — memory-only decode, loss 39.18%

### DIFF
--- a/sim/latency/evolved_model.go
+++ b/sim/latency/evolved_model.go
@@ -33,8 +33,8 @@ import (
 //  3. FP8 peak FLOPS: Select TFlopsFP8 for FP8 models on GPUs with native FP8
 //     tensor cores (H100), matching roofline.go's logic.
 //
-// Step-time formula (up to 9-term, extends trained-roofline with MoE overhead
-// and optional prefill compute/memory split):
+// Step-time formula (up to 10-term, extends trained-roofline with MoE overhead
+// and optional prefill/decode compute/memory splits):
 //
 // With 8 betas (default):
 //
@@ -42,14 +42,20 @@ import (
 //	+ β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇
 //	+ β₈·nMoELayers
 //
-// With 9 betas (prefill split — separates compute and memory corrections):
+// With 9 betas (prefill split — prefill is compute-dominated):
 //
 //	β₁ₐ·T_pf_compute + β₁ᵦ·T_pf_kv + β₂·max(T_dc_compute, T_dc_kv)
 //	+ β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇
 //	+ β₈·nMoELayers
 //
-// The prefill split allows independent correction of compute (FlashAttention may
-// reduce effective FLOPs) and memory bandwidth (closer to roofline prediction).
+// With 10 betas (prefill + decode split — decode is memory-dominated):
+//
+//	β₁ₐ·T_pf_compute + β₁ᵦ·T_pf_kv + β₂ₐ·T_dc_compute + β₂ᵦ·T_dc_kv
+//	+ β₃·T_weight + β₄·T_tp + β₅·L + β₆·batchSize + β₇
+//	+ β₈·nMoELayers
+//
+// Physical insight: prefill is compute-bound (FlashAttention), decode is
+// memory-bound (single-token bandwidth). Each uses only its bottleneck term.
 //
 // Where β₁/β₁ₐ-β₃ are dimensionless roofline corrections (analytical prior ≈ 1.0),
 // β₁ᵦ (β₉) is prefill memory correction, β₄ is TP communication correction,
@@ -63,10 +69,11 @@ import (
 //   - α₂: OutputTokenProcessingTime — per-output-token overhead (µs/token)
 type EvolvedModel struct {
 	Alpha [3]float64 // [α₀, α₁, α₂]
-	Beta  []float64  // [β₁..β₉] — 7-9 coefficients (backward compat: 7→β₈=0, 8→β₉ unused)
+	Beta  []float64  // [β₁..β₁₀] — 7-10 coefficients (7→β₈=0, 8→MoE, 9→pf split, 10→dc split)
 
 	// Mode flags.
-	prefillSplit bool // true when 9 betas provided: β₁ₐ·compute + β₁ᵦ·kv instead of β₁·max
+	prefillSplit bool // true when ≥9 betas: β₁ₐ·compute + β₁ᵦ·kv instead of β₁·max
+	decodeSplit  bool // true when ≥10 betas: β₂ₐ·compute + β₂ᵦ·kv instead of β₂·max
 
 	// Pre-computed architecture features (frozen at construction).
 	numLayers      int
@@ -222,8 +229,17 @@ func (m *EvolvedModel) StepTime(batch []*sim.Request) int64 {
 		prefillTerm = m.Beta[0] * math.Max(tPfCompute, tPfKv)
 	}
 
+	// Decode term: β₂·max(compute, kv) when ≤9 betas,
+	//              β₂ₐ·compute + β₂ᵦ·kv when 10 betas (decode is memory-dominated).
+	var decodeTerm float64
+	if m.decodeSplit {
+		decodeTerm = m.Beta[1]*tDcCompute + m.Beta[9]*tDcKv
+	} else {
+		decodeTerm = m.Beta[1] * math.Max(tDcCompute, tDcKv)
+	}
+
 	stepTime := prefillTerm +
-		m.Beta[1]*math.Max(tDcCompute, tDcKv) +
+		decodeTerm +
 		m.Beta[2]*tWeight +
 		m.Beta[3]*tTp +
 		m.Beta[4]*L +
@@ -270,8 +286,8 @@ func NewEvolvedModel(coeffs sim.LatencyCoeffs, hw sim.ModelHardwareConfig) (*Evo
 	}
 
 	// Backward compatible: 7→β₈=0, 8→no prefill split, 9→prefill split active
-	betaSlice := make([]float64, 9)
-	copy(betaSlice, coeffs.BetaCoeffs[:min(9, len(coeffs.BetaCoeffs))])
+	betaSlice := make([]float64, 10)
+	copy(betaSlice, coeffs.BetaCoeffs[:min(10, len(coeffs.BetaCoeffs))])
 
 	// Validate hardware config
 	if hw.TP <= 0 {
@@ -350,6 +366,7 @@ func NewEvolvedModel(coeffs sim.LatencyCoeffs, hw sim.ModelHardwareConfig) (*Evo
 		Alpha:          [3]float64{coeffs.AlphaCoeffs[0], coeffs.AlphaCoeffs[1], coeffs.AlphaCoeffs[2]},
 		Beta:           betaSlice,
 		prefillSplit:   len(coeffs.BetaCoeffs) >= 9,
+		decodeSplit:    len(coeffs.BetaCoeffs) >= 10,
 		numLayers:      hw.ModelConfig.NumLayers,
 		numMoELayers:   numMoELayers,
 		numDenseLayers: numDenseLayers,


### PR DESCRIPTION
## Summary

Adds the iter24 decode compute/memory split to \`evolved_model.go\`, completing the iter24 results that were already committed to the training branch data (PR #924).

**Finding**: Decode is memory-dominated (opposite of prefill). Splitting \`β₂·max(T_dc_compute, T_dc_kv)\` into \`β₂ₐ·T_dc_compute + β₂ᵦ·T_dc_kv\` and setting β₂ₐ=0 gives the best result — decode uses only the memory bandwidth term.

**Final formula physical structure**:
- Prefill = compute-only: \`β₁ₐ=0.139\` (FlashAttention 7.2× FLOPs discount)  
- Decode = memory-only: \`β₂ᵦ=1.263\` (26% above roofline bandwidth)
- MoE overhead: \`β₈=427.3 µs/MoE-layer\`

## Reproducing iter24 results

### Prerequisites

```bash
# 1. Build BLIS from project root
go build -o blis main.go

# 2. Pre-cache Llama model configs (one-time, if not already done)
mkdir -p model_configs/llama-2-7b-hf model_configs/llama-3.1-70b-instruct
curl -sL "https://huggingface.co/NousResearch/Llama-2-7b-hf/resolve/main/config.json" \
  -o model_configs/llama-2-7b-hf/config.json
curl -sL "https://huggingface.co/NousResearch/Meta-Llama-3.1-70B-Instruct/resolve/main/config.json" \
  -o model_configs/llama-3.1-70b-instruct/config.json
```

### Verify iter24 coefficients (should give 39.18% loss)

```bash
cd training
python3 run_blis_and_compute_loss.py \
  --latency-model evolved \
  --alpha-coeffs "15561.959717498621,776.243476414174,45.910232684500556" \
  --beta-coeffs "0.138541,0.0,1.363060401466404,0.3960942587233032,62.28932987355146,2.7976795228174027,169.36568163371626,427.3,0.0,1.2632" \
  --blis-binary ../blis \
  --data-dir trainval_data \
  --evaluate-per-experiment
```

**Expected output**: \`overall_loss ≈ 39.18\`, \`num_succeeded: 15\`, \`num_experiments: 15\`

Note: The 10 beta coefficients correspond to:
- β₁ₐ=0.138541 (prefill compute), β₂ₐ=0.0 (decode compute, dropped)
- β₃=1.363, β₄=0.396, β₅=62.29 µs/layer, β₆=2.80 µs/req, β₇=169.37 µs/step
- β₈=427.3 µs/MoE-layer
- β₁ᵦ=0.0 (prefill memory, dropped), β₂ᵦ=1.2632 (decode memory)

### Re-run iter24 optimization (optional, ~2 hours)

```bash
cd training
python3.11 inner_loop_optimize.py \
  --iteration 24 \
  --n-trials 200 \
  --n-jobs 15 \
  --patience 100 \
  --timeout 200 \
  --sampler tpe \
  --data-dir /path/to/trainval_data
```

## Backward compatibility

| Betas | Mode |
|---|---|
| 7 | β₈=0 (no MoE term) |
| 8 | MoE overhead only |
| 9 | + prefill split |
| **10** | **+ decode split (this PR)** |

## Test plan

- [x] \`go build\` succeeds
- [x] \`go test ./sim/latency/...\` passes
- [x] 10-beta coefficients reproduce 39.18% on 15/15 experiments
- [x] Backward compat: 7/8/9-beta calls unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)