### PR TITLE
fix(autoscaler): scaleUp stub never created InstanceSimulator (Bug 1)

### DIFF
--- a/examples/autoscaler-demo.yaml
+++ b/examples/autoscaler-demo.yaml
@@ -1,0 +1,104 @@
+# BLIS Autoscaler Demo — Scale Up and Scale Down
+#
+# Demonstrates the Phase 1C-1b model autoscaler (WVA-aligned pipeline):
+#   DefaultCollector → V2SaturationAnalyzer → UnlimitedEngine → DirectActuator
+#
+# The autoscaler fires every 30s of simulated time, measures KV utilization and
+# queue depth via the V2SaturationAnalyzer, and:
+#   - Scales UP  when demand exceeds 80% of total supply (kv_cache + queue tokens)
+#   - Scales DOWN when removing one replica still leaves supply above 40% utilization
+#
+# The node pool provides spare GPU capacity the autoscaler can grow into.
+# start: 1 instance (from --num-instances)
+# max:   up to 8 total (initial_nodes=8 pre-provisions nodes; 1 for startup, 7 for autoscaler)
+# note: UnlimitedEngine ignores inventory, so PlaceInstance errors are expected when pool
+#       ceiling is reached. GreedyEngine (1C-1d, planned) will prevent excess scale-up attempts.
+#
+# ============================================================================
+# TRY IT
+# ============================================================================
+#
+#   # Build first
+#   go build -o blis main.go
+#
+#   # Baseline: 1 fixed instance, no autoscaler — observe queue buildup under load
+#   ./blis run \
+#     --model meta-llama/Llama-2-7b-hf \
+#     --latency-model roofline --hardware A100-80 --tp 1 \
+#     --num-instances 1 \
+#     --workload-spec examples/regression_workload_load_spikes.yaml \
+#     --rate 30 --num-requests 3000
+#
+#   # With autoscaler: starts at 1 instance, scales up to 4 under load, scales down when quiet
+#   ./blis run \
+#     --model meta-llama/Llama-2-7b-hf \
+#     --latency-model roofline --hardware A100-80 --tp 1 \
+#     --num-instances 1 \
+#     --policy-config examples/autoscaler-demo.yaml \
+#     --workload-spec examples/regression_workload_load_spikes.yaml \
+#     --rate 30 --num-requests 3000 \
+#     --log info
+#
+# ============================================================================
+# What to observe in the log output (--log info)
+# ============================================================================
+#
+#   [autoscaler] tick at t=... — pipeline fires every 30s
+#   [actuator] scale-up: placed instance autoscale-... — scale-up decision applied
+#   [actuator] scale-down: draining instance ... — scale-down decision applied
+#
+# ============================================================================
+# Tuning guide
+# ============================================================================
+#
+#   interval_us              Lower = more responsive autoscaler (try 10000000 = 10s)
+#   scale_up_threshold       Lower = scale up earlier (try 0.7 for more headroom)
+#   scale_down_boundary      Higher = scale down later, more conservatively (try 0.5)
+#   scale_up_cooldown_us     Higher = less aggressive scale-up flapping prevention
+#   scale_down_cooldown_us   Higher = more stable scale-down (avoid premature removal)
+#   actuation_delay.mean     Models HPA/KEDA scrape lag; set 0.0 for ideal conditions
+#   provisioning_delay.mean  Set to 30.0–120.0 to model realistic node boot times
+# ============================================================================
+
+admission:
+  policy: always-admit
+
+routing:
+  policy: weighted
+  scorers:
+    - name: queue-depth
+      weight: 2.0
+    - name: kv-utilization
+      weight: 1.0
+
+# Node pool: spare GPU capacity the autoscaler can grow into.
+# Each node holds 1 GPU, allowing 1 instance per node at TP=1 (blackbox default).
+# initial_nodes=1: 1 node pre-provisioned and ready (instant first scale-up).
+# max_nodes=3:     up to 3 additional instances beyond --num-instances.
+# cost_per_hour:   used by Engine to prefer cheaper variants when deciding allocation.
+node_pools:
+  - name: demo-pool
+    gpu_type: A100-80    # must match --hardware flag value
+    gpus_per_node: 1     # 1 GPU per node → 1 instance at TP=1
+    gpu_memory_gib: 40.0
+    initial_nodes: 8     # pre-provision 8 nodes: 1 consumed by startup, 7 free for autoscaler
+    min_nodes: 0
+    max_nodes: 8         # upper bound: 1 initial + 7 autoscaled
+    cost_per_hour: 2.0
+    provisioning_delay:
+      mean: 0.0          # 0s for demo clarity; set to 30.0 for realistic K8s node boot
+      stddev: 0.0
+
+# Autoscaler pipeline configuration.
+autoscaler:
+  interval_us: 5000000             # tick every 5s of simulated time
+  scale_up_cooldown_us: 5000000    # wait 5s between scale-up decisions
+  scale_down_cooldown_us: 60000000 # wait 60s before scaling down (conservative — avoid premature drain)
+  actuation_delay:
+    mean: 2.0    # 2s mean HPA/KEDA scrape lag (reduced for demo clarity)
+    stddev: 0.5  # ±0.5s variance
+  analyzer:
+    kv_cache_threshold: 0.8    # treat 80% of KV capacity as effective supply
+    scale_up_threshold: 0.7    # scale up when demand > 70% of supply
+    scale_down_boundary: 0.15  # scale down only when utilization < 15% (very conservative)
+    avg_input_tokens: 512.0    # converts queue depth to token demand units

--- a/sim/cluster/direct_actuator.go
+++ b/sim/cluster/direct_actuator.go
@@ -4,9 +4,11 @@
 package cluster
 
 import (
+	"container/heap"
 	"fmt"
 	"sort"
 
+	"github.com/inference-sim/inference-sim/sim"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,7 +51,8 @@ func (a *DirectActuator) Apply(decisions []ScaleDecision) error {
 	return nil
 }
 
-// scaleUp places new instance(s) for the given decision. Returns error if any placement fails.
+// scaleUp places new instance(s) for the given decision and wires them into the cluster.
+// Mirrors the NodeReadyEvent.Execute() creation path: place → construct → register → schedule.
 func (a *DirectActuator) scaleUp(d ScaleDecision) error {
 	if a.cluster.placement == nil {
 		err := fmt.Errorf("scale-up for model %q: PlacementManager not available (INV-A2)", d.ModelID)
@@ -57,19 +60,84 @@ func (a *DirectActuator) scaleUp(d ScaleDecision) error {
 		return err
 	}
 
+	cs := a.cluster
+	tpDegree := d.Variant.TPDegree
+	if tpDegree < 1 {
+		tpDegree = 1
+	}
+
 	var lastErr error
 	for i := 0; i < d.Delta; i++ {
 		a.nextInstSeq++
 		id := InstanceID(fmt.Sprintf("autoscale-%s-%06d", d.ModelID, a.nextInstSeq))
 
-		nodeID, gpuIDs, matchedGPU, err := a.cluster.placement.PlaceInstance(
-			id, d.ModelID, d.Variant.GPUType, d.Variant.TPDegree,
+		nodeID, gpuIDs, matchedGPU, err := cs.placement.PlaceInstance(
+			id, d.ModelID, d.Variant.GPUType, tpDegree,
 		)
 		if err != nil {
 			logrus.Errorf("[actuator] scale-up for model %q variant %v failed: %v (INV-A2)", d.ModelID, d.Variant, err)
 			lastErr = err
 			continue
 		}
+
+		// Build SimConfig for the new instance (mirrors NodeReadyEvent.Execute).
+		simCfg := cs.config.resolveConfigForRole(0)
+		simCfg.GPU = matchedGPU
+		if hc, ok := cs.config.HWConfigByGPU[matchedGPU]; ok {
+			simCfg.HWConfig = hc
+		}
+		var costPerHour float64
+		for i := range cs.config.NodePools {
+			if cs.config.NodePools[i].GPUType == matchedGPU {
+				costPerHour = cs.config.NodePools[i].CostPerHour
+				break
+			}
+		}
+
+		inst := NewInstanceSimulator(id, simCfg)
+		inst.Model = d.ModelID
+		inst.nodeID = nodeID
+		inst.allocatedGPUIDs = gpuIDs
+		inst.TPDegree = tpDegree
+		inst.CostPerHour = costPerHour
+		inst.warmUpRemaining = cs.config.InstanceLifecycle.WarmUpRequestCount
+		inst.TransitionTo(InstanceStateLoading)
+
+		// Register with snapshot provider so the instance is routable.
+		csp, ok := cs.snapshotProvider.(*CachedSnapshotProvider)
+		if !ok {
+			logrus.Warnf("[actuator] scale-up: snapshotProvider is not *CachedSnapshotProvider for instance %s — releasing GPUs and skipping", id)
+			cs.releaseInstanceGPUs(inst)
+			continue
+		}
+		csp.AddInstance(id, inst)
+		cs.scheduleInstanceLoadedEvent(inst)
+		cs.instances = append(cs.instances, inst)
+		cs.inFlightRequests[string(id)] = 0
+
+		if cs.cacheQueryFn != nil {
+			cs.registerInstanceCacheQueryFn(id, inst)
+		}
+		if cs.tenantTracker != nil || cs.sessionCallback != nil {
+			onRequestDone := cs.sessionCallback
+			inst.sim.OnRequestDone = func(req *sim.Request, tick int64) []*sim.Request {
+				if cs.tenantTracker != nil {
+					cs.tenantTracker.OnComplete(req.TenantID)
+				}
+				if onRequestDone == nil {
+					return nil
+				}
+				nextReqs := onRequestDone(req, tick)
+				for _, next := range nextReqs {
+					heap.Push(&cs.clusterEvents, clusterEventEntry{
+						event: &ClusterArrivalEvent{time: next.ArrivalTime, request: next},
+						seqID: cs.nextSeqID(),
+					})
+				}
+				return nil
+			}
+		}
+
 		logrus.Infof("[actuator] scale-up: placed instance %s for model %q on node %s (gpus=%v, matchedGPU=%s)",
 			id, d.ModelID, nodeID, gpuIDs, matchedGPU)
 	}


### PR DESCRIPTION
## Summary

Fixes #1021. Stacked on #1024 (Bug 2 termination guard — must merge first).

`DirectActuator.scaleUp` was a stub: it called `PlaceInstance()` to reserve GPU slots on a node, then returned. No `InstanceSimulator` was ever constructed, so newly scaled-up instances were phantom GPU reservations that could not accept any requests. Scale-up events silently did nothing.

- **Root cause**: `scaleUp` was implemented as a stub (`PlaceInstance` only) during initial scaffolding and was never completed.
- **Fix**: Rewrote `scaleUp` to mirror the 7-step creation path in `NodeReadyEvent.Execute()`: place instance → construct `InstanceSimulator` → transition to Loading → register with `CachedSnapshotProvider` → schedule `InstanceLoadedEvent` → append to `cs.instances` → initialize `inFlightRequests` and wire `OnRequestDone`.
- **Added**: `examples/autoscaler-demo.yaml` — a self-contained demo config showing `node_pools` + `autoscaler` together, runnable with `blis run --policy-bundle examples/autoscaler-demo.yaml --model <model>`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./sim/cluster/...` passes
- [ ] Manual: `blis run --policy-bundle examples/autoscaler-demo.yaml --model qwen/qwen3-14b` runs without phantom-instance errors
- [ ] Regression tests from Bug 2 (#1024) and Bug 3 (#1025) still pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)