### PR TITLE
fix(workload): correct inference-perf request count inflation

### DIFF
--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -177,7 +177,7 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 					// Validate sampler parameters before construction (prevent panic on user input)
 					if requestsPerClient <= 0 {
-						return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
+						return nil, fmt.Errorf("inference_perf: client %s got 0 requests (totalRequests=%d < numClients=%d); increase rate or duration", clientID, totalRequests, numClientsPerStage)
 					}
 					if requestsPerClient > 10_000_000 {
 						return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -315,3 +315,30 @@ func constantDist(value float64) DistSpec {
 		Params: map[string]float64{"value": value},
 	}
 }
+
+// distributeRequestsEvenly distributes totalRequests across n clients,
+// ensuring the sum equals exactly totalRequests (no ceiling inflation).
+// Returns per-client counts where max difference is 1.
+//
+// Algorithm: base = total/n (floor), remainder = total%n.
+// First 'remainder' clients get base+1, others get base.
+//
+// Example: distributeRequestsEvenly(10, 3) -> [4, 3, 3] (sum=10)
+func distributeRequestsEvenly(totalRequests, n int) []int {
+	if n <= 0 {
+		panic("distributeRequestsEvenly: n must be positive")
+	}
+	if totalRequests < 0 {
+		panic("distributeRequestsEvenly: totalRequests must be non-negative")
+	}
+	base := totalRequests / n
+	remainder := totalRequests % n
+	dist := make([]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = base
+		if i < remainder {
+			dist[i]++
+		}
+	}
+	return dist
+}

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -117,7 +117,13 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 		if sp.EnableMultiTurnChat {
 			// Multi-turn: distribute total requests evenly across sessions
 			totalRequests := int(stage.Rate * float64(stage.Duration))
-			perSessionRounds := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+			if totalRequests < 1 {
+				return nil, fmt.Errorf("inference_perf.stages[0]: rate %.4f × duration %d produces %d requests (< 1); increase rate or duration", stage.Rate, stage.Duration, totalRequests)
+			}
+			perSessionRounds, err := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+			if err != nil {
+				return nil, fmt.Errorf("distributing requests for single-stage multi-turn: %w", err)
+			}
 
 			clientIdx := 0
 			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
@@ -146,7 +152,13 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 			// Distribute total requests evenly across clients using fair allocation
 			// (floor-with-remainder) to match real inference-perf exact counts.
 			totalRequests := int(stage.Rate * float64(stage.Duration))
-			perClientDist := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+			if totalRequests < 1 {
+				return nil, fmt.Errorf("inference_perf.stages[0]: rate %.4f × duration %d produces %d requests (< 1); increase rate or duration", stage.Rate, stage.Duration, totalRequests)
+			}
+			perClientDist, err := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+			if err != nil {
+				return nil, fmt.Errorf("distributing requests for single-stage non-multi-turn: %w", err)
+			}
 			durationUs := stage.Duration * 1_000_000 // seconds to microseconds
 
 			// Defensive: prevent integer overflow in seed calculation (cast before multiply)
@@ -228,7 +240,13 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 			if sp.EnableMultiTurnChat {
 				// Multi-turn: distribute total requests evenly across sessions for this stage
 				totalRequests := int(stage.Rate * float64(stage.Duration))
-				perSessionRounds := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+				if totalRequests < 1 {
+					return nil, fmt.Errorf("inference_perf.stages[%d]: rate %.4f × duration %d produces %d requests (< 1); increase rate or duration", s, stage.Rate, stage.Duration, totalRequests)
+				}
+				perSessionRounds, err := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+				if err != nil {
+					return nil, fmt.Errorf("distributing requests for stage %d multi-turn: %w", s, err)
+				}
 
 				clientIdx := 0
 				for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
@@ -352,12 +370,14 @@ func constantDist(value float64) DistSpec {
 // First 'remainder' clients get base+1, others get base.
 //
 // Example: distributeRequestsEvenly(10, 3) -> [4, 3, 3] (sum=10)
-func distributeRequestsEvenly(totalRequests, n int) []int {
+//
+// Returns error if preconditions are violated (n <= 0 or totalRequests < 0).
+func distributeRequestsEvenly(totalRequests, n int) ([]int, error) {
 	if n <= 0 {
-		panic("distributeRequestsEvenly: n must be positive")
+		return nil, fmt.Errorf("distributeRequestsEvenly: n must be positive, got %d", n)
 	}
 	if totalRequests < 0 {
-		panic("distributeRequestsEvenly: totalRequests must be non-negative")
+		return nil, fmt.Errorf("distributeRequestsEvenly: totalRequests must be non-negative, got %d", totalRequests)
 	}
 	base := totalRequests / n
 	remainder := totalRequests % n
@@ -368,5 +388,5 @@ func distributeRequestsEvenly(totalRequests, n int) []int {
 			dist[i]++
 		}
 	}
-	return dist
+	return dist, nil
 }

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -110,21 +110,23 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 		rateFraction := 1.0 / float64(numClientsPerStage)
 		clients = make([]ClientSpec, 0, numClientsPerStage)
 
-		var reasoning *ReasoningSpec
-		if sp.EnableMultiTurnChat {
-			reasoning = computeReasoningSpec(stage.Rate, stage.Duration, numClientsPerStage)
-		}
-
 		// For multi-turn (reasoning) workloads, use Poisson arrival for session start time.
 		// The rounds within each session are spaced by ThinkTimeUs (not sampled IATs).
 		// NormalizedExponentialSampler only applies to non-reasoning (language) workloads
 		// where each request is independent (not part of a multi-round session).
 		if sp.EnableMultiTurnChat {
-			// Multi-turn: use Poisson, rounds controlled by MaxRounds + ThinkTimeUs
+			// Multi-turn: distribute total requests evenly across sessions
+			totalRequests := int(stage.Rate * float64(stage.Duration))
+			perSessionRounds := distributeRequestsEvenly(totalRequests, numClientsPerStage)
+
+			clientIdx := 0
 			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 				prefixGroup := fmt.Sprintf("prompt-%d", p)
 				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 					clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
+					reasoning := computeReasoningSpec(stage.Rate, numClientsPerStage, perSessionRounds[clientIdx])
+					clientIdx++
+
 					clients = append(clients, ClientSpec{
 						ID:           clientID,
 						TenantID:     prefixGroup,
@@ -190,7 +192,6 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 						OutputDist:           outputDist,
 						PrefixGroup:          prefixGroup,
 						PrefixLength:         sp.SystemPromptLen,
-						Reasoning:            reasoning,
 					})
 				}
 			}
@@ -224,28 +225,53 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 				Windows: []ActiveWindow{windows[s]},
 			}
 
-			var reasoning *ReasoningSpec
 			if sp.EnableMultiTurnChat {
-				reasoning = computeReasoningSpec(stage.Rate, stage.Duration, numClientsPerStage)
-			}
+				// Multi-turn: distribute total requests evenly across sessions for this stage
+				totalRequests := int(stage.Rate * float64(stage.Duration))
+				perSessionRounds := distributeRequestsEvenly(totalRequests, numClientsPerStage)
 
-			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
-				prefixGroup := fmt.Sprintf("prompt-%d", p)
-				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
-					clientID := fmt.Sprintf("stage-%d-prompt-%d-user-%d", s, p, u)
-					clients = append(clients, ClientSpec{
-						ID:           clientID,
-						TenantID:     prefixGroup,
-						SLOClass:     "standard",
-						RateFraction: rateFraction,
-						Arrival:      ArrivalSpec{Process: "poisson"},
-						InputDist:    inputDist,
-						OutputDist:   outputDist,
-						PrefixGroup:  prefixGroup,
-						PrefixLength: sp.SystemPromptLen,
-						Reasoning:    reasoning,
-						Lifecycle:    stageLifecycle,
-					})
+				clientIdx := 0
+				for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
+					prefixGroup := fmt.Sprintf("prompt-%d", p)
+					for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
+						clientID := fmt.Sprintf("stage-%d-prompt-%d-user-%d", s, p, u)
+						reasoning := computeReasoningSpec(stage.Rate, numClientsPerStage, perSessionRounds[clientIdx])
+						clientIdx++
+
+						clients = append(clients, ClientSpec{
+							ID:           clientID,
+							TenantID:     prefixGroup,
+							SLOClass:     "standard",
+							RateFraction: rateFraction,
+							Arrival:      ArrivalSpec{Process: "poisson"},
+							InputDist:    inputDist,
+							OutputDist:   outputDist,
+							PrefixGroup:  prefixGroup,
+							PrefixLength: sp.SystemPromptLen,
+							Reasoning:    reasoning,
+							Lifecycle:    stageLifecycle,
+						})
+					}
+				}
+			} else {
+				// Non-multi-turn multi-stage: use Poisson
+				for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
+					prefixGroup := fmt.Sprintf("prompt-%d", p)
+					for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
+						clientID := fmt.Sprintf("stage-%d-prompt-%d-user-%d", s, p, u)
+						clients = append(clients, ClientSpec{
+							ID:           clientID,
+							TenantID:     prefixGroup,
+							SLOClass:     "standard",
+							RateFraction: rateFraction,
+							Arrival:      ArrivalSpec{Process: "poisson"},
+							InputDist:    inputDist,
+							OutputDist:   outputDist,
+							PrefixGroup:  prefixGroup,
+							PrefixLength: sp.SystemPromptLen,
+							Lifecycle:    stageLifecycle,
+						})
+					}
 				}
 			}
 		}
@@ -283,7 +309,8 @@ func stagesToWindows(stages []StageSpec) []ActiveWindow {
 // computeReasoningSpec builds a ReasoningSpec for inference-perf multi-turn mode.
 // It derives MaxRounds and ThinkTimeUs from stage parameters to match inference-perf's
 // round-robin cycling behavior: N sessions cycle at rate R over duration D seconds.
-// MaxRounds = ceil(R * D / N): total requests per session
+//
+// MaxRounds = roundsForThisSession (from fair distribution of total requests)
 // ThinkTimeUs = floor((N / R) * 1e6): inter-round delay in microseconds
 //
 // ContextGrowth is intentionally empty (fixed-length inputs per round) because
@@ -293,8 +320,7 @@ func stagesToWindows(stages []StageSpec) []ActiveWindow {
 // Note: ThinkTimeUs does not account for the 1µs/token output completion heuristic
 // in GenerateReasoningRequests. This is negligible for typical parameterizations
 // (e.g., OutputLen=248 adds 248µs to a ThinkTimeUs of 600,000µs = 0.04% error).
-func computeReasoningSpec(stageRate float64, stageDurationSec int64, numSessions int) *ReasoningSpec {
-	maxRounds := int(math.Ceil(stageRate * float64(stageDurationSec) / float64(numSessions)))
+func computeReasoningSpec(stageRate float64, numSessions int, roundsForThisSession int) *ReasoningSpec {
 	thinkTimeUs := int64(float64(numSessions) / stageRate * 1e6)
 	return &ReasoningSpec{
 		ReasonRatioDist: DistSpec{
@@ -302,7 +328,7 @@ func computeReasoningSpec(stageRate float64, stageDurationSec int64, numSessions
 			Params: map[string]float64{"value": 0},
 		},
 		MultiTurn: &MultiTurnSpec{
-			MaxRounds:     maxRounds,
+			MaxRounds:     roundsForThisSession,
 			ThinkTimeUs:   thinkTimeUs,
 			ContextGrowth: "", // fixed-length: matches real inference-perf behavior
 			SingleSession: true,

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -140,24 +140,12 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 				}
 			}
 		} else {
-			// Single-request (language) workload: use NormalizedExponentialSampler
-			// Each client gets exactly ceil(stageRate * duration / numClients) requests
-			// over the stage duration, using normalized exponential distribution.
-			// NOTE: math.Ceil means total requests may exceed stage.Rate * stage.Duration
-			// by up to numClients-1. This matches inference-perf behavior.
-			requestsPerClient := int64(math.Ceil(stage.Rate * float64(stage.Duration) / float64(numClientsPerStage)))
+			// Single-request (language) workload: use NormalizedExponentialSampler.
+			// Distribute total requests evenly across clients using fair allocation
+			// (floor-with-remainder) to match real inference-perf exact counts.
+			totalRequests := int(stage.Rate * float64(stage.Duration))
+			perClientDist := distributeRequestsEvenly(totalRequests, numClientsPerStage)
 			durationUs := stage.Duration * 1_000_000 // seconds to microseconds
-
-			// Validate sampler parameters before construction (prevent panic on user input)
-			if requestsPerClient <= 0 {
-				return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
-			}
-			if requestsPerClient > 10_000_000 {
-				return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)
-			}
-			if durationUs < requestsPerClient {
-				return nil, fmt.Errorf("inference_perf: durationUs (%d) < requestsPerClient (%d) produces degenerate distribution", durationUs, requestsPerClient)
-			}
 
 			// Defensive: prevent integer overflow in seed calculation (cast before multiply)
 			totalClients := int64(sp.NumUniqueSystemPrompts) * int64(sp.NumUsersPerSystemPrompt)
@@ -165,17 +153,31 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 				return nil, fmt.Errorf("total client count %d exceeds safety limit (1M)", totalClients)
 			}
 
-			// Create factory closure that captures requestsPerClient and durationUs.
-			// Each GenerateRequests call will invoke this factory with a sub-RNG,
-			// producing a fresh sampler instance (workload reusability).
-			factory := func(rng *rand.Rand) ArrivalSampler {
-				return NewNormalizedExponentialSampler(rng, requestsPerClient, durationUs)
-			}
-
+			clientIdx := 0
 			for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 				prefixGroup := fmt.Sprintf("prompt-%d", p)
 				for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 					clientID := fmt.Sprintf("prompt-%d-user-%d", p, u)
+					requestsPerClient := int64(perClientDist[clientIdx])
+					clientIdx++
+
+					// Validate sampler parameters before construction (prevent panic on user input)
+					if requestsPerClient <= 0 {
+						return nil, fmt.Errorf("inference_perf: requestsPerClient must be positive, got %d", requestsPerClient)
+					}
+					if requestsPerClient > 10_000_000 {
+						return nil, fmt.Errorf("inference_perf: requestsPerClient %d exceeds safety limit (10M); reduce rate, duration, or increase clients", requestsPerClient)
+					}
+					if durationUs < requestsPerClient {
+						return nil, fmt.Errorf("inference_perf: durationUs (%d) < requestsPerClient (%d) produces degenerate distribution", durationUs, requestsPerClient)
+					}
+
+					// Create factory closure that captures requestsPerClient and durationUs.
+					// Each GenerateRequests call will invoke this factory with a sub-RNG,
+					// producing a fresh sampler instance (workload reusability).
+					factory := func(rng *rand.Rand) ArrivalSampler {
+						return NewNormalizedExponentialSampler(rng, requestsPerClient, durationUs)
+					}
 
 					clients = append(clients, ClientSpec{
 						ID:                   clientID,

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -2016,3 +2016,64 @@ func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_FairDistribution(t *tes
 		t.Errorf("total requests = %d, want 600 (exact)", len(requests))
 	}
 }
+
+// --- Determinism regression test (Task 4) ---
+
+func TestExpandInferencePerfSpec_ExactDistribution_PreservesDeterminism(t *testing.T) {
+	// BC-5: Determinism preserved after fix (INV-6)
+	spec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 5.0, Duration: 600},
+			{Rate: 10.0, Duration: 600},
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  11,
+			NumUsersPerSystemPrompt: 4,
+			SystemPromptLen:         100,
+			QuestionLen:             200,
+			OutputLen:               50,
+			EnableMultiTurnChat:     true,
+		},
+	}
+
+	// Generate twice with same seed
+	horizon := int64(1_200_000_000)
+
+	expanded1, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion1 error: %v", err)
+	}
+	r1, err := GenerateRequests(expanded1, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation1 error: %v", err)
+	}
+
+	expanded2, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion2 error: %v", err)
+	}
+	r2, err := GenerateRequests(expanded2, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation2 error: %v", err)
+	}
+
+	// Verify byte-identical output
+	if len(r1) != len(r2) {
+		t.Fatalf("different counts: %d vs %d", len(r1), len(r2))
+	}
+	for i := range r1 {
+		if r1[i].ArrivalTime != r2[i].ArrivalTime {
+			t.Errorf("request %d: arrival %d vs %d", i, r1[i].ArrivalTime, r2[i].ArrivalTime)
+			if i >= 5 {
+				t.Logf("... (stopping after 5 mismatches)")
+				break
+			}
+		}
+		if r1[i].ID != r2[i].ID {
+			t.Errorf("request %d: ID %q vs %q", i, r1[i].ID, r2[i].ID)
+			if i >= 5 {
+				break
+			}
+		}
+	}
+}

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -2,7 +2,6 @@ package workload
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1514,18 +1513,18 @@ func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
 }
 
 func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T) {
-	// Invariant test: sum(per_client_requests) == total expected requests
-	// Tests the conservation law that requestsPerClient allocation sums correctly.
+	// Invariant test: sum(per_client_requests) == int(rate * duration)
+	// Tests the conservation law: exact total with fair distribution (max diff <= 1).
 	cases := []struct {
 		rate       float64
 		duration   int64
 		numPrompts int
 		numUsers   int
 	}{
-		{rate: 10.0, duration: 60, numPrompts: 3, numUsers: 2},  // 600 total / 6 clients = 100 each
-		{rate: 10.0, duration: 61, numPrompts: 2, numUsers: 2},  // 610 total / 4 clients = ceil(152.5)=153 each
-		{rate: 5.0, duration: 100, numPrompts: 1, numUsers: 7},  // 500 total / 7 clients
-		{rate: 100.0, duration: 10, numPrompts: 10, numUsers: 3}, // 1000 total / 30 clients
+		{rate: 10.0, duration: 60, numPrompts: 3, numUsers: 2},   // 600 total / 6 clients = 100 each
+		{rate: 10.0, duration: 61, numPrompts: 2, numUsers: 2},   // 610 total / 4 clients = 152 or 153
+		{rate: 5.0, duration: 100, numPrompts: 1, numUsers: 7},   // 500 total / 7 clients = 71 or 72
+		{rate: 100.0, duration: 10, numPrompts: 10, numUsers: 3}, // 1000 total / 30 clients = 33 or 34
 	}
 
 	for _, tc := range cases {
@@ -1547,7 +1546,7 @@ func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T)
 				t.Fatalf("expansion error: %v", err)
 			}
 
-			// Horizon = 2× duration: ensures sampler exhaustion (not horizon) stops generation.
+			// Horizon = 2x duration: ensures sampler exhaustion (not horizon) stops generation.
 			// With horizon == duration, sampler and horizon guard race, creating test fragility.
 			horizon := tc.duration * 2_000_000
 			requests, err := GenerateRequests(expanded, horizon, 0)
@@ -1561,22 +1560,26 @@ func TestExpandInferencePerfSpec_SingleStage_ConservationInvariant(t *testing.T)
 				perClientCounts[req.ClientID]++
 			}
 
-			// Expected: each client gets ceil(rate * duration / numClients) requests
-			numClients := tc.numPrompts * tc.numUsers
-			expectedPerClient := int(math.Ceil(tc.rate * float64(tc.duration) / float64(numClients)))
-
-			// Verify each client got exactly expectedPerClient requests
-			for clientID, count := range perClientCounts {
-				if count != expectedPerClient {
-					t.Errorf("client %s: got %d requests, want %d", clientID, count, expectedPerClient)
-				}
+			// Conservation: total requests == int(rate * duration) (exact, no ceiling inflation)
+			expectedTotal := int(tc.rate * float64(tc.duration))
+			if len(requests) != expectedTotal {
+				t.Errorf("total requests = %d, want %d (exact: int(rate*duration))",
+					len(requests), expectedTotal)
 			}
 
-			// Verify sum equals numClients * expectedPerClient (conservation)
-			expectedTotal := numClients * expectedPerClient
-			if len(requests) != expectedTotal {
-				t.Errorf("total requests = %d, want %d (conservation: %d clients * %d each)",
-					len(requests), expectedTotal, numClients, expectedPerClient)
+			// Fair distribution: per-client counts differ by at most 1
+			minCount, maxCount := len(requests), 0
+			for _, count := range perClientCounts {
+				if count < minCount {
+					minCount = count
+				}
+				if count > maxCount {
+					maxCount = count
+				}
+			}
+			if maxCount-minCount > 1 {
+				t.Errorf("unfair distribution: max=%d min=%d diff=%d (want diff <= 1)",
+					maxCount, minCount, maxCount-minCount)
 			}
 		})
 	}
@@ -1800,4 +1803,95 @@ func slicesEqual(a, b []int) bool {
 		}
 	}
 	return true
+}
+
+func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_ExactRequestCount(t *testing.T) {
+	// BC-1: exact total request count (no ceiling inflation)
+	tests := []struct {
+		rate       float64
+		duration   int64
+		numPrompts int
+		numUsers   int
+		wantTotal  int
+	}{
+		{10.0, 60, 3, 2, 600},    // 10*60=600, 6 clients
+		{5.0, 600, 11, 4, 3000},  // Issue #978 stage 0 example
+		{10.0, 600, 11, 4, 6000}, // Issue #978 stage 1 example
+		{7.5, 100, 2, 3, 750},    // Non-integer per-client
+		{20.0, 30, 7, 3, 600},    // 600/21 = 28.57 → was 630 with ceil, now 600
+	}
+	for _, tt := range tests {
+		spec := &InferencePerfSpec{
+			Stages: []StageSpec{{Rate: tt.rate, Duration: tt.duration}},
+			SharedPrefix: &SharedPrefixSpec{
+				NumUniqueSystemPrompts:  tt.numPrompts,
+				NumUsersPerSystemPrompt: tt.numUsers,
+				SystemPromptLen:         10,
+				QuestionLen:             10,
+				OutputLen:               10,
+				EnableMultiTurnChat:     false, // non-multi-turn path
+			},
+		}
+		expanded, err := ExpandInferencePerfSpec(spec, 42)
+		if err != nil {
+			t.Fatalf("expansion error: %v", err)
+		}
+		horizon := tt.duration * 2_000_000 // 2× duration (sampler-limited)
+		requests, err := GenerateRequests(expanded, horizon, 0)
+		if err != nil {
+			t.Fatalf("generation error: %v", err)
+		}
+		if len(requests) != tt.wantTotal {
+			t.Errorf("rate=%.1f dur=%d clients=%dx%d: got %d requests, want %d (exact, no ceiling)",
+				tt.rate, tt.duration, tt.numPrompts, tt.numUsers,
+				len(requests), tt.wantTotal)
+		}
+	}
+}
+
+func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_FairDistribution(t *testing.T) {
+	// BC-4: Per-client counts differ by at most 1
+	spec := &InferencePerfSpec{
+		Stages: []StageSpec{{Rate: 10.0, Duration: 60}}, // 600 requests / 7 clients
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  7,
+			NumUsersPerSystemPrompt: 1,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+			EnableMultiTurnChat:     false,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	horizon := int64(120_000_000) // 120 seconds
+	requests, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+	// Count per client
+	perClient := make(map[string]int)
+	for _, req := range requests {
+		perClient[req.ClientID]++
+	}
+	// Find min and max counts
+	minCount, maxCount := 999999, 0
+	for _, count := range perClient {
+		if count < minCount {
+			minCount = count
+		}
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+	if maxCount-minCount > 1 {
+		t.Errorf("unfair distribution: max=%d min=%d diff=%d (want diff <= 1)",
+			maxCount, minCount, maxCount-minCount)
+	}
+	// Verify total is exact
+	if len(requests) != 600 {
+		t.Errorf("total requests = %d, want 600 (exact)", len(requests))
+	}
 }

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1740,3 +1740,64 @@ func TestInferencePerfClients_SLOClass_IsStandard(t *testing.T) {
 		})
 	}
 }
+
+func TestDistributeRequestsEvenly_ExactTotal(t *testing.T) {
+	// BC-4: Fair distribution with max difference <= 1, sum equals total
+	tests := []struct {
+		total int
+		n     int
+		want  []int
+	}{
+		{total: 100, n: 3, want: []int{34, 33, 33}}, // 34+33+33=100
+		{total: 10, n: 10, want: []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+		{total: 44, n: 7, want: []int{7, 7, 6, 6, 6, 6, 6}}, // 2x7 + 5x6 = 44
+		{total: 3000, n: 44, want: nil},                       // Just verify sum=3000
+		{total: 6000, n: 44, want: nil},                       // Issue #978 example
+		{total: 0, n: 5, want: []int{0, 0, 0, 0, 0}},         // Edge: zero requests
+		{total: 7, n: 1, want: []int{7}},                      // Edge: single client
+	}
+	for _, tt := range tests {
+		dist := distributeRequestsEvenly(tt.total, tt.n)
+		sum := 0
+		for _, count := range dist {
+			sum += count
+		}
+		if sum != tt.total {
+			t.Errorf("distributeRequestsEvenly(%d, %d): sum=%d, want %d",
+				tt.total, tt.n, sum, tt.total)
+		}
+		if tt.want != nil {
+			if !slicesEqual(dist, tt.want) {
+				t.Errorf("distributeRequestsEvenly(%d, %d) = %v, want %v",
+					tt.total, tt.n, dist, tt.want)
+			}
+		}
+		// Check fairness: max difference <= 1
+		if len(dist) > 1 {
+			min, max := dist[0], dist[0]
+			for _, v := range dist {
+				if v < min {
+					min = v
+				}
+				if v > max {
+					max = v
+				}
+			}
+			if max-min > 1 {
+				t.Errorf("unfair distribution: max-min=%d > 1", max-min)
+			}
+		}
+	}
+}
+
+func slicesEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -548,7 +548,7 @@ func TestExpandInferencePerfSpec_MultiTurn_MapsToReasoning(t *testing.T) {
 			t.Fatalf("client %q: MultiTurn should be set", c.ID)
 		}
 		// rate=10, duration=600, sessions=2*3=6
-		// MaxRounds = ceil(10*600/6) = 1000
+		// MaxRounds = floor(10*600/6) = 1000 (evenly divisible)
 		// ThinkTimeUs = floor(6/10 * 1e6) = 600_000
 		if mt.MaxRounds != 1000 {
 			t.Errorf("client %q: MaxRounds = %d, want 1000", c.ID, mt.MaxRounds)
@@ -648,7 +648,7 @@ func TestExpandInferencePerfSpec_MultiStageMultiTurn_Succeeds(t *testing.T) {
 func TestExpandInferencePerfSpec_MultiTurn_ComputedParameters(t *testing.T) {
 	// BC-3: MaxRounds, ThinkTimeUs, SingleSession computed from stage parameters.
 	// 1 stage, rate=10, duration=600, 2 prompts × 5 users = 10 sessions
-	// MaxRounds = ceil(10*600/10) = 600
+	// MaxRounds = floor(10*600/10) = 600 (evenly divisible)
 	// ThinkTimeUs = floor(10/10 * 1e6) = 1_000_000
 	spec := &InferencePerfSpec{
 		Stages: []StageSpec{
@@ -687,8 +687,8 @@ func TestExpandInferencePerfSpec_MultiTurn_ComputedParameters(t *testing.T) {
 func TestExpandInferencePerfSpec_MultiStageMultiTurn_PerStageParameters(t *testing.T) {
 	// BC-4: Each stage gets its own computed MaxRounds and ThinkTimeUs.
 	// 2 stages (rate=5/dur=600, rate=20/dur=300), 1 prompt × 1 user = 1 session
-	// Stage 0: MaxRounds = ceil(5*600/1) = 3000, ThinkTimeUs = floor(1/5 * 1e6) = 200_000
-	// Stage 1: MaxRounds = ceil(20*300/1) = 6000, ThinkTimeUs = floor(1/20 * 1e6) = 50_000
+	// Stage 0: MaxRounds = floor(5*600/1) = 3000, ThinkTimeUs = floor(1/5 * 1e6) = 200_000
+	// Stage 1: MaxRounds = floor(20*300/1) = 6000, ThinkTimeUs = floor(1/20 * 1e6) = 50_000
 	spec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 5.0, Duration: 600},
@@ -1346,8 +1346,8 @@ func TestGenerateRequests_InferencePerfSpec_MultiTurnMultiStage_Integration(t *t
 
 func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T) {
 	// BC-2: Single-stage expansion uses normalized exponential and produces
-	// exactly ceil(rate*duration/numClients) requests per client, summing to
-	// the stage duration.
+	// floor(total/numClients) requests per client (with remainder distributed
+	// to first clients), summing to the stage total.
 	ipSpec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 10.0, Duration: 60}, // 10 req/s for 60s = 600 total requests
@@ -1364,7 +1364,7 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedExponential(t *testing.T)
 	if err != nil {
 		t.Fatalf("expansion error: %v", err)
 	}
-	// 3*2 = 6 clients, each should get ceil(600/6) = 100 requests
+	// 3*2 = 6 clients, each should get floor(600/6) = 100 requests (evenly divisible)
 	// Horizon = 2× duration: ensures sampler exhaustion (not horizon) stops generation.
 	horizon := int64(120_000_000) // 120 seconds in µs (2× stage duration)
 	requests, err := GenerateRequests(expanded, horizon, 0)

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1920,24 +1920,11 @@ func TestExpandInferencePerfSpec_ZeroRequestsError(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
-			if !containsString(err.Error(), tt.expectedErrorMsg) {
+			if !strings.Contains(err.Error(), tt.expectedErrorMsg) {
 				t.Errorf("error message %q does not contain %q", err.Error(), tt.expectedErrorMsg)
 			}
 		})
 	}
-}
-
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 func TestExpandInferencePerfSpec_SingleStageMultiTurn_ExactRequestCount(t *testing.T) {

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1760,7 +1760,10 @@ func TestDistributeRequestsEvenly_ExactTotal(t *testing.T) {
 		{total: 7, n: 1, want: []int{7}},                      // Edge: single client
 	}
 	for _, tt := range tests {
-		dist := distributeRequestsEvenly(tt.total, tt.n)
+		dist, err := distributeRequestsEvenly(tt.total, tt.n)
+		if err != nil {
+			t.Fatalf("distributeRequestsEvenly(%d, %d) unexpected error: %v", tt.total, tt.n, err)
+		}
 		sum := 0
 		for _, count := range dist {
 			sum += count
@@ -1790,6 +1793,26 @@ func TestDistributeRequestsEvenly_ExactTotal(t *testing.T) {
 				t.Errorf("unfair distribution: max-min=%d > 1", max-min)
 			}
 		}
+	}
+}
+
+func TestDistributeRequestsEvenly_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		total int
+		n     int
+	}{
+		{"n <= 0", 10, 0},
+		{"n < 0", 10, -1},
+		{"totalRequests < 0", -5, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := distributeRequestsEvenly(tt.total, tt.n)
+			if err == nil {
+				t.Errorf("distributeRequestsEvenly(%d, %d) expected error, got nil", tt.total, tt.n)
+			}
+		})
 	}
 }
 
@@ -1849,9 +1872,85 @@ func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_ExactRequestCount(t *te
 	}
 }
 
+func TestExpandInferencePerfSpec_ZeroRequestsError(t *testing.T) {
+	// Test error handling when rate × duration produces zero requests.
+	// This addresses issue #978 review feedback (silent failure in multi-turn path).
+	tests := []struct {
+		name             string
+		stages           []StageSpec
+		enableMultiTurn  bool
+		expectedErrorMsg string
+	}{
+		{
+			name:             "single-stage non-multi-turn",
+			stages:           []StageSpec{{Rate: 0.5, Duration: 1}},
+			enableMultiTurn:  false,
+			expectedErrorMsg: "rate 0.5000 × duration 1 produces 0 requests",
+		},
+		{
+			name:             "single-stage multi-turn",
+			stages:           []StageSpec{{Rate: 0.001, Duration: 1}},
+			enableMultiTurn:  true,
+			expectedErrorMsg: "rate 0.0010 × duration 1 produces 0 requests",
+		},
+		{
+			name: "multi-stage multi-turn (stage 1 has zero)",
+			stages: []StageSpec{
+				{Rate: 10.0, Duration: 60},   // OK: 600 requests
+				{Rate: 0.001, Duration: 1},   // Zero requests
+			},
+			enableMultiTurn:  true,
+			expectedErrorMsg: "stages[1]: rate 0.0010 × duration 1 produces 0 requests",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &InferencePerfSpec{
+				Stages: tt.stages,
+				SharedPrefix: &SharedPrefixSpec{
+					NumUniqueSystemPrompts:  2,
+					NumUsersPerSystemPrompt: 2,
+					SystemPromptLen:         10,
+					QuestionLen:             10,
+					OutputLen:               10,
+					EnableMultiTurnChat:     tt.enableMultiTurn,
+				},
+			}
+			_, err := ExpandInferencePerfSpec(spec, 42)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !containsString(err.Error(), tt.expectedErrorMsg) {
+				t.Errorf("error message %q does not contain %q", err.Error(), tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 func TestExpandInferencePerfSpec_SingleStageMultiTurn_ExactRequestCount(t *testing.T) {
 	// BC-2: Single-stage multi-turn generates exact request count.
-	// Uses horizon = 2x duration so Poisson start-time stagger doesn't clip rounds.
+	//
+	// Horizon calculation: For rate=5, duration=600, sessions=44:
+	// - totalRequests = 3000, MaxRounds ≈ 68 per session (fair distribution)
+	// - ThinkTimeUs = 8,800,000 µs (sessions/rate = 44/5 * 1e6)
+	// - Last round of any session arrives at: startTime + (MaxRounds-1) × ThinkTimeUs
+	//   ≈ startTime + 67 × 8,800,000 µs = startTime + 589.6s
+	// - For seed=42 Poisson sampling, all sessions start before ~601s (duration boundary)
+	// - Horizon = 2×600 = 1200s provides ~599s margin, accommodating all rounds.
+	// This ensures no lifecycle window clipping of rounds.
 	spec := &InferencePerfSpec{
 		Stages: []StageSpec{{Rate: 5.0, Duration: 600}},
 		SharedPrefix: &SharedPrefixSpec{

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -1849,6 +1849,127 @@ func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_ExactRequestCount(t *te
 	}
 }
 
+func TestExpandInferencePerfSpec_SingleStageMultiTurn_ExactRequestCount(t *testing.T) {
+	// BC-2: Single-stage multi-turn generates exact request count.
+	// Uses horizon = 2x duration so Poisson start-time stagger doesn't clip rounds.
+	spec := &InferencePerfSpec{
+		Stages: []StageSpec{{Rate: 5.0, Duration: 600}},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  11,
+			NumUsersPerSystemPrompt: 4,
+			SystemPromptLen:         100,
+			QuestionLen:             200,
+			OutputLen:               50,
+			EnableMultiTurnChat:     true,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	// Use 2x duration as horizon so all sessions complete their rounds
+	// (same pattern as non-multi-turn tests).
+	horizon := int64(1_200_000_000) // 1200 seconds = 2 × 600
+	requests, err := GenerateRequests(expanded, horizon, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+	// Should get exactly 3000 requests (not 3036 from ceil inflation)
+	if len(requests) != 3000 {
+		t.Errorf("multi-turn request count = %d, want 3000 (exact, issue #978 example)",
+			len(requests))
+	}
+}
+
+func TestExpandInferencePerfSpec_MultiStageMultiTurn_ExactMaxRoundsSum(t *testing.T) {
+	// BC-3: Multi-stage multi-turn: sum of per-session MaxRounds equals
+	// int(rate * duration) per stage (the expansion contract).
+	// Note: actual generated request count may be lower due to lifecycle window
+	// clipping of late-starting sessions. This test verifies the expansion math.
+	spec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 5.0, Duration: 600},
+			{Rate: 10.0, Duration: 600},
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  11,
+			NumUsersPerSystemPrompt: 4,
+			SystemPromptLen:         100,
+			QuestionLen:             200,
+			OutputLen:               50,
+			EnableMultiTurnChat:     true,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+
+	numClientsPerStage := 11 * 4 // 44
+	// Stage 0 clients: first 44, Stage 1 clients: next 44
+	var stage0Sum, stage1Sum int
+	for i, client := range expanded.Clients {
+		if client.Reasoning == nil || client.Reasoning.MultiTurn == nil {
+			t.Fatalf("client %d (%s): missing Reasoning/MultiTurn", i, client.ID)
+		}
+		if i < numClientsPerStage {
+			stage0Sum += client.Reasoning.MultiTurn.MaxRounds
+		} else {
+			stage1Sum += client.Reasoning.MultiTurn.MaxRounds
+		}
+	}
+
+	// Stage 0: int(5.0 * 600) = 3000 (not 3036 from ceil)
+	if stage0Sum != 3000 {
+		t.Errorf("stage 0 MaxRounds sum = %d, want 3000 (exact)", stage0Sum)
+	}
+	// Stage 1: int(10.0 * 600) = 6000 (not 6028 from ceil)
+	if stage1Sum != 6000 {
+		t.Errorf("stage 1 MaxRounds sum = %d, want 6000 (exact)", stage1Sum)
+	}
+}
+
+func TestExpandInferencePerfSpec_MultiTurn_PerSessionFairness(t *testing.T) {
+	// BC-4: Multi-turn sessions have MaxRounds differing by at most 1.
+	// 600 requests / 7 sessions = 85 or 86 rounds per session (5 get 86, 2 get 85).
+	spec := &InferencePerfSpec{
+		Stages: []StageSpec{{Rate: 10.0, Duration: 60}}, // 600 requests / 7 sessions
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  7,
+			NumUsersPerSystemPrompt: 1,
+			SystemPromptLen:         10,
+			QuestionLen:             10,
+			OutputLen:               10,
+			EnableMultiTurnChat:     true,
+		},
+	}
+	expanded, err := ExpandInferencePerfSpec(spec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+	// Check that MaxRounds varies by at most 1 across clients
+	minR, maxR := 999999, 0
+	totalRounds := 0
+	for _, client := range expanded.Clients {
+		rounds := client.Reasoning.MultiTurn.MaxRounds
+		totalRounds += rounds
+		if rounds < minR {
+			minR = rounds
+		}
+		if rounds > maxR {
+			maxR = rounds
+		}
+	}
+	if maxR-minR > 1 {
+		t.Errorf("unfair MaxRounds distribution: max=%d min=%d diff=%d (want diff <= 1)",
+			maxR, minR, maxR-minR)
+	}
+	// Sum must equal exactly int(rate * duration) = 600
+	if totalRounds != 600 {
+		t.Errorf("total MaxRounds = %d, want 600 (exact)", totalRounds)
+	}
+}
+
 func TestExpandInferencePerfSpec_SingleStageNonMultiTurn_FairDistribution(t *testing.T) {
 	// BC-4: Per-client counts differ by at most 1
 	spec := &InferencePerfSpec{

--- a/testdata/roofline_goldendataset.json
+++ b/testdata/roofline_goldendataset.json
@@ -38,16 +38,16 @@
         }
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 32.51628674463937,
-        "ttft_p90_ms": 94.666,
-        "ttft_p99_ms": 164.351,
-        "e2e_mean_ms": 1008.402364717349,
-        "e2e_p90_ms": 1753.196,
-        "e2e_p99_ms": 1753.196,
-        "itl_mean_ms": 3.9509557812660305
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 28.036537843137257,
+        "ttft_p90_ms": 75.521,
+        "ttft_p99_ms": 158.903,
+        "e2e_mean_ms": 944.6026382352942,
+        "e2e_p90_ms": 1749.715,
+        "e2e_p99_ms": 1749.715,
+        "itl_mean_ms": 3.7107939287131857
       }
     },
     {
@@ -86,16 +86,16 @@
         }
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 62.941204986760816,
-        "ttft_p90_ms": 151.44,
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 62.534974000000005,
+        "ttft_p90_ms": 146.534,
         "ttft_p99_ms": 166.775,
-        "e2e_mean_ms": 1450.0135584730804,
+        "e2e_mean_ms": 1445.7567813333333,
         "e2e_p90_ms": 1743.657,
         "e2e_p99_ms": 1825.876,
-        "itl_mean_ms": 5.638505501976909
+        "itl_mean_ms": 5.622852875338753
       }
     },
     {
@@ -134,16 +134,16 @@
         }
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 190.58033208296558,
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 190.19576333333333,
         "ttft_p90_ms": 410.024,
         "ttft_p99_ms": 424.898,
-        "e2e_mean_ms": 2107.7360828552514,
+        "e2e_mean_ms": 2104.335259777778,
         "e2e_p90_ms": 2312.299,
-        "e2e_p99_ms": 3661.16501,
-        "itl_mean_ms": 7.793316060049944
+        "e2e_p99_ms": 3661.8837499999995,
+        "itl_mean_ms": 7.781054863595303
       }
     },
     {
@@ -226,16 +226,16 @@
         }
       },
       "expected": {
-        "completed_requests": 16830,
-        "total_input_tokens": 9206010,
-        "total_output_tokens": 4157010,
-        "ttft_mean_ms": 217.479834818776,
+        "completed_requests": 16800,
+        "total_input_tokens": 9189600,
+        "total_output_tokens": 4149600,
+        "ttft_mean_ms": 217.3450801190476,
         "ttft_p90_ms": 411.249,
         "ttft_p99_ms": 493.587,
-        "e2e_mean_ms": 2348.738510160428,
-        "e2e_p90_ms": 2802.631,
+        "e2e_mean_ms": 2346.472362857143,
+        "e2e_p90_ms": 2800.18,
         "e2e_p99_ms": 3807.441,
-        "itl_mean_ms": 8.628577632962154
+        "itl_mean_ms": 8.619948513109698
       }
     },
     {
@@ -314,16 +314,16 @@
         }
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 12.20519688269073,
-        "ttft_p90_ms": 18.512200000000004,
-        "ttft_p99_ms": 21.279639999999997,
-        "e2e_mean_ms": 2961.2132953240357,
-        "e2e_p90_ms": 3527.8534000000004,
-        "e2e_p99_ms": 3712.8311,
-        "itl_mean_ms": 2.0380152719014135
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 12.1684725,
+        "ttft_p90_ms": 18.4942,
+        "ttft_p99_ms": 21.28,
+        "e2e_mean_ms": 2959.1177025,
+        "e2e_p90_ms": 3527.8312,
+        "e2e_p99_ms": 3712.99284,
+        "itl_mean_ms": 2.036592418797512
       }
     },
     {
@@ -362,16 +362,16 @@
         }
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 569.1367302144249,
-        "ttft_p90_ms": 1109.091,
-        "ttft_p99_ms": 1331.656,
-        "e2e_mean_ms": 2866.761032553606,
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 562.622844117647,
+        "ttft_p90_ms": 1106.794,
+        "ttft_p99_ms": 1177.023,
+        "e2e_mean_ms": 2850.3926449019605,
         "e2e_p90_ms": 3141.027,
-        "e2e_p99_ms": 4387.703,
-        "itl_mean_ms": 9.302122681535147
+        "e2e_p99_ms": 4057.2552699999997,
+        "itl_mean_ms": 9.262225914106534
       }
     },
     {
@@ -410,16 +410,16 @@
         }
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 549.3513719108561,
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 548.3526712222223,
         "ttft_p90_ms": 1074.595,
-        "ttft_p99_ms": 1164.609599999999,
-        "e2e_mean_ms": 3074.265229148279,
-        "e2e_p90_ms": 3240.265,
-        "e2e_p99_ms": 4412.599,
-        "itl_mean_ms": 10.263877468444807
+        "ttft_p99_ms": 1172.455509999999,
+        "e2e_mean_ms": 3069.011061222222,
+        "e2e_p90_ms": 3223.6956,
+        "e2e_p99_ms": 4412.60767,
+        "itl_mean_ms": 10.246578821138211
       }
     },
     {
@@ -458,16 +458,16 @@
         }
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 63.33066900584795,
-        "ttft_p90_ms": 193.952,
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 63.90182843137255,
+        "ttft_p90_ms": 195.2814,
         "ttft_p99_ms": 328.936,
-        "e2e_mean_ms": 834.906318128655,
+        "e2e_mean_ms": 836.13399,
         "e2e_p90_ms": 1190.078,
         "e2e_p99_ms": 1190.078,
-        "itl_mean_ms": 3.123788053128773
+        "itl_mean_ms": 3.126445998253552
       }
     },
     {
@@ -506,16 +506,16 @@
         }
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 359.8650970873786,
-        "ttft_p90_ms": 675.6151000000001,
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 358.501275,
+        "ttft_p90_ms": 675.613,
         "ttft_p99_ms": 747.436,
-        "e2e_mean_ms": 2362.950187886143,
-        "e2e_p90_ms": 2462.406,
-        "e2e_p99_ms": 3478.74,
-        "itl_mean_ms": 8.14262232032018
+        "e2e_mean_ms": 2356.4846262222222,
+        "e2e_p90_ms": 2455.58,
+        "e2e_p99_ms": 3357.48438,
+        "itl_mean_ms": 8.121883541553748
       }
     },
     {
@@ -598,16 +598,16 @@
         }
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 454.47979239766084,
-        "ttft_p90_ms": 1030.508,
-        "ttft_p99_ms": 1416.0212899999997,
-        "e2e_mean_ms": 2900.7737736842105,
-        "e2e_p90_ms": 3162.332,
-        "e2e_p99_ms": 4483.889,
-        "itl_mean_ms": 9.904024215735019
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 443.61430647058825,
+        "ttft_p90_ms": 986.332,
+        "ttft_p99_ms": 1180.0557499999986,
+        "e2e_mean_ms": 2881.71704,
+        "e2e_p90_ms": 3159.683,
+        "e2e_p99_ms": 4387.571,
+        "itl_mean_ms": 9.870861269349845
       }
     },
     {
@@ -642,16 +642,16 @@
         }
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 26.21899097621001,
-        "ttft_p90_ms": 39.4448,
-        "ttft_p99_ms": 56.17658,
-        "e2e_mean_ms": 4268.60657588187,
-        "e2e_p90_ms": 4346.8832,
-        "e2e_p99_ms": 4399.650640000001,
-        "itl_mean_ms": 2.9318504387737803
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 26.14547166666667,
+        "ttft_p90_ms": 39.425,
+        "ttft_p99_ms": 56.1412,
+        "e2e_mean_ms": 4268.168456666667,
+        "e2e_p90_ms": 4346.5904,
+        "e2e_p99_ms": 4398.26002,
+        "itl_mean_ms": 2.931598469246717
       }
     },
     {
@@ -686,16 +686,16 @@
         }
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 26.011490566037736,
-        "ttft_p90_ms": 27.0354,
-        "ttft_p99_ms": 62.115259999999985,
-        "e2e_mean_ms": 6549.824048400328,
-        "e2e_p90_ms": 7029.905000000001,
-        "e2e_p99_ms": 7531.5951000000005,
-        "itl_mean_ms": 4.508509024073455
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 25.939975833333335,
+        "ttft_p90_ms": 26.929000000000002,
+        "ttft_p99_ms": 62.339,
+        "e2e_mean_ms": 6547.379883333334,
+        "e2e_p90_ms": 7035.1229,
+        "e2e_p99_ms": 7532.97888,
+        "itl_mean_ms": 4.506869321008984
       }
     }
   ]

--- a/testdata/trained_physics_iter29.json
+++ b/testdata/trained_physics_iter29.json
@@ -55,16 +55,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 54.28152339181287,
-        "ttft_p90_ms": 64.3794,
-        "ttft_p99_ms": 68.03326,
-        "e2e_mean_ms": 6268.954041325535,
-        "e2e_p90_ms": 6613.820900000001,
-        "e2e_p99_ms": 6707.64647,
-        "itl_mean_ms": 25.157471732525195
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 54.510524705882354,
+        "ttft_p90_ms": 64.30810000000001,
+        "ttft_p99_ms": 68.05506000000001,
+        "e2e_mean_ms": 6266.126684705882,
+        "e2e_p90_ms": 6602.2344,
+        "e2e_p99_ms": 6705.10462,
+        "itl_mean_ms": 25.145097813765183
       }
     },
     {
@@ -103,16 +103,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 55.52767917034422,
-        "ttft_p90_ms": 65.8884,
-        "ttft_p99_ms": 69.407,
-        "e2e_mean_ms": 6517.131375110326,
-        "e2e_p90_ms": 6780.313,
-        "e2e_p99_ms": 6840.519740000001,
-        "itl_mean_ms": 26.26352315422757
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 55.52551666666667,
+        "ttft_p90_ms": 65.9966,
+        "ttft_p99_ms": 69.45903,
+        "e2e_mean_ms": 6515.546669666666,
+        "e2e_p90_ms": 6780.811199999999,
+        "e2e_p99_ms": 6840.521,
+        "itl_mean_ms": 26.257090052845527
       }
     },
     {
@@ -151,16 +151,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 31.70683594439541,
-        "ttft_p90_ms": 36.723,
-        "ttft_p99_ms": 42.93793999999999,
-        "e2e_mean_ms": 2505.0620808693734,
-        "e2e_p90_ms": 3230.7561000000005,
-        "e2e_p99_ms": 3632.25686,
-        "itl_mean_ms": 10.051131076930805
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 31.695497,
+        "ttft_p90_ms": 36.603,
+        "ttft_p99_ms": 42.85512,
+        "e2e_mean_ms": 2494.186436333333,
+        "e2e_p90_ms": 3202.5683,
+        "e2e_p99_ms": 3632.50088,
+        "itl_mean_ms": 10.00696723306233
       }
     },
     {
@@ -243,16 +243,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 16830,
-        "total_input_tokens": 9206010,
-        "total_output_tokens": 4157010,
-        "ttft_mean_ms": 36.25370926916221,
-        "ttft_p90_ms": 43.7841,
-        "ttft_p99_ms": 50.73,
-        "e2e_mean_ms": 3099.3036950683304,
-        "e2e_p90_ms": 4182.973,
-        "e2e_p99_ms": 4439.55565,
-        "itl_mean_ms": 12.397866339267887
+        "completed_requests": 16800,
+        "total_input_tokens": 9189600,
+        "total_output_tokens": 4149600,
+        "ttft_mean_ms": 36.27619,
+        "ttft_p90_ms": 43.7603,
+        "ttft_p99_ms": 50.93401,
+        "e2e_mean_ms": 3095.5977995238095,
+        "e2e_p90_ms": 4179.469700000001,
+        "e2e_p99_ms": 4439.56205,
+        "itl_mean_ms": 12.382771698476962
       }
     },
     {
@@ -331,16 +331,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 55.41061607875307,
-        "ttft_p90_ms": 65.2404,
-        "ttft_p99_ms": 68.71328,
-        "e2e_mean_ms": 36567.968657916324,
-        "e2e_p90_ms": 37720.428199999995,
-        "e2e_p99_ms": 38042.018619999995,
-        "itl_mean_ms": 25.232744327462036
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 55.39499416666666,
+        "ttft_p90_ms": 65.2502,
+        "ttft_p99_ms": 68.7337,
+        "e2e_mean_ms": 36538.317689999996,
+        "e2e_p90_ms": 37722.3723,
+        "e2e_p99_ms": 38042.46017,
+        "itl_mean_ms": 25.212263784266298
       }
     },
     {
@@ -379,16 +379,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 52.408987719298246,
-        "ttft_p90_ms": 67.786,
-        "ttft_p99_ms": 127.95749999999992,
-        "e2e_mean_ms": 4438.576400389863,
-        "e2e_p90_ms": 4614.457,
-        "e2e_p99_ms": 4685.8,
-        "itl_mean_ms": 17.75461705534642
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 50.71192980392157,
+        "ttft_p90_ms": 70.271,
+        "ttft_p99_ms": 93.371,
+        "e2e_mean_ms": 4433.453591176471,
+        "e2e_p90_ms": 4607.165,
+        "e2e_p99_ms": 4649.138,
+        "itl_mean_ms": 17.74074761689291
       }
     },
     {
@@ -427,16 +427,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 67.18229931597529,
-        "ttft_p90_ms": 121.19270000000056,
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 67.15683422222223,
+        "ttft_p90_ms": 119.301,
         "ttft_p99_ms": 157.512,
-        "e2e_mean_ms": 4568.813456531333,
-        "e2e_p90_ms": 4706.8615,
-        "e2e_p99_ms": 4839.07651,
-        "itl_mean_ms": 18.296155110631535
+        "e2e_mean_ms": 4566.275003777778,
+        "e2e_p90_ms": 4698.3409,
+        "e2e_p99_ms": 4839.406,
+        "itl_mean_ms": 18.28593971364047
       }
     },
     {
@@ -475,16 +475,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 26.17804931773879,
-        "ttft_p90_ms": 28.773,
-        "ttft_p99_ms": 29.87497,
-        "e2e_mean_ms": 1636.4889251461989,
-        "e2e_p90_ms": 1686.775,
-        "e2e_p99_ms": 1749.4940199999999,
-        "itl_mean_ms": 6.516331481086882
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 26.18501039215686,
+        "ttft_p90_ms": 28.808,
+        "ttft_p99_ms": 29.82808,
+        "e2e_mean_ms": 1635.2134350980393,
+        "e2e_p90_ms": 1681.441,
+        "e2e_p99_ms": 1745.4671,
+        "itl_mean_ms": 6.511139371278876
       }
     },
     {
@@ -523,16 +523,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 9064,
-        "total_input_tokens": 5130224,
-        "total_output_tokens": 2229744,
-        "ttft_mean_ms": 40.120723190644306,
-        "ttft_p90_ms": 50.776,
-        "ttft_p99_ms": 70.609,
-        "e2e_mean_ms": 3186.5229637025595,
-        "e2e_p90_ms": 3471.1354,
-        "e2e_p99_ms": 3584.469,
-        "itl_mean_ms": 12.787094473625672
+        "completed_requests": 9000,
+        "total_input_tokens": 5094000,
+        "total_output_tokens": 2214000,
+        "ttft_mean_ms": 39.299857777777774,
+        "ttft_p90_ms": 47.791,
+        "ttft_p99_ms": 66.601,
+        "e2e_mean_ms": 3177.2461804444447,
+        "e2e_p90_ms": 3465.1335999999997,
+        "e2e_p99_ms": 3584.1342799999998,
+        "itl_mean_ms": 12.752720823848238
       }
     },
     {
@@ -615,16 +615,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 5130,
-        "total_input_tokens": 2806110,
-        "total_output_tokens": 1267110,
-        "ttft_mean_ms": 46.9293358674464,
-        "ttft_p90_ms": 56.6159,
-        "ttft_p99_ms": 74.697,
-        "e2e_mean_ms": 4244.198876413255,
-        "e2e_p90_ms": 4404.592000000001,
-        "e2e_p99_ms": 4477.505,
-        "itl_mean_ms": 16.989848342290724
+        "completed_requests": 5100,
+        "total_input_tokens": 2789700,
+        "total_output_tokens": 1259700,
+        "ttft_mean_ms": 46.55270333333333,
+        "ttft_p90_ms": 55.51,
+        "ttft_p99_ms": 74.628,
+        "e2e_mean_ms": 4242.510950196078,
+        "e2e_p90_ms": 4414.6623,
+        "e2e_p99_ms": 4473.622,
+        "itl_mean_ms": 16.984539460982774
       }
     },
     {
@@ -659,16 +659,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 27.942819524200164,
-        "ttft_p90_ms": 30.708000000000002,
-        "ttft_p99_ms": 34.75876,
-        "e2e_mean_ms": 9925.427751435602,
-        "e2e_p90_ms": 10073.824799999999,
-        "e2e_p99_ms": 10131.051599999999,
-        "itl_mean_ms": 6.839466435322325
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 27.945933333333333,
+        "ttft_p90_ms": 30.6613,
+        "ttft_p99_ms": 34.766909999999996,
+        "e2e_mean_ms": 9924.43652,
+        "e2e_p90_ms": 10074.0548,
+        "e2e_p99_ms": 10131.169670000001,
+        "itl_mean_ms": 6.838779258235429
       }
     },
     {
@@ -703,16 +703,16 @@
         "version": "2"
       },
       "expected": {
-        "completed_requests": 1219,
-        "total_input_tokens": 1260446,
-        "total_output_tokens": 1763893,
-        "ttft_mean_ms": 35.12285151763741,
-        "ttft_p90_ms": 40.092000000000006,
-        "ttft_p99_ms": 42.34668,
-        "e2e_mean_ms": 17049.486731747333,
-        "e2e_p90_ms": 17354.3738,
-        "e2e_p99_ms": 17795.79558,
-        "itl_mean_ms": 11.757834747912714
+        "completed_requests": 1200,
+        "total_input_tokens": 1240800,
+        "total_output_tokens": 1736400,
+        "ttft_mean_ms": 35.12971666666667,
+        "ttft_p90_ms": 40.125,
+        "ttft_p99_ms": 42.35174,
+        "e2e_mean_ms": 17031.301476666667,
+        "e2e_p90_ms": 17353.2964,
+        "e2e_p99_ms": 17797.124789999998,
+        "itl_mean_ms": 11.745262446440913
       }
     }
   ]


### PR DESCRIPTION
## Summary

Fixes #978 - BLIS was generating more requests than specified due to `math.Ceil` rounding in `ExpandInferencePerfSpec`. For example, a workload spec with `rate=10, duration=900` and 44 clients produced 9064 requests instead of 9000 (64 extra).

## Root Cause

The implementation used `math.Ceil(rate × duration / numClients)` to allocate requests per client. With ceiling rounding, each client gets ⌈total/n⌉ requests, inflating the total by up to `n-1` requests.

Real inference-perf uses `int(rate × duration)` (floor/truncation) with no inflation.

## Changes

**Core fix:**
- Replaced `math.Ceil` allocation with floor-based fair distribution via new `distributeRequestsEvenly()` helper
- Algorithm: `base = floor(total/n)`, distribute `remainder = total % n` to first clients
- Result: exactly `total` requests, fairly distributed (max difference ≤ 1)

**Three code paths fixed:**
1. Single-stage non-multi-turn (line 148): NormalizedExponentialSampler allocation
2. Single-stage multi-turn (line 115): MaxRounds per session
3. Multi-stage multi-turn (line 295): MaxRounds per stage per session

**Behavioral contracts verified:**
- BC-1: Single-stage non-multi-turn generates exactly `int(rate × duration)` requests
- BC-2: Single-stage multi-turn generates exactly `int(rate × duration)` requests  
- BC-3: Multi-stage multi-turn MaxRounds sum equals `int(rate × duration)` per stage
- BC-4: Per-client/per-session distribution differs by at most 1 (fairness)
- BC-5: Determinism (INV-6) preserved after fix

## Test Plan

**New tests (9 test functions, 30+ cases):**
- `TestDistributeRequestsEvenly_ExactTotal`: Helper function behavioral contract
- `TestExpandInferencePerfSpec_SingleStageNonMultiTurn_ExactRequestCount`: BC-1, issue #978 examples
- `TestExpandInferencePerfSpec_SingleStageNonMultiTurn_FairDistribution`: BC-4 for single-stage
- `TestExpandInferencePerfSpec_SingleStageMultiTurn_ExactRequestCount`: BC-2
- `TestExpandInferencePerfSpec_MultiStageMultiTurn_ExactMaxRoundsSum`: BC-3
- `TestExpandInferencePerfSpec_MultiTurn_PerSessionFairness`: BC-4 for multi-turn
- `TestExpandInferencePerfSpec_ExactDistribution_PreservesDeterminism`: BC-5/INV-6

**Updated tests:**
- Pre-existing ConservationInvariant test updated to match floor-based behavior
- All stale `ceil` references in test comments replaced with `floor` descriptions

**Golden datasets updated:**
- `testdata/trained_physics_iter29.json`: 15 experiments (request counts corrected: 5130→5100, etc.)
- `testdata/roofline_goldendataset.json`: 15 experiments (request counts corrected: 9064→9000, etc.)

**Verification:**
- ✅ All workload tests pass (BC-1 through BC-5 verified)
- ✅ Full project test suite passes (`go test ./... -count=1`)
- ✅ Lint clean (`go vet ./...`)
- ✅ Binary builds successfully

## Files Changed

- `sim/workload/inference_perf.go`: Core fix (165 lines modified)
- `sim/workload/inference_perf_test.go`: 9 new test functions (393 lines added)
- `testdata/trained_physics_iter29.json`: Golden dataset update
- `testdata/roofline_goldendataset.json`: Golden dataset update

🤖 Generated with Claude Code