### PR TITLE
fix(autoscaler): promoteDeferred must increment pendingArrivals (Bug 3)

### DIFF
--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1080,6 +1080,7 @@ func (c *ClusterSimulator) promoteDeferred() {
 			event: &ClusterArrivalEvent{time: c.clock, request: req},
 			seqID: c.nextSeqID(),
 		})
+		c.pendingArrivals++ // mirror Run() — re-injected arrivals must be tracked so scheduleNextTick doesn't go negative
 	}
 	c.deferredQueue = c.deferredQueue[:0]
 }

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2618,3 +2618,43 @@ func TestAutoscaler_RequestBoundedRun_Terminates(t *testing.T) {
 	}
 }
 
+// TestAutoscaler_WithBatchRequests_Terminates verifies that a request-bounded run
+// with batch SLO-class requests and the autoscaler enabled terminates correctly.
+// Regression test for Bug 3: promoteDeferred() did not increment pendingArrivals for
+// re-injected arrivals, driving the counter negative and breaking the termination guard.
+func TestAutoscaler_WithBatchRequests_Terminates(t *testing.T) {
+	cfg := newTestDeploymentConfig(1)
+	cfg.ModelAutoscalerIntervalUs = 100_000 // 100 ms ticks
+
+	// Build a mixed workload: half critical (bypass deferred queue),
+	// half batch (go through deferredQueue and promoteDeferred path).
+	base := newTestRequests(10)
+	for i, r := range base {
+		if i%2 == 0 {
+			r.SLOClass = "batch"
+		} else {
+			r.SLOClass = "critical"
+		}
+	}
+
+	cs := NewClusterSimulator(cfg, base, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- cs.Run() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+		// Verify all requests were accounted for (INV-1).
+		m := cs.AggregatedMetrics()
+		total := m.CompletedRequests + m.StillQueued + m.StillRunning +
+			m.DroppedUnservable + m.TimedOutRequests
+		if total != len(base) {
+			t.Errorf("request conservation violated: completed+queued+running+dropped+timedout = %d, want %d", total, len(base))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not terminate within 2s — pendingArrivals likely went negative (Bug 3 regression)")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1023 — autoscaler-enabled runs with `batch` or `background` SLO-class requests still hung after the Bug 2 fix (#1024).

Part of tracking issue #995 (Phase 1C CLI wiring).

**Stacked on:** #1024 (Bug 2 fix). Merge #1024 first; this PR's base will auto-retarget to `main`.

---

## Root cause

`promoteDeferred()` re-injects held `batch`/`background` requests as new `ClusterArrivalEvent`s when the cluster becomes idle. It pushed these events without incrementing `pendingArrivals`.

Each re-injected `ClusterArrivalEvent.Execute()` decremented the counter → `pendingArrivals` reached **`-N`** for N deferred requests. The Bug 2 guard checks `== 0` exactly — never true when negative → infinite tick loop on any workload with batch/background requests.

## Fix

One line in `promoteDeferred()` in `sim/cluster/cluster.go`:

```go
c.pendingArrivals++ // mirror Run() — re-injected arrivals must be tracked
```

This restores the invariant: `pendingArrivals == count of ClusterArrivalEvents in cs.clusterEvents` at all times.

---

## Diff

This PR is a single-commit, 2-file change on top of #1024:
- `sim/cluster/cluster.go` — one line added in `promoteDeferred()`
- `sim/cluster/cluster_test.go` — `TestAutoscaler_WithBatchRequests_Terminates` added

---

## Test plan

- [ ] `go test ./sim/cluster/...` passes
- [ ] `TestAutoscaler_WithBatchRequests_Terminates` passes in < 2s
- [ ] `TestAutoscaler_RequestBoundedRun_Terminates` still passes (no regression on Bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)