### PR TITLE
fix(routing): update DefaultScorerConfigs to llm-d production default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Full details: see [`docs/contributing/standards/principles.md`](docs/contributin
 
 ### Current Implementation Focus
 
-Composable Scorer Framework completed: PR17 (scorer framework + stateless scorers) and PR18 (prefix-affinity scorer + router-side cache). Default weighted routing profile: `prefix-affinity:3,queue-depth:2,kv-utilization:2` (llm-d parity). Precise prefix scoring (#883): `precise-prefix-cache` scorer queries actual instance KV cache state with min-max normalization (llm-d production parity); `no-hit-lru` scorer distributes cold requests to least-recently-used endpoints. Valid scorer names: `prefix-affinity`, `precise-prefix-cache`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`.
+Composable Scorer Framework completed: PR17 (scorer framework + stateless scorers) and PR18 (prefix-affinity scorer + router-side cache). Default weighted routing profile: `precise-prefix-cache:2,queue-depth:1,kv-utilization:1` (llm-d parity). Precise prefix scoring (#883): `precise-prefix-cache` scorer queries actual instance KV cache state with min-max normalization (llm-d production parity); `no-hit-lru` scorer distributes cold requests to least-recently-used endpoints. Valid scorer names: `prefix-affinity`, `precise-prefix-cache`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`.
 
 Phase 0 workload unification complete (see issue #420): W0-1 (spec v2 schema + SLO tiers), W0-2 (binary rename + converters), W0-3 (cohort population dynamics), W0-4 (legacy retirement). All workload generation now flows through `sim/workload/GenerateRequests()`. SLO tiers: critical, standard, sheddable, batch, background. Arrival processes: poisson, gamma, weibull, constant. CLI binary renamed from `simulation_worker` to `blis`.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You should see JSON output on stdout with key fields:
 ```bash
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --routing-policy weighted \
-  --routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2" \
+  --routing-scorers "precise-prefix-cache:2,queue-depth:1,kv-utilization:1" \
   --rate 100 --num-requests 500
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1004,7 +1004,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 
 	// Routing policy config
 	cmd.Flags().StringVar(&routingPolicy, "routing-policy", "round-robin", "Routing policy: round-robin, least-loaded, weighted, always-busiest")
-	cmd.Flags().StringVar(&routingScorers, "routing-scorers", "", "Scorer weights for weighted routing (e.g., queue-depth:2,kv-utilization:2,load-balance:1). Default: prefix-affinity:3,queue-depth:2,kv-utilization:2")
+	cmd.Flags().StringVar(&routingScorers, "routing-scorers", "", "Scorer weights for weighted routing (e.g., queue-depth:2,kv-utilization:2,load-balance:1). Default: precise-prefix-cache:2,queue-depth:1,kv-utilization:1")
 
 	// Priority and scheduler config (PR7)
 	cmd.Flags().StringVar(&priorityPolicy, "priority-policy", "constant", "Priority policy: constant, slo-based, inverted-slo")

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -13,7 +13,7 @@ flowchart TD
     WG["Workload<br/>Generator"] -->|Requests| Adm{"Admission<br/>Policy"}
     Adm -->|rejected| Rej["Rejected<br/>(counted)"]
     Adm -->|admitted| GQ["Gateway Queue<br/>(opt: --flow-control)"]
-    GQ -->|dispatch| Rtr["Routing Policy<br/>(WeightedScoring)<br/>PA:3 QD:2 KV:2"]
+    GQ -->|dispatch| Rtr["Routing Policy<br/>(WeightedScoring)<br/>PPC:2 QD:1 KV:1"]
 
     style GQ fill:#e7f5ff,stroke:#90caf9
 
@@ -111,7 +111,7 @@ The routing decision follows this pipeline:
 4. **Sum:** Weighted scores are summed across scorers for each instance
 5. **Select:** The instance with the highest total score is chosen (argmax)
 
-Default weights: `prefix-affinity:3, queue-depth:2, kv-utilization:2` (llm-d parity). Note: weights are normalized to sum to 1.0 before scoring, so only weight ratios matter — `prefix-affinity:3,queue-depth:2` is identical to `prefix-affinity:30,queue-depth:20`. To add a new scorer, see [Extension Recipes](../contributing/extension-recipes.md).
+Default weights: `precise-prefix-cache:2, queue-depth:1, kv-utilization:1` (llm-d parity). Note: weights are normalized to sum to 1.0 before scoring, so only weight ratios matter — `precise-prefix-cache:2,queue-depth:1` is identical to `precise-prefix-cache:20,queue-depth:10`. To add a new scorer, see [Extension Recipes](../contributing/extension-recipes.md).
 
 ```mermaid
 flowchart TD
@@ -119,17 +119,15 @@ flowchart TD
     Snap["Routing Snapshots<br/>(per instance)<br/>QD, BS, KVUtil"] --> S2
     Snap --> S3
 
-    S1["prefix-affinity<br/>(prefix overlap proportion)"] --> W1["× weight (3)"]
-    S2["queue-depth<br/>(min-max norm of load)"] --> W2["× weight (2)"]
-    S3["kv-utilization<br/>(1 − KVUtilization)"] --> W3["× weight (2)"]
+    S1["precise-prefix-cache<br/>(KV cache state query, min-max norm)"] --> W1["× weight (2)"]
+    S2["queue-depth<br/>(min-max norm of load)"] --> W2["× weight (1)"]
+    S3["kv-utilization<br/>(1 − KVUtilization)"] --> W3["× weight (1)"]
 
-    W1 --> Sum["Weighted Sum<br/>(per instance)<br/>3×PA + 2×QD + 2×KV"]
+    W1 --> Sum["Weighted Sum<br/>(per instance)<br/>2×PPC + 1×QD + 1×KV"]
     W2 --> Sum
     W3 --> Sum
 
     Sum --> Sel["Argmax<br/>→ Selected Instance"]
-    Sel -->|observer callback| Obs["Update prefix<br/>cache index"]
-    Obs -.->|stateful feedback| S1
 
     style Req fill:#a5d8ff
     style Snap fill:#e7f5ff
@@ -137,7 +135,6 @@ flowchart TD
     style S2 fill:#fff3e0
     style S3 fill:#fff3e0
     style Sel fill:#c8e6c9
-    style Obs fill:#ffecb3
 ```
 
 ## Scorer Composition

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -134,7 +134,7 @@ A point-in-time view of instance state used for routing decisions. Contains queu
 
 ### Scorer
 
-A component in the weighted scoring pipeline that produces a per-instance score in [0, 1] for a specific signal dimension. Built-in scorers: `prefix-affinity`, `queue-depth`, `kv-utilization`, `load-balance`. Scores are multiplied by weights and summed. See [Cluster Architecture: Scorer Composition](architecture.md#scorer-composition).
+A component in the weighted scoring pipeline that produces a per-instance score in [0, 1] for a specific signal dimension. Built-in scorers: `precise-prefix-cache`, `prefix-affinity`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`. Scores are multiplied by weights and summed. See [Cluster Architecture: Scorer Composition](architecture.md#scorer-composition).
 
 ### Seed
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -61,7 +61,7 @@ Scale to 4 instances with routing:
   --rate 100 --num-requests 500
 ```
 
-This simulates a 4-instance cluster receiving 100 requests/second. The `weighted` routing policy uses the default scorer profile (`prefix-affinity:3, queue-depth:2, kv-utilization:2`) to distribute requests across instances.
+This simulates a 4-instance cluster receiving 100 requests/second. The `weighted` routing policy uses the default scorer profile (`precise-prefix-cache:2, queue-depth:1, kv-utilization:1`) to distribute requests across instances.
 
 !!! note "Multi-instance output format"
     In cluster mode, BLIS prints one JSON block per instance plus a cluster-level summary (5 blocks total for 4 instances). The cluster summary has `"instance_id": "cluster"`. If piping to `jq`, use `--slurp` to handle multiple JSON objects: `./blis run ... 2>/dev/null | jq --slurp '.[] | select(.instance_id == "cluster")'` to extract the cluster summary.

--- a/docs/guide/kv-cache.md
+++ b/docs/guide/kv-cache.md
@@ -26,12 +26,11 @@ KV cache is allocated in **blocks** of `--block-size-in-tokens` tokens (default:
 
 When requests share common prefixes (e.g., system prompts in RAG), BLIS can reuse KV cache blocks from prior computations. This reduces prefill tokens and improves TTFT.
 
-Prefix caching is automatic when using the `prefix-affinity` scorer with `weighted` routing:
+Prefix caching is automatic when using the `weighted` routing policy. The default profile (`precise-prefix-cache:2, queue-depth:1, kv-utilization:1`) queries actual instance KV cache state to route requests to instances with cached prefix blocks:
 
 ```bash
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --routing-policy weighted \
-  --routing-scorers "prefix-affinity:3,queue-depth:1" \
   --prefix-tokens 512 --rate 100 --num-requests 500
 ```
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -23,7 +23,7 @@ This guide covers how BLIS distributes incoming requests across instances in clu
 The `weighted` routing policy is the most flexible. It combines multiple scoring dimensions, each evaluating instances on a `[0, 1]` scale:
 
 ```bash
---routing-policy weighted --routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2"
+--routing-policy weighted --routing-scorers "precise-prefix-cache:2,queue-depth:1,kv-utilization:1"
 ```
 
 ### Available Scorers
@@ -31,6 +31,8 @@ The `weighted` routing policy is the most flexible. It combines multiple scoring
 | Scorer | What It Measures | llm-d Equivalent |
 |--------|-----------------|------------------|
 | `prefix-affinity` | Proportional prefix match ratio via router-side block hash cache | prefix-scorer |
+| `precise-prefix-cache` | Actual KV cache state query with min-max normalization | precise-prefix-cache-scorer |
+| `no-hit-lru` | LRU positional scoring for cold requests (warm = 0.5) | no-hit-lru-scorer |
 | `queue-depth` | Effective load: `QueueDepth + BatchSize + InFlightRequests` (min-max normalized) | queue-scorer |
 | `kv-utilization` | Inverse KV utilization: `1 - KVUtilization` | kv-cache-utilization-scorer |
 | `load-balance` | Inverse transform: `1 / (1 + effectiveLoad)` | BLIS-native (no llm-d equivalent) |
@@ -43,10 +45,10 @@ The `weighted` routing policy is the most flexible. It combines multiple scoring
 When `--routing-scorers` is not specified, the default profile is:
 
 ```
-prefix-affinity:3, queue-depth:2, kv-utilization:2
+precise-prefix-cache:2, queue-depth:1, kv-utilization:1
 ```
 
-This matches the llm-d Endpoint Picker scoring pipeline. Weights are relative — only ratios matter. `[3, 2, 2]` behaves identically to `[0.43, 0.29, 0.29]`.
+This matches the llm-d production scoring pipeline. Weights are relative — only ratios matter. `[2, 1, 1]` behaves identically to `[0.5, 0.25, 0.25]`.
 
 ## Signal Freshness
 
@@ -77,14 +79,14 @@ BLIS models three signal freshness tiers:
 At high request rates, many routing decisions occur between KV utilization updates (step time varies by model — ~6ms for Qwen3-14B / H100 / TP=1 at low load, longer under batch saturation). If using `kv-utilization:1` alone, all decisions within one step see the same stale utilization — this can cause severe load imbalance.
 
 !!! tip "Safe zone for `--snapshot-refresh-interval`"
-    Below **5ms** (~1 step time): no degradation. At 10ms: 14% TTFT p99 increase. At 100ms: +354%. The default composite profile (`prefix-affinity:3, queue-depth:2, kv-utilization:2`) is inherently resilient — queue-depth's Immediate signal corrects stale KV signals, mitigating ~99% of the effect.
+    Below **5ms** (~1 step time): no degradation. At 10ms: 14% TTFT p99 increase. At 100ms: +354% (measured with the prior default `prefix-affinity:3, queue-depth:2, kv-utilization:2`). The default composite profile (`precise-prefix-cache:2, queue-depth:1, kv-utilization:1`) is inherently resilient — queue-depth's Immediate signal corrects stale KV signals. The exact mitigation percentage may differ from the prior profile due to different weight ratios and scorer staleness characteristics (`precise-prefix-cache` has its own staleness model via `--cache-signal-delay`).
 
 ## When to Use Which Policy
 
 | Workload | Recommended Policy | Why |
 |----------|-------------------|-----|
 | Uniform traffic, no prefix sharing | `least-loaded` or `weighted` with `queue-depth:1` | Load balance is the only signal that matters |
-| RAG with shared system prompts | `weighted` with `prefix-affinity:3,queue-depth:1` | Prefix affinity maximizes KV cache reuse |
+| RAG with shared system prompts | `weighted` default or `precise-prefix-cache:3,queue-depth:1` | Prefix-aware scoring maximizes KV cache reuse |
 | Mixed SLO classes | `weighted` default + [priority scheduling](scheduling.md) | Routing distributes load; scheduling prioritizes critical requests |
 | Low traffic (< 10 req/s) | Any | All policies produce equivalent results within 5% |
 

--- a/docs/guide/workloads.md
+++ b/docs/guide/workloads.md
@@ -51,17 +51,17 @@ clients:
         mean: 128
 ```
 
-Pair with prefix-affinity routing for cache reuse:
+Pair with weighted routing for cache-aware request distribution (the default profile uses `precise-prefix-cache`):
 
 ```bash
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --workload-spec chat.yaml \
-  --routing-policy weighted --routing-scorers "prefix-affinity:3,queue-depth:2"
+  --routing-policy weighted
 ```
 
 ### RAG with Shared Prefixes
 
-Retrieval-augmented generation workloads share a common document context across requests. The `prefix_group` and `prefix_length` fields model this shared context, and prefix-affinity routing ensures requests with the same prefix hit cached KV blocks on the same instance.
+Retrieval-augmented generation workloads share a common document context across requests. The `prefix_group` and `prefix_length` fields model this shared context, and prefix-aware routing (the default `precise-prefix-cache` scorer) ensures requests with the same prefix hit cached KV blocks on the same instance.
 
 ```yaml
 clients:
@@ -85,12 +85,12 @@ clients:
         mean: 64
 ```
 
-Run with aggressive prefix-affinity to maximize cache reuse:
+Run with weighted routing to maximize cache reuse (the default `precise-prefix-cache` scorer queries actual KV cache state):
 
 ```bash
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --workload-spec rag.yaml \
-  --routing-policy weighted --routing-scorers "prefix-affinity:3,queue-depth:1"
+  --routing-policy weighted
 ```
 
 ### Batch / Offline Processing
@@ -465,7 +465,7 @@ The `reasoning` field generates multi-turn conversation sessions where each roun
 - `multi_turn.max_rounds`: number of conversation rounds per session
 - `multi_turn.think_time_us`: inter-round delay (user think time, in microseconds)
 - `multi_turn.context_growth`: controls how each round's input is constructed.
-    - `"accumulate"`: round N's input = all prior rounds' inputs + all prior rounds' outputs + freshly sampled new user turn. Input length grows linearly with round index, creating expanding KV cache pressure and enabling prefix-affinity routing reuse across rounds — use this for realistic chat or reasoning sessions.
+    - `"accumulate"`: round N's input = all prior rounds' inputs + all prior rounds' outputs + freshly sampled new user turn. Input length grows linearly with round index, creating expanding KV cache pressure and enabling prefix-aware routing reuse across rounds — use this for realistic chat or reasoning sessions.
     - `""` (omit): each round uses only freshly sampled tokens. Input length is stationary across rounds; no cross-round prefix sharing. Use this for agent workloads that do not maintain conversation history.
 - `multi_turn.single_session`: if `true`, each client creates exactly one session (useful for modeling persistent chat sessions like inference-perf's `enable_multi_turn_chat`). Default: `false` (multiple independent sessions per client)
 - `closed_loop`: controls whether round scheduling adapts to actual server latency. `null` (omit): closed-loop by default for multi-turn clients — each subsequent round is generated after the prior round completes, scheduling its arrival at `completion_time + think_time_us`. `false`: open-loop — all round arrival times are pre-stamped before simulation using a `1 µs/output-token` heuristic; inter-round spacing does not adapt to server latency. Use `false` to reproduce inference-perf-style pre-generated workloads.
@@ -532,7 +532,7 @@ BLIS ships with example workload specs in `examples/`:
 
 | File | Description |
 |------|-------------|
-| `multiturn-chat-demo.yaml` | Multi-turn chat with prefix-affinity routing |
+| `multiturn-chat-demo.yaml` | Multi-turn chat with prefix-aware weighted routing |
 | `prefix-affinity-demo.yaml` | Shared-prefix workload for cache testing |
 | `servegen-language.yaml` | ServeGen-derived language workload |
 | `inference-perf-shared-prefix.yaml` | inference-perf format compatibility |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ go build -o blis main.go
 - **Chunked prefill and preemption-aware batch formation**
 - **Pluggable latency models** — roofline (default, analytical FLOPs/bandwidth), blackbox (data-driven coefficients), cross-model (physics-informed, MoE-aware), and trained-roofline (roofline × learned corrections), with an extensible interface for custom backends
 - **Multi-instance cluster simulation** with shared-clock event loop
-- **Pluggable routing policies** — round-robin, least-loaded, and composable weighted-scoring with prefix-affinity, queue-depth, and KV-utilization scorers
+- **Pluggable routing policies** — round-robin, least-loaded, and composable weighted-scoring with six pluggable scorers (default: precise-prefix-cache, queue-depth, kv-utilization)
 - **Admission control**, **priority policies**, and **instance schedulers** — each a pluggable policy axis
 - **Canonical workload specification** — multi-client YAML DSL with Poisson/Gamma/Weibull/constant arrival processes, 5 distribution types, SLO classes (critical/standard/sheddable/batch/background), prefix groups, cohort dynamics, multimodal, reasoning multi-turn, and composable specs via `blis compose`
 - **Rich metrics pipeline** — per-request, per-instance, and cluster-level metrics including TTFT/ITL/E2E distributions, KV cache diagnostics, anomaly detection (priority inversions, HOL blocking), SLO attainment, Jain fairness index, and multi-objective fitness evaluation

--- a/docs/methodology/principles.md
+++ b/docs/methodology/principles.md
@@ -23,7 +23,7 @@ Principles extracted from 30 iterations of [Strategy Evolution](strategy-evoluti
 | RP-7 | **The optimal strategy is regime-dependent** — Normal KV: `pa:3,qd:2,kv:2`. Under pressure: `pa:3,qd:2`. At high load with admission: `pa:4,qd:3`. | Iter 8, 10 | Static default fails under KV pressure (23–25% worse than RR) |
 
 !!! info "Reconciling with BLIS Defaults"
-    The current BLIS default is `prefix-affinity:3,queue-depth:2,kv-utilization:2` (llm-d parity). Strategy Evolution discovered that `pa:4,qd:3` (no kv-util) performs better under KV pressure and at high load with admission control. The default is maintained for compatibility with the llm-d ecosystem. Users running Strategy Evolution experiments should consider the regime-dependent recommendation in RP-7 rather than assuming the default is optimal for all scenarios.
+    The current BLIS default is `precise-prefix-cache:2,queue-depth:1,kv-utilization:1` (llm-d parity). Strategy Evolution discovered that `pa:4,qd:3` (no kv-util) performs better under KV pressure and at high load with admission control. The default is maintained for compatibility with the llm-d ecosystem. Users running Strategy Evolution experiments should consider the regime-dependent recommendation in RP-7 rather than assuming the default is optimal for all scenarios.
 
 | # | Principle | Source | Evidence |
 |---|-----------|--------|----------|

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -232,12 +232,12 @@ Controls how admitted requests are assigned to instances. See [Cluster Architect
 When using `--routing-policy weighted`, the `--routing-scorers` flag configures which scorers are used and their relative weights:
 
 ```bash
---routing-scorers "prefix-affinity:3,queue-depth:2,kv-utilization:2"
+--routing-scorers "precise-prefix-cache:2,queue-depth:1,kv-utilization:1"
 ```
 
 Available scorers: `prefix-affinity`, `precise-prefix-cache`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`.
 
-Default (when `--routing-scorers` is empty): `prefix-affinity:3, queue-depth:2, kv-utilization:2` (llm-d parity).
+Default (when `--routing-scorers` is empty): `precise-prefix-cache:2, queue-depth:1, kv-utilization:1` (llm-d parity).
 
 See [Cluster Architecture: Scorer Composition](../concepts/architecture.md#scorer-composition) for details on each scorer.
 

--- a/examples/multiturn-chat-demo.yaml
+++ b/examples/multiturn-chat-demo.yaml
@@ -3,7 +3,8 @@
 # Simulates many concurrent multi-turn chat sessions. Each session has 5
 # rounds with context accumulation (each round prepends all prior context).
 #
-# KEY INSIGHT: With prefix-affinity routing, sessions stick to one instance,
+# KEY INSIGHT: With prefix-aware routing (the default precise-prefix-cache scorer),
+# sessions stick to one instance,
 # so the KV cache from prior rounds is reused — fewer prefill tokens → lower
 # TTFT for subsequent rounds. With load-only routing, rounds scatter across
 # instances, causing full prefill every round.
@@ -12,11 +13,10 @@
 # TRY IT
 # ============================================================================
 #
-#   # Prefix-affinity dominant (sessions cluster on instances)
+#   # Default profile — precise-prefix-cache dominant (sessions cluster on instances)
 #   ./blis run \
 #     --model meta-llama/llama-3.1-8b-instruct \
 #     --num-instances 4 --routing-policy weighted \
-#     --routing-scorers "prefix-affinity:3,queue-depth:2" \
 #     --workload-spec examples/multiturn-chat-demo.yaml \
 #     --trace-level decisions --summarize-trace
 #
@@ -28,7 +28,7 @@
 #     --workload-spec examples/multiturn-chat-demo.yaml \
 #     --trace-level decisions --summarize-trace
 #
-# Expected: prefix-affinity produces lower TTFT because later rounds in each
+# Expected: precise-prefix-cache produces lower TTFT because later rounds in each
 # session reuse the prior rounds' KV cache (fewer prefill tokens needed).
 
 version: "2"

--- a/examples/routing-comparison.sh
+++ b/examples/routing-comparison.sh
@@ -85,7 +85,7 @@ run_experiment "weighted (queue-depth:1 — fast signal)" \
 run_experiment "weighted (kv-utilization:1 — lagging signal)" \
     --routing-policy weighted --routing-scorers "kv-utilization:1"
 
-run_experiment "weighted (default: prefix-affinity:3,queue-depth:2,kv-utilization:2)" \
+run_experiment "weighted (default: precise-prefix-cache:2,queue-depth:1,kv-utilization:1)" \
     --routing-policy weighted
 
 echo "================================================================"

--- a/examples/weighted-routing.yaml
+++ b/examples/weighted-routing.yaml
@@ -5,22 +5,24 @@
 # configurable weights: score = clamp(s_i) * w_i, then argmax.
 #
 # Available scorers:
-#   prefix-affinity — proportional prefix match ratio via router-side cache
-#   queue-depth     — min-max normalization of effective load (llm-d match)
-#   kv-utilization  — inverse utilization: 1 - KVUtilization (llm-d match)
-#   load-balance    — inverse transform: 1/(1 + effectiveLoad) (BLIS-native)
+#   precise-prefix-cache — actual KV cache state query with min-max normalization
+#   prefix-affinity      — proportional prefix match ratio via router-side cache
+#   no-hit-lru           — LRU positional scoring for cold requests (warm = 0.5)
+#   queue-depth          — min-max normalization of effective load (llm-d match)
+#   kv-utilization       — inverse utilization: 1 - KVUtilization (llm-d match)
+#   load-balance         — inverse transform: 1/(1 + effectiveLoad) (BLIS-native)
 #
 # Default profile (when --routing-scorers is not specified):
-#   prefix-affinity:3, queue-depth:2, kv-utilization:2 (llm-d parity)
+#   precise-prefix-cache:2, queue-depth:1, kv-utilization:1 (llm-d parity)
 #
-# Weights are relative — only ratios matter. [3,2,2] behaves identically
-# to [0.43,0.29,0.29]. The framework normalizes weights to sum to 1.0.
+# Weights are relative — only ratios matter. [2,1,1] behaves identically
+# to [0.5,0.25,0.25]. The framework normalizes weights to sum to 1.0.
 #
 # ============================================================================
 # TRY IT: Compare scorer configurations
 # ============================================================================
 #
-#   # Default profile (llm-d parity: prefix-affinity dominant)
+#   # Default profile (llm-d parity: precise-prefix-cache dominant)
 #   ./blis run \
 #     --model meta-llama/llama-3.1-8b-instruct \
 #     --num-instances 4 --routing-policy weighted \
@@ -59,12 +61,12 @@ admission:
 routing:
   policy: weighted
   scorers:
-    - name: prefix-affinity
-      weight: 3.0
+    - name: precise-prefix-cache
+      weight: 2.0
     - name: queue-depth
-      weight: 2.0
+      weight: 1.0
     - name: kv-utilization
-      weight: 2.0
+      weight: 1.0
 
 priority:
   policy: constant

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -1430,7 +1430,7 @@ func TestClusterSimulator_AdmissionLatency_ExactOffset(t *testing.T) {
 // TestClusterSimulator_FullStackConservation verifies INV-1 conservation
 // across the full policy stack: weighted routing + admission control +
 // priority scheduling (promoted from H25 experiment, PR #372, issue #379):
-// GIVEN weighted routing (prefix-affinity:3,queue-depth:2,kv-utilization:2),
+// GIVEN weighted routing (DefaultScorerConfigs: precise-prefix-cache:2,queue-depth:1,kv-utilization:1),
 //
 //	priority-FCFS scheduling, and multiple admission/KV configurations
 //

--- a/sim/routing_prefix_scorer_test.go
+++ b/sim/routing_prefix_scorer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // makeTokens creates a sequential token slice of the given length.
@@ -146,17 +147,17 @@ func TestPrefixAffinityScorer_IsValidAndRegistered(t *testing.T) {
 	assert.True(t, found, "prefix-affinity must be in ValidScorerNames()")
 }
 
-// TestDefaultScorerConfigs_IncludesPrefixAffinity verifies BC-5.
-func TestDefaultScorerConfigs_IncludesPrefixAffinity(t *testing.T) {
+// TestDefaultScorerConfigs_MatchesLLMdProductionProfile verifies BC-1 (#952):
+// the full default profile matches llm-d's epp-precise-prefix-cache-config.yaml.
+func TestDefaultScorerConfigs_MatchesLLMdProductionProfile(t *testing.T) {
 	configs := DefaultScorerConfigs()
-	found := false
-	for _, c := range configs {
-		if c.Name == "prefix-affinity" {
-			found = true
-			assert.Equal(t, 3.0, c.Weight, "prefix-affinity default weight should be 3.0")
-		}
-	}
-	assert.True(t, found, "DefaultScorerConfigs must include prefix-affinity")
+	require.Len(t, configs, 3, "default profile must have exactly 3 scorers")
+	assert.Equal(t, "precise-prefix-cache", configs[0].Name)
+	assert.Equal(t, 2.0, configs[0].Weight)
+	assert.Equal(t, "queue-depth", configs[1].Name)
+	assert.Equal(t, 1.0, configs[1].Weight)
+	assert.Equal(t, "kv-utilization", configs[2].Name)
+	assert.Equal(t, 1.0, configs[2].Weight)
 }
 
 // TestPrefixAffinityScorer_Deterministic verifies BC-9 (INV-3):

--- a/sim/routing_scorers.go
+++ b/sim/routing_scorers.go
@@ -40,12 +40,12 @@ func IsValidScorer(name string) bool { return validScorerNames[name] }
 func ValidScorerNames() []string { return validNamesList(validScorerNames) }
 
 // DefaultScorerConfigs returns the default scorer configuration for weighted routing.
-// Default profile: prefix-affinity:3, queue-depth:2, kv-utilization:2 (llm-d parity).
+// Default profile: precise-prefix-cache:2, queue-depth:1, kv-utilization:1 (llm-d parity).
 func DefaultScorerConfigs() []ScorerConfig {
 	return []ScorerConfig{
-		{Name: "prefix-affinity", Weight: 3.0},
-		{Name: "queue-depth", Weight: 2.0},
-		{Name: "kv-utilization", Weight: 2.0},
+		{Name: "precise-prefix-cache", Weight: 2.0},
+		{Name: "queue-depth", Weight: 1.0},
+		{Name: "kv-utilization", Weight: 1.0},
 	}
 }
 
@@ -103,7 +103,7 @@ func normalizeScorerWeights(configs []ScorerConfig) []float64 {
 
 // newScorerWithObserver creates a scorer function and optional observer for a named scorer.
 // Returns (scorer, observer) where observer is nil for stateless scorers.
-// blockSize is used by stateful scorers (prefix-affinity) for block hash computation.
+// blockSize is used by stateful scorers (e.g., prefix-affinity) for block hash computation.
 // Panics on unknown name (validation should catch this before reaching here).
 func newScorerWithObserver(name string, blockSize int, cacheFn cacheQueryFn) (scorerFunc, observerFunc) {
 	switch name {


### PR DESCRIPTION
## Summary

- Update `DefaultScorerConfigs()` from `prefix-affinity:3, queue-depth:2, kv-utilization:2` to `precise-prefix-cache:2, queue-depth:1, kv-utilization:1` matching llm-d production config (`epp-precise-prefix-cache-config.yaml`)
- Update test, CLI help text, docs, examples, and Mermaid diagrams for consistency
- `precise-prefix-cache` handles nil `cacheFn` gracefully (returns 1.0 for all instances) — safe as default in sim-level tests without cluster instances

## Behavioral Contracts

**BC-1: Default scorer config matches llm-d production profile**
- GIVEN no explicit `--routing-scorers` flag
- WHEN `DefaultScorerConfigs()` is called
- THEN it returns `[{precise-prefix-cache, 2.0}, {queue-depth, 1.0}, {kv-utilization, 1.0}]`

## Testing

- `go build ./...` — clean
- `go test ./... -count=1` — all pass (10 packages)
- `golangci-lint run ./...` — only pre-existing errors (confirmed on base branch)

Fixes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)