### PR TITLE
fix(routing): align PPC scorer zero-cache normalization to llm-d

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -152,7 +152,7 @@ Scorers are the building blocks of the weighted routing policy. Each scorer eval
 | Scorer | Signal | Score Computation | Notes |
 |--------|--------|-------------------|-------|
 | `prefix-affinity` | Prefix cache overlap | Proportion of request's block hashes found in instance's cache index | Stateful: updates cache index after routing via observer |
-| `precise-prefix-cache` | Actual KV cache state | Min-max normalization of cached prefix block count per instance | Stateless: queries instance KV cache directly via `CacheQueryFn` |
+| `precise-prefix-cache` | Actual KV cache state | Min-max normalization of cached prefix block count per instance; all-equal (including all-zero) → 1.0 (llm-d parity) | Stateless: queries instance KV cache directly via `CacheQueryFn` |
 | `no-hit-lru` | Routing history | Cold requests (zero cache hits): LRU positional scoring; warm requests: neutral 0.5 | Stateful: observer tracks LRU order on cold routing only |
 | `queue-depth` | Queue depth | Min-max normalization of QueueDepth (lower depth = higher score) | Stateless |
 | `kv-utilization` | Memory pressure | `1 - KVUtilization` (lower utilization = higher score) | Stateless |

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -31,7 +31,7 @@ The `weighted` routing policy is the most flexible. It combines multiple scoring
 | Scorer | What It Measures | llm-d Equivalent |
 |--------|-----------------|------------------|
 | `prefix-affinity` | Proportional prefix match ratio via router-side block hash cache | prefix-scorer |
-| `precise-prefix-cache` | Actual KV cache state query with min-max normalization | precise-prefix-cache-scorer |
+| `precise-prefix-cache` | Actual KV cache state query with min-max normalization; all-equal (including all-zero) → 1.0 (llm-d parity) | precise-prefix-cache-scorer |
 | `no-hit-lru` | LRU positional scoring for cold requests (warm = 0.5) | no-hit-lru-scorer |
 | `queue-depth` | Queue depth: `QueueDepth` only (min-max normalized) | queue-scorer |
 | `kv-utilization` | Inverse KV utilization: `1 - KVUtilization` | kv-cache-utilization-scorer |

--- a/sim/routing_precise_prefix_scorer.go
+++ b/sim/routing_precise_prefix_scorer.go
@@ -44,14 +44,10 @@ func newPrecisePrefixCacheScorer(cacheFn cacheQueryFn) (scorerFunc, observerFunc
 		// Pass 2: min-max normalize (higher cached → higher score)
 		for _, snap := range snapshots {
 			if maxRaw == minRaw {
-				// All-equal: 1.0 when there is actual cache affinity, 0.5 (neutral)
-				// when no instance has any cached blocks — avoids inflating the cache
-				// scorer's contribution when there is no cache data to differentiate.
-				if maxRaw == 0 {
-					scores[snap.ID] = 0.5
-				} else {
-					scores[snap.ID] = 1.0
-				}
+				// All-equal (including all-zero): 1.0. Matches llm-d's
+				// indexedScoresToNormalizedScoredPods which returns 1.0
+				// unconditionally when minScore == maxScore.
+				scores[snap.ID] = 1.0
 			} else {
 				scores[snap.ID] = float64(raw[snap.ID]-minRaw) / float64(maxRaw-minRaw)
 			}

--- a/sim/routing_precise_prefix_scorer_test.go
+++ b/sim/routing_precise_prefix_scorer_test.go
@@ -36,7 +36,7 @@ func TestPrecisePrefixCache_MinMaxNormalization(t *testing.T) {
 	}
 }
 
-// TestPrecisePrefixCache_AllEqual verifies BC-2: all-equal cached blocks produce uniform scores.
+// TestPrecisePrefixCache_AllEqual verifies all-equal cached blocks produce uniform 1.0 scores.
 // All-zero → 1.0 (llm-d parity: all-equal always returns 1.0).
 // All-equal nonzero → 1.0 (all instances equally good).
 func TestPrecisePrefixCache_AllEqual(t *testing.T) {

--- a/sim/routing_precise_prefix_scorer_test.go
+++ b/sim/routing_precise_prefix_scorer_test.go
@@ -37,7 +37,7 @@ func TestPrecisePrefixCache_MinMaxNormalization(t *testing.T) {
 }
 
 // TestPrecisePrefixCache_AllEqual verifies BC-2: all-equal cached blocks produce uniform scores.
-// All-zero → 0.5 (neutral, no cache data to differentiate).
+// All-zero → 1.0 (llm-d parity: all-equal always returns 1.0).
 // All-equal nonzero → 1.0 (all instances equally good).
 func TestPrecisePrefixCache_AllEqual(t *testing.T) {
 	tests := []struct {
@@ -45,7 +45,7 @@ func TestPrecisePrefixCache_AllEqual(t *testing.T) {
 		counts map[string]int
 		want   float64
 	}{
-		{"all zero", map[string]int{"a": 0, "b": 0, "c": 0}, 0.5},
+		{"all zero", map[string]int{"a": 0, "b": 0, "c": 0}, 1.0},
 		{"all equal nonzero", map[string]int{"a": 4, "b": 4, "c": 4}, 1.0},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Align `precise-prefix-cache` scorer's all-zero-cache normalization from `0.5` to `1.0`, matching llm-d's `indexedScoresToNormalizedScoredPods` behavior
- Remove the special-case `if maxRaw == 0` branch; the all-equal path now unconditionally returns `1.0`
- Update test expectations and comments accordingly

## Behavioral Contracts

**BC-1: All-equal zero-cache returns 1.0 (llm-d parity)**
- GIVEN all instances have zero cached prefix blocks
- WHEN the `precise-prefix-cache` scorer normalizes scores
- THEN all instances score `1.0`

**BC-2: All-equal nonzero-cache still returns 1.0 (no regression)**
- GIVEN all instances have the same nonzero cached prefix blocks
- WHEN the scorer normalizes
- THEN all instances score `1.0`

**BC-3: Min-max normalization unchanged (no regression)**
- GIVEN instances have different cached prefix block counts
- WHEN the scorer normalizes
- THEN scores follow `(raw - min) / (max - min)`

## Testing

```
go test ./sim/... -count=1   # All pass
go build ./...               # OK
golangci-lint run ./sim/...  # 0 new issues
```

Fixes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)