### PR TITLE
test(cluster): add roofline golden dataset and regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ __pycache__/*
 *.json
 !testdata/goldendataset.json
 !testdata/trained_physics_iter29.json
+!testdata/roofline_goldendataset.json
 !model_configs/*/config.json
 !hardware_config.json
 data/

--- a/sim/cluster/golden_test_helpers_test.go
+++ b/sim/cluster/golden_test_helpers_test.go
@@ -1,0 +1,90 @@
+package cluster
+
+import (
+	"math"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// Shared golden test helpers used by both roofline_golden_test.go and
+// trained_physics_golden_test.go to avoid duplication.
+
+// goldenExpected holds expected metrics for a golden dataset experiment.
+type goldenExpected struct {
+	CompletedRequests int     `json:"completed_requests"`
+	TotalInputTokens  int     `json:"total_input_tokens"`
+	TotalOutputTokens int     `json:"total_output_tokens"`
+	TTFTMeanMs        float64 `json:"ttft_mean_ms"`
+	TTFTP90Ms         float64 `json:"ttft_p90_ms"`
+	TTFTP99Ms         float64 `json:"ttft_p99_ms"`
+	E2EMeanMs         float64 `json:"e2e_mean_ms"`
+	E2EP90Ms          float64 `json:"e2e_p90_ms"`
+	E2EP99Ms          float64 `json:"e2e_p99_ms"`
+	ITLMeanMs         float64 `json:"itl_mean_ms"`
+}
+
+// goldenWorkloadSpec mirrors the top-level keys written by the Python runner's
+// write_workload_spec (v2 inference_perf format). Fields carry both json and
+// yaml struct tags so the struct can be decoded from either format.
+type goldenWorkloadSpec struct {
+	Version       string                 `json:"version"       yaml:"version"`
+	Seed          int64                  `json:"seed"          yaml:"seed"`
+	NumRequests   int                    `json:"num_requests"  yaml:"num_requests"`
+	InferencePerf *goldenInferencePerfWS `json:"inference_perf" yaml:"inference_perf"`
+}
+
+type goldenInferencePerfWS struct {
+	Stages       []goldenStage              `json:"stages"        yaml:"stages"`
+	SharedPrefix *workload.SharedPrefixSpec `json:"shared_prefix" yaml:"shared_prefix"`
+}
+
+type goldenStage struct {
+	Rate     float64 `json:"rate"     yaml:"rate"`
+	Duration int64   `json:"duration" yaml:"duration"`
+}
+
+// goldenRepoRoot returns the absolute path to the repository root, resolved
+// relative to the calling source file (sim/cluster/ → ../.. → repo root).
+func goldenRepoRoot() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+// goldenSortedValues returns the values of a map[string]float64 sorted in
+// ascending order. The key iteration is sorted first (R2: deterministic map
+// traversal), then the extracted values are sorted by value for use in
+// percentile and mean calculations.
+func goldenSortedValues(m map[string]float64) []float64 {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // R2: deterministic iteration order
+	vals := make([]float64, len(keys))
+	for i, k := range keys {
+		vals[i] = m[k]
+	}
+	sort.Float64s(vals) // sort by value for percentile/mean computation
+	return vals
+}
+
+// goldenAssertApprox asserts that got ≈ want within the given relative tolerance.
+func goldenAssertApprox(t *testing.T, name string, want, got, relTol float64) {
+	t.Helper()
+	if want == 0 && got == 0 {
+		return
+	}
+	diff := math.Abs(want - got)
+	maxVal := math.Max(math.Abs(want), math.Abs(got))
+	if maxVal > 0 && diff/maxVal > relTol {
+		t.Errorf("%s: got %.10f, want %.10f (relDiff=%.2e, tolerance=%.2e)",
+			name, got, want, diff/maxVal, relTol)
+	}
+}

--- a/sim/cluster/roofline_golden_test.go
+++ b/sim/cluster/roofline_golden_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"testing"
 
@@ -36,53 +35,13 @@ type rooflineGoldenExperiment struct {
 	TotalKVBlocks       int64           `json:"total_kv_blocks"`
 	CPUKVBlocks         int64           `json:"cpu_kv_blocks"`
 	Workload            json.RawMessage `json:"workload"`
-	Expected            rfGoldenExpected `json:"expected"`
-}
-
-type rfGoldenExpected struct {
-	CompletedRequests int     `json:"completed_requests"`
-	TotalInputTokens  int     `json:"total_input_tokens"`
-	TotalOutputTokens int     `json:"total_output_tokens"`
-	TTFTMeanMs        float64 `json:"ttft_mean_ms"`
-	TTFTP90Ms         float64 `json:"ttft_p90_ms"`
-	TTFTP99Ms         float64 `json:"ttft_p99_ms"`
-	E2EMeanMs         float64 `json:"e2e_mean_ms"`
-	E2EP90Ms          float64 `json:"e2e_p90_ms"`
-	E2EP99Ms          float64 `json:"e2e_p99_ms"`
-	ITLMeanMs         float64 `json:"itl_mean_ms"`
-}
-
-// rfWorkloadSpec mirrors the workload spec structure (same as tpWorkloadSpec).
-type rfWorkloadSpec struct {
-	Version       string             `json:"version"       yaml:"version"`
-	Seed          int64              `json:"seed"          yaml:"seed"`
-	NumRequests   int                `json:"num_requests"  yaml:"num_requests"`
-	InferencePerf *rfInferencePerfWS `json:"inference_perf" yaml:"inference_perf"`
-}
-
-type rfInferencePerfWS struct {
-	Stages       []rfStage                  `json:"stages"        yaml:"stages"`
-	SharedPrefix *workload.SharedPrefixSpec `json:"shared_prefix" yaml:"shared_prefix"`
-}
-
-type rfStage struct {
-	Rate     float64 `json:"rate"     yaml:"rate"`
-	Duration int64   `json:"duration" yaml:"duration"`
-}
-
-// rfRepoRoot returns the absolute path to the repository root.
-func rfRepoRoot() string {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+	Expected            goldenExpected  `json:"expected"`
 }
 
 // loadRooflineGoldenDataset reads testdata/roofline_goldendataset.json.
 func loadRooflineGoldenDataset(t *testing.T) *rooflineGoldenDataset {
 	t.Helper()
-	path := filepath.Join(rfRepoRoot(), "testdata", "roofline_goldendataset.json")
+	path := filepath.Join(goldenRepoRoot(), "testdata", "roofline_goldendataset.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("loadRooflineGoldenDataset: %v", err)
@@ -119,10 +78,13 @@ func TestRoofline_GoldenDataset(t *testing.T) {
 		t.Skip("skipping roofline golden dataset test in short mode (-short flag)")
 	}
 
-	root := rfRepoRoot()
+	root := goldenRepoRoot()
 	ds := loadRooflineGoldenDataset(t)
 	if len(ds.Experiments) == 0 {
 		t.Fatal("golden dataset has no experiments")
+	}
+	if ds.Backend != "roofline" {
+		t.Fatalf("unexpected backend in dataset: got %q, want \"roofline\"", ds.Backend)
 	}
 
 	hwConfigPath := filepath.Join(root, "hardware_config.json")
@@ -156,7 +118,7 @@ func TestRoofline_GoldenDataset(t *testing.T) {
 			}
 
 			// ── Decode workload spec and generate requests ───────────────────
-			var ws rfWorkloadSpec
+			var ws goldenWorkloadSpec
 			if err := yaml.Unmarshal(exp.Workload, &ws); err != nil {
 				t.Fatalf("decode workload: %v", err)
 			}
@@ -238,8 +200,8 @@ func TestRoofline_GoldenDataset(t *testing.T) {
 			}
 
 			// ── Compute output metrics from raw Metrics struct ────────────
-			sortedTTFTs := rfSortedValues(m.RequestTTFTs)
-			sortedE2Es := rfSortedValues(m.RequestE2Es)
+			sortedTTFTs := goldenSortedValues(m.RequestTTFTs)
+			sortedE2Es := goldenSortedValues(m.RequestE2Es)
 			allITLs := make([]float64, len(m.AllITLs))
 			for i, v := range m.AllITLs {
 				allITLs[i] = float64(v)
@@ -271,43 +233,14 @@ func TestRoofline_GoldenDataset(t *testing.T) {
 			// first (e.g. "roofline-v2"). See comment on
 			// TestRoofline_GoldenDataset.
 			const relTol = 1e-9
-			rfAssertGolden(t, "ttft_mean_ms", exp.Expected.TTFTMeanMs, ttftMean, relTol)
-			rfAssertGolden(t, "ttft_p90_ms", exp.Expected.TTFTP90Ms, ttftP90, relTol)
-			rfAssertGolden(t, "ttft_p99_ms", exp.Expected.TTFTP99Ms, ttftP99, relTol)
-			rfAssertGolden(t, "e2e_mean_ms", exp.Expected.E2EMeanMs, e2eMean, relTol)
-			rfAssertGolden(t, "e2e_p90_ms", exp.Expected.E2EP90Ms, e2eP90, relTol)
-			rfAssertGolden(t, "e2e_p99_ms", exp.Expected.E2EP99Ms, e2eP99, relTol)
-			rfAssertGolden(t, "itl_mean_ms", exp.Expected.ITLMeanMs, itlMean, relTol)
+			goldenAssertApprox(t, "ttft_mean_ms", exp.Expected.TTFTMeanMs, ttftMean, relTol)
+			goldenAssertApprox(t, "ttft_p90_ms", exp.Expected.TTFTP90Ms, ttftP90, relTol)
+			goldenAssertApprox(t, "ttft_p99_ms", exp.Expected.TTFTP99Ms, ttftP99, relTol)
+			goldenAssertApprox(t, "e2e_mean_ms", exp.Expected.E2EMeanMs, e2eMean, relTol)
+			goldenAssertApprox(t, "e2e_p90_ms", exp.Expected.E2EP90Ms, e2eP90, relTol)
+			goldenAssertApprox(t, "e2e_p99_ms", exp.Expected.E2EP99Ms, e2eP99, relTol)
+			goldenAssertApprox(t, "itl_mean_ms", exp.Expected.ITLMeanMs, itlMean, relTol)
 		})
 	}
 }
 
-// rfSortedValues returns the values of a map[string]float64 sorted in ascending
-// order (same as sortedValues but with rf prefix to avoid collision).
-func rfSortedValues(m map[string]float64) []float64 {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys) // R2: deterministic iteration order
-	vals := make([]float64, len(keys))
-	for i, k := range keys {
-		vals[i] = m[k]
-	}
-	sort.Float64s(vals) // sort by value for percentile/mean computation
-	return vals
-}
-
-// rfAssertGolden asserts that got ≈ want within the given relative tolerance.
-func rfAssertGolden(t *testing.T, name string, want, got, relTol float64) {
-	t.Helper()
-	if want == 0 && got == 0 {
-		return
-	}
-	diff := math.Abs(want - got)
-	maxVal := math.Max(math.Abs(want), math.Abs(got))
-	if maxVal > 0 && diff/maxVal > relTol {
-		t.Errorf("%s: got %.10f, want %.10f (relDiff=%.2e, tolerance=%.2e)",
-			name, got, want, diff/maxVal, relTol)
-	}
-}

--- a/sim/cluster/roofline_golden_test.go
+++ b/sim/cluster/roofline_golden_test.go
@@ -1,0 +1,313 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/latency"
+	"github.com/inference-sim/inference-sim/sim/workload"
+	"gopkg.in/yaml.v3"
+)
+
+// rooflineGoldenDataset is the root structure of testdata/roofline_iter29.json.
+type rooflineGoldenDataset struct {
+	Description string                   `json:"description"`
+	Backend     string                   `json:"backend"`
+	Experiments []rooflineGoldenExperiment `json:"experiments"`
+}
+
+// rooflineGoldenExperiment holds a single iter29 experiment configuration and
+// its expected simulation outputs using the roofline backend.
+type rooflineGoldenExperiment struct {
+	ID                  string          `json:"id"`
+	Model               string          `json:"model"`
+	ModelConfigDir      string          `json:"model_config_dir"`
+	Hardware            string          `json:"hardware"`
+	TP                  int             `json:"tp"`
+	MaxNumSeqs          int             `json:"max_num_seqs"`
+	MaxNumBatchedTokens int             `json:"max_num_batched_tokens"`
+	TotalKVBlocks       int64           `json:"total_kv_blocks"`
+	CPUKVBlocks         int64           `json:"cpu_kv_blocks"`
+	Workload            json.RawMessage `json:"workload"`
+	Expected            rfGoldenExpected `json:"expected"`
+}
+
+type rfGoldenExpected struct {
+	CompletedRequests int     `json:"completed_requests"`
+	TotalInputTokens  int     `json:"total_input_tokens"`
+	TotalOutputTokens int     `json:"total_output_tokens"`
+	TTFTMeanMs        float64 `json:"ttft_mean_ms"`
+	TTFTP90Ms         float64 `json:"ttft_p90_ms"`
+	TTFTP99Ms         float64 `json:"ttft_p99_ms"`
+	E2EMeanMs         float64 `json:"e2e_mean_ms"`
+	E2EP90Ms          float64 `json:"e2e_p90_ms"`
+	E2EP99Ms          float64 `json:"e2e_p99_ms"`
+	ITLMeanMs         float64 `json:"itl_mean_ms"`
+}
+
+// rfWorkloadSpec mirrors the workload spec structure (same as tpWorkloadSpec).
+type rfWorkloadSpec struct {
+	Version       string             `json:"version"       yaml:"version"`
+	Seed          int64              `json:"seed"          yaml:"seed"`
+	NumRequests   int                `json:"num_requests"  yaml:"num_requests"`
+	InferencePerf *rfInferencePerfWS `json:"inference_perf" yaml:"inference_perf"`
+}
+
+type rfInferencePerfWS struct {
+	Stages       []rfStage                  `json:"stages"        yaml:"stages"`
+	SharedPrefix *workload.SharedPrefixSpec `json:"shared_prefix" yaml:"shared_prefix"`
+}
+
+type rfStage struct {
+	Rate     float64 `json:"rate"     yaml:"rate"`
+	Duration int64   `json:"duration" yaml:"duration"`
+}
+
+// rfRepoRoot returns the absolute path to the repository root.
+func rfRepoRoot() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+// loadRooflineGoldenDataset reads testdata/roofline_goldendataset.json.
+func loadRooflineGoldenDataset(t *testing.T) *rooflineGoldenDataset {
+	t.Helper()
+	path := filepath.Join(rfRepoRoot(), "testdata", "roofline_goldendataset.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("loadRooflineGoldenDataset: %v", err)
+	}
+	var ds rooflineGoldenDataset
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatalf("loadRooflineGoldenDataset: parse: %v", err)
+	}
+	return &ds
+}
+
+// TestRoofline_GoldenDataset verifies that the roofline latency backend
+// produces byte-for-byte identical TTFT and E2E predictions to the iter29
+// roofline baseline.
+//
+// This test serves as a regression guard for the analytical roofline model.
+// Any change to roofline FLOPs/bandwidth calculations, MoE handling, or TP
+// communication modeling will be caught by this test.
+//
+// Companion invariant assertions (conservation, causality, non-zero TTFT) catch
+// bugs independently of the golden values, satisfying the "test laws not just
+// values" principle from principles.md.
+//
+// Golden values must not be regenerated in place. If the roofline backend
+// behavior needs to change intentionally, rename the backend (e.g.
+// "roofline-v2") and add a new dataset. Renaming prevents silent behavioral
+// regressions from accumulating.
+//
+// Regression guard: This test will catch any unintended changes to roofline
+// model calculations, including Scout MoE interleaved architecture handling
+// (issue #877), weight bandwidth calculations, or TP all-reduce modeling.
+func TestRoofline_GoldenDataset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping roofline golden dataset test in short mode (-short flag)")
+	}
+
+	root := rfRepoRoot()
+	ds := loadRooflineGoldenDataset(t)
+	if len(ds.Experiments) == 0 {
+		t.Fatal("golden dataset has no experiments")
+	}
+
+	hwConfigPath := filepath.Join(root, "hardware_config.json")
+
+	for _, exp := range ds.Experiments {
+		exp := exp // capture loop variable
+		t.Run(fmt.Sprintf("exp_%s_%s", exp.ID, exp.Model), func(t *testing.T) {
+			t.Parallel() // each sub-test owns independent state; safe to run concurrently
+			// ── Load model + hardware configuration ──────────────────────────
+			mcPath := filepath.Join(root, exp.ModelConfigDir, "config.json")
+			mc, err := latency.GetModelConfig(mcPath)
+			if err != nil {
+				t.Fatalf("GetModelConfig(%s): %v", mcPath, err)
+			}
+			hc, err := latency.GetHWConfig(hwConfigPath, exp.Hardware)
+			if err != nil {
+				t.Fatalf("GetHWConfig(%s): %v", exp.Hardware, err)
+			}
+
+			// ── Build roofline latency model ─────────────────────────────────
+			// Roofline uses zero coefficients (pure analytical model)
+			coeffs := sim.NewLatencyCoeffs(
+				[]float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // beta coeffs (unused in roofline)
+				[]float64{0, 0, 0},                      // alpha coeffs (unused in roofline)
+			)
+			hwCfg := sim.NewModelHardwareConfig(*mc, hc, exp.Model, exp.Hardware, exp.TP, ds.Backend, 0)
+
+			// Validate that the backend is accepted; fail fast with a clear error.
+			if _, err := latency.NewLatencyModel(coeffs, hwCfg); err != nil {
+				t.Fatalf("NewLatencyModel: %v", err)
+			}
+
+			// ── Decode workload spec and generate requests ───────────────────
+			var ws rfWorkloadSpec
+			if err := yaml.Unmarshal(exp.Workload, &ws); err != nil {
+				t.Fatalf("decode workload: %v", err)
+			}
+			if ws.InferencePerf == nil {
+				t.Fatalf("experiment %s: workload JSON missing inference_perf field", exp.ID)
+			}
+
+			ipSpec := &workload.InferencePerfSpec{
+				SharedPrefix: ws.InferencePerf.SharedPrefix,
+			}
+			for _, s := range ws.InferencePerf.Stages {
+				ipSpec.Stages = append(ipSpec.Stages, workload.StageSpec{
+					Rate:     s.Rate,
+					Duration: s.Duration,
+				})
+			}
+			fullSpec, err := workload.ExpandInferencePerfSpec(ipSpec, ws.Seed)
+			if err != nil {
+				t.Fatalf("ExpandInferencePerfSpec: %v", err)
+			}
+			wl, err := workload.GenerateWorkload(fullSpec, math.MaxInt64, int64(ws.NumRequests))
+			if err != nil {
+				t.Fatalf("GenerateWorkload: %v", err)
+			}
+			var onDone func(*sim.Request, int64) []*sim.Request
+			if len(wl.Sessions) > 0 {
+				sessionMgr := workload.NewSessionManager(wl.Sessions)
+				if wl.FollowUpBudget >= 0 {
+					sessionMgr.SetFollowUpBudget(wl.FollowUpBudget)
+				}
+				onDone = sessionMgr.OnComplete
+			}
+
+			// ── Configure and run ClusterSimulator ──────────────────────────
+			cfg := DeploymentConfig{
+				SimConfig: sim.SimConfig{
+					Horizon:             math.MaxInt64,
+					Seed:                ws.Seed,
+					KVCacheConfig:       sim.NewKVCacheConfig(exp.TotalKVBlocks, 16, exp.CPUKVBlocks, 0.9, 0.2, 0),
+					BatchConfig:         sim.NewBatchConfig(int64(exp.MaxNumSeqs), int64(exp.MaxNumBatchedTokens), 0),
+					LatencyCoeffs:       coeffs,
+					ModelHardwareConfig: hwCfg,
+				},
+				NumInstances: 1,
+			}
+			cs := NewClusterSimulator(cfg, wl.Requests, onDone)
+			if err := cs.Run(); err != nil {
+				t.Fatalf("ClusterSimulator.Run: %v", err)
+			}
+
+			m := cs.AggregatedMetrics()
+
+			// ── Invariant: request conservation (INV-1) ───────────────────
+			if m.StillQueued != 0 {
+				t.Errorf("INV-1: still_queued=%d, want 0 (requests stuck in wait queue)", m.StillQueued)
+			}
+			if m.StillRunning != 0 {
+				t.Errorf("INV-1: still_running=%d, want 0 (requests stuck in running batch)", m.StillRunning)
+			}
+			if m.DroppedUnservable != 0 {
+				t.Errorf("INV-1: dropped_unservable=%d, want 0", m.DroppedUnservable)
+			}
+			if m.TimedOutRequests != 0 {
+				t.Errorf("INV-1: timed_out_requests=%d, want 0", m.TimedOutRequests)
+			}
+			if cs.RejectedRequests() != 0 {
+				t.Errorf("INV-1: rejected_requests=%d, want 0", cs.RejectedRequests())
+			}
+			if m.CompletedRequests != exp.Expected.CompletedRequests {
+				t.Errorf("completed_requests: got %d, want %d", m.CompletedRequests, exp.Expected.CompletedRequests)
+			}
+
+			// ── Invariant: token conservation ────────────────────────────
+			if m.TotalInputTokens != exp.Expected.TotalInputTokens {
+				t.Errorf("total_input_tokens: got %d, want %d", m.TotalInputTokens, exp.Expected.TotalInputTokens)
+			}
+			if m.TotalOutputTokens != exp.Expected.TotalOutputTokens {
+				t.Errorf("total_output_tokens: got %d, want %d", m.TotalOutputTokens, exp.Expected.TotalOutputTokens)
+			}
+
+			// ── Compute output metrics from raw Metrics struct ────────────
+			sortedTTFTs := rfSortedValues(m.RequestTTFTs)
+			sortedE2Es := rfSortedValues(m.RequestE2Es)
+			allITLs := make([]float64, len(m.AllITLs))
+			for i, v := range m.AllITLs {
+				allITLs[i] = float64(v)
+			}
+			sort.Float64s(allITLs)
+
+			ttftMean := sim.CalculateMean(sortedTTFTs)
+			ttftP90 := sim.CalculatePercentile(sortedTTFTs, 90)
+			ttftP99 := sim.CalculatePercentile(sortedTTFTs, 99)
+			e2eMean := sim.CalculateMean(sortedE2Es)
+			e2eP90 := sim.CalculatePercentile(sortedE2Es, 90)
+			e2eP99 := sim.CalculatePercentile(sortedE2Es, 99)
+			itlMean := sim.CalculateMean(allITLs)
+
+			// ── Invariant: causality (INV-5) ──────────────────────────────
+			if ttftMean <= 0 {
+				t.Errorf("ttft_mean: got %.6f, want > 0 (every request must have a first token)", ttftMean)
+			}
+			if ttftMean > e2eMean {
+				t.Errorf("causality: ttft_mean %.6f > e2e_mean %.6f", ttftMean, e2eMean)
+			}
+
+			// ── Golden values: byte-for-byte identical floats ─────────────
+			// relTol=1e-9 catches floating-point rounding from platform
+			// differences while rejecting any behavioral change to the
+			// roofline backend.
+			//
+			// To update these values, the roofline backend MUST be renamed
+			// first (e.g. "roofline-v2"). See comment on
+			// TestRoofline_GoldenDataset.
+			const relTol = 1e-9
+			rfAssertGolden(t, "ttft_mean_ms", exp.Expected.TTFTMeanMs, ttftMean, relTol)
+			rfAssertGolden(t, "ttft_p90_ms", exp.Expected.TTFTP90Ms, ttftP90, relTol)
+			rfAssertGolden(t, "ttft_p99_ms", exp.Expected.TTFTP99Ms, ttftP99, relTol)
+			rfAssertGolden(t, "e2e_mean_ms", exp.Expected.E2EMeanMs, e2eMean, relTol)
+			rfAssertGolden(t, "e2e_p90_ms", exp.Expected.E2EP90Ms, e2eP90, relTol)
+			rfAssertGolden(t, "e2e_p99_ms", exp.Expected.E2EP99Ms, e2eP99, relTol)
+			rfAssertGolden(t, "itl_mean_ms", exp.Expected.ITLMeanMs, itlMean, relTol)
+		})
+	}
+}
+
+// rfSortedValues returns the values of a map[string]float64 sorted in ascending
+// order (same as sortedValues but with rf prefix to avoid collision).
+func rfSortedValues(m map[string]float64) []float64 {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // R2: deterministic iteration order
+	vals := make([]float64, len(keys))
+	for i, k := range keys {
+		vals[i] = m[k]
+	}
+	sort.Float64s(vals) // sort by value for percentile/mean computation
+	return vals
+}
+
+// rfAssertGolden asserts that got ≈ want within the given relative tolerance.
+func rfAssertGolden(t *testing.T, name string, want, got, relTol float64) {
+	t.Helper()
+	if want == 0 && got == 0 {
+		return
+	}
+	diff := math.Abs(want - got)
+	maxVal := math.Max(math.Abs(want), math.Abs(got))
+	if maxVal > 0 && diff/maxVal > relTol {
+		t.Errorf("%s: got %.10f, want %.10f (relDiff=%.2e, tolerance=%.2e)",
+			name, got, want, diff/maxVal, relTol)
+	}
+}

--- a/sim/cluster/trained_physics_golden_test.go
+++ b/sim/cluster/trained_physics_golden_test.go
@@ -82,6 +82,9 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 	if len(ds.Experiments) == 0 {
 		t.Fatal("golden dataset has no experiments")
 	}
+	if ds.Backend != "trained-physics" {
+		t.Fatalf("unexpected backend in dataset: got %q, want \"trained-physics\"", ds.Backend)
+	}
 
 	hwConfigPath := filepath.Join(root, "hardware_config.json")
 

--- a/sim/cluster/trained_physics_golden_test.go
+++ b/sim/cluster/trained_physics_golden_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"testing"
 
@@ -38,57 +37,13 @@ type trainedPhysicsExperiment struct {
 	TotalKVBlocks       int64           `json:"total_kv_blocks"`
 	CPUKVBlocks         int64           `json:"cpu_kv_blocks"`
 	Workload            json.RawMessage `json:"workload"`
-	Expected            tpGoldenExpected `json:"expected"`
-}
-
-type tpGoldenExpected struct {
-	CompletedRequests int     `json:"completed_requests"`
-	TotalInputTokens  int     `json:"total_input_tokens"`
-	TotalOutputTokens int     `json:"total_output_tokens"`
-	TTFTMeanMs        float64 `json:"ttft_mean_ms"`
-	TTFTP90Ms         float64 `json:"ttft_p90_ms"`
-	TTFTP99Ms         float64 `json:"ttft_p99_ms"`
-	E2EMeanMs         float64 `json:"e2e_mean_ms"`
-	E2EP90Ms          float64 `json:"e2e_p90_ms"`
-	E2EP99Ms          float64 `json:"e2e_p99_ms"`
-	ITLMeanMs         float64 `json:"itl_mean_ms"`
-}
-
-// tpWorkloadSpec mirrors the top-level keys written by the Python runner's
-// write_workload_spec (v2 inference_perf format). Fields carry both json and
-// yaml struct tags so the struct can be decoded from either format. The golden
-// JSON stores these with snake_case keys; yaml.v3 uses the yaml tag.
-type tpWorkloadSpec struct {
-	Version       string             `json:"version"       yaml:"version"`
-	Seed          int64              `json:"seed"          yaml:"seed"`
-	NumRequests   int                `json:"num_requests"  yaml:"num_requests"`
-	InferencePerf *tpInferencePerfWS `json:"inference_perf" yaml:"inference_perf"`
-}
-
-type tpInferencePerfWS struct {
-	Stages       []tpStage                 `json:"stages"        yaml:"stages"`
-	SharedPrefix *workload.SharedPrefixSpec `json:"shared_prefix" yaml:"shared_prefix"`
-}
-
-type tpStage struct {
-	Rate     float64 `json:"rate"     yaml:"rate"`
-	Duration int64   `json:"duration" yaml:"duration"`
-}
-
-// tpRepoRoot returns the absolute path to the repository root, resolved
-// relative to this source file (sim/cluster/ → ../.. → repo root).
-func tpRepoRoot() string {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("runtime.Caller failed")
-	}
-	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+	Expected            goldenExpected `json:"expected"`
 }
 
 // loadTrainedPhysicsGoldenDataset reads testdata/trained_physics_iter29.json.
 func loadTrainedPhysicsGoldenDataset(t *testing.T) *trainedPhysicsGoldenDataset {
 	t.Helper()
-	path := filepath.Join(tpRepoRoot(), "testdata", "trained_physics_iter29.json")
+	path := filepath.Join(goldenRepoRoot(), "testdata", "trained_physics_iter29.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("loadTrainedPhysicsGoldenDataset: %v", err)
@@ -122,7 +77,7 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 		t.Skip("skipping trained-physics golden dataset test in short mode (-short flag)")
 	}
 
-	root := tpRepoRoot()
+	root := goldenRepoRoot()
 	ds := loadTrainedPhysicsGoldenDataset(t)
 	if len(ds.Experiments) == 0 {
 		t.Fatal("golden dataset has no experiments")
@@ -158,7 +113,7 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 			// ── Decode workload spec and generate requests ───────────────────
 			// SharedPrefixSpec uses yaml struct tags; use yaml.v3 to decode
 			// (JSON is valid YAML so this works for either format).
-			var ws tpWorkloadSpec
+			var ws goldenWorkloadSpec
 			if err := yaml.Unmarshal(exp.Workload, &ws); err != nil {
 				t.Fatalf("decode workload: %v", err)
 			}
@@ -249,8 +204,8 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 			}
 
 			// ── Compute output metrics from raw Metrics struct ────────────
-			sortedTTFTs := sortedValues(m.RequestTTFTs)
-			sortedE2Es := sortedValues(m.RequestE2Es)
+			sortedTTFTs := goldenSortedValues(m.RequestTTFTs)
+			sortedE2Es := goldenSortedValues(m.RequestE2Es)
 			allITLs := make([]float64, len(m.AllITLs))
 			for i, v := range m.AllITLs {
 				allITLs[i] = float64(v)
@@ -282,46 +237,13 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 			// renamed first (e.g. "trained-physics-v2"). See comment on
 			// TestTrainedPhysics_GoldenDataset.
 			const relTol = 1e-9
-			tpAssertGolden(t, "ttft_mean_ms", exp.Expected.TTFTMeanMs, ttftMean, relTol)
-			tpAssertGolden(t, "ttft_p90_ms", exp.Expected.TTFTP90Ms, ttftP90, relTol)
-			tpAssertGolden(t, "ttft_p99_ms", exp.Expected.TTFTP99Ms, ttftP99, relTol)
-			tpAssertGolden(t, "e2e_mean_ms", exp.Expected.E2EMeanMs, e2eMean, relTol)
-			tpAssertGolden(t, "e2e_p90_ms", exp.Expected.E2EP90Ms, e2eP90, relTol)
-			tpAssertGolden(t, "e2e_p99_ms", exp.Expected.E2EP99Ms, e2eP99, relTol)
-			tpAssertGolden(t, "itl_mean_ms", exp.Expected.ITLMeanMs, itlMean, relTol)
+			goldenAssertApprox(t, "ttft_mean_ms", exp.Expected.TTFTMeanMs, ttftMean, relTol)
+			goldenAssertApprox(t, "ttft_p90_ms", exp.Expected.TTFTP90Ms, ttftP90, relTol)
+			goldenAssertApprox(t, "ttft_p99_ms", exp.Expected.TTFTP99Ms, ttftP99, relTol)
+			goldenAssertApprox(t, "e2e_mean_ms", exp.Expected.E2EMeanMs, e2eMean, relTol)
+			goldenAssertApprox(t, "e2e_p90_ms", exp.Expected.E2EP90Ms, e2eP90, relTol)
+			goldenAssertApprox(t, "e2e_p99_ms", exp.Expected.E2EP99Ms, e2eP99, relTol)
+			goldenAssertApprox(t, "itl_mean_ms", exp.Expected.ITLMeanMs, itlMean, relTol)
 		})
-	}
-}
-
-// sortedValues returns the values of a map[string]float64 sorted in ascending
-// order. The key iteration is sorted first (R2: deterministic map traversal),
-// then the extracted values are sorted by value for use in percentile and mean
-// calculations. Both steps together ensure reproducible output regardless of
-// Go's non-deterministic map iteration order.
-func sortedValues(m map[string]float64) []float64 {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys) // R2: deterministic iteration order
-	vals := make([]float64, len(keys))
-	for i, k := range keys {
-		vals[i] = m[k]
-	}
-	sort.Float64s(vals) // sort by value for percentile/mean computation
-	return vals
-}
-
-// tpAssertGolden asserts that got ≈ want within the given relative tolerance.
-func tpAssertGolden(t *testing.T, name string, want, got, relTol float64) {
-	t.Helper()
-	if want == 0 && got == 0 {
-		return
-	}
-	diff := math.Abs(want - got)
-	maxVal := math.Max(math.Abs(want), math.Abs(got))
-	if maxVal > 0 && diff/maxVal > relTol {
-		t.Errorf("%s: got %.10f, want %.10f (relDiff=%.2e, tolerance=%.2e)",
-			name, got, want, diff/maxVal, relTol)
 	}
 }

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -33,3 +33,47 @@ invariant test. The companions are:
 - `TestSimulator_GoldenDataset` -> inline INV-1, INV-4, INV-5 checks (sim/simulator_test.go)
 - `TestInstanceSimulator_GoldenDataset_Equivalence` -> `TestInstanceSimulator_GoldenDataset_Invariants` (sim/cluster/instance_test.go)
 - `TestClusterSimulator_SingleInstance_GoldenEquivalence` -> `TestClusterSimulator_SingleInstance_GoldenInvariants` (sim/cluster/cluster_test.go)
+
+---
+
+## Latency Backend Golden Datasets
+
+These datasets validate latency backend predictions remain stable across code changes.
+
+### Trained-Physics Dataset (`trained_physics_iter29.json`)
+
+Contains 15 iter29 training experiments with expected TTFT, E2E, and ITL metrics from the `trained-physics` latency backend (iter29 alpha/beta coefficients, loss=34.5675%).
+
+**Test:** `TestTrainedPhysics_GoldenDataset` in `sim/cluster/trained_physics_golden_test.go`
+
+**When to regenerate:** NEVER update values in place. If trained-physics backend behavior must change intentionally, rename the backend (e.g., `trained-physics-v2`) and create a new dataset. This prevents silent regressions from accumulating.
+
+**How to regenerate (new backend only):**
+1. Generate golden values by running BLIS with the new backend across all 15 experiments
+2. Create a new JSON file: `testdata/<new-backend>_iter29.json`
+3. Update test to reference the new file
+4. Keep old dataset for historical comparison
+
+**Experiments:** 15 experiments across Scout (TP2), Llama-2-7B (TP1), Llama-3.1-70B (TP4), Mistral-Nemo (TP1/TP2), Qwen2.5-7B (TP1), Yi-34B (TP2) on H100 hardware.
+
+**Invariants checked:** INV-1 (request conservation), token conservation, INV-5 (causality: TTFT > 0, TTFT < E2E)
+
+### Roofline Dataset (`roofline_goldendataset.json`)
+
+Contains the same 15 iter29 experiments with expected metrics from the analytical `roofline` latency backend (no learned coefficients).
+
+**Test:** `TestRoofline_GoldenDataset` in `sim/cluster/roofline_golden_test.go`
+
+**When to regenerate:** NEVER update values in place. If roofline backend calculations must change intentionally, rename the backend (e.g., `roofline-v2`) and create a new dataset.
+
+**How to regenerate (new backend only):**
+1. Manually run BLIS with `--latency-model roofline` for all 15 experiments
+2. Capture TTFT, E2E, ITL metrics (mean/P90/P99)
+3. Create a new JSON file: `testdata/roofline-v2_goldendataset.json`
+4. Update test to reference the new file
+
+**Experiments:** Identical to trained-physics dataset (15 experiments, same models/TP/hardware)
+
+**Invariants checked:** INV-1 (request conservation), token conservation, INV-5 (causality)
+
+**Regression protection:** Guards against unintended changes to roofline FLOPs/bandwidth calculations, Scout MoE interleaved architecture handling (issue #877), weight bandwidth calculations, and TP all-reduce modeling.

--- a/testdata/roofline_goldendataset.json
+++ b/testdata/roofline_goldendataset.json
@@ -1,0 +1,702 @@
+{
+  "description": "Roofline latency model golden values. Generated from iter29 training experiments for regression testing.",
+  "backend": "roofline",
+  "experiments": [
+    {
+      "id": "17",
+      "model": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic",
+      "model_config_dir": "model_configs/llama-4-scout-17b-16e-instruct-fp8-dynamic",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 8253,
+      "cpu_kv_blocks": 0,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 5100,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 9,
+            "num_users_per_system_prompt": 5,
+            "output_len": 248,
+            "question_len": 447,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 2.5
+            },
+            {
+              "duration": 600,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 3060,
+        "total_input_tokens": 1673820,
+        "total_output_tokens": 755820,
+        "ttft_mean_ms": 12.802288888888889,
+        "ttft_p90_ms": 24.026,
+        "ttft_p99_ms": 49.10201999999997,
+        "e2e_mean_ms": 655.0136189542484,
+        "e2e_p90_ms": 1007.349,
+        "e2e_p99_ms": 1204.675,
+        "itl_mean_ms": 2.600045870709957
+      }
+    },
+    {
+      "id": "20",
+      "model": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic",
+      "model_config_dir": "model_configs/llama-4-scout-17b-16e-instruct-fp8-dynamic",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 8253,
+      "cpu_kv_blocks": 0,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 9000,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 11,
+            "num_users_per_system_prompt": 4,
+            "output_len": 247,
+            "question_len": 466,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 5
+            },
+            {
+              "duration": 600,
+              "rate": 10
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 6072,
+        "total_input_tokens": 3436752,
+        "total_output_tokens": 1493712,
+        "ttft_mean_ms": 63.928052371541504,
+        "ttft_p90_ms": 149.8729000000001,
+        "ttft_p99_ms": 199.07408999999973,
+        "e2e_mean_ms": 1422.2407653162056,
+        "e2e_p90_ms": 1783.834,
+        "e2e_p99_ms": 2164.7211599999996,
+        "itl_mean_ms": 5.521596394084
+      }
+    },
+    {
+      "id": "20260217-155451",
+      "model": "meta-llama/Llama-2-7b-hf",
+      "model_config_dir": "model_configs/llama-2-7b-hf",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 7463,
+      "cpu_kv_blocks": 1023,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 9000,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 11,
+            "num_users_per_system_prompt": 4,
+            "output_len": 247,
+            "question_len": 466,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 5
+            },
+            {
+              "duration": 600,
+              "rate": 10
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 6072,
+        "total_input_tokens": 3436752,
+        "total_output_tokens": 1493712,
+        "ttft_mean_ms": 192.2329403820817,
+        "ttft_p90_ms": 417.536,
+        "ttft_p99_ms": 691.872,
+        "e2e_mean_ms": 2163.1867824440055,
+        "e2e_p90_ms": 3338.8075000000003,
+        "e2e_p99_ms": 3805.105,
+        "itl_mean_ms": 8.0120074880566
+      }
+    },
+    {
+      "id": "20260217-162547",
+      "model": "meta-llama/Llama-2-7b-hf",
+      "model_config_dir": "model_configs/llama-2-7b-hf",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 7463,
+      "cpu_kv_blocks": 1023,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 7200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 10,
+            "num_users_per_system_prompt": 5,
+            "output_len": 251,
+            "question_len": 600,
+            "system_prompt_len": 150
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 7200,
+        "total_input_tokens": 5400000,
+        "total_output_tokens": 1800000,
+        "ttft_mean_ms": 272.24331805555556,
+        "ttft_p90_ms": 563.056,
+        "ttft_p99_ms": 612.886,
+        "e2e_mean_ms": 2707.444317361111,
+        "e2e_p90_ms": 3031.549,
+        "e2e_p99_ms": 3031.549,
+        "itl_mean_ms": 9.740803997222221
+      }
+    },
+    {
+      "id": "20260217-231439",
+      "model": "meta-llama/Llama-2-7b-hf",
+      "model_config_dir": "model_configs/llama-2-7b-hf",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 7463,
+      "cpu_kv_blocks": 1023,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 16800,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 9,
+            "num_users_per_system_prompt": 5,
+            "output_len": 248,
+            "question_len": 447,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 8
+            },
+            {
+              "duration": 600,
+              "rate": 20
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 9630,
+        "total_input_tokens": 5267610,
+        "total_output_tokens": 2378610,
+        "ttft_mean_ms": 246.91873073727933,
+        "ttft_p90_ms": 456.861,
+        "ttft_p99_ms": 776.561,
+        "e2e_mean_ms": 2560.5354852544133,
+        "e2e_p90_ms": 3790.926,
+        "e2e_p99_ms": 3790.926,
+        "itl_mean_ms": 9.366869451486373
+      }
+    },
+    {
+      "id": "21",
+      "model": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic",
+      "model_config_dir": "model_configs/llama-4-scout-17b-16e-instruct-fp8-dynamic",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 8253,
+      "cpu_kv_blocks": 0,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 7200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 10,
+            "num_users_per_system_prompt": 5,
+            "output_len": 251,
+            "question_len": 600,
+            "system_prompt_len": 150
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 7200,
+        "total_input_tokens": 5400000,
+        "total_output_tokens": 1800000,
+        "ttft_mean_ms": 89.02130513888889,
+        "ttft_p90_ms": 213.569,
+        "ttft_p99_ms": 241.628,
+        "e2e_mean_ms": 1603.24187625,
+        "e2e_p90_ms": 1954.341,
+        "e2e_p99_ms": 1954.341,
+        "itl_mean_ms": 6.056882284444445
+      }
+    },
+    {
+      "id": "48",
+      "model": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic",
+      "model_config_dir": "model_configs/llama-4-scout-17b-16e-instruct-fp8-dynamic",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 8253,
+      "cpu_kv_blocks": 0,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 1200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 23,
+            "num_users_per_system_prompt": 1,
+            "output_len": 1448,
+            "question_len": 934,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 1
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 1219,
+        "total_input_tokens": 1260446,
+        "total_output_tokens": 1763893,
+        "ttft_mean_ms": 12.20519688269073,
+        "ttft_p90_ms": 18.512200000000004,
+        "ttft_p99_ms": 21.279639999999997,
+        "e2e_mean_ms": 2961.2132953240357,
+        "e2e_p90_ms": 3527.8534000000004,
+        "e2e_p99_ms": 3712.8311,
+        "itl_mean_ms": 2.0380152719014135
+      }
+    },
+    {
+      "id": "60",
+      "model": "meta-llama/Llama-3.1-70B-Instruct",
+      "model_config_dir": "model_configs/llama-3.1-70b-instruct",
+      "hardware": "H100",
+      "tp": 4,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 8192,
+      "total_kv_blocks": 30425,
+      "cpu_kv_blocks": 6553,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 5100,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 9,
+            "num_users_per_system_prompt": 5,
+            "output_len": 248,
+            "question_len": 447,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 2.5
+            },
+            {
+              "duration": 600,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 3060,
+        "total_input_tokens": 1673820,
+        "total_output_tokens": 755820,
+        "ttft_mean_ms": 231.14582189542483,
+        "ttft_p90_ms": 612.844,
+        "ttft_p99_ms": 934.489,
+        "e2e_mean_ms": 2295.544737254902,
+        "e2e_p90_ms": 2766.159,
+        "e2e_p99_ms": 3119.085,
+        "itl_mean_ms": 8.357890345584927
+      }
+    },
+    {
+      "id": "61",
+      "model": "meta-llama/Llama-3.1-70B-Instruct",
+      "model_config_dir": "model_configs/llama-3.1-70b-instruct",
+      "hardware": "H100",
+      "tp": 4,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 30425,
+      "cpu_kv_blocks": 6553,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 9000,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 11,
+            "num_users_per_system_prompt": 4,
+            "output_len": 247,
+            "question_len": 466,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 5
+            },
+            {
+              "duration": 600,
+              "rate": 10
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 6072,
+        "total_input_tokens": 3436752,
+        "total_output_tokens": 1493712,
+        "ttft_mean_ms": 588.1262384716732,
+        "ttft_p90_ms": 1100.896,
+        "ttft_p99_ms": 2075.742,
+        "e2e_mean_ms": 3148.6095166337286,
+        "e2e_p90_ms": 4323.568,
+        "e2e_p99_ms": 4358.637,
+        "itl_mean_ms": 10.40846861041486
+      }
+    },
+    {
+      "id": "62",
+      "model": "mistralai/Mistral-Nemo-Instruct-2407",
+      "model_config_dir": "model_configs/mistral-nemo-instruct-2407",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 1024,
+      "total_kv_blocks": 48009,
+      "cpu_kv_blocks": 6553,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 5100,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 9,
+            "num_users_per_system_prompt": 5,
+            "output_len": 248,
+            "question_len": 447,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 2.5
+            },
+            {
+              "duration": 600,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 3060,
+        "total_input_tokens": 1673820,
+        "total_output_tokens": 755820,
+        "ttft_mean_ms": 20.740536928104575,
+        "ttft_p90_ms": 47.414600000000014,
+        "ttft_p99_ms": 100.462,
+        "e2e_mean_ms": 699.0519545751634,
+        "e2e_p90_ms": 764.7159,
+        "e2e_p99_ms": 832.85434,
+        "itl_mean_ms": 2.7462000714455823
+      }
+    },
+    {
+      "id": "63",
+      "model": "mistralai/Mistral-Nemo-Instruct-2407",
+      "model_config_dir": "model_configs/mistral-nemo-instruct-2407",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 19251,
+      "cpu_kv_blocks": 3276,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 9000,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 11,
+            "num_users_per_system_prompt": 4,
+            "output_len": 247,
+            "question_len": 466,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 5
+            },
+            {
+              "duration": 600,
+              "rate": 10
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 6072,
+        "total_input_tokens": 3436752,
+        "total_output_tokens": 1493712,
+        "ttft_mean_ms": 374.63505747694336,
+        "ttft_p90_ms": 748.525,
+        "ttft_p99_ms": 1311.544,
+        "e2e_mean_ms": 2401.105218050066,
+        "e2e_p90_ms": 3237.933,
+        "e2e_p99_ms": 3627.80432,
+        "itl_mean_ms": 8.23768357956554
+      }
+    },
+    {
+      "id": "64",
+      "model": "Qwen/Qwen2.5-7B-Instruct",
+      "model_config_dir": "model_configs/qwen2.5-7b-instruct",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 65368,
+      "cpu_kv_blocks": 9361,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 7200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 10,
+            "num_users_per_system_prompt": 5,
+            "output_len": 251,
+            "question_len": 600,
+            "system_prompt_len": 150
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 7200,
+        "total_input_tokens": 5400000,
+        "total_output_tokens": 1800000,
+        "ttft_mean_ms": 204.30150041666667,
+        "ttft_p90_ms": 452.885,
+        "ttft_p99_ms": 601.738,
+        "e2e_mean_ms": 1181.3630855555555,
+        "e2e_p90_ms": 1475.199,
+        "e2e_p99_ms": 1475.199,
+        "itl_mean_ms": 3.9082463405555554
+      }
+    },
+    {
+      "id": "65",
+      "model": "01-ai/Yi-34B",
+      "model_config_dir": "model_configs/yi-34b",
+      "hardware": "H100",
+      "tp": 2,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 20793,
+      "cpu_kv_blocks": 4369,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 5100,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 9,
+            "num_users_per_system_prompt": 5,
+            "output_len": 248,
+            "question_len": 447,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 600,
+              "rate": 2.5
+            },
+            {
+              "duration": 600,
+              "rate": 6
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 3060,
+        "total_input_tokens": 1673820,
+        "total_output_tokens": 755820,
+        "ttft_mean_ms": 178.24979934640524,
+        "ttft_p90_ms": 551.4106000000002,
+        "ttft_p99_ms": 768.4055699999999,
+        "e2e_mean_ms": 2300.3278267973856,
+        "e2e_p90_ms": 2820.2378000000003,
+        "e2e_p99_ms": 3170.95457,
+        "itl_mean_ms": 8.591409018020164
+      }
+    },
+    {
+      "id": "66",
+      "model": "Qwen/Qwen2.5-7B-Instruct",
+      "model_config_dir": "model_configs/qwen2.5-7b-instruct",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 1024,
+      "total_kv_blocks": 65368,
+      "cpu_kv_blocks": 9361,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 1200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 23,
+            "num_users_per_system_prompt": 1,
+            "output_len": 1448,
+            "question_len": 934,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 1
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 1219,
+        "total_input_tokens": 1260446,
+        "total_output_tokens": 1763893,
+        "ttft_mean_ms": 26.21899097621001,
+        "ttft_p90_ms": 39.4448,
+        "ttft_p99_ms": 56.17658,
+        "e2e_mean_ms": 4268.60657588187,
+        "e2e_p90_ms": 4346.8832,
+        "e2e_p99_ms": 4399.650640000001,
+        "itl_mean_ms": 2.9318504387737803
+      }
+    },
+    {
+      "id": "67",
+      "model": "meta-llama/Llama-2-7b-hf",
+      "model_config_dir": "model_configs/llama-2-7b-hf",
+      "hardware": "H100",
+      "tp": 1,
+      "max_num_seqs": 128,
+      "max_num_batched_tokens": 2048,
+      "total_kv_blocks": 7463,
+      "cpu_kv_blocks": 1023,
+      "workload": {
+        "version": "2",
+        "seed": 42,
+        "num_requests": 1200,
+        "inference_perf": {
+          "shared_prefix": {
+            "enable_multi_turn_chat": true,
+            "num_unique_system_prompts": 23,
+            "num_users_per_system_prompt": 1,
+            "output_len": 1448,
+            "question_len": 934,
+            "system_prompt_len": 100
+          },
+          "stages": [
+            {
+              "duration": 1200,
+              "rate": 1
+            }
+          ]
+        }
+      },
+      "expected": {
+        "completed_requests": 1219,
+        "total_input_tokens": 1260446,
+        "total_output_tokens": 1763893,
+        "ttft_mean_ms": 26.011490566037736,
+        "ttft_p90_ms": 27.0354,
+        "ttft_p99_ms": 62.115259999999985,
+        "e2e_mean_ms": 6549.824048400328,
+        "e2e_p90_ms": 7029.905000000001,
+        "e2e_p99_ms": 7531.5951000000005,
+        "itl_mean_ms": 4.508509024073455
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a roofline golden dataset (`testdata/roofline_goldendataset.json`) and companion regression test (`TestRoofline_GoldenDataset`) to catch unintended changes to the analytical roofline latency model.

Fixes #970

## Changes

| File | Change |
|------|--------|
| `testdata/roofline_goldendataset.json` | Golden dataset with 15 iter29 experiments (Scout, Llama-2/3.1, Mistral-Nemo, Qwen2.5, Yi-34B across various TP/hardware configs) |
| `sim/cluster/roofline_golden_test.go` | Regression test following `trained_physics_golden_test.go` pattern |
| `.gitignore` | Add exception for `testdata/roofline_goldendataset.json` |

## Test Plan

- [x] `go test ./sim/cluster/... -run TestRoofline_GoldenDataset` — all 15/15 experiments pass
- [x] Metrics match with 1e-9 relative tolerance (byte-identical floats)
- [x] Invariant checks (INV-1: request conservation, INV-5: causality, token conservation)
- [x] `go test ./...` — full suite passes
- [x] `go build ./...` — builds cleanly

## Behavioral Contracts

**BC-1:** TestRoofline_GoldenDataset verifies that the roofline backend produces byte-for-byte identical TTFT, E2E, and ITL metrics to the iter29 baseline across 15 experiments.

**BC-2:** Any change to roofline FLOPs/bandwidth calculations, MoE handling, or TP communication modeling will be caught by this test (preventing silent regressions).

## Regression Protection

This test guards against:
- Unintended changes to roofline analytical model
- Scout MoE interleaved architecture regressions (issue #877)
- Weight bandwidth calculation changes
- TP all-reduce modeling drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)