### PR TITLE
feat(cluster): decode-first routing + instance-local cache query (D1+D2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,8 @@ See [`docs/guide/latency-models.md`](docs/guide/latency-models.md) for details.
 
 Request processing pipeline: Arrival → Admission → Routing → WaitQueue → Batch Formation → Step Execution → Completion. Admission and Routing apply in cluster mode only; single-instance skips directly to WaitQueue. See [`docs/concepts/architecture.md`](docs/concepts/architecture.md) for the full diagram.
 
+**PD disaggregation pipeline (decode-first):** When P/D pools are configured, the pipeline uses a decode-first flow matching llm-d's `DisaggProfileHandler`: `Admission(1) → DecodeRouting(3) → DisaggDecision(4) → skip: DecodeEnqueue(5) | disagg: PrefillRouting(5) → KVTransferStart(6) → KVTransferComplete(7) → DecodeEnqueue(8)`. The decode instance is selected first; disaggregation is skipped when that instance already has the prefix cached (`DecodeContext.CachedBlockCount`). Event priorities: 0=Arrival, 1=Admission, 2=Routing (non-PD), 3=DecodeRouting, 4=DisaggDecision, 5=PrefillRouting/DecodeEnqueue(skip), 6=KVTransferStart, 7=KVTransferComplete, 8=DecodeEnqueue(disagg), 9=ScalingTick, 10=ScaleActuation.
+
 ## Project Governance Documents
 
 ### Standards (what rules apply)

--- a/docs/contributing/standards/invariants.md
+++ b/docs/contributing/standards/invariants.md
@@ -159,9 +159,9 @@ Invariants are properties that must hold at all times during and after simulatio
 
 **Statement:** For every disaggregated request, `decode_enqueue_time >= kv_transfer_completion_time`. A decode sub-request must not be enqueued before its KV transfer completes.
 
-**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_RequestCompletesFullPath` checks DecodeEnqueueTime >= TransferCompleteTime for every parent request. Runtime defensive check in `DecodeRoutingEvent.Execute()`.
+**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_RequestCompletesFullPath` checks DecodeEnqueueTime >= TransferCompleteTime for every parent request.
 
-**Evidence:** By event priority ordering: KVTransferCompletedEvent (priority 6) schedules DecodeRoutingEvent (priority 7) at the same timestamp. DecodeEnqueueTime is set in DecodeRoutingEvent which fires after transfer completion.
+**Evidence:** By event priority ordering: KVTransferCompletedEvent (priority 7) schedules DecodeEnqueueEvent (priority 8) at the same timestamp. DecodeEnqueueTime is set in DecodeEnqueueEvent (disagg path) which fires after transfer completion.
 
 ### INV-PD-2: Pool Exclusivity
 
@@ -181,11 +181,13 @@ Invariants are properties that must hold at all times during and after simulatio
 
 ### INV-PD-4: Phase Causality
 
-**Statement:** For every disaggregated request: `arrival <= prefill_enqueue <= prefill_complete <= transfer_start <= transfer_complete <= decode_enqueue <= completion`.
+**Statement:** The decode-first PD pipeline enforces two causal chains:
+- **Disagg path:** `arrival ≤ decode_route ≤ disagg_decision ≤ prefill_enqueue ≤ prefill_complete ≤ transfer_start ≤ transfer_complete ≤ decode_enqueue ≤ completion`
+- **Skip path (cache hit):** `arrival ≤ decode_route ≤ disagg_decision ≤ decode_enqueue ≤ completion`
 
-**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_PhaseCausality` checks the full causal chain for every parent request.
+**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_PhaseCausality` checks both causal chains for every parent request (disagg and skip-path variants).
 
-**Evidence:** Each phase transition is enforced by DES event ordering: earlier phases schedule later-phase events at `time >= current_time`.
+**Evidence:** Each phase transition is enforced by DES event priority ordering: DecodeRoutingEvent (3) → DisaggregationDecisionEvent (4) → PrefillRoutingEvent/DecodeEnqueueEvent (5) → KVTransferStartedEvent (6) → KVTransferCompletedEvent (7) → DecodeEnqueueEvent (8).
 
 ### INV-PD-5: Pool Stability
 
@@ -210,6 +212,22 @@ Invariants are properties that must hold at all times during and after simulatio
 **Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_CompletionTime_IncludesNonZeroOverhead` verifies that `E2E_with_overhead − E2E_without_overhead == overhead` exactly for trained-roofline clusters (directly exercises the bug-fix site). `TestDisaggregation_CompletionTime_GeqAllPriorPhaseTimestamps` verifies `CompletionTime >= DecodeEnqueueTime` and `CompletionTime >= TransferCompleteTime` (phase causality preserved). `TestDisaggregation_E2E_IncludesOverhead_ZeroOverheadRegression` verifies `RequestE2Es[parentID] == CompletionTime − ArrivalTime` and `E2E >= TTFT` for blackbox (overhead=0) clusters.
 
 **Evidence:** `detectDecodeCompletions()` in `sim/cluster/cluster.go` stamps `parent.CompletionTime = c.clock + inst.PostDecodeFixedOverhead()`. Fixed in issue #846.
+
+### INV-PD-7: Decode-First Ordering
+
+**Statement:** For every `ParentRequest`, `DecodeRouteDecisionTime ≤ DisaggDecisionTime`. The decode instance is always selected before the disaggregation decision is made — the decision is conditioned on the chosen instance's cache state, not the reverse.
+
+**Verification:** `sim/cluster/disaggregation_test.go` — `TestINVPD7_DecodeFirstOrdering` verifies the invariant across ≥20 table-driven cases (varying request count, decider, pool size, flow control, transfer contention). `TestINVPD8_InstanceLocalCacheQuery` also asserts INV-PD-7 as a precondition for each INV-PD-8 case.
+
+**Evidence:** `DecodeRoutingEvent` (priority 3) creates `ParentRequest` and stamps `DecodeRouteDecisionTime`, then schedules `DisaggregationDecisionEvent` (priority 4) which stamps `DisaggDecisionTime`. By event priority, priority 3 always fires before priority 4 at the same timestamp.
+
+### INV-PD-8: Instance-Local Cache Query
+
+**Statement:** The disaggregation decision is conditioned on the selected decode instance's actual KV cache state (queried via `cacheQueryFn`). The same request may disaggregate on one decode instance (prefix not cached) but skip disaggregation on another (prefix cached). The decider has no global router-side prefix cache; each decision reflects only the chosen instance's local state.
+
+**Verification:** `sim/cluster/disaggregation_test.go` — `TestINVPD8_InstanceLocalCacheQuery` verifies ≥20 table-driven cases: same request with varying prefix overlap against the decode instance cache produces the expected skip/disagg outcome. Uses a single decode instance per sub-test for deterministic routing. `TestPrefixThreshold_InstanceLocalCacheQuery` provides end-to-end wiring verification.
+
+**Evidence:** `DecodeRoutingEvent.Execute()` queries `cs.cacheQueryFn[targetInstance](req.InputTokens)` to get `CachedBlockCount`, which is passed to `DisaggregationDecider.Decide(req, DecodeContext{InstanceID, CachedBlockCount})`. `PrefixThresholdDecider` is stateless — it computes `nonCachedTokens = len(req.InputTokens) - ctx.CachedBlockCount * blockSize` without maintaining any internal prefix index.
 
 ### INV-P2-1: Pool-Config Consistency
 

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1106,10 +1106,10 @@ func (c *ClusterSimulator) tryDispatchFromGatewayQueue() bool {
 	}
 	req.GatewayDispatchTime = c.clock
 
-	// Schedule routing or disaggregation event (BC-9)
+	// Schedule decode-first PD pipeline or standard routing event (BC-9)
 	if c.poolsConfigured() {
 		heap.Push(&c.clusterEvents, clusterEventEntry{
-			event: &DisaggregationDecisionEvent{
+			event: &DecodeRoutingEvent{
 				time:    c.clock,
 				request: req,
 			},
@@ -1161,17 +1161,6 @@ func (c *ClusterSimulator) PerInstanceMetricsByID() map[string]*sim.Metrics {
 	return result
 }
 
-// notifyDisaggregationObserver calls ObserveRouting on the disaggregationDecider if it
-// implements sim.DisaggregationObserver. Called synchronously within the event loop,
-// so the prefix cache is always current at the next Decide() call.
-func (c *ClusterSimulator) notifyDisaggregationObserver(req *sim.Request, instanceID string) {
-	if c.disaggregationDecider == nil {
-		return
-	}
-	if obs, ok := c.disaggregationDecider.(sim.DisaggregationObserver); ok {
-		obs.ObserveRouting(req, instanceID)
-	}
-}
 
 // PeakConcurrentTransfers returns the maximum number of KV transfers in flight simultaneously.
 // Returns 0 when --pd-transfer-contention is disabled (backward-compat).
@@ -1316,6 +1305,14 @@ func (c *ClusterSimulator) projectPDMetrics() {
 	m := c.aggregatedMetrics
 
 	for _, parent := range c.parentRequests {
+		// Skip-path parents (cache hit, no disaggregation): the original request was
+		// injected directly via InjectRequestOnline. Instance metrics are already keyed
+		// by parent.ID and reflect correct user-facing latencies. No sub-request keys
+		// exist to clean up; no projection needed.
+		if parent.SkippedDisaggregation {
+			continue
+		}
+
 		pfx := parent.PrefillSubReqID // "req_N_prefill"
 		dec := parent.DecodeSubReqID  // "req_N_decode"
 		pid := parent.ID              // "req_N"

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -14,7 +14,7 @@ import (
 // These are separate from sim.Event and processed by ClusterSimulator's control plane.
 type ClusterEvent interface {
 	Timestamp() int64
-	Priority() int // 0=Arrival, 1=Admission, 2=Routing, 3=Disaggregation, 4-7=PD, 8=ScalingTick, 9=ScaleActuation
+	Priority() int // 0=Arrival, 1=Admission, 2=Routing, 3=DecodeRouting(PD), 4=DisaggDecision, 5=PrefillRouting/DecodeEnqueue(skip), 6=KVTransferStart, 7=KVTransferComplete, 8=DecodeEnqueue(disagg), 9=ScalingTick, 10=ScaleActuation
 	Execute(*ClusterSimulator)
 }
 
@@ -231,11 +231,11 @@ func (e *AdmissionDecisionEvent) Execute(cs *ClusterSimulator) {
 		return
 	}
 
-	// BC-PD-4: When pools are configured, schedule DisaggregationDecisionEvent
-	// between admission and routing. When not configured, go directly to routing.
+	// BC-PD-4: When pools are configured, start the decode-first PD pipeline
+	// (DecodeRoutingEvent → DisaggregationDecisionEvent). When not configured, go directly to routing.
 	if cs.poolsConfigured() {
 		heap.Push(&cs.clusterEvents, clusterEventEntry{
-			event: &DisaggregationDecisionEvent{
+			event: &DecodeRoutingEvent{
 				time:    e.time,
 				request: e.request,
 			},
@@ -327,9 +327,6 @@ func (e *RoutingDecisionEvent) Execute(cs *ClusterSimulator) {
 					}
 			
 					inst.InjectRequestOnline(e.request, e.time)
-					// Notify observer so stateful deciders (e.g., PrefixThresholdDecider) can learn
-					// from this routing decision (synchronous call -- cache is always current).
-					cs.notifyDisaggregationObserver(e.request, decision.TargetInstance)
 					return		}
 	}
 
@@ -337,81 +334,12 @@ func (e *RoutingDecisionEvent) Execute(cs *ClusterSimulator) {
 	panic(fmt.Sprintf("RoutingDecisionEvent: invalid TargetInstance %q", decision.TargetInstance))
 }
 
-// DisaggregationDecisionEvent represents the PD disaggregation decision point for a request.
-// Priority 3: scheduled by AdmissionEvent in place of RoutingDecisionEvent (2) when pool
-// topology is configured; fires after admission but before per-pool routing events (4+).
-// Bifurcates: disaggregate=true → PrefillRoutingEvent, disaggregate=false → RoutingDecisionEvent.
-type DisaggregationDecisionEvent struct {
-	time    int64
-	request *sim.Request
-}
-
-func (e *DisaggregationDecisionEvent) Timestamp() int64 { return e.time }
-func (e *DisaggregationDecisionEvent) Priority() int     { return 3 }
-
-// Execute calls the disaggregation decider and bifurcates the request flow.
-// disaggregate=true: splits request into prefill sub-request, schedules PrefillRoutingEvent.
-// disaggregate=false: schedules standard RoutingDecisionEvent (unchanged path).
-func (e *DisaggregationDecisionEvent) Execute(cs *ClusterSimulator) {
-	decision := cs.disaggregationDecider.Decide(e.request)
-	logrus.Debugf("[cluster] req %s: disaggregate=%v", e.request.ID, decision.Disaggregate)
-
-	// Record disaggregation decision if tracing is enabled (BC-PD-17)
-	if cs.trace != nil {
-		cs.trace.RecordDisaggregation(trace.DisaggregationRecord{
-			RequestID:    e.request.ID,
-			Clock:        cs.clock,
-			Disaggregate: decision.Disaggregate,
-		})
-	}
-
-	if !decision.Disaggregate {
-		// Local path: standard routing (unchanged)
-		heap.Push(&cs.clusterEvents, clusterEventEntry{
-			event: &RoutingDecisionEvent{
-				time:    e.time + cs.routingLatency,
-				request: e.request,
-			},
-			seqID: cs.nextSeqID(),
-		})
-		return
-	}
-
-	// Disaggregated path: split request and route to prefill pool
-	parent := NewParentRequest(e.request, cs.config.BlockSizeTokens)
-	cs.parentRequests[parent.ID] = parent
-
-	// Create prefill sub-request: same input, no output (completes after prefill).
-	// Output is intentionally nil: zero-output request completes at prefill end.
-	prefillSubReq := &sim.Request{
-		ID:           parent.PrefillSubReqID,
-		InputTokens:  e.request.InputTokens,
-		MaxOutputLen: e.request.MaxOutputLen,
-		Deadline:     e.request.Deadline,
-		PrefixGroup:  e.request.PrefixGroup,
-		State:        sim.StateQueued,
-		ArrivalTime:  e.request.ArrivalTime,
-		TenantID:     e.request.TenantID,
-		SLOClass:     e.request.SLOClass,
-		Model:        e.request.Model,
-	}
-
-	heap.Push(&cs.clusterEvents, clusterEventEntry{
-		event: &PrefillRoutingEvent{
-			time:      e.time + cs.routingLatency,
-			request:   prefillSubReq,
-			parentReq: parent,
-		},
-		seqID: cs.nextSeqID(),
-	})
-}
-
 // ---------------------------------------------------------------------------
 // Phase 1C: Autoscaler events
 // ---------------------------------------------------------------------------
 
 // ScalingTickEvent fires the autoscaling pipeline at the configured interval.
-// Priority 8: after all request-path events (0–7) at the same timestamp, so the
+// Priority 9: after all request-path events (0–8) at the same timestamp, so the
 // scaler observes a stable snapshot of completed request state.
 // Self-scheduling: Execute() schedules the next ScalingTickEvent.
 // Zero-interval guard: when ModelAutoscalerIntervalUs == 0, no tick is ever scheduled.
@@ -420,7 +348,7 @@ type ScalingTickEvent struct {
 }
 
 func (e *ScalingTickEvent) Timestamp() int64 { return e.At }
-func (e *ScalingTickEvent) Priority() int     { return 8 }
+func (e *ScalingTickEvent) Priority() int     { return 9 }
 
 // Execute runs the autoscaling pipeline: Collect → Analyze → Optimize → cooldown filter
 // → schedule ScaleActuationEvent → schedule next ScalingTickEvent.
@@ -435,14 +363,14 @@ func (e *ScalingTickEvent) Execute(cs *ClusterSimulator) {
 
 // ScaleActuationEvent carries scale decisions to apply after the actuation delay elapses.
 // Separates the "decide" step from the "act" step to model HPA/KEDA scrape lag.
-// Priority 9: after ScalingTickEvent at the same timestamp.
+// Priority 10: after ScalingTickEvent at the same timestamp.
 type ScaleActuationEvent struct {
 	At        int64
 	Decisions []ScaleDecision
 }
 
 func (e *ScaleActuationEvent) Timestamp() int64 { return e.At }
-func (e *ScaleActuationEvent) Priority() int     { return 9 }
+func (e *ScaleActuationEvent) Priority() int     { return 10 }
 
 // Execute calls Actuator.Apply(decisions).
 // Full actuator logic is wired in US3 (T019–T023).

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -327,7 +327,11 @@ func TestDisaggregation_DroppedAtDecodeKV(t *testing.T) {
 }
 
 func TestDisaggregation_PhaseCausality(t *testing.T) {
-	// BC-PD-9 / INV-PD-4: Full causal chain for every disaggregated request
+	// BC-PD-9 / INV-PD-4: Full causal chain for every disaggregated request.
+	// In the decode-first flow, the chain includes DecodeRouteDecisionTime and DisaggDecisionTime.
+	// Disagg path: arrival ≤ decodeRoute ≤ disaggDecision ≤ prefillEnqueue ≤ prefillComplete
+	//              ≤ transferStart ≤ transferComplete ≤ decodeEnqueue
+	// Skip path:   arrival ≤ decodeRoute ≤ disaggDecision ≤ decodeEnqueue
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(10)
 
@@ -335,26 +339,47 @@ func TestDisaggregation_PhaseCausality(t *testing.T) {
 	mustRun(t, cs)
 
 	for _, parent := range cs.parentRequests {
-		chain := []struct {
-			name  string
-			value int64
-		}{
-			{"ArrivalTime", parent.ArrivalTime},
-			{"PrefillEnqueueTime", parent.PrefillEnqueueTime},
-			{"PrefillCompleteTime", parent.PrefillCompleteTime},
-			{"TransferStartTime", parent.TransferStartTime},
-			{"TransferCompleteTime", parent.TransferCompleteTime},
-			{"DecodeEnqueueTime", parent.DecodeEnqueueTime},
-		}
-		// Note: CompletionTime is not included in the chain because it is set by
-		// detectDecodeCompletions using c.clock at detection time, which may differ
-		// from the actual decode completion instant. A dedicated CompletionTime test
-		// would need to use instance-level RequestCompletionTimes directly.
-
-		for i := 1; i < len(chain); i++ {
-			if chain[i].value < chain[i-1].value {
-				t.Errorf("parent %s: causality violated: %s (%d) < %s (%d)",
-					parent.ID, chain[i].name, chain[i].value, chain[i-1].name, chain[i-1].value)
+		if parent.SkippedDisaggregation {
+			// Skip path: only arrival → decodeRoute → disaggDecision → decodeEnqueue
+			chain := []struct {
+				name  string
+				value int64
+			}{
+				{"ArrivalTime", parent.ArrivalTime},
+				{"DecodeRouteDecisionTime", parent.DecodeRouteDecisionTime},
+				{"DisaggDecisionTime", parent.DisaggDecisionTime},
+				{"DecodeEnqueueTime", parent.DecodeEnqueueTime},
+			}
+			for i := 1; i < len(chain); i++ {
+				if chain[i].value < chain[i-1].value {
+					t.Errorf("parent %s (skip): causality violated: %s (%d) < %s (%d)",
+						parent.ID, chain[i].name, chain[i].value, chain[i-1].name, chain[i-1].value)
+				}
+			}
+		} else {
+			// Disagg path: full pipeline
+			chain := []struct {
+				name  string
+				value int64
+			}{
+				{"ArrivalTime", parent.ArrivalTime},
+				{"DecodeRouteDecisionTime", parent.DecodeRouteDecisionTime},
+				{"DisaggDecisionTime", parent.DisaggDecisionTime},
+				{"PrefillEnqueueTime", parent.PrefillEnqueueTime},
+				{"PrefillCompleteTime", parent.PrefillCompleteTime},
+				{"TransferStartTime", parent.TransferStartTime},
+				{"TransferCompleteTime", parent.TransferCompleteTime},
+				{"DecodeEnqueueTime", parent.DecodeEnqueueTime},
+			}
+			// Note: CompletionTime is not included in the chain because it is set by
+			// detectDecodeCompletions using c.clock at detection time, which may differ
+			// from the actual decode completion instant. A dedicated CompletionTime test
+			// would need to use instance-level RequestCompletionTimes directly.
+			for i := 1; i < len(chain); i++ {
+				if chain[i].value < chain[i-1].value {
+					t.Errorf("parent %s (disagg): causality violated: %s (%d) < %s (%d)",
+						parent.ID, chain[i].name, chain[i].value, chain[i-1].name, chain[i-1].value)
+				}
 			}
 		}
 	}
@@ -576,8 +601,8 @@ func newTestPrefixThresholdConfig(threshold int) DeploymentConfig {
 
 // TestPrefixThreshold_BelowThresholdNotDisaggregated verifies BC-PD-21 at the cluster level:
 // requests with non-cached token counts well below the threshold must not be disaggregated
-// (absent from parentRequests). Tests the full NewClusterSimulator → PrefixThresholdDecider
-// constructor path and the DisaggregationDecisionEvent bifurcation.
+// (skip-path: SkippedDisaggregation=true). Tests the full NewClusterSimulator →
+// PrefixThresholdDecider constructor path and the DisaggregationDecisionEvent bifurcation.
 func TestPrefixThreshold_BelowThresholdNotDisaggregated(t *testing.T) {
 	const threshold = 200
 	config := newTestPrefixThresholdConfig(threshold)
@@ -601,11 +626,19 @@ func TestPrefixThreshold_BelowThresholdNotDisaggregated(t *testing.T) {
 	cs := NewClusterSimulator(config, requests, nil)
 	mustRun(t, cs)
 
-	if len(cs.parentRequests) != 0 {
-		t.Errorf("parentRequests = %d, want 0: short requests (20 tokens <= %d threshold) should not be disaggregated",
-			len(cs.parentRequests), threshold)
+	// In the decode-first flow, ALL PD requests create a ParentRequest (decode routing fires first).
+	// Below-threshold requests must have SkippedDisaggregation=true (served locally on decode instance).
+	if len(cs.parentRequests) != len(requests) {
+		t.Errorf("parentRequests = %d, want %d: all PD requests create a parent in decode-first flow",
+			len(cs.parentRequests), len(requests))
 	}
-	// INV-1: below-threshold requests route through RoutingDecisionEvent; verify all complete.
+	for _, pr := range cs.parentRequests {
+		if !pr.SkippedDisaggregation {
+			t.Errorf("parent %s: SkippedDisaggregation=false, want true (20 tokens <= %d threshold)",
+				pr.ID, threshold)
+		}
+	}
+	// INV-1: skip-path requests complete via InjectRequestOnline; verify all complete.
 	assertINV1Conservation(t, cs.AggregatedMetrics(), len(requests), "below-threshold")
 }
 
@@ -641,18 +674,27 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 	}
 }
 
-// TestPrefixThreshold_ObserverWarmsCache verifies BC-PD-24 at the cluster level:
-// req1 (disaggregated) warms the prefix cache via notifyDisaggregationObserver in
-// PrefillRoutingEvent.Execute (pd_events.go); req2 (non-disaggregated) verifies that
-// the warmed cache is consulted in DisaggregationDecisionEvent, reducing non-cached
-// token count below the threshold. Tests the full end-to-end wiring path.
-func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
+// TestPrefixThreshold_InstanceLocalCacheQuery verifies INV-PD-8 at the cluster level:
+// PrefixThresholdDecider reads the selected decode instance's actual KV cache state
+// (via cacheQueryFn) to compute non-cached tokens. A request that previously warmed
+// the decode instance's KV cache (via the disagg path) causes a subsequent request
+// with the same prefix to skip disaggregation (cache hit).
+//
+// This test uses a single decode instance to ensure deterministic routing: both req1
+// and req2 are routed to the same decode instance, so req1's cache warming is visible
+// to req2's disaggregation decision.
+func TestPrefixThreshold_InstanceLocalCacheQuery(t *testing.T) {
 	const threshold = 300
 	const blockSize = 16
-	config := newTestPrefixThresholdConfig(threshold)
+	// Use 1 decode instance to guarantee req2 sees req1's cached blocks.
+	config := newTestDisaggDeploymentConfig(2, 1, 1)
+	config.PDDecider = "prefix-threshold"
+	config.PDPrefixThreshold = threshold
 
 	// req1: 400 tokens (25 complete blocks), no prior cache.
-	// nonCached = 400 > 300 → disaggregated; ObserveRouting warms 25 blocks in cache.
+	// nonCachedTokens = 400 - 0*16 = 400 > 300 → disaggregated.
+	// After req1 completes on the decode instance, AllocateTransferredKV populates
+	// the instance's KV block hash index with all 25 complete blocks.
 	prefix := make([]int, 400)
 	for i := range prefix {
 		prefix[i] = i + 1
@@ -666,8 +708,9 @@ func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
 	}
 
 	// req2: same 400-token prefix + 50 new tokens = 450 total.
-	// After req1 warms the cache: nonCached = 450 - 25*16 = 450 - 400 = 50 <= 300 → NOT disaggregated.
-	// req2 arrives 2s after req1, well after req1's PrefillRoutingEvent fires and warms the cache.
+	// After req1 runs: decode instance has 25 blocks cached.
+	// nonCachedTokens = 450 - 25*16 = 50 <= 300 → skip-path (NOT disaggregated).
+	// req2 arrives 2s after req1, well after req1's full pipeline completes.
 	extended := make([]int, len(prefix)+50)
 	copy(extended, prefix)
 	for i := len(prefix); i < len(extended); i++ {
@@ -678,8 +721,7 @@ func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
 		InputTokens:  extended,
 		OutputTokens: make([]int, 5),
 		State:        sim.StateQueued,
-		ArrivalTime:  2000000, // req1's PrefillRoutingEvent fires at t=0+routingLatency=0; req2 arrives at t=2,000,000;
-		// ordering is guaranteed by event timestamps alone (t=0 < t=2,000,000), not the gap magnitude
+		ArrivalTime:  2000000, // 2s after req1; well after req1 completes
 	}
 	_ = blockSize // documents the block arithmetic above
 
@@ -687,24 +729,24 @@ func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
 	mustRun(t, cs)
 
 	// req1 must be disaggregated (400 non-cached tokens > 300 threshold).
-	var req1Disaggregated bool
-	for _, pr := range cs.parentRequests {
-		if pr.ID == "req-warm" {
-			req1Disaggregated = true
-		}
+	pr1, ok := cs.parentRequests["req-warm"]
+	if !ok {
+		t.Fatal("req-warm not in parentRequests — DecodeRoutingEvent must create parent for all PD requests")
 	}
-	if !req1Disaggregated {
+	if pr1.SkippedDisaggregation {
 		t.Error("req-warm (400 uncached tokens > 300 threshold) must be disaggregated; " +
 			"check PrefixThresholdDecider constructor wiring in NewClusterSimulator")
 	}
 
-	// req2 must NOT be disaggregated: prefix is cached after req1's PrefillRoutingEvent
-	// fires ObserveRouting, so only 50 tokens are non-cached (50 <= 300 threshold).
-	for _, pr := range cs.parentRequests {
-		if pr.ID == "req-follow" {
-			t.Error("req-follow (50 non-cached tokens <= 300 threshold after cache warming) must NOT be disaggregated; " +
-				"check notifyDisaggregationObserver wiring in PrefillRoutingEvent.Execute (pd_events.go)")
-		}
+	// req2 must be skip-path: the single decode instance has req1's 25 blocks cached,
+	// so only 50 tokens are non-cached (50 <= 300 threshold).
+	pr2, ok := cs.parentRequests["req-follow"]
+	if !ok {
+		t.Fatal("req-follow not in parentRequests — DecodeRoutingEvent must create parent for all PD requests")
+	}
+	if !pr2.SkippedDisaggregation {
+		t.Error("req-follow (50 non-cached tokens <= 300 threshold after instance cache warming) " +
+			"must be skip-path; check cacheQueryFn wiring in DecodeRoutingEvent.Execute (pd_events.go)")
 	}
 }
 
@@ -738,9 +780,17 @@ func TestDirectToDecode_BelowThresholdNotDisaggregated(t *testing.T) {
 	cs := NewClusterSimulator(config, requests, nil)
 	mustRun(t, cs)
 
-	if len(cs.parentRequests) != 0 {
-		t.Errorf("parentRequests = %d, want 0: short requests (20 tokens < %d threshold) should not be disaggregated",
-			len(cs.parentRequests), threshold)
+	// In the decode-first flow, ALL PD requests create a ParentRequest.
+	// Below-threshold requests must be skip-path (SkippedDisaggregation=true).
+	if len(cs.parentRequests) != len(requests) {
+		t.Errorf("parentRequests = %d, want %d: all PD requests create a parent in decode-first flow",
+			len(cs.parentRequests), len(requests))
+	}
+	for _, pr := range cs.parentRequests {
+		if !pr.SkippedDisaggregation {
+			t.Errorf("parent %s: SkippedDisaggregation=false, want true (20 tokens < %d threshold)",
+				pr.ID, threshold)
+		}
 	}
 	assertINV1Conservation(t, cs.AggregatedMetrics(), len(requests), "direct-to-decode below threshold")
 }
@@ -1801,4 +1851,403 @@ func TestDisaggregation_PD_SessionManager_ContextAccumulation(t *testing.T) {
 
 	// INV-1 conservation
 	assertINV1Conservation(t, metrics, 2, "PD SessionManager context accumulation")
+}
+
+// ---------------------------------------------------------------------------
+// INV-PD-7: Decode-first ordering
+// For all parents: DecodeRouteDecisionTime ≤ DisaggDecisionTime
+// ---------------------------------------------------------------------------
+
+// invPD7Cases holds parameters for INV-PD-7 table tests.
+type invPD7Case struct {
+	name         string
+	numRequests  int
+	decider      string
+	totalInst    int
+	prefillInst  int
+	decodeInst   int
+	flowControl  bool
+	contention   bool
+}
+
+// TestINVPD7_DecodeFirstOrdering verifies INV-PD-7: for every ParentRequest,
+// DecodeRouteDecisionTime ≤ DisaggDecisionTime (decode routing always precedes
+// the disaggregation decision in the decode-first PD pipeline).
+func TestINVPD7_DecodeFirstOrdering(t *testing.T) {
+	cases := []invPD7Case{
+		// Single request, various deciders
+		{"1req-always-2P2D", 1, "always", 4, 2, 2, false, false},
+		{"1req-never-2P2D", 1, "never", 4, 2, 2, false, false},
+		{"1req-always-1P1D", 1, "always", 2, 1, 1, false, false},
+		{"1req-never-1P1D", 1, "never", 2, 1, 1, false, false},
+		// Multiple requests, various pool sizes
+		{"3req-always-2P2D", 3, "always", 4, 2, 2, false, false},
+		{"5req-always-2P2D", 5, "always", 4, 2, 2, false, false},
+		{"10req-always-2P2D", 10, "always", 4, 2, 2, false, false},
+		{"20req-always-2P2D", 20, "always", 4, 2, 2, false, false},
+		{"3req-never-2P2D", 3, "never", 4, 2, 2, false, false},
+		{"5req-never-2P2D", 5, "never", 4, 2, 2, false, false},
+		// Asymmetric pool sizes
+		{"5req-always-1P3D", 5, "always", 4, 1, 3, false, false},
+		{"5req-always-3P1D", 5, "always", 4, 3, 1, false, false},
+		// Mixed deciders (prefix-threshold: all disaggregate since no cache)
+		{"5req-prefix-threshold-2P2D", 5, "prefix-threshold", 4, 2, 2, false, false},
+		// Flow control enabled
+		{"3req-always-2P2D-fc", 3, "always", 4, 2, 2, true, false},
+		{"5req-never-2P2D-fc", 5, "never", 4, 2, 2, true, false},
+		// Transfer contention
+		{"5req-always-2P2D-contention", 5, "always", 4, 2, 2, false, true},
+		{"10req-always-2P2D-contention", 10, "always", 4, 2, 2, false, true},
+		// Combined flow control + contention
+		{"3req-always-2P2D-fc-contention", 3, "always", 4, 2, 2, true, true},
+		// Direct-to-decode (short requests → skip path, long → disaggregate)
+		{"5req-direct-to-decode-2P2D", 5, "direct-to-decode", 4, 2, 2, false, false},
+		// Large request count
+		{"20req-never-2P2D", 20, "never", 4, 2, 2, false, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newTestDisaggDeploymentConfig(tc.totalInst, tc.prefillInst, tc.decodeInst)
+			switch tc.decider {
+			case "always":
+				cfg.PDDecider = "always"
+			case "never":
+				cfg.PDDecider = "never"
+			case "prefix-threshold":
+				cfg.PDDecider = "prefix-threshold"
+				cfg.PDPrefixThreshold = 0 // disaggregate everything (any non-zero non-cached tokens)
+			case "direct-to-decode":
+				cfg.PDDecider = "direct-to-decode"
+				cfg.PDDirectDecodeThreshold = 100 // short requests (< 100 tokens) skip
+			}
+			if tc.flowControl {
+				cfg.FlowControlEnabled = true
+			}
+			if tc.contention {
+				cfg.PDTransferContention = true
+			}
+
+			var requests []*sim.Request
+			for i := 0; i < tc.numRequests; i++ {
+				inputLen := 200 // long enough to disaggregate with direct-to-decode threshold=100
+				requests = append(requests, &sim.Request{
+					ID:           fmt.Sprintf("req_%d", i),
+					InputTokens:  make([]int, inputLen),
+					OutputTokens: make([]int, 3),
+					State:        sim.StateQueued,
+					ArrivalTime:  int64(i * 200000),
+				})
+			}
+
+			cs := NewClusterSimulator(cfg, requests, nil)
+			mustRun(t, cs)
+
+			for _, parent := range cs.parentRequests {
+				if parent.DecodeRouteDecisionTime > parent.DisaggDecisionTime {
+					t.Errorf("[%s] parent %s: INV-PD-7 violated: DecodeRouteDecisionTime (%d) > DisaggDecisionTime (%d)",
+						tc.name, parent.ID, parent.DecodeRouteDecisionTime, parent.DisaggDecisionTime)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// INV-PD-8: Instance-local cache query
+// ---------------------------------------------------------------------------
+
+// TestINVPD8_InstanceLocalCacheQuery verifies INV-PD-8: the disaggregation decision
+// is conditioned on the selected decode instance's actual KV cache state. The same
+// request disaggregates on an instance without the prefix cached, but skips
+// disaggregation on an instance that has the prefix cached.
+//
+// Test approach: use a single decode instance (1P1D), run req1 (disaggregated, warms cache),
+// then req2 with the same prefix. Verify req2 is skip-path (cache hit). Also verify
+// that without the warm instance (1P1D with a fresh instance per sub-test), req2 disaggregates.
+func TestINVPD8_InstanceLocalCacheQuery(t *testing.T) {
+	const threshold = 300
+	const blockSize = 16
+
+	type cacheCase struct {
+		name                 string
+		req2InputLen         int
+		req2CachePrefix      int // number of prefix tokens shared with req1 (expected cached blocks = req2CachePrefix/blockSize)
+		expectSkip           bool
+		req1ArrivalDelta     int64 // time before req2 arrives; req1 must complete first
+	}
+
+	cases := []cacheCase{
+		// req1 warms 25 blocks (400 tokens / 16). req2 has same 400-token prefix + extension.
+		// nonCached = (400+50) - 25*16 = 50 <= 300 → skip
+		{"warmPrefix-50extra", 450, 400, true, 2000000},
+		// req2 has same 400-token prefix + 250 more → nonCached = 650 - 25*16 = 250 <= 300 → skip
+		{"warmPrefix-250extra", 650, 400, true, 2000000},
+		// req2 has same 400-token prefix + 301 more → nonCached = 701 - 25*16 = 301 > 300 → disagg
+		{"warmPrefix-301extra", 701, 400, false, 2000000},
+		// req2 has same 400-token prefix exactly → nonCached = 400 - 25*16 = 0 <= 300 → skip
+		{"warmPrefix-exact", 400, 400, true, 2000000},
+		// req2 has different tokens (no shared prefix) → 0 cached → nonCached = req2 len > 300 → disagg
+		{"noSharedPrefix-400", 400, 0, false, 2000000},
+		// req2 with only 16 shared tokens (1 block prefix) → nonCached = 400 - 1*16 = 384 > 300 → disagg
+		{"sharedPrefix-1block", 400, 16, false, 2000000},
+		// req2 with 320 shared tokens (20 blocks) → nonCached = 400 - 20*16 = 80 <= 300 → skip
+		{"sharedPrefix-20blocks", 400, 320, true, 2000000},
+		// req2 with 208 shared tokens (13 blocks) → nonCached = 400 - 13*16 = 192 <= 300 → skip
+		{"sharedPrefix-13blocks", 400, 208, true, 2000000},
+		// req2 with 192 shared tokens (12 blocks) → nonCached = 400 - 12*16 = 208 <= 300 → skip
+		{"sharedPrefix-12blocks", 400, 192, true, 2000000},
+		// zero threshold: any nonCached > 0 disaggregates
+		{"zero-threshold-skip", 400, 400, true, 2000000},   // fully cached → skip
+		{"zero-threshold-disagg", 400, 0, false, 2000000},  // no cache → disagg
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			thr := threshold
+			if tc.name == "zero-threshold-skip" || tc.name == "zero-threshold-disagg" {
+				thr = 0
+			}
+			cfg := newTestDisaggDeploymentConfig(2, 1, 1)
+			cfg.PDDecider = "prefix-threshold"
+			cfg.PDPrefixThreshold = thr
+
+			// req1: 400 tokens to warm the decode instance cache
+			req1Tokens := make([]int, 400)
+			for i := range req1Tokens {
+				req1Tokens[i] = i + 1
+			}
+			req1 := &sim.Request{
+				ID:           "req-warm",
+				InputTokens:  req1Tokens,
+				OutputTokens: make([]int, 3),
+				State:        sim.StateQueued,
+				ArrivalTime:  0,
+			}
+
+			// req2: tc.req2CachePrefix tokens shared with req1, rest unique
+			req2Tokens := make([]int, tc.req2InputLen)
+			copy(req2Tokens, req1Tokens[:tc.req2CachePrefix])
+			for i := tc.req2CachePrefix; i < tc.req2InputLen; i++ {
+				req2Tokens[i] = 100000 + i
+			}
+			req2 := &sim.Request{
+				ID:           "req-follow",
+				InputTokens:  req2Tokens,
+				OutputTokens: make([]int, 3),
+				State:        sim.StateQueued,
+				ArrivalTime:  tc.req1ArrivalDelta,
+			}
+
+			cs := NewClusterSimulator(cfg, []*sim.Request{req1, req2}, nil)
+			mustRun(t, cs)
+
+			pr2, ok := cs.parentRequests["req-follow"]
+			if !ok {
+				t.Fatal("req-follow not in parentRequests")
+			}
+
+			_ = blockSize
+			if tc.expectSkip && !pr2.SkippedDisaggregation {
+				t.Errorf("[%s] req-follow expected skip (cache hit), got disaggregated", tc.name)
+			}
+			if !tc.expectSkip && pr2.SkippedDisaggregation {
+				t.Errorf("[%s] req-follow expected disaggregation (cache miss), got skip", tc.name)
+			}
+
+			// INV-PD-7: DecodeRouteDecisionTime ≤ DisaggDecisionTime for both parents
+			for _, pr := range cs.parentRequests {
+				if pr.DecodeRouteDecisionTime > pr.DisaggDecisionTime {
+					t.Errorf("[%s] parent %s: INV-PD-7: DecodeRouteDecisionTime (%d) > DisaggDecisionTime (%d)",
+						tc.name, pr.ID, pr.DecodeRouteDecisionTime, pr.DisaggDecisionTime)
+				}
+			}
+		})
+	}
+
+	// Additional table: verify INV-PD-8 across varying pool sizes
+	// When the single decode instance has the cache, all similar follow-up requests skip.
+	t.Run("PoolSizeVariations", func(t *testing.T) {
+		poolCases := []struct {
+			name  string
+			total int
+			p     int
+			d     int
+		}{
+			{"1P1D", 2, 1, 1},
+			{"1P2D_singleTarget", 3, 1, 2}, // with 2 decode instances, routing may vary
+			{"2P1D", 3, 2, 1},
+			{"3P1D", 4, 3, 1},
+		}
+		for _, pc := range poolCases {
+			pc := pc
+			t.Run(pc.name, func(t *testing.T) {
+				cfg := newTestDisaggDeploymentConfig(pc.total, pc.p, pc.d)
+				cfg.PDDecider = "prefix-threshold"
+				cfg.PDPrefixThreshold = threshold
+
+				// Verify INV-PD-7 holds for any pool topology
+				req1Tokens := make([]int, 400)
+				for i := range req1Tokens {
+					req1Tokens[i] = i + 1
+				}
+				req := &sim.Request{
+					ID:           "req-A",
+					InputTokens:  req1Tokens,
+					OutputTokens: make([]int, 3),
+					State:        sim.StateQueued,
+				}
+				cs := NewClusterSimulator(cfg, []*sim.Request{req}, nil)
+				mustRun(t, cs)
+
+				for _, pr := range cs.parentRequests {
+					if pr.DecodeRouteDecisionTime > pr.DisaggDecisionTime {
+						t.Errorf("[%s] parent %s: INV-PD-7: DecodeRouteDecisionTime (%d) > DisaggDecisionTime (%d)",
+							pc.name, pr.ID, pr.DecodeRouteDecisionTime, pr.DisaggDecisionTime)
+					}
+				}
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Skip-path integration tests (≥20 cases)
+// ---------------------------------------------------------------------------
+
+// TestSkipPath_Integration provides comprehensive integration coverage for
+// the skip-path (NeverDisaggregate or threshold-based cache hit).
+// Verifies INV-1, INV-5, INV-PD-7 and correct metric projection.
+func TestSkipPath_Integration(t *testing.T) {
+	type skipCase struct {
+		name        string
+		numRequests int
+		decider     string
+		totalInst   int
+		prefillInst int
+		decodeInst  int
+		flowControl bool
+		contention  bool
+	}
+
+	cases := []skipCase{
+		// All skip (NeverDisaggregate)
+		{"all-skip-1req-2P2D", 1, "never", 4, 2, 2, false, false},
+		{"all-skip-3req-2P2D", 3, "never", 4, 2, 2, false, false},
+		{"all-skip-5req-2P2D", 5, "never", 4, 2, 2, false, false},
+		{"all-skip-10req-2P2D", 10, "never", 4, 2, 2, false, false},
+		{"all-skip-20req-2P2D", 20, "never", 4, 2, 2, false, false},
+		{"all-skip-1req-1P1D", 1, "never", 2, 1, 1, false, false},
+		{"all-skip-5req-1P1D", 5, "never", 2, 1, 1, false, false},
+		{"all-skip-5req-1P3D", 5, "never", 4, 1, 3, false, false},
+		{"all-skip-5req-3P1D", 5, "never", 4, 3, 1, false, false},
+		// Skip with flow control
+		{"all-skip-5req-fc", 5, "never", 4, 2, 2, true, false},
+		{"all-skip-10req-fc", 10, "never", 4, 2, 2, true, false},
+		// Mixed skip+disagg (direct-to-decode with threshold > short request length)
+		{"mixed-short-skip-5req-2P2D", 5, "direct-to-decode", 4, 2, 2, false, false},
+		{"mixed-short-skip-10req-2P2D", 10, "direct-to-decode", 4, 2, 2, false, false},
+		// Mixed with flow control
+		{"mixed-short-skip-5req-fc", 5, "direct-to-decode", 4, 2, 2, true, false},
+		// Skip determinism (INV-6 base)
+		{"determinism-skip-5req", 5, "never", 4, 2, 2, false, false},
+		// Skip with transfer contention flag (NeverDisaggregate: no transfers, so contention is no-op)
+		{"all-skip-5req-contention-flag", 5, "never", 4, 2, 2, false, true},
+		// Larger pools
+		{"all-skip-10req-2P4D", 10, "never", 6, 2, 4, false, false},
+		{"all-skip-10req-4P2D", 10, "never", 6, 4, 2, false, false},
+		// With sessions (NeverDisaggregate, skip path)
+		{"all-skip-20req-2P2D-large", 20, "never", 4, 2, 2, false, false},
+		// Direct-to-decode: requests above threshold disaggregate, below skip
+		{"direct-to-decode-20req-2P2D", 20, "direct-to-decode", 4, 2, 2, false, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newTestDisaggDeploymentConfig(tc.totalInst, tc.prefillInst, tc.decodeInst)
+			switch tc.decider {
+			case "never":
+				cfg.PDDecider = "never"
+			case "direct-to-decode":
+				cfg.PDDecider = "direct-to-decode"
+				cfg.PDDirectDecodeThreshold = 100 // short requests (20 tokens) skip, long (200) disagg
+			}
+			if tc.flowControl {
+				cfg.FlowControlEnabled = true
+			}
+			if tc.contention {
+				cfg.PDTransferContention = true
+			}
+
+			var requests []*sim.Request
+			for i := 0; i < tc.numRequests; i++ {
+				inputLen := 20 // short: all skip under direct-to-decode threshold=100
+				requests = append(requests, &sim.Request{
+					ID:           fmt.Sprintf("req_%d", i),
+					InputTokens:  make([]int, inputLen),
+					OutputTokens: make([]int, 3),
+					State:        sim.StateQueued,
+					ArrivalTime:  int64(i * 200000),
+				})
+			}
+
+			cs := NewClusterSimulator(cfg, requests, nil)
+			mustRun(t, cs)
+
+			// INV-1: all requests must complete
+			assertINV1Conservation(t, cs.AggregatedMetrics(), tc.numRequests, tc.name)
+
+			// INV-PD-7: DecodeRouteDecisionTime ≤ DisaggDecisionTime for all parents
+			for _, pr := range cs.parentRequests {
+				if pr.DecodeRouteDecisionTime > pr.DisaggDecisionTime {
+					t.Errorf("[%s] parent %s: INV-PD-7: DecodeRouteDecisionTime (%d) > DisaggDecisionTime (%d)",
+						tc.name, pr.ID, pr.DecodeRouteDecisionTime, pr.DisaggDecisionTime)
+				}
+			}
+
+			// All requests should create ParentRequest entries in PD mode
+			if len(cs.parentRequests) != tc.numRequests {
+				t.Errorf("[%s] parentRequests = %d, want %d (all PD requests create a parent)",
+					tc.name, len(cs.parentRequests), tc.numRequests)
+			}
+
+			// For NeverDisaggregate: ALL parents must be skip-path
+			if tc.decider == "never" {
+				for _, pr := range cs.parentRequests {
+					if !pr.SkippedDisaggregation {
+						t.Errorf("[%s] parent %s: SkippedDisaggregation=false, want true (NeverDisaggregate)",
+							tc.name, pr.ID)
+					}
+				}
+			}
+
+			// For direct-to-decode with short requests (20 < 100): all skip
+			if tc.decider == "direct-to-decode" {
+				for _, pr := range cs.parentRequests {
+					if !pr.SkippedDisaggregation {
+						t.Errorf("[%s] parent %s: SkippedDisaggregation=false, want true (direct-to-decode, 20 < 100 threshold)",
+							tc.name, pr.ID)
+					}
+				}
+			}
+
+			// INV-5 (causality): for skip-path, arrival ≤ decodeRoute ≤ disaggDecision ≤ decodeEnqueue
+			for _, pr := range cs.parentRequests {
+				if !pr.SkippedDisaggregation {
+					continue
+				}
+				if pr.DecodeRouteDecisionTime < pr.ArrivalTime {
+					t.Errorf("[%s] parent %s: DecodeRouteDecisionTime (%d) < ArrivalTime (%d)",
+						tc.name, pr.ID, pr.DecodeRouteDecisionTime, pr.ArrivalTime)
+				}
+				if pr.DecodeEnqueueTime < pr.DisaggDecisionTime {
+					t.Errorf("[%s] parent %s: DecodeEnqueueTime (%d) < DisaggDecisionTime (%d)",
+						tc.name, pr.ID, pr.DecodeEnqueueTime, pr.DisaggDecisionTime)
+				}
+			}
+		})
+	}
 }

--- a/sim/cluster/parent_request.go
+++ b/sim/cluster/parent_request.go
@@ -13,12 +13,14 @@ type ParentRequest struct {
 	NumKVBlocks     int64        // KV blocks to transfer (ceil(inputLen / blockSize))
 
 	// Phase timestamps (microseconds). Zero means phase not yet reached.
-	ArrivalTime          int64
-	PrefillEnqueueTime   int64
-	PrefillCompleteTime  int64
-	TransferStartTime    int64
-	TransferCompleteTime int64
-	DecodeEnqueueTime    int64
+	ArrivalTime              int64
+	DecodeRouteDecisionTime  int64 // When the decode instance was selected (decode-first step)
+	DisaggDecisionTime       int64 // When the disaggregation decision was made
+	PrefillEnqueueTime       int64
+	PrefillCompleteTime      int64
+	TransferStartTime        int64
+	TransferCompleteTime     int64
+	DecodeEnqueueTime        int64
 	// CompletionTime has three meanings depending on outcome:
 	//   - Successful decode: set by detectDecodeCompletions to
 	//     clusterClock + decodeInstance.PostDecodeFixedOverhead() when the decode
@@ -33,6 +35,12 @@ type ParentRequest struct {
 	//   - Decode timeout: set by detectDecodeCompletions to the cluster clock at
 	//     timeout detection time. The session is cancelled via sessionCallback.
 	CompletionTime int64
+
+	// SkippedDisaggregation is true when the disaggregation decider chose to serve
+	// the request locally on the selected decode instance (cache hit path).
+	// When true: no prefill sub-request is created; PrefillSubReqID/DecodeSubReqID
+	// are populated but unused; the original request is injected directly.
+	SkippedDisaggregation bool
 
 	// Instance assignment
 	PrefillInstanceID InstanceID

--- a/sim/cluster/parent_request.go
+++ b/sim/cluster/parent_request.go
@@ -21,19 +21,24 @@ type ParentRequest struct {
 	TransferStartTime        int64
 	TransferCompleteTime     int64
 	DecodeEnqueueTime        int64
-	// CompletionTime has three meanings depending on outcome:
-	//   - Successful decode: set by detectDecodeCompletions to
+	// CompletionTime has four meanings depending on outcome:
+	//   - Successful disagg decode: set by detectDecodeCompletions to
 	//     clusterClock + decodeInstance.PostDecodeFixedOverhead() when the decode
 	//     sub-request finishes its last step. Includes PostDecodeFixedOverhead so
 	//     that projectPDMetrics() computes the same client-visible E2E as non-PD
 	//     recordRequestCompletion (issue #846). For blackbox/roofline/cross-model
 	//     (overhead=0), equals the raw cluster clock tick.
-	//   - Dropped at decode KV allocation: set to the DecodeRoutingEvent time (the
+	//   - Dropped at decode KV allocation: set to the DecodeEnqueueEvent time (the
 	//     point when the drop was detected). Since decode never ran, this reflects
 	//     the drop-detection time, not a decode completion time.
 	//     Use DecodeInstanceID == "" to distinguish dropped requests.
 	//   - Decode timeout: set by detectDecodeCompletions to the cluster clock at
 	//     timeout detection time. The session is cancelled via sessionCallback.
+	//   - Skip-path (SkippedDisaggregation=true): CompletionTime is NOT set
+	//     (remains 0). The request completes via the decode instance's normal
+	//     completion machinery (InjectRequestOnline); instance metrics are keyed
+	//     by parent.ID directly. projectPDMetrics() early-continues for these
+	//     parents and does not read CompletionTime.
 	CompletionTime int64
 
 	// SkippedDisaggregation is true when the disaggregation decider chose to serve

--- a/sim/cluster/pd_events.go
+++ b/sim/cluster/pd_events.go
@@ -12,8 +12,298 @@ import (
 	"github.com/inference-sim/inference-sim/sim/trace"
 )
 
+// DecodeRoutingEvent is the first step in the decode-first PD pipeline.
+// Selects the decode instance, queries its cache state, and schedules
+// DisaggregationDecisionEvent with the instance context.
+// Priority 3: after admission (1) and standard routing (2), before disaggregation decision (4).
+type DecodeRoutingEvent struct {
+	time    int64
+	request *sim.Request
+}
+
+func (e *DecodeRoutingEvent) Timestamp() int64 { return e.time }
+func (e *DecodeRoutingEvent) Priority() int     { return 3 }
+
+// Execute selects the decode instance, builds DecodeContext, and schedules
+// DisaggregationDecisionEvent. Routing rejection increments routingRejections.
+func (e *DecodeRoutingEvent) Execute(cs *ClusterSimulator) {
+	filteredSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
+	if len(filteredSnapshots) == 0 {
+		logrus.Warnf("[cluster] req %s: no routable instances in decode pool — request rejected at decode routing", e.request.ID)
+		cs.routingRejections++
+		return
+	}
+	state := &sim.RouterState{Snapshots: filteredSnapshots, Clock: cs.clock}
+
+	policy := cs.decodeRoutingPolicy
+	if policy == nil {
+		policy = cs.routingPolicy
+	}
+	decision := policy.Route(e.request, state)
+
+	logrus.Debugf("[cluster] decode-first req %s → decode instance %s", e.request.ID, decision.TargetInstance)
+
+	// Create parent request tracking record.
+	parent := NewParentRequest(e.request, cs.config.BlockSizeTokens)
+	parent.DecodeRouteDecisionTime = e.time
+	parent.DecodeInstanceID = InstanceID(decision.TargetInstance)
+	cs.parentRequests[parent.ID] = parent
+
+	// Query cache state on selected decode instance (INV-PD-8).
+	// Defaults to 0 (no cache hit) if the instance is not in cacheQueryFn (defensive).
+	var cachedBlockCount int
+	if queryFn, ok := cs.cacheQueryFn[decision.TargetInstance]; ok {
+		cachedBlockCount = queryFn(e.request.InputTokens)
+	}
+
+	decodeCtx := sim.DecodeContext{
+		InstanceID:       decision.TargetInstance,
+		CachedBlockCount: cachedBlockCount,
+	}
+
+	// Record decode routing decision in trace (BC-PD-19).
+	// Recorded here (decode-first) so the record is always present regardless of
+	// the disaggregation outcome. Skip-path and disagg-path both produce a record.
+	if cs.trace != nil {
+		decodeRecord := trace.DecodeRoutingRecord{
+			ParentRequestID: parent.ID,
+			Clock:           cs.clock,
+			ChosenInstance:  decision.TargetInstance,
+			Scores:          copyScores(decision.Scores),
+		}
+		if cs.trace.Config.CounterfactualK > 0 {
+			decodeRecord.Candidates, decodeRecord.Regret = computeCounterfactual(
+				decision.TargetInstance, decision.Scores,
+				filteredSnapshots, cs.trace.Config.CounterfactualK,
+			)
+		}
+		cs.trace.RecordDecodeRouting(decodeRecord)
+	}
+
+	heap.Push(&cs.clusterEvents, clusterEventEntry{
+		event: &DisaggregationDecisionEvent{
+			time:          e.time,
+			request:       e.request,
+			parentReq:     parent,
+			decodeContext: decodeCtx,
+		},
+		seqID: cs.nextSeqID(),
+	})
+}
+
+// DisaggregationDecisionEvent decides whether a request should be disaggregated
+// (sent to a dedicated prefill pool) or served locally on the already-selected decode instance.
+// Priority 4: after DecodeRoutingEvent (3), before PrefillRoutingEvent/DecodeEnqueueEvent (5).
+//
+// In the decode-first flow, the decode instance has already been chosen by DecodeRoutingEvent
+// before this event fires. decodeContext carries the instance's identity and cache state so
+// the disaggregation decider can make a per-instance decision (INV-PD-8).
+type DisaggregationDecisionEvent struct {
+	time          int64
+	request       *sim.Request
+	parentReq     *ParentRequest
+	decodeContext sim.DecodeContext
+}
+
+func (e *DisaggregationDecisionEvent) Timestamp() int64 { return e.time }
+func (e *DisaggregationDecisionEvent) Priority() int     { return 4 }
+
+// Execute calls the disaggregation decider with decode context and bifurcates:
+//   - skip path (Disaggregate=false): DecodeEnqueueEvent at priority 5 (serves locally)
+//   - disagg path (Disaggregate=true): PrefillRoutingEvent at priority 5
+func (e *DisaggregationDecisionEvent) Execute(cs *ClusterSimulator) {
+	decision := cs.disaggregationDecider.Decide(e.request, e.decodeContext)
+	logrus.Debugf("[cluster] req %s: disaggregate=%v (decodeInstance=%s, cachedBlocks=%d)",
+		e.request.ID, decision.Disaggregate, e.decodeContext.InstanceID, e.decodeContext.CachedBlockCount)
+
+	e.parentReq.DisaggDecisionTime = e.time
+
+	// Record disaggregation decision in trace (BC-PD-17).
+	if cs.trace != nil {
+		cs.trace.RecordDisaggregation(trace.DisaggregationRecord{
+			RequestID:        e.request.ID,
+			Clock:            cs.clock,
+			Disaggregate:     decision.Disaggregate,
+			DecodeInstanceID: e.decodeContext.InstanceID,
+			CachedBlockCount: e.decodeContext.CachedBlockCount,
+		})
+	}
+
+	if !decision.Disaggregate {
+		// Skip path: serve directly on the already-selected decode instance.
+		// InjectRequestOnline handles full prefill+decode on the instance.
+		e.parentReq.SkippedDisaggregation = true
+		heap.Push(&cs.clusterEvents, clusterEventEntry{
+			event: &DecodeEnqueueEvent{
+				time:      e.time,
+				priority:  5,
+				parentReq: e.parentReq,
+				skipPath:  true,
+			},
+			seqID: cs.nextSeqID(),
+		})
+		return
+	}
+
+	// Disagg path: create prefill sub-request and route to prefill pool.
+	// Output is intentionally nil: zero-output request completes at prefill end.
+	prefillSubReq := &sim.Request{
+		ID:           e.parentReq.PrefillSubReqID,
+		InputTokens:  e.request.InputTokens,
+		MaxOutputLen: e.request.MaxOutputLen,
+		Deadline:     e.request.Deadline,
+		PrefixGroup:  e.request.PrefixGroup,
+		State:        sim.StateQueued,
+		ArrivalTime:  e.request.ArrivalTime,
+		TenantID:     e.request.TenantID,
+		SLOClass:     e.request.SLOClass,
+		Model:        e.request.Model,
+	}
+
+	heap.Push(&cs.clusterEvents, clusterEventEntry{
+		event: &PrefillRoutingEvent{
+			time:      e.time + cs.routingLatency,
+			request:   prefillSubReq,
+			parentReq: e.parentReq,
+		},
+		seqID: cs.nextSeqID(),
+	})
+}
+
+// DecodeEnqueueEvent injects the request (or decode sub-request) onto the already-selected
+// decode instance. Used in both the skip path (priority 5) and the disagg path (priority 8).
+//
+//   - skipPath=true (priority 5): injects original request via InjectRequestOnline;
+//     instance handles full prefill+decode locally. The request is NOT tracked in
+//     pendingDecodeCompletions — the instance's normal completion machinery handles it.
+//   - skipPath=false (priority 8): creates decode sub-request, allocates transferred KV,
+//     and injects via InjectDecodeOnline after a successful KV transfer.
+type DecodeEnqueueEvent struct {
+	time      int64
+	priority  int // 5 for skip path, 8 for disagg path
+	parentReq *ParentRequest
+	skipPath  bool
+}
+
+func (e *DecodeEnqueueEvent) Timestamp() int64 { return e.time }
+func (e *DecodeEnqueueEvent) Priority() int     { return e.priority }
+
+// Execute injects the request onto the selected decode instance.
+func (e *DecodeEnqueueEvent) Execute(cs *ClusterSimulator) {
+	instID := string(e.parentReq.DecodeInstanceID)
+
+	// Find the decode instance by ID (set by DecodeRoutingEvent).
+	var targetInst *InstanceSimulator
+	for _, inst := range cs.instances {
+		if string(inst.ID()) == instID {
+			targetInst = inst
+			break
+		}
+	}
+	if targetInst == nil {
+		// Should never happen: DecodeRoutingEvent validates the target.
+		panic(fmt.Sprintf("DecodeEnqueueEvent: decode instance %q not found (programming error)", instID))
+	}
+
+	if e.skipPath {
+		e.executeSkipPath(cs, targetInst, instID)
+	} else {
+		e.executeDisaggPath(cs, targetInst, instID)
+	}
+}
+
+// executeSkipPath injects the original request directly onto the decode instance.
+// The instance processes prefill+decode locally (no KV transfer needed).
+func (e *DecodeEnqueueEvent) executeSkipPath(cs *ClusterSimulator, inst *InstanceSimulator, instID string) {
+	orig := e.parentReq.OriginalRequest
+	orig.AssignedInstance = instID
+	e.parentReq.DecodeEnqueueTime = e.time
+
+	cs.inFlightRequests[instID]++
+	if cs.tenantTracker != nil {
+		cs.tenantTracker.OnStart(orig.TenantID)
+	}
+
+	logrus.Debugf("[cluster] skip-path req %s → decode instance %s", orig.ID, instID)
+	inst.InjectRequestOnline(orig, e.time)
+}
+
+// executeDisaggPath creates the decode sub-request, allocates transferred KV, and injects.
+func (e *DecodeEnqueueEvent) executeDisaggPath(cs *ClusterSimulator, inst *InstanceSimulator, instID string) {
+	orig := e.parentReq.OriginalRequest
+	decodeSubReq := &sim.Request{
+		ID:                 e.parentReq.DecodeSubReqID,
+		InputTokens:        orig.InputTokens,
+		OutputTokens:       orig.OutputTokens,
+		MaxOutputLen:       orig.MaxOutputLen,
+		Deadline:           orig.Deadline,
+		PrefixGroup:        orig.PrefixGroup,
+		State:              sim.StateQueued,
+		ArrivalTime:        orig.ArrivalTime,
+		TenantID:           orig.TenantID,
+		SLOClass:           orig.SLOClass,
+		Model:              orig.Model,
+		IsDecodeSubRequest: true,
+	}
+
+	// Pre-allocate KV blocks for the transferred input.
+	if ok := inst.AllocateTransferredKV(decodeSubReq); !ok {
+		logrus.Warnf("[cluster] decode instance %s: insufficient KV capacity for %s (%d input tokens)",
+			instID, decodeSubReq.ID, len(decodeSubReq.InputTokens))
+		// R1/INV-1: count the drop so aggregated DroppedUnservable remains accurate.
+		cs.droppedAtDecodeKV++
+		// Mark parent CompletionTime so ParentRequests() doesn't contain records in limbo.
+		e.parentReq.CompletionTime = e.time
+		return
+	}
+
+	// Set state after successful allocation (R5: no partial state on failure path).
+	decodeSubReq.AssignedInstance = instID
+	e.parentReq.DecodeEnqueueTime = e.time
+
+	// INV-PD-1 structural guarantee: DecodeEnqueueTime >= TransferCompleteTime.
+	// KVTransferCompletedEvent (priority 7) schedules DecodeEnqueueEvent (priority 8)
+	// at the same timestamp, so both fields are equal by construction.
+
+	// Record KV transfer after successful allocation (BC-PD-17).
+	// Placement after AllocateTransferredKV ensures no KVTransferRecord is written for drops.
+	if cs.trace != nil {
+		// INV-PD-4: transfer_start ≤ transfer_complete by timestamp sequencing.
+		// Defensive clamp: warn and record 0 if violated.
+		transferDuration := e.parentReq.TransferCompleteTime - e.parentReq.TransferStartTime
+		if transferDuration < 0 {
+			logrus.Warnf("[cluster] INV-PD-4 violated: TransferCompleteTime (%d) < TransferStartTime (%d) for req %s; recording 0",
+				e.parentReq.TransferCompleteTime, e.parentReq.TransferStartTime, e.parentReq.ID)
+			transferDuration = 0
+		}
+		cs.trace.RecordKVTransfer(trace.KVTransferRecord{
+			ParentRequestID:   e.parentReq.ID,
+			TransferStartTime: e.parentReq.TransferStartTime,
+			TransferDuration:  transferDuration,
+			NumKVBlocks:       e.parentReq.NumKVBlocks,
+			PrefillInstanceID: string(e.parentReq.PrefillInstanceID),
+			DecodeInstanceID:  instID,
+		})
+	}
+
+	cs.inFlightRequests[instID]++
+	// Phase 1B-2a: track decode slot for fair-share (see PrefillRoutingEvent comment
+	// for PD slot-doubling semantics). OnStart placement here (after AllocateTransferredKV)
+	// ensures balance: a failed KV allocation returns early above without calling OnStart,
+	// matching the zero OnComplete calls for the dropped decode sub-request.
+	if cs.tenantTracker != nil {
+		cs.tenantTracker.OnStart(decodeSubReq.TenantID)
+	}
+	// Register decode sub-request so detectDecodeCompletions can stamp ParentRequest.CompletionTime
+	// and read DecodeSubReq.State/ProgressIndex for timeout detection and context accumulation.
+	e.parentReq.DecodeSubReq = decodeSubReq
+	cs.pendingDecodeCompletions[decodeSubReq.ID] = e.parentReq.ID
+	logrus.Debugf("[cluster] disagg-path decode req %s → instance %s", decodeSubReq.ID, instID)
+	inst.InjectDecodeOnline(decodeSubReq, e.time)
+}
+
 // PrefillRoutingEvent routes a prefill sub-request to a prefill pool instance.
-// Priority 4: after DisaggregationDecisionEvent (3), before KV transfer events.
+// Priority 5: after DisaggregationDecisionEvent (4), before KV transfer events.
 type PrefillRoutingEvent struct {
 	time      int64
 	request   *sim.Request   // Prefill sub-request
@@ -21,7 +311,7 @@ type PrefillRoutingEvent struct {
 }
 
 func (e *PrefillRoutingEvent) Timestamp() int64 { return e.time }
-func (e *PrefillRoutingEvent) Priority() int     { return 4 }
+func (e *PrefillRoutingEvent) Priority() int     { return 5 }
 
 // Execute routes the prefill sub-request to a prefill pool instance using pool-filtered snapshots.
 func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
@@ -71,7 +361,7 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 			cs.inFlightRequests[decision.TargetInstance]++
 			// Phase 1B-2a: track tenant in-flight count for fair-share enforcement in PD mode.
 			// PD disaggregation semantics: OnStart is called once here (prefill) and once in
-			// DecodeRoutingEvent (decode), so one parent request consumes 2 capacity slots —
+			// DecodeEnqueueEvent (disagg path), so one parent request consumes 2 capacity slots —
 			// one on the prefill pool, one on the decode pool. IsOverBudget reflects actual
 			// resource occupancy across both pools. OnComplete fires symmetrically via
 			// OnRequestDone when each sub-request finishes.
@@ -79,9 +369,6 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 				cs.tenantTracker.OnStart(e.request.TenantID)
 			}
 			inst.InjectRequestOnline(e.request, e.time)
-			// Notify observer so stateful deciders (e.g., PrefixThresholdDecider) can learn
-			// from this prefill routing decision (synchronous call -- cache is always current).
-			cs.notifyDisaggregationObserver(e.request, decision.TargetInstance)
 			return
 		}
 	}
@@ -91,14 +378,14 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 
 // KVTransferStartedEvent fires when a prefill sub-request completes.
 // Records transfer initiation, computes duration, schedules completion.
-// Priority 5: after prefill routing.
+// Priority 6: after prefill routing.
 type KVTransferStartedEvent struct {
 	time      int64
 	parentReq *ParentRequest
 }
 
 func (e *KVTransferStartedEvent) Timestamp() int64 { return e.time }
-func (e *KVTransferStartedEvent) Priority() int     { return 5 }
+func (e *KVTransferStartedEvent) Priority() int     { return 6 }
 
 // Execute computes transfer duration and schedules KVTransferCompletedEvent.
 func (e *KVTransferStartedEvent) Execute(cs *ClusterSimulator) {
@@ -169,17 +456,18 @@ func (e *KVTransferStartedEvent) Execute(cs *ClusterSimulator) {
 }
 
 // KVTransferCompletedEvent fires after transfer duration elapses.
-// Creates decode sub-request, schedules decode routing.
-// Priority 6: after transfer start.
+// Schedules DecodeEnqueueEvent (disagg path, priority 8).
+// Priority 7: after transfer start.
+// The decode instance was already selected by DecodeRoutingEvent (priority 3).
 type KVTransferCompletedEvent struct {
 	time      int64
 	parentReq *ParentRequest
 }
 
 func (e *KVTransferCompletedEvent) Timestamp() int64 { return e.time }
-func (e *KVTransferCompletedEvent) Priority() int     { return 6 }
+func (e *KVTransferCompletedEvent) Priority() int     { return 7 }
 
-// Execute creates the decode sub-request and schedules DecodeRoutingEvent.
+// Execute records transfer completion and schedules DecodeEnqueueEvent (disagg path).
 func (e *KVTransferCompletedEvent) Execute(cs *ClusterSimulator) {
 	cs.transfersCompleted++
 	e.parentReq.TransferCompleteTime = e.time
@@ -199,138 +487,16 @@ func (e *KVTransferCompletedEvent) Execute(cs *ClusterSimulator) {
 		}
 	}
 
-	orig := e.parentReq.OriginalRequest
-	decodeSubReq := &sim.Request{
-		ID:                 e.parentReq.DecodeSubReqID,
-		InputTokens:        orig.InputTokens,
-		OutputTokens:       orig.OutputTokens,
-		MaxOutputLen:       orig.MaxOutputLen,
-		Deadline:           orig.Deadline,
-		PrefixGroup:        orig.PrefixGroup,
-		State:              sim.StateQueued,
-		ArrivalTime:        orig.ArrivalTime,
-		TenantID:           orig.TenantID,
-		SLOClass:           orig.SLOClass,
-		Model:              orig.Model,
-		IsDecodeSubRequest: true,
-	}
-
-	logrus.Debugf("[cluster] KV transfer completed for %s, scheduling decode routing", e.parentReq.ID)
+	logrus.Debugf("[cluster] KV transfer completed for %s, scheduling decode enqueue on instance %s",
+		e.parentReq.ID, e.parentReq.DecodeInstanceID)
 
 	heap.Push(&cs.clusterEvents, clusterEventEntry{
-		event: &DecodeRoutingEvent{
-			time:         e.time,
-			parentReq:    e.parentReq,
-			decodeSubReq: decodeSubReq,
+		event: &DecodeEnqueueEvent{
+			time:      e.time,
+			priority:  8,
+			parentReq: e.parentReq,
+			skipPath:  false,
 		},
 		seqID: cs.nextSeqID(),
 	})
-}
-
-// DecodeRoutingEvent routes a decode sub-request to a decode pool instance.
-// Priority 7: after transfer completion.
-type DecodeRoutingEvent struct {
-	time         int64
-	parentReq    *ParentRequest
-	decodeSubReq *sim.Request
-}
-
-func (e *DecodeRoutingEvent) Timestamp() int64 { return e.time }
-func (e *DecodeRoutingEvent) Priority() int     { return 7 }
-
-// Execute routes the decode sub-request to a decode pool instance, pre-allocates KV, and injects.
-func (e *DecodeRoutingEvent) Execute(cs *ClusterSimulator) {
-	filteredSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
-	if len(filteredSnapshots) == 0 {
-		logrus.Warnf("[cluster] decode req %s: no routable instances in decode pool — request dropped", e.parentReq.ID)
-		cs.droppedAtDecodeKV++
-		e.parentReq.CompletionTime = e.time
-		return
-	}
-	state := &sim.RouterState{Snapshots: filteredSnapshots, Clock: cs.clock}
-
-	policy := cs.decodeRoutingPolicy
-	if policy == nil {
-		policy = cs.routingPolicy
-	}
-	decision := policy.Route(e.decodeSubReq, state)
-
-	logrus.Debugf("[cluster] decode req %s → instance %s", e.decodeSubReq.ID, decision.TargetInstance)
-
-	// Find target decode instance
-	for _, inst := range cs.instances {
-		if string(inst.ID()) == decision.TargetInstance {
-			// Pre-allocate KV blocks for transferred input
-			if ok := inst.AllocateTransferredKV(e.decodeSubReq); !ok {
-				logrus.Warnf("[cluster] decode instance %s: insufficient KV capacity for %s (%d input tokens)",
-					decision.TargetInstance, e.decodeSubReq.ID, len(e.decodeSubReq.InputTokens))
-				// R1/INV-1: count the drop so aggregated DroppedUnservable remains accurate.
-				cs.droppedAtDecodeKV++
-				// Mark parent CompletionTime so ParentRequests() doesn't contain records in limbo.
-				e.parentReq.CompletionTime = e.time
-				return
-			}
-
-			// Set state after successful allocation (R5: no partial state on failure path)
-			e.decodeSubReq.AssignedInstance = decision.TargetInstance
-			e.parentReq.DecodeInstanceID = InstanceID(decision.TargetInstance)
-			e.parentReq.DecodeEnqueueTime = e.time
-
-			// INV-PD-1 structural guarantee: DecodeEnqueueTime >= TransferCompleteTime.
-			// KVTransferCompletedEvent (priority 6) schedules DecodeRoutingEvent (priority 7)
-			// at the same timestamp (e.time), so both fields are equal by construction.
-
-			// Record KV transfer and decode routing after successful KV allocation (BC-PD-17, BC-PD-19).
-			// Placement after AllocateTransferredKV ensures no KVTransferRecord or DecodeRoutingRecord
-			// is written for a request that will not begin the decode phase.
-			// KVTransferRecord is recorded here so DecodeInstanceID is fully populated.
-			if cs.trace != nil {
-				// INV-PD-4: transfer_start ≤ transfer_complete by timestamp sequencing.
-				// Defensive clamp: warn and record 0 if violated.
-				transferDuration := e.parentReq.TransferCompleteTime - e.parentReq.TransferStartTime
-				if transferDuration < 0 {
-					logrus.Warnf("[cluster] INV-PD-4 violated: TransferCompleteTime (%d) < TransferStartTime (%d) for req %s; recording 0",
-						e.parentReq.TransferCompleteTime, e.parentReq.TransferStartTime, e.parentReq.ID)
-					transferDuration = 0
-				}
-				cs.trace.RecordKVTransfer(trace.KVTransferRecord{
-					ParentRequestID:   e.parentReq.ID,
-					TransferStartTime: e.parentReq.TransferStartTime,
-					TransferDuration:  transferDuration,
-					NumKVBlocks:       e.parentReq.NumKVBlocks,
-					PrefillInstanceID: string(e.parentReq.PrefillInstanceID),
-					DecodeInstanceID:  string(e.parentReq.DecodeInstanceID),
-				})
-				decodeRecord := trace.DecodeRoutingRecord{
-					ParentRequestID: e.parentReq.ID,
-					Clock:           cs.clock,
-					ChosenInstance:  decision.TargetInstance,
-					Scores:          copyScores(decision.Scores),
-				}
-				if cs.trace.Config.CounterfactualK > 0 {
-					decodeRecord.Candidates, decodeRecord.Regret = computeCounterfactual(
-						decision.TargetInstance, decision.Scores,
-						filteredSnapshots, cs.trace.Config.CounterfactualK,
-					)
-				}
-				cs.trace.RecordDecodeRouting(decodeRecord)
-			}
-
-			cs.inFlightRequests[decision.TargetInstance]++
-			// Phase 1B-2a: track decode slot for fair-share (see PrefillRoutingEvent comment
-			// for PD slot-doubling semantics). OnStart placement here (after AllocateTransferredKV)
-			// ensures balance: a failed KV allocation returns early above without calling OnStart,
-			// matching the zero OnComplete calls for the dropped decode sub-request.
-			if cs.tenantTracker != nil {
-				cs.tenantTracker.OnStart(e.decodeSubReq.TenantID)
-			}
-			// Register decode sub-request so detectDecodeCompletions can stamp ParentRequest.CompletionTime
-			// and read DecodeSubReq.State/ProgressIndex for timeout detection and context accumulation.
-			e.parentReq.DecodeSubReq = e.decodeSubReq
-			cs.pendingDecodeCompletions[e.decodeSubReq.ID] = e.parentReq.ID
-			inst.InjectDecodeOnline(e.decodeSubReq, e.time)
-			return
-		}
-	}
-	panic(fmt.Sprintf("DecodeRoutingEvent: invalid TargetInstance %q", decision.TargetInstance))
 }

--- a/sim/cluster/pd_traces_test.go
+++ b/sim/cluster/pd_traces_test.go
@@ -191,10 +191,17 @@ func TestPDTrace_DisaggMode_Counterfactual(t *testing.T) {
 	}
 }
 
-// TestPDTrace_DisaggMode_Cardinality verifies the PD trace cardinality conservation law (R7):
-// with AlwaysDisaggregate, DisaggregatedCount == len(PrefillRoutings) == len(KVTransfers) == len(DecodeRoutings).
-// Note: len(Disaggregations) >= DisaggregatedCount (Disaggregations records ALL decisions, including disaggregate=false).
-// The general invariant is DisaggregatedCount == len(PrefillRoutings) == len(KVTransfers) == len(DecodeRoutings).
+// TestPDTrace_DisaggMode_Cardinality verifies PD trace cardinality with AlwaysDisaggregate.
+//
+// Decode-first cardinality invariants:
+//   - len(DecodeRoutings) == len(Disaggregations): decode routing fires once per PD request,
+//     always before the disaggregation decision, regardless of skip or disagg path.
+//   - len(PrefillRoutings) == len(KVTransfers) == DisaggregatedCount: prefill routing and KV
+//     transfer records are emitted only on the disagg path.
+//
+// This test uses AlwaysDisaggregate, so all paths are disagg and all four counts are equal.
+// For a mixed skip/disagg scenario: len(DecodeRoutings) == len(Disaggregations) == N, but
+// len(PrefillRoutings) == len(KVTransfers) == DisaggregatedCount < N.
 func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	// GIVEN disaggregated simulation with trace enabled
 	const numRequests = 5
@@ -221,7 +228,7 @@ func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	if disaggCount != len(tr.Disaggregations) {
 		t.Errorf("cardinality violation: DisaggregatedCount=%d != len(Disaggregations)=%d (AlwaysDisaggregate expects all true)", disaggCount, len(tr.Disaggregations))
 	}
-	// The general PD cardinality law: DisaggregatedCount == PrefillRoutings == KVTransfers == DecodeRoutings
+	// With AlwaysDisaggregate, all paths are disagg so all four counts are equal.
 	if np != disaggCount {
 		t.Errorf("cardinality violation: PrefillRoutings=%d != DisaggregatedCount=%d", np, disaggCount)
 	}
@@ -368,6 +375,65 @@ func TestPDTrace_NeverDecider_WithPools_OnlyDisaggRecords(t *testing.T) {
 	// Standard routing records are only written by RoutingDecisionEvent (non-PD path).
 	if len(tr.Routings) != 0 {
 		t.Errorf("expected 0 standard routing records in PD mode (skip-path uses DecodeEnqueueEvent), got %d", len(tr.Routings))
+	}
+}
+
+// TestPDTrace_SkipPath_TraceRecords verifies trace record presence for skip-path requests.
+// With NeverDisaggregate, all PD requests take the skip path (cache hit: served locally
+// on the selected decode instance). The decode-first invariant means DecodeRoutingRecord
+// and DisaggregationRecord (Disaggregate=false) are always emitted, while PrefillRoutingRecord
+// and KVTransferRecord are absent (no prefill routing, no KV transfer on skip path).
+func TestPDTrace_SkipPath_TraceRecords(t *testing.T) {
+	// GIVEN pools configured with NeverDisaggregate (all requests → skip path)
+	const numRequests = 4
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	config.PDDecider = "never"
+	config.TraceLevel = "decisions"
+	requests := newTestRequests(numRequests)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// WHEN run
+	mustRun(t, cs)
+
+	tr := cs.Trace()
+	if tr == nil {
+		t.Fatal("expected non-nil trace")
+	}
+
+	// THEN DecodeRoutingRecord present for every request (decode-first always records)
+	if len(tr.DecodeRoutings) != numRequests {
+		t.Errorf("DecodeRoutings=%d, want %d (decode-first: always written per PD request)", len(tr.DecodeRoutings), numRequests)
+	}
+
+	// THEN DisaggregationRecord present for every request, all Disaggregate=false
+	if len(tr.Disaggregations) != numRequests {
+		t.Errorf("Disaggregations=%d, want %d", len(tr.Disaggregations), numRequests)
+	}
+	for i, r := range tr.Disaggregations {
+		if r.Disaggregate {
+			t.Errorf("Disaggregations[%d]: Disaggregate=true, want false (NeverDisaggregate)", i)
+		}
+		if r.RequestID == "" {
+			t.Errorf("Disaggregations[%d]: RequestID empty", i)
+		}
+		if r.DecodeInstanceID == "" {
+			t.Errorf("Disaggregations[%d]: DecodeInstanceID empty (decode-first: always set before disagg decision)", i)
+		}
+	}
+
+	// THEN no PrefillRoutingRecord (skip path: no prefill routing)
+	if len(tr.PrefillRoutings) != 0 {
+		t.Errorf("PrefillRoutings=%d, want 0 (skip path)", len(tr.PrefillRoutings))
+	}
+
+	// THEN no KVTransferRecord (skip path: no KV transfer)
+	if len(tr.KVTransfers) != 0 {
+		t.Errorf("KVTransfers=%d, want 0 (skip path)", len(tr.KVTransfers))
+	}
+
+	// THEN no standard RoutingRecord (skip path uses DecodeEnqueueEvent, not RoutingDecisionEvent)
+	if len(tr.Routings) != 0 {
+		t.Errorf("Routings=%d, want 0 (PD skip path does not emit standard routing records)", len(tr.Routings))
 	}
 }
 

--- a/sim/cluster/pd_traces_test.go
+++ b/sim/cluster/pd_traces_test.go
@@ -297,10 +297,14 @@ func TestPDTrace_DroppedAtDecodeKV_NoOrphanRecords(t *testing.T) {
 		t.Fatal("expected non-nil trace with trace-level decisions")
 	}
 
-	// The cardinality law under drops: KVTransfers == DecodeRoutings (they are always co-recorded)
-	// and KVTransfers < DisaggregatedCount (dropped requests have no KV record).
-	if len(tr.KVTransfers) != len(tr.DecodeRoutings) {
-		t.Errorf("KVTransfers=%d != DecodeRoutings=%d (must be co-recorded)", len(tr.KVTransfers), len(tr.DecodeRoutings))
+	// In the decode-first flow, DecodeRoutingRecord is written at priority 3 (before
+	// disaggregation decision). KVTransferRecord is written only after a successful
+	// AllocateTransferredKV in DecodeEnqueueEvent. Under decode KV drops:
+	//   DecodeRoutings == Disaggregations (all disagg requests have both)
+	//   KVTransfers < DecodeRoutings (drops reduce KV count, not decode routing count)
+	if len(tr.DecodeRoutings) != len(tr.Disaggregations) {
+		t.Errorf("DecodeRoutings=%d != Disaggregations=%d under decode KV drops (decode routing is decode-first; all disagg requests get a record)",
+			len(tr.DecodeRoutings), len(tr.Disaggregations))
 	}
 	if len(tr.KVTransfers) >= len(tr.Disaggregations) {
 		t.Errorf("KVTransfers=%d >= Disaggregations=%d under drops (drops must reduce KV record count)", len(tr.KVTransfers), len(tr.Disaggregations))
@@ -347,19 +351,23 @@ func TestPDTrace_NeverDecider_WithPools_OnlyDisaggRecords(t *testing.T) {
 			t.Errorf("Disaggregations[%d]: RequestID empty", i)
 		}
 	}
-	// No downstream PD records emitted
+	// No prefill/KV records emitted (all requests are skip-path)
 	if len(tr.PrefillRoutings) != 0 {
 		t.Errorf("expected 0 PrefillRoutings with NeverDisaggregate, got %d", len(tr.PrefillRoutings))
 	}
 	if len(tr.KVTransfers) != 0 {
 		t.Errorf("expected 0 KVTransfers with NeverDisaggregate, got %d", len(tr.KVTransfers))
 	}
-	if len(tr.DecodeRoutings) != 0 {
-		t.Errorf("expected 0 DecodeRoutings with NeverDisaggregate, got %d", len(tr.DecodeRoutings))
+	// In the decode-first flow, DecodeRoutingRecord is always written for PD requests
+	// (decode routing happens before the disaggregation decision).
+	if len(tr.DecodeRoutings) != numRequests {
+		t.Errorf("expected %d DecodeRoutings with NeverDisaggregate (decode routing always fires in PD mode), got %d",
+			numRequests, len(tr.DecodeRoutings))
 	}
-	// Standard routing still fires for every request (BC-TRACE-COMPAT)
-	if len(tr.Routings) != numRequests {
-		t.Errorf("expected %d standard routing records with NeverDisaggregate, got %d", numRequests, len(tr.Routings))
+	// Skip-path requests go through DecodeEnqueueEvent, not RoutingDecisionEvent.
+	// Standard routing records are only written by RoutingDecisionEvent (non-PD path).
+	if len(tr.Routings) != 0 {
+		t.Errorf("expected 0 standard routing records in PD mode (skip-path uses DecodeEnqueueEvent), got %d", len(tr.Routings))
 	}
 }
 

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -1,36 +1,41 @@
 package sim
 
-import (
-	"fmt"
-
-	"github.com/sirupsen/logrus"
-)
+import "fmt"
 
 // DisaggregationDecision encapsulates the prefill-decode disaggregation decision for a request.
 type DisaggregationDecision struct {
-	Disaggregate bool // true = route to prefill pool, false = route to shared/decode pool
+	Disaggregate bool // true = route to prefill pool, false = serve on selected decode instance
 }
 
-// DisaggregationDecider decides whether a request should be disaggregated
-// (sent to a dedicated prefill pool) or handled by the default routing pipeline.
+// DecodeContext carries the selected decode instance's identity and current cache state
+// to the disaggregation decider. Populated by DecodeRoutingEvent before calling Decide.
+type DecodeContext struct {
+	InstanceID       string // ID of the decode-pool instance selected by DecodeRoutingEvent
+	CachedBlockCount int    // number of complete KV blocks already cached on that instance
+}
+
+// DisaggregationDecider decides whether a request should be disaggregated (sent to a
+// dedicated prefill pool) or served locally on the already-selected decode instance.
 // Used by ClusterSimulator's event pipeline when pool topology is configured.
+//
+// In the decode-first flow, the decode instance has already been chosen by DecodeRoutingEvent
+// before Decide is called. ctx carries the instance's identity and cache state, enabling
+// per-instance disaggregation decisions: the same request may disaggregate on one decode
+// instance (prefix not cached) but skip disaggregation on another (prefix cached).
 //
 // Implementations must not read Request.OutputTokens (INV-9 oracle boundary);
 // use len(req.InputTokens) and req.MaxOutputLen only.
 //
 // req is guaranteed non-nil; implementations may assume a non-nil pointer.
-//
-// Stateful implementations may additionally implement DisaggregationObserver to
-// learn from routing outcomes (e.g., PrefixThresholdDecider).
 type DisaggregationDecider interface {
-	Decide(req *Request) DisaggregationDecision
+	Decide(req *Request, ctx DecodeContext) DisaggregationDecision
 }
 
 // NeverDisaggregate always returns Disaggregate=false.
 // Default decider when PD disaggregation is not configured.
 type NeverDisaggregate struct{}
 
-func (n *NeverDisaggregate) Decide(_ *Request) DisaggregationDecision {
+func (n *NeverDisaggregate) Decide(_ *Request, _ DecodeContext) DisaggregationDecision {
 	return DisaggregationDecision{Disaggregate: false}
 }
 
@@ -38,7 +43,7 @@ func (n *NeverDisaggregate) Decide(_ *Request) DisaggregationDecision {
 // Test-oriented decider for validating disaggregation pipeline wiring.
 type AlwaysDisaggregate struct{}
 
-func (a *AlwaysDisaggregate) Decide(_ *Request) DisaggregationDecision {
+func (a *AlwaysDisaggregate) Decide(_ *Request, _ DecodeContext) DisaggregationDecision {
 	return DisaggregationDecision{Disaggregate: true}
 }
 
@@ -67,7 +72,8 @@ func NewDirectToDecodeDecider(threshold int) *DirectToDecodeDecider {
 // Disaggregate=false when input length < threshold (short prompt -> direct to decode pool).
 // Empty inputs (len == 0) always return Disaggregate=false regardless of threshold.
 // req must be non-nil (interface contract); panics on nil req (programming error).
-func (d *DirectToDecodeDecider) Decide(req *Request) DisaggregationDecision {
+// ctx is not used: this decider is purely input-length based.
+func (d *DirectToDecodeDecider) Decide(req *Request, _ DecodeContext) DisaggregationDecision {
 	if req == nil {
 		panic("DirectToDecodeDecider.Decide: req is nil (programming error)")
 	}
@@ -104,60 +110,21 @@ func NewDisaggregationDecider(name string) DisaggregationDecider {
 	}
 }
 
-// globalVirtualInstance is the single key used in PrefixThresholdDecider's PrefixCacheIndex
-// to represent cluster-wide prefix knowledge. All requests update the same virtual instance
-// so the decider tracks the global set of recently-seen prefixes.
-// Using a single virtual key repurposes the per-instance PrefixCacheIndex structure to
-// maintain one aggregate view of cluster-wide prefix state without modifying its interface.
-// Collision with real instance IDs is not a risk: instance IDs use a numeric index (e.g.,
-// "instance_0"), whereas this sentinel uses the "__" prefix convention.
-const globalVirtualInstance = "__global__"
-
-// defaultDisaggLRUCapacity is the number of block hash slots tracked in PrefixThresholdDecider's
-// router-side prefix cache (LRU capacity). Independent of block size.
-const defaultDisaggLRUCapacity = 10000
-
-// DisaggregationObserver is an optional interface for stateful DisaggregationDeciders that need
-// to learn from routing decisions. ClusterSimulator calls ObserveRouting after each routing
-// decision that assigns a request to an instance: after standard routing (RoutingDecisionEvent
-// in cluster_event.go) and after prefill routing (PrefillRoutingEvent in pd_events.go).
-// It is not called for decode routing, because the decider's prefix knowledge is based on
-// input tokens, which are identical between prefill and decode sub-requests.
+// PrefixThresholdDecider disaggregates a request when the number of non-cached input tokens
+// on the selected decode instance exceeds the configured threshold.
 //
-// ObserveRouting is called synchronously within the event loop immediately after each
-// routing decision, so the prefix cache is always current at the next Decide() call.
-//
-// req is guaranteed non-nil. Implementations must treat req as read-only.
-// instanceID is the routing target; implementations maintaining per-instance state should
-// record it; implementations with global state (like PrefixThresholdDecider) may ignore it.
-type DisaggregationObserver interface {
-	ObserveRouting(req *Request, instanceID string)
-}
-
-// PrefixThresholdDecider disaggregates a request when its non-cached token count exceeds
-// the configured threshold. Maintains a router-side prefix cache (globalVirtualInstance)
-// to estimate how many input tokens are already cached cluster-wide.
-//
-// Non-cached token count: len(req.InputTokens) - cachedBlocks * blockSize (always >= 0,
-// because ComputeBlockHashes only produces complete-block hashes so cachedBlocks*blockSize
-// never exceeds len(InputTokens)). threshold and blockSize are in token counts, not bytes.
+// Non-cached token count: len(req.InputTokens) - ctx.CachedBlockCount * blockSize (clamped >= 0).
 // Decision: Disaggregate = (nonCachedTokens > threshold).
 //
-// The prefix cache is always current at decision time: ObserveRouting is called
-// synchronously within the event loop immediately after each routing decision.
+// Unlike the previous implementation, this decider is stateless: it does not maintain a
+// router-side prefix cache. Instead, it reads the selected decode instance's actual KV cache
+// state from ctx.CachedBlockCount, which is populated by DecodeRoutingEvent via cacheQueryFn.
+// This matches llm-d's prefix-based-pd-decider architecture (INV-PD-8).
 //
-// Threading: cachedHashes and cachedReqID are a single-use scratchpad — Decide() writes
-// them and ObserveRouting() consumes and clears them. This is safe only because the DES
-// event loop is single-threaded: no Decide() can interleave between a Decide() call and
-// its paired ObserveRouting() call. If routing is rejected after Decide() (no routable
-// instances), ObserveRouting() is not called; the stale scratchpad is harmlessly
-// overwritten by the next Decide() call.
+// threshold and blockSize are in token counts, not bytes.
 type PrefixThresholdDecider struct {
-	threshold    int
-	blockSize    int
-	idx          *PrefixCacheIndex
-	cachedHashes []string
-	cachedReqID  string
+	threshold int
+	blockSize int
 }
 
 // NewPrefixThresholdDecider creates a PrefixThresholdDecider with the given threshold and block size.
@@ -172,46 +139,23 @@ func NewPrefixThresholdDecider(threshold, blockSize int) *PrefixThresholdDecider
 	return &PrefixThresholdDecider{
 		threshold: threshold,
 		blockSize: blockSize,
-		idx:       NewPrefixCacheIndex(blockSize, defaultDisaggLRUCapacity),
 	}
 }
 
-// Decide returns Disaggregate=true when non-cached token count exceeds the threshold.
+// Decide returns Disaggregate=true when the non-cached token count exceeds the threshold.
+// Non-cached tokens = len(req.InputTokens) - ctx.CachedBlockCount * blockSize, clamped to 0.
 // Empty requests (len(InputTokens) == 0) always return Disaggregate=false.
-// Caches block hashes for reuse by ObserveRouting when the same request is routed next.
-func (p *PrefixThresholdDecider) Decide(req *Request) DisaggregationDecision {
+func (p *PrefixThresholdDecider) Decide(req *Request, ctx DecodeContext) DisaggregationDecision {
 	if len(req.InputTokens) == 0 {
 		return DisaggregationDecision{Disaggregate: false}
 	}
-	p.cachedHashes = p.idx.ComputeBlockHashes(req.InputTokens)
-	p.cachedReqID = req.ID
-	cachedBlocks := p.idx.MatchLength(p.cachedHashes, globalVirtualInstance)
-	nonCachedTokens := len(req.InputTokens) - cachedBlocks*p.blockSize
+	nonCachedTokens := len(req.InputTokens) - ctx.CachedBlockCount*p.blockSize
+	if nonCachedTokens < 0 {
+		nonCachedTokens = 0
+	}
 	return DisaggregationDecision{Disaggregate: nonCachedTokens > p.threshold}
 }
 
-// ObserveRouting updates the prefix cache after a routing decision, recording the request's
-// block hashes under globalVirtualInstance. Reuses hashes from Decide when the request ID
-// matches; otherwise recomputes. The ID mismatch case is expected in the disaggregated path:
-// notifyDisaggregationObserver is called with the prefill sub-request (ID "<parent>_prefill"),
-// which differs from the parent request evaluated by Decide.
-func (p *PrefixThresholdDecider) ObserveRouting(req *Request, _ string) {
-	if req == nil {
-		logrus.Errorf("PrefixThresholdDecider.ObserveRouting: req is nil (contract violation); skipping cache update")
-		return
-	}
-	if len(req.InputTokens) == 0 {
-		return // no complete blocks to record; consistent with Decide's early-return for empty tokens
-	}
-	hashes := p.cachedHashes
-	if req.ID != p.cachedReqID || p.cachedHashes == nil {
-		hashes = p.idx.ComputeBlockHashes(req.InputTokens)
-	}
-	p.idx.RecordBlocks(hashes, globalVirtualInstance)
-	p.cachedHashes = nil
-	p.cachedReqID = ""
-}
-
 // Compile-time interface compliance checks.
-var _ DisaggregationObserver = (*PrefixThresholdDecider)(nil)
 var _ DisaggregationDecider = (*DirectToDecodeDecider)(nil)
+var _ DisaggregationDecider = (*PrefixThresholdDecider)(nil)

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -1,7 +1,6 @@
 package sim
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -11,7 +10,7 @@ func TestNeverDisaggregate_AlwaysReturnsFalse(t *testing.T) {
 	decider := &NeverDisaggregate{}
 	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
 
-	decision := decider.Decide(req)
+	decision := decider.Decide(req, DecodeContext{InstanceID: "i0", CachedBlockCount: 0})
 
 	if decision.Disaggregate {
 		t.Error("NeverDisaggregate should return Disaggregate=false")
@@ -24,7 +23,7 @@ func TestAlwaysDisaggregate_AlwaysReturnsTrue(t *testing.T) {
 	decider := &AlwaysDisaggregate{}
 	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
 
-	decision := decider.Decide(req)
+	decision := decider.Decide(req, DecodeContext{InstanceID: "i0", CachedBlockCount: 0})
 
 	if !decision.Disaggregate {
 		t.Error("AlwaysDisaggregate should return Disaggregate=true")
@@ -36,12 +35,14 @@ func TestDisaggregationDecider_Interface(t *testing.T) {
 	var _ DisaggregationDecider = &NeverDisaggregate{}
 	var _ DisaggregationDecider = &AlwaysDisaggregate{}
 	var _ DisaggregationDecider = &DirectToDecodeDecider{}
+	var _ DisaggregationDecider = &PrefixThresholdDecider{}
 }
 
 // TestNewDisaggregationDecider_Factory verifies factory dispatches correctly
 // by asserting observable behavior (Decide output), not concrete type names.
 func TestNewDisaggregationDecider_Factory(t *testing.T) {
 	req := &Request{ID: "req-1", InputTokens: make([]int, 10)}
+	ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
 	tests := []struct {
 		name             string
 		wantDisaggregate bool
@@ -56,7 +57,7 @@ func TestNewDisaggregationDecider_Factory(t *testing.T) {
 			if d == nil {
 				t.Fatal("NewDisaggregationDecider returned nil")
 			}
-			got := d.Decide(req).Disaggregate
+			got := d.Decide(req, ctx).Disaggregate
 			if got != tc.wantDisaggregate {
 				t.Errorf("NewDisaggregationDecider(%q).Decide().Disaggregate = %v, want %v",
 					tc.name, got, tc.wantDisaggregate)
@@ -141,6 +142,7 @@ func TestValidDisaggregationDeciderNames(t *testing.T) {
 // enforced by reading only InputTokens and MaxOutputLen. The test verifies the observable
 // behavior: decisions are the same regardless of OutputTokens content.
 func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
+	ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
 	req1 := &Request{ID: "req-1", InputTokens: make([]int, 100), OutputTokens: nil}
 	req2 := &Request{ID: "req-2", InputTokens: make([]int, 100), OutputTokens: make([]int, 9999)}
 
@@ -151,8 +153,8 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 		NewDirectToDecodeDecider(256),
 	}
 	for _, d := range deciders {
-		d1 := d.Decide(req1)
-		d2 := d.Decide(req2)
+		d1 := d.Decide(req1, ctx)
+		d2 := d.Decide(req2, ctx)
 		if d1 != d2 {
 			t.Errorf("%T: decision differs with different OutputTokens (d1=%v, d2=%v); INV-9 violation",
 				d, d1, d2)
@@ -167,7 +169,7 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 func TestDirectToDecodeDecider_ShortPromptDoesNotDisaggregate(t *testing.T) {
 	d := NewDirectToDecodeDecider(256)
 	req := &Request{InputTokens: make([]int, 100)} // 100 < 256
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if decision.Disaggregate {
 		t.Error("short prompt (100 tokens < threshold 256) should not disaggregate")
 	}
@@ -178,7 +180,7 @@ func TestDirectToDecodeDecider_ShortPromptDoesNotDisaggregate(t *testing.T) {
 func TestDirectToDecodeDecider_LongPromptDisaggregates(t *testing.T) {
 	d := NewDirectToDecodeDecider(256)
 	req := &Request{InputTokens: make([]int, 500)} // 500 >= 256
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if !decision.Disaggregate {
 		t.Error("long prompt (500 tokens >= threshold 256) should disaggregate")
 	}
@@ -189,7 +191,7 @@ func TestDirectToDecodeDecider_LongPromptDisaggregates(t *testing.T) {
 func TestDirectToDecodeDecider_ExactThresholdDisaggregates(t *testing.T) {
 	d := NewDirectToDecodeDecider(256)
 	req := &Request{InputTokens: make([]int, 256)} // 256 >= 256
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if !decision.Disaggregate {
 		t.Error("exact threshold (256 tokens >= threshold 256) should disaggregate")
 	}
@@ -201,7 +203,7 @@ func TestDirectToDecodeDecider_BelowThresholdDoesNotDisaggregate(t *testing.T) {
 	const threshold = 256
 	d := NewDirectToDecodeDecider(threshold)
 	req := &Request{InputTokens: make([]int, threshold-1)} // 255 < 256
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if decision.Disaggregate {
 		t.Errorf("threshold-1 tokens (%d) must not disaggregate (threshold=%d, boundary is >=)",
 			threshold-1, threshold)
@@ -213,7 +215,7 @@ func TestDirectToDecodeDecider_BelowThresholdDoesNotDisaggregate(t *testing.T) {
 func TestDirectToDecodeDecider_EmptyInputDoesNotDisaggregate(t *testing.T) {
 	d := NewDirectToDecodeDecider(256)
 	req := &Request{InputTokens: nil}
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if decision.Disaggregate {
 		t.Error("empty input should not disaggregate")
 	}
@@ -224,7 +226,7 @@ func TestDirectToDecodeDecider_EmptyInputDoesNotDisaggregate(t *testing.T) {
 func TestDirectToDecodeDecider_ZeroThresholdAlwaysDisaggregates(t *testing.T) {
 	d := NewDirectToDecodeDecider(0)
 	req := &Request{InputTokens: make([]int, 1)}
-	decision := d.Decide(req)
+	decision := d.Decide(req, DecodeContext{InstanceID: "i0"})
 	if !decision.Disaggregate {
 		t.Error("threshold 0 with non-empty input should always disaggregate")
 	}
@@ -249,7 +251,7 @@ func TestDirectToDecodeDecider_PanicsOnNilRequest(t *testing.T) {
 			t.Error("expected panic when req is nil")
 		}
 	}()
-	d.Decide(nil)
+	d.Decide(nil, DecodeContext{InstanceID: "i0"})
 }
 
 // --- PrefixThresholdDecider tests ---
@@ -274,35 +276,163 @@ func TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize(t *testing.T) {
 	NewPrefixThresholdDecider(512, 0)
 }
 
-// noopDisaggregationObserver is a no-op DisaggregationObserver used in tests to satisfy R13:
-// DisaggregationObserver must work for >=2 backends (not tightly coupled to PrefixThresholdDecider).
-// Any future stateful decider (e.g., adaptive-rate, popularity-based) should also implement it.
-type noopDisaggregationObserver struct{}
-
-func (*noopDisaggregationObserver) ObserveRouting(_ *Request, _ string) {}
-
-// TestPrefixThresholdDecider_Interface verifies PrefixThresholdDecider satisfies both interfaces.
-// Also verifies DisaggregationObserver is a general extension point (R13: works for >=2 backends).
-func TestPrefixThresholdDecider_Interface(t *testing.T) {
-	var _ DisaggregationDecider = &PrefixThresholdDecider{}
-	var _ DisaggregationObserver = &PrefixThresholdDecider{}
-	var _ DisaggregationObserver = &noopDisaggregationObserver{} // R13: second backend
-}
-
 // TestPrefixThresholdDecider_EmptyTokens verifies BC-PD-20: empty input returns Disaggregate=false.
 func TestPrefixThresholdDecider_EmptyTokens(t *testing.T) {
 	decider := NewPrefixThresholdDecider(512, 16)
 	req := &Request{ID: "req-empty", InputTokens: []int{}}
+	ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
 
-	decision := decider.Decide(req)
+	decision := decider.Decide(req, ctx)
 
 	if decision.Disaggregate {
 		t.Error("BC-PD-20: empty InputTokens must return Disaggregate=false")
 	}
 }
 
+// TestPrefixThresholdDecider_DecodeContext_TableDriven verifies INV-PD-8: the decider
+// uses ctx.CachedBlockCount from the selected decode instance to determine non-cached token count.
+// ≥20 cases covering zero cached, partial cached, full cached, at-threshold, above, below, etc.
+func TestPrefixThresholdDecider_DecodeContext_TableDriven(t *testing.T) {
+	const blockSize = 16
+	const threshold = 512 // in tokens
+
+	tests := []struct {
+		name             string
+		inputLen         int
+		cachedBlockCount int
+		wantDisaggregate bool
+	}{
+		// Zero cached blocks — non-cached = all tokens
+		{"zero_cached_below_threshold", 100, 0, false},     // 100 <= 512
+		{"zero_cached_at_threshold", 512, 0, false},        // 512 == 512, not > threshold
+		{"zero_cached_above_threshold", 513, 0, true},      // 513 > 512
+		{"zero_cached_well_above", 1000, 0, true},          // 1000 > 512
+		{"zero_cached_single_token", 1, 0, false},          // 1 <= 512
+		{"zero_cached_empty", 0, 0, false},                 // empty input always false
+		// Partial cached — non-cached = input - cached_blocks * blockSize
+		{"partial_cached_under_threshold", 800, 20, false}, // 800 - 20*16=320 <= 512
+		{"partial_cached_at_threshold", 824, 20, false},    // 824 - 320=504 <= 512
+		{"partial_cached_above_threshold", 900, 20, true},  // 900 - 320=580 > 512
+		{"partial_cached_one_block", 520, 1, false},        // 520 - 16=504 <= 512
+		{"partial_cached_many_blocks", 1500, 60, true},     // 1500 - 960=540 > 512
+		// Fully cached — non-cached = 0 (clamped)
+		{"fully_cached_exact", 320, 20, false},             // 320 - 320=0 <= 512
+		{"fully_cached_over_count", 160, 20, false},        // 160 - 320 < 0 → clamped 0
+		{"fully_cached_large", 1000, 100, false},           // 1000 - 1600 < 0 → clamped 0
+		// Zero threshold — any non-cached token triggers disagg
+		{"zero_threshold_all_cached", 32, 2, false},        // threshold=0, cached=32, non-cached=0
+		// (use separate decider for zero threshold tests below)
+		// Boundary around blockSize grain
+		{"one_block_cached_under", blockSize + threshold, 1, false}, // (16+512) - 16 = 512, not > 512
+		{"one_block_cached_over", blockSize + threshold + 1, 1, true}, // 513 > 512
+		// Large input, high cache count
+		{"large_input_high_cache", 5000, 250, false}, // 5000 - 4000=1000 > 512 → wait, 1000 > 512 → true
+		// (re-check): 5000 - 250*16 = 5000 - 4000 = 1000 > 512 → disaggregate=true
+		{"large_input_very_high_cache", 5000, 300, false}, // 5000 - 4800=200 <= 512
+		{"large_input_moderate_cache", 5000, 30, true},    // 5000 - 480=4520 > 512
+	}
+
+	// Fix the large_input_high_cache entry
+	for i := range tests {
+		if tests[i].name == "large_input_high_cache" {
+			tests[i].wantDisaggregate = true // 5000 - 4000 = 1000 > 512
+		}
+	}
+
+	decider := NewPrefixThresholdDecider(threshold, blockSize)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens := make([]int, tc.inputLen)
+			for i := range tokens {
+				tokens[i] = i + 1
+			}
+			req := &Request{ID: "req-" + tc.name, InputTokens: tokens}
+			ctx := DecodeContext{InstanceID: "instance_0", CachedBlockCount: tc.cachedBlockCount}
+
+			got := decider.Decide(req, ctx)
+
+			if got.Disaggregate != tc.wantDisaggregate {
+				nonCached := tc.inputLen - tc.cachedBlockCount*blockSize
+				if nonCached < 0 {
+					nonCached = 0
+				}
+				t.Errorf("inputLen=%d cachedBlocks=%d nonCached=%d threshold=%d: Disaggregate=%v, want %v",
+					tc.inputLen, tc.cachedBlockCount, nonCached, threshold, got.Disaggregate, tc.wantDisaggregate)
+			}
+		})
+	}
+}
+
+// TestPrefixThresholdDecider_ZeroThreshold verifies threshold=0 means always disaggregate
+// when tokens are non-empty and no cache coverage.
+func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
+	const blockSize = 16
+	decider := NewPrefixThresholdDecider(0, blockSize)
+
+	// 100 uncached tokens -> 100 > 0 -> disaggregate
+	tokens := make([]int, 100)
+	for i := range tokens {
+		tokens[i] = i + 1
+	}
+	req := &Request{ID: "req-zero-thresh", InputTokens: tokens}
+	ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
+
+	decision := decider.Decide(req, ctx)
+
+	if !decision.Disaggregate {
+		t.Error("threshold=0 with non-empty uncached tokens should return Disaggregate=true")
+	}
+}
+
+// TestPrefixThresholdDecider_ZeroThreshold_AllCached verifies threshold=0 with all tokens
+// cached returns Disaggregate=false (0 non-cached tokens, 0 is not > 0).
+func TestPrefixThresholdDecider_ZeroThreshold_AllCached(t *testing.T) {
+	const blockSize = 16
+	decider := NewPrefixThresholdDecider(0, blockSize)
+
+	// 32 tokens = 2 blocks, both cached
+	tokens := make([]int, 32)
+	req := &Request{InputTokens: tokens}
+	ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 2}
+
+	decision := decider.Decide(req, ctx)
+
+	if decision.Disaggregate {
+		t.Error("threshold=0 with all tokens cached (0 non-cached) should not disaggregate")
+	}
+}
+
+// TestPrefixThresholdDecider_InstanceLocalBehavior verifies INV-PD-8: the same request
+// with the same input produces different disaggregation decisions depending on which
+// decode instance is selected (and thus ctx.CachedBlockCount varies).
+func TestPrefixThresholdDecider_InstanceLocalBehavior(t *testing.T) {
+	const blockSize = 16
+	const threshold = 200 // tokens
+	decider := NewPrefixThresholdDecider(threshold, blockSize)
+
+	tokens := make([]int, 300) // 300 total tokens
+	for i := range tokens {
+		tokens[i] = i + 1
+	}
+	req := &Request{ID: "req-locality", InputTokens: tokens}
+
+	// Instance A: 10 blocks cached = 160 tokens → non-cached = 300-160=140 <= 200 → skip
+	ctxA := DecodeContext{InstanceID: "instance_0", CachedBlockCount: 10}
+	decisionA := decider.Decide(req, ctxA)
+	if decisionA.Disaggregate {
+		t.Error("INV-PD-8: instance A has prefix cached → should skip disaggregation")
+	}
+
+	// Instance B: 0 blocks cached → non-cached = 300 > 200 → disaggregate
+	ctxB := DecodeContext{InstanceID: "instance_1", CachedBlockCount: 0}
+	decisionB := decider.Decide(req, ctxB)
+	if !decisionB.Disaggregate {
+		t.Error("INV-PD-8: instance B has no cache → should disaggregate")
+	}
+}
+
 // TestPrefixThresholdDecider_AboveThreshold verifies BC-PD-21: non-cached tokens > threshold -> true.
-// Uses threshold+1 as the boundary case to pin the strict > semantics (not >=).
 func TestPrefixThresholdDecider_AboveThreshold(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
@@ -312,18 +442,19 @@ func TestPrefixThresholdDecider_AboveThreshold(t *testing.T) {
 		name   string
 		tokens int
 	}{
-		{"threshold_plus_one", threshold + 1}, // tightest boundary: first value that must disaggregate
+		{"threshold_plus_one", threshold + 1},
 		{"well_above_threshold", 600},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tokens := make([]int, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1 // unique tokens, no cache hit
+				tokens[i] = i + 1
 			}
-			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
+			req := &Request{ID: "req-" + tc.name, InputTokens: tokens}
+			ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
 
-			decision := decider.Decide(req)
+			decision := decider.Decide(req, ctx)
 
 			if !decision.Disaggregate {
 				t.Errorf("BC-PD-21: %d uncached tokens with threshold=%d should return Disaggregate=true",
@@ -350,122 +481,17 @@ func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tokens := make([]int, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1000 // unique tokens, no cache hit
+				tokens[i] = i + 1000
 			}
-			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
+			req := &Request{ID: "req-" + tc.name, InputTokens: tokens}
+			ctx := DecodeContext{InstanceID: "i0", CachedBlockCount: 0}
 
-			decision := decider.Decide(req)
+			decision := decider.Decide(req, ctx)
 
 			if decision.Disaggregate {
 				t.Errorf("BC-PD-22: %d non-cached tokens with threshold=%d should return Disaggregate=false",
 					tc.tokens, threshold)
 			}
 		})
-	}
-}
-
-// TestPrefixThresholdDecider_CacheAware verifies BC-PD-24: cached prefix reduces non-cached count.
-// Scenario: warm cache has N blocks cached. New request with same prefix + additional tokens.
-// Non-cached tokens = total_tokens - cached_blocks * blockSize.
-func TestPrefixThresholdDecider_CacheAware(t *testing.T) {
-	const blockSize = 16
-	const threshold = 512
-
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
-
-	// Warm cache: record 40 blocks (640 tokens) for a known prefix.
-	// Use consecutive tokens 1..640 as the shared prefix.
-	prefix := make([]int, 640) // 40 blocks
-	for i := range prefix {
-		prefix[i] = i + 1
-	}
-	prefixReq := &Request{ID: "req-warm", InputTokens: prefix}
-	// Calling Decide records cachedHashes, then ObserveRouting warms the cache.
-	decider.Decide(prefixReq)
-	decider.ObserveRouting(prefixReq, "instance_0")
-
-	// New request: same 640-token prefix + 200 new tokens = 840 tokens total.
-	// Cached: 40 blocks * 16 = 640 tokens. Non-cached: 840 - 640 = 200 tokens.
-	// 200 <= 512 threshold -> should NOT disaggregate.
-	extended := make([]int, len(prefix)+200)
-	copy(extended, prefix)
-	for i := len(prefix); i < len(extended); i++ {
-		extended[i] = 10000 + i // unique suffix tokens
-	}
-	req := &Request{ID: "req-cached", InputTokens: extended}
-
-	decision := decider.Decide(req)
-
-	if decision.Disaggregate {
-		t.Errorf("BC-PD-24: with 640 tokens cached (40 blocks), 200 non-cached tokens should not disaggregate (threshold=%d)", threshold)
-	}
-}
-
-// TestPrefixThresholdDecider_CacheAware_SubRequestIDMismatch verifies BC-PD-24 via the
-// disaggregated pipeline path: ObserveRouting is called with a sub-request whose ID
-// differs from the parent request passed to Decide (e.g., "<parent>_prefill" vs "<parent>").
-// ObserveRouting must recompute hashes and still correctly populate the cache.
-func TestPrefixThresholdDecider_CacheAware_SubRequestIDMismatch(t *testing.T) {
-	const blockSize = 16
-	const threshold = 512
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
-
-	// Shared prefix: 40 blocks (640 tokens), unique token values.
-	prefix := make([]int, 640)
-	for i := range prefix {
-		prefix[i] = i + 1
-	}
-
-	// Step 1: Decide is called with the parent request.
-	parentReq := &Request{ID: "req-parent", InputTokens: prefix}
-	decider.Decide(parentReq)
-
-	// Step 2: Overwrite cachedHashes with a stale unrelated request so that ObserveRouting
-	// MUST recompute when it sees the mismatched sub-request ID. Without this step, the
-	// original test cannot detect an inversion of the != check: parentReq and subReq share
-	// the same token content, so stale hashes from parentReq would produce the same result.
-	staleReq := &Request{ID: "req-stale", InputTokens: []int{99999, 99998}} // < blockSize, 0 hashes
-	decider.Decide(staleReq) // overwrites cachedHashes (empty) and cachedReqID = "req-stale"
-
-	// Step 3: ObserveRouting is called with a sub-request (different ID from stale, same
-	// InputTokens as prefix). ID mismatch must trigger recompute — without it the empty stale
-	// hashes would be recorded and the follow-up request would incorrectly disaggregate.
-	subReq := &Request{ID: "req-parent_prefill", InputTokens: prefix}
-	decider.ObserveRouting(subReq, "prefill_0") // ID mismatch → must recompute + record
-
-	// Step 4: New request with same prefix + 200 unique tokens = 840 total.
-	// Cached: 40 blocks * 16 = 640 tokens. Non-cached: 200 <= 512 → should NOT disaggregate.
-	extended := make([]int, len(prefix)+200)
-	copy(extended, prefix)
-	for i := len(prefix); i < len(extended); i++ {
-		extended[i] = 10000 + i
-	}
-	req := &Request{ID: "req-follow", InputTokens: extended}
-
-	decision := decider.Decide(req)
-
-	if decision.Disaggregate {
-		t.Errorf("CacheAware/SubRequestIDMismatch: ObserveRouting with mismatched ID should still "+
-			"populate the cache; 200 non-cached tokens should not disaggregate (threshold=%d)", threshold)
-	}
-}
-
-// TestPrefixThresholdDecider_ZeroThreshold verifies threshold=0 means always disaggregate
-// when tokens are non-empty (any non-cached token > 0).
-func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
-	const blockSize = 16
-	decider := NewPrefixThresholdDecider(0, blockSize)
-
-	// 100 uncached tokens -> 100 > 0 -> disaggregate
-	tokens := make([]int, 100)
-	for i := range tokens {
-		tokens[i] = i + 1
-	}
-	req := &Request{ID: "req-zero-thresh", InputTokens: tokens}
-
-	decision := decider.Decide(req)
-
-	if !decision.Disaggregate {
-		t.Error("threshold=0 with non-empty uncached tokens should return Disaggregate=true")
 	}
 }

--- a/sim/trace/record.go
+++ b/sim/trace/record.go
@@ -33,19 +33,26 @@ type RoutingRecord struct {
 }
 
 // DisaggregationRecord captures a PD disaggregation decision.
-// When Disaggregate=true, the request follows the disaggregated path. Paired
-// PrefillRoutingRecord, KVTransferRecord, and DecodeRoutingRecord are recorded
-// for the same RequestID except in three drop scenarios:
 //
-//  1. No routable prefill pool instances (routingRejections++): no downstream records.
-//  2. No routable decode pool instances (droppedAtDecodeKV++): PrefillRoutingRecord
-//     exists but KVTransferRecord and DecodeRoutingRecord are absent.
+// With decode-first routing, a DecodeRoutingRecord always precedes this record
+// for the same request (decode instance is selected before the disaggregation
+// decision is made). When Disaggregate=false (skip path), no further records
+// are emitted; the request is served locally on the selected decode instance.
+//
+// When Disaggregate=true (disagg path), paired PrefillRoutingRecord,
+// KVTransferRecord are also recorded, except in these drop scenarios:
+//
+//  1. No routable decode instances: DecodeRoutingEvent fires routingRejections++;
+//     no records are created at all (parent request is never constructed, so
+//     neither DecodeRoutingRecord nor DisaggregationRecord appear).
+//  2. No routable prefill instances (routingRejections++): DecodeRoutingRecord
+//     and DisaggregationRecord both exist; PrefillRoutingRecord and
+//     KVTransferRecord are absent. To detect: check absence of a
+//     PrefillRoutingRecord with a matching ParentRequestID.
 //  3. AllocateTransferredKV fails on the decode instance (droppedAtDecodeKV++):
-//     same as case 2.
-//
-// To detect case 1: check for the absence of a PrefillRoutingRecord with a
-// matching ParentRequestID in the trace. To detect cases 2 and 3: check the
-// absence of a KVTransferRecord for a given ParentRequestID.
+//     DecodeRoutingRecord, DisaggregationRecord, and PrefillRoutingRecord all
+//     exist; KVTransferRecord is absent. To detect: check absence of a
+//     KVTransferRecord for a given ParentRequestID.
 type DisaggregationRecord struct {
 	RequestID        string
 	Clock            int64
@@ -82,7 +89,7 @@ type DecodeRoutingRecord struct {
 
 // KVTransferRecord captures a KV cache transfer event between prefill and decode instances.
 // TransferDuration is always >= 0; negative values are clamped to 0 with a warning in
-// DecodeRoutingEvent.Execute() (sim/cluster/pd_events.go) if INV-PD-4 is ever violated.
+// DecodeEnqueueEvent.executeDisaggPath() (sim/cluster/pd_events.go) if INV-PD-4 is ever violated.
 type KVTransferRecord struct {
 	ParentRequestID   string
 	TransferStartTime int64 // microseconds (sim clock)

--- a/sim/trace/record.go
+++ b/sim/trace/record.go
@@ -47,9 +47,11 @@ type RoutingRecord struct {
 // matching ParentRequestID in the trace. To detect cases 2 and 3: check the
 // absence of a KVTransferRecord for a given ParentRequestID.
 type DisaggregationRecord struct {
-	RequestID    string
-	Clock        int64
-	Disaggregate bool // true = routed to prefill pool; false = standard routing
+	RequestID        string
+	Clock            int64
+	Disaggregate     bool   // true = routed to prefill pool; false = skip (direct to decode)
+	DecodeInstanceID string // ID of the decode instance selected before this decision
+	CachedBlockCount int    // KV blocks already cached on the selected decode instance
 }
 
 // PrefillRoutingRecord captures a prefill pool routing decision with optional counterfactual analysis.


### PR DESCRIPTION
## Summary

- **Inverts the PD disaggregation pipeline to decode-first**, matching llm-d's `DisaggProfileHandler`: the decode instance is selected first (new `DecodeRoutingEvent`, priority 3), and the disaggregation decision is conditioned on that instance's actual KV cache state via a new `DecodeContext{InstanceID, CachedBlockCount}` parameter
- **Skip path**: when the selected decode instance already has the prefix cached, the request is served locally via `InjectRequestOnline` — no prefill routing, no KV transfer; the instance's existing completion machinery handles it transparently
- **`PrefixThresholdDecider` is now stateless**: removed `PrefixCacheIndex`, `DisaggregationObserver`, and per-request LRU; now reads `ctx.CachedBlockCount * blockSize` directly from `DecodeContext`
- **New invariants**: INV-PD-7 (decode-first ordering: `DecodeRouteDecisionTime ≤ DisaggDecisionTime`) and INV-PD-8 (instance-local cache query: same prefix may disaggregate on one instance and skip on another), each with ≥20 table-driven test cases

## Changes

| File | Change |
|------|--------|
| `sim/disaggregation.go` | `DecodeContext` struct; `Decide(req, ctx)` signature; stateless `PrefixThresholdDecider`; removed `DisaggregationObserver` |
| `sim/cluster/pd_events.go` | New `DecodeRoutingEvent` (pri 3), `DisaggregationDecisionEvent` (pri 4), `DecodeEnqueueEvent` (pri 5/8); `PrefillRouting` pri 5, `KVTransferStart` pri 6, `KVTransferComplete` pri 7; deleted old `DecodeRoutingEvent` (pri 7) |
| `sim/cluster/cluster_event.go` | Admission bifurcation → `DecodeRoutingEvent`; `ScalingTick` pri 9, `ScaleActuation` pri 10; removed `DisaggregationDecisionEvent` and `notifyDisaggregationObserver` |
| `sim/cluster/cluster.go` | `tryDispatchFromGatewayQueue` → `DecodeRoutingEvent`; `projectPDMetrics` skip-path early-continue |
| `sim/cluster/parent_request.go` | Added `DecodeRouteDecisionTime`, `DisaggDecisionTime`, `SkippedDisaggregation` |
| `sim/trace/record.go` | Added `DecodeInstanceID`, `CachedBlockCount` to `DisaggregationRecord` |
| `sim/disaggregation_test.go` | Updated all `Decide` calls; 20+ table-driven cases for `PrefixThresholdDecider` with `DecodeContext` |
| `sim/cluster/disaggregation_test.go` | INV-PD-7 tests (20+ cases), INV-PD-8 tests (11+ cases + pool variations), skip-path integration (20+ cases), updated INV-PD-4 causality chains |
| `sim/cluster/pd_traces_test.go` | Updated trace cardinality assertions for new flow |
| `docs/contributing/standards/invariants.md` | INV-PD-7, INV-PD-8 added; INV-PD-4 updated for two-chain causality |
| `CLAUDE.md` | PD pipeline description updated with decode-first event priority table |

## Test plan

- [ ] `go build ./...` — clean build
- [ ] `go test ./... -count=1` — all packages pass (cmd, sim, sim/cluster, sim/trace, sim/workload)
- [ ] INV-PD-7: `TestINVPD7_DecodeFirstOrdering` — 20+ cases, zero violations
- [ ] INV-PD-8: `TestINVPD8_InstanceLocalCacheQuery` — 11+ cases + pool variations, zero violations
- [ ] INV-PD-4: `TestDisaggregation_PhaseCausality` — both disagg and skip-path chains pass
- [ ] Skip-path integration: `TestSkipPath_Integration` — INV-1, INV-PD-7, INV-5 all hold
- [ ] Existing invariant tests (INV-1 through INV-PD-6b) — unchanged, still pass

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)