### PR TITLE
docs(blog): publish physics of simulation blog post

### DIFF
--- a/docs/blog/posts/building-trust-physics-of-simulation.md
+++ b/docs/blog/posts/building-trust-physics-of-simulation.md
@@ -1,6 +1,5 @@
 ---
 date: 2026-04-09
-draft: true
 authors:
   - dipanwita
   - mert


### PR DESCRIPTION
## Summary
- Remove `draft: true` flag from the "Physics of High-Fidelity Distributed Inference Platform Simulation" blog post

## Context
The blog post was merged in #997 but marked as draft, making it visible in local `mkdocs serve` but hidden on the deployed site (https://inference-sim.github.io/inference-sim/). This PR publishes it by removing the draft flag.

## Test plan
- [x] Verify file change removes only the draft line
- [ ] Confirm blog post appears on https://inference-sim.github.io/inference-sim/blog/ after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)