### PR TITLE
fix(autoscaler): DirectActuator.scaleUp creates live instances (Bug 1)

### DIFF
--- a/sim/cluster/actuator_test.go
+++ b/sim/cluster/actuator_test.go
@@ -186,11 +186,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		}
 
 		// THEN: instance registered with snapshotProvider so it is routable.
-		csp, ok := cs.snapshotProvider.(*CachedSnapshotProvider)
-		if !ok {
-			t.Fatal("snapshotProvider is not *CachedSnapshotProvider")
-		}
-		if _, registered := csp.instances[inst.ID()]; !registered {
+		if !cs.snapshotProvider.HasInstance(inst.ID()) {
 			t.Errorf("instance %q not registered with snapshotProvider (routing blind spot)", inst.ID())
 		}
 	})
@@ -217,10 +213,9 @@ func TestDirectActuatorApply(t *testing.T) {
 		if len(cs.instances) != 2 {
 			t.Fatalf("len(cs.instances) = %d, want 2", len(cs.instances))
 		}
-		csp, _ := cs.snapshotProvider.(*CachedSnapshotProvider)
 		for _, inst := range cs.instances {
-			if _, ok := csp.instances[inst.ID()]; !ok {
-				t.Errorf("instance %q not in snapshotProvider", inst.ID())
+			if !cs.snapshotProvider.HasInstance(inst.ID()) {
+				t.Errorf("instance %q not registered with snapshotProvider", inst.ID())
 			}
 		}
 	})

--- a/sim/cluster/actuator_test.go
+++ b/sim/cluster/actuator_test.go
@@ -137,4 +137,117 @@ func TestDirectActuatorApply(t *testing.T) {
 			t.Errorf("ID = %q, want %q (zero-padded for correct lexicographic order)", got, expected)
 		}
 	})
+
+	t.Run("scale_up_creates_live_instance", func(t *testing.T) {
+		// GIVEN: a cluster with 0 initial instances and 1 Ready node (2 GPU slots, TP=1).
+		// The snapshotProvider is initialized empty by NewClusterSimulator.
+		base := newTestDeploymentConfig(1)
+		base.Model = "test-model"
+		base.NodePools = []NodePoolConfig{
+			{Name: "a100-pool", GPUType: "A100-80", GPUsPerNode: 2, InitialNodes: 1, MaxNodes: 2, GPUMemoryGiB: 80},
+		}
+		cs := NewClusterSimulator(base, nil, nil)
+		cs.instances = []*InstanceSimulator{} // Clear initial instances to simulate scale-up from empty
+
+		// WHEN: scaleUp is called for 1 instance.
+		actuator := NewDirectActuator(cs)
+		err := actuator.Apply([]ScaleDecision{
+			{ModelID: "test-model", Variant: NewVariantSpec("A100-80", 1), Delta: 1},
+		})
+		if err != nil {
+			t.Fatalf("Apply returned unexpected error: %v", err)
+		}
+
+		// THEN: exactly one InstanceSimulator exists in cs.instances.
+		if len(cs.instances) != 1 {
+			t.Fatalf("len(cs.instances) = %d, want 1 (scaleUp must create an InstanceSimulator)", len(cs.instances))
+		}
+		inst := cs.instances[0]
+
+		// THEN: instance is past Scheduling (Loading if delay>0, WarmingUp/Active if delay==0).
+		if inst.State == InstanceStateScheduling {
+			t.Errorf("instance State = %q: must be past Scheduling after scaleUp (Loading/WarmingUp/Active expected)", inst.State)
+		}
+
+		// THEN: GPU type is pool-authoritative (SC-004).
+		if got := inst.GPU(); got != "A100-80" {
+			t.Errorf("GPU() = %q, want %q (pool gpu_type must override CLI --gpu)", got, "A100-80")
+		}
+
+		// THEN: model matches the scale decision.
+		if inst.Model != "test-model" {
+			t.Errorf("Model = %q, want %q", inst.Model, "test-model")
+		}
+
+		// THEN: in-flight counter initialised to 0 (R4: every path initialises this).
+		id := string(inst.ID())
+		if v, ok := cs.inFlightRequests[id]; !ok || v != 0 {
+			t.Errorf("inFlightRequests[%q] = %d ok=%v, want 0/true", id, v, ok)
+		}
+
+		// THEN: instance registered with snapshotProvider so it is routable.
+		csp, ok := cs.snapshotProvider.(*CachedSnapshotProvider)
+		if !ok {
+			t.Fatal("snapshotProvider is not *CachedSnapshotProvider")
+		}
+		if _, registered := csp.instances[inst.ID()]; !registered {
+			t.Errorf("instance %q not registered with snapshotProvider (routing blind spot)", inst.ID())
+		}
+	})
+
+	t.Run("scale_up_delta_2_creates_two_instances", func(t *testing.T) {
+		// GIVEN: a node with 4 GPU slots allows 4 TP=1 instances.
+		base := newTestDeploymentConfig(1)
+		base.Model = "test-model"
+		base.NodePools = []NodePoolConfig{
+			{Name: "a100-pool", GPUType: "A100-80", GPUsPerNode: 4, InitialNodes: 1, MaxNodes: 2, GPUMemoryGiB: 80},
+		}
+		cs := NewClusterSimulator(base, nil, nil)
+		cs.instances = []*InstanceSimulator{} // Clear initial instances to simulate scale-up from empty
+
+		actuator := NewDirectActuator(cs)
+		err := actuator.Apply([]ScaleDecision{
+			{ModelID: "test-model", Variant: NewVariantSpec("A100-80", 1), Delta: 2},
+		})
+		if err != nil {
+			t.Fatalf("Apply returned error: %v", err)
+		}
+
+		// THEN: two instances created and both registered.
+		if len(cs.instances) != 2 {
+			t.Fatalf("len(cs.instances) = %d, want 2", len(cs.instances))
+		}
+		csp, _ := cs.snapshotProvider.(*CachedSnapshotProvider)
+		for _, inst := range cs.instances {
+			if _, ok := csp.instances[inst.ID()]; !ok {
+				t.Errorf("instance %q not in snapshotProvider", inst.ID())
+			}
+		}
+	})
+
+	t.Run("scale_up_no_capacity_returns_error", func(t *testing.T) {
+		// GIVEN: node has 2 GPU slots; NumInstances=1 consumes 1 at startup, leaving 1 available.
+		// Requesting Delta=2 means: first placement succeeds, second exhausts capacity.
+		base := newTestDeploymentConfig(1)
+		base.Model = "test-model"
+		base.NodePools = []NodePoolConfig{
+			{Name: "tiny-pool", GPUType: "A100-80", GPUsPerNode: 2, InitialNodes: 1, MaxNodes: 1, GPUMemoryGiB: 80},
+		}
+		cs := NewClusterSimulator(base, nil, nil)
+		cs.instances = []*InstanceSimulator{} // Clear initial instances; placement already consumed 1 slot
+
+		actuator := NewDirectActuator(cs)
+		err := actuator.Apply([]ScaleDecision{
+			{ModelID: "test-model", Variant: NewVariantSpec("A100-80", 1), Delta: 2},
+		})
+
+		// THEN: first succeeds, second fails — Apply returns error.
+		if err == nil {
+			t.Error("Apply should return error when placement capacity is exhausted")
+		}
+		// And 1 instance was created (first iteration succeeded).
+		if len(cs.instances) != 1 {
+			t.Errorf("len(cs.instances) = %d, want 1 (first placement should succeed)", len(cs.instances))
+		}
+	})
 }

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -758,6 +758,82 @@ func (c *ClusterSimulator) nextSeqID() int64 {
 	return id
 }
 
+// addLiveInstance constructs, registers, and activates an InstanceSimulator for a
+// placement that succeeded while the cluster is already running.
+// Called from NodeReadyEvent.Execute (deferred placement) and DirectActuator.scaleUp
+// (autoscaler direct placement). NOT used by the NewClusterSimulator startup path,
+// which bulk-initialises the snapshot provider with a full instance map.
+//
+// simCfg must already have GPU and HWConfig set (pool-authoritative, SC-004).
+// Returns true on success. On false, GPU allocations have been released — callers
+// must not touch the instance and should skip/continue.
+//
+// Maintenance note: if you add a new field to instance initialisation here, also
+// check NewClusterSimulator's construction loop (which does NOT call this method).
+func (cs *ClusterSimulator) addLiveInstance(
+	id InstanceID,
+	model string,
+	simCfg sim.SimConfig,
+	nodeID string,
+	gpuIDs []string,
+	tpDegree int,
+	costPerHour float64,
+) bool {
+	inst := NewInstanceSimulator(id, simCfg)
+	inst.Model = model
+	inst.nodeID = nodeID
+	inst.allocatedGPUIDs = gpuIDs
+	inst.TPDegree = tpDegree
+	inst.CostPerHour = costPerHour
+	inst.warmUpRemaining = cs.config.InstanceLifecycle.WarmUpRequestCount
+	inst.TransitionTo(InstanceStateLoading)
+
+	csp, ok := cs.snapshotProvider.(*CachedSnapshotProvider)
+	if !ok {
+		// snapshotProvider is nil or not *CachedSnapshotProvider — can only happen in unit
+		// tests that bypass NewClusterSimulator. Release GPUs so they are not held by a
+		// phantom instance (R1: no silent data loss).
+		logrus.Warnf("[cluster] addLiveInstance: snapshotProvider is not *CachedSnapshotProvider for instance %s — releasing GPUs and skipping", id)
+		cs.releaseInstanceGPUs(inst)
+		return false
+	}
+	csp.AddInstance(id, inst)
+
+	cs.scheduleInstanceLoadedEvent(inst)
+	cs.instances = append(cs.instances, inst)
+	cs.inFlightRequests[string(id)] = 0
+
+	// Register with cacheQueryFn for precise prefix scoring.
+	// registerInstanceCacheQueryFn handles both oracle and stale modes (R23).
+	if cs.cacheQueryFn != nil {
+		cs.registerInstanceCacheQueryFn(id, inst)
+	}
+
+	// Wire OnRequestDone callback — mirrors startup path in NewClusterSimulator (R4).
+	onRequestDone := cs.sessionCallback
+	if onRequestDone != nil || cs.tenantTracker != nil {
+		inst.sim.OnRequestDone = func(req *sim.Request, tick int64) []*sim.Request {
+			if cs.tenantTracker != nil {
+				cs.tenantTracker.OnComplete(req.TenantID)
+			}
+			if onRequestDone == nil {
+				return nil
+			}
+			nextReqs := onRequestDone(req, tick)
+			for _, next := range nextReqs {
+				heap.Push(&cs.clusterEvents, clusterEventEntry{
+					event: &ClusterArrivalEvent{time: next.ArrivalTime, request: next},
+					seqID: cs.nextSeqID(),
+				})
+				cs.pendingArrivals++ // mirror Run() — session follow-ups must be tracked
+			}
+			return nil // don't inject locally — route through cluster pipeline
+		}
+	}
+
+	return true
+}
+
 // poolsConfigured returns true if PD disaggregation pool topology is active.
 func (c *ClusterSimulator) poolsConfigured() bool {
 	return c.poolMembership != nil

--- a/sim/cluster/direct_actuator.go
+++ b/sim/cluster/direct_actuator.go
@@ -62,16 +62,46 @@ func (a *DirectActuator) scaleUp(d ScaleDecision) error {
 		a.nextInstSeq++
 		id := InstanceID(fmt.Sprintf("autoscale-%s-%06d", d.ModelID, a.nextInstSeq))
 
+		// Reserve GPU slots. GPUType comes from the scale decision (variant-authoritative).
 		nodeID, gpuIDs, matchedGPU, err := a.cluster.placement.PlaceInstance(
 			id, d.ModelID, d.Variant.GPUType, d.Variant.TPDegree,
 		)
 		if err != nil {
-			logrus.Errorf("[actuator] scale-up for model %q variant %v failed: %v (INV-A2)", d.ModelID, d.Variant, err)
+			logrus.Errorf("[actuator] scale-up for model %q variant %v: PlaceInstance failed: %v (INV-A2)", d.ModelID, d.Variant, err)
 			lastErr = err
 			continue
 		}
-		logrus.Infof("[actuator] scale-up: placed instance %s for model %q on node %s (gpus=%v, matchedGPU=%s)",
-			id, d.ModelID, nodeID, gpuIDs, matchedGPU)
+
+		// Build simCfg: start from the cluster default, then apply pool-authoritative GPU
+		// type and HWConfig override (SC-004, mirrors NewClusterSimulator startup path).
+		simCfg := a.cluster.config.resolveConfigForRole(PoolRole(0))
+		simCfg.GPU = matchedGPU
+		if hc, ok := a.cluster.config.HWConfigByGPU[matchedGPU]; ok {
+			if hc.TFlopsPeak <= 0 || hc.BwPeakTBs <= 0 {
+				panic(fmt.Sprintf("HWConfigByGPU[%q]: TFlopsPeak and BwPeakTBs must be positive, got TFlopsPeak=%v BwPeakTBs=%v",
+					matchedGPU, hc.TFlopsPeak, hc.BwPeakTBs))
+			}
+			simCfg.HWConfig = hc
+		}
+
+		// Look up CostPerHour for this GPU type (mirrors NodeReadyEvent and startup path).
+		var costPerHour float64
+		for i := range a.cluster.config.NodePools {
+			if a.cluster.config.NodePools[i].GPUType == matchedGPU {
+				costPerHour = a.cluster.config.NodePools[i].CostPerHour
+				break
+			}
+		}
+
+		// Construct, register, and activate the instance. GPU release on snapshotProvider
+		// failure is handled inside addLiveInstance.
+		if !a.cluster.addLiveInstance(id, d.ModelID, simCfg, nodeID, gpuIDs, d.Variant.TPDegree, costPerHour) {
+			lastErr = fmt.Errorf("scale-up for model %q: instance %s could not be registered (snapshotProvider type mismatch)", d.ModelID, id)
+			continue
+		}
+
+		logrus.Infof("[actuator] scale-up: placed instance %s for model %q on node %s (gpu=%s, tp=%d)",
+			id, d.ModelID, nodeID, matchedGPU, d.Variant.TPDegree)
 	}
 	return lastErr
 }

--- a/sim/cluster/direct_actuator.go
+++ b/sim/cluster/direct_actuator.go
@@ -74,6 +74,9 @@ func (a *DirectActuator) scaleUp(d ScaleDecision) error {
 
 		// Build simCfg: start from the cluster default, then apply pool-authoritative GPU
 		// type and HWConfig override (SC-004, mirrors NewClusterSimulator startup path).
+		// PoolRole(0) returns the global SimConfig unchanged — autoscaler does not yet
+		// support PD disaggregation. If PD + autoscaler are combined in future, this
+		// will need to resolve the correct prefill/decode role for the pool.
 		simCfg := a.cluster.config.resolveConfigForRole(PoolRole(0))
 		simCfg.GPU = matchedGPU
 		if hc, ok := a.cluster.config.HWConfigByGPU[matchedGPU]; ok {

--- a/sim/cluster/infra_lifecycle_event.go
+++ b/sim/cluster/infra_lifecycle_event.go
@@ -6,7 +6,6 @@ import (
 	"container/heap"
 	"fmt"
 
-	"github.com/inference-sim/inference-sim/sim"
 	"github.com/sirupsen/logrus"
 )
 
@@ -55,11 +54,7 @@ func (e *NodeReadyEvent) Execute(cs *ClusterSimulator) {
 			}
 			p.simCfg.HWConfig = hc
 		}
-		inst := NewInstanceSimulator(p.id, p.simCfg)
-		inst.Model = cs.config.Model
-		inst.nodeID = p.nodeID
-		inst.allocatedGPUIDs = p.gpuIDs
-		inst.TPDegree = p.tpDegree
+
 		// Phase 1C: look up CostPerHour for this GPU type (mirrors cluster.go startup path).
 		var poolCostPerHour float64
 		for i := range cs.config.NodePools {
@@ -68,55 +63,9 @@ func (e *NodeReadyEvent) Execute(cs *ClusterSimulator) {
 				break
 			}
 		}
-		inst.CostPerHour = poolCostPerHour
-		inst.warmUpRemaining = cs.config.InstanceLifecycle.WarmUpRequestCount
-		inst.TransitionTo(InstanceStateLoading)
 
-		// Register with snapshot provider for routing (deferred instances were not
-		// in the initial instanceMap passed to NewCachedSnapshotProvider).
-		// Must happen BEFORE scheduleInstanceLoadedEvent so the instance is routable
-		// when the load event fires.
-		csp, ok := cs.snapshotProvider.(*CachedSnapshotProvider)
-		if !ok {
-			// snapshotProvider is nil or not *CachedSnapshotProvider — release GPUs and skip.
-			// R1: no silent data loss; this can occur in unit tests that bypass NewClusterSimulator.
-			// Release GPUs so they are not held by an instance that can never be routed to.
-			logrus.Warnf("[cluster] NodeReadyEvent: snapshotProvider is not *CachedSnapshotProvider for instance %s — releasing GPUs and skipping", p.id)
-			cs.releaseInstanceGPUs(inst)
-			continue
-		}
-		csp.AddInstance(p.id, inst)
-
-		cs.scheduleInstanceLoadedEvent(inst)
-		cs.instances = append(cs.instances, inst)
-		cs.inFlightRequests[string(p.id)] = 0
-
-		// Register with cacheQueryFn for precise prefix scoring (deferred instances).
-		// registerInstanceCacheQueryFn handles both oracle and stale modes (R23).
-		if cs.cacheQueryFn != nil {
-			cs.registerInstanceCacheQueryFn(p.id, inst)
-		}
-
-		// Wire OnRequestDone callback — mirror startup path in NewClusterSimulator (R4).
-		onRequestDone := cs.sessionCallback
-		if onRequestDone != nil || cs.tenantTracker != nil {
-			inst.sim.OnRequestDone = func(req *sim.Request, tick int64) []*sim.Request {
-				if cs.tenantTracker != nil {
-					cs.tenantTracker.OnComplete(req.TenantID)
-				}
-				if onRequestDone == nil {
-					return nil
-				}
-				nextReqs := onRequestDone(req, tick)
-				for _, next := range nextReqs {
-					heap.Push(&cs.clusterEvents, clusterEventEntry{
-						event: &ClusterArrivalEvent{time: next.ArrivalTime, request: next},
-						seqID: cs.nextSeqID(),
-					})
-					cs.pendingArrivals++ // mirror Run() — session follow-ups must be tracked
-				}
-				return nil // don't inject locally — route through cluster pipeline
-			}
+		if !cs.addLiveInstance(p.id, cs.config.Model, p.simCfg, p.nodeID, p.gpuIDs, p.tpDegree, poolCostPerHour) {
+			continue // GPU release already handled by addLiveInstance
 		}
 	}
 }

--- a/sim/cluster/snapshot.go
+++ b/sim/cluster/snapshot.go
@@ -59,6 +59,8 @@ func newObservabilityConfig(refreshInterval int64) ObservabilityConfig {
 type SnapshotProvider interface {
 	Snapshot(id InstanceID, clock int64) sim.RoutingSnapshot
 	RefreshAll(clock int64)
+	// HasInstance returns true if the given ID is registered and routable.
+	HasInstance(id InstanceID) bool
 }
 
 // fieldTimestamps tracks the last refresh time per field per instance.
@@ -156,6 +158,13 @@ func (p *CachedSnapshotProvider) AddInstance(id InstanceID, inst *InstanceSimula
 	p.instances[id] = inst
 	p.cache[id] = sim.NewRoutingSnapshot(string(id))
 	p.lastRefresh[id] = fieldTimestamps{}
+}
+
+// HasInstance returns true if the given instance ID is registered with this provider.
+// Used by tests to verify routability without accessing internal fields.
+func (p *CachedSnapshotProvider) HasInstance(id InstanceID) bool {
+	_, ok := p.instances[id]
+	return ok
 }
 
 // shouldRefresh returns true if a field should be refreshed based on its config.


### PR DESCRIPTION
## Summary

Fixes #1021 — scale-up decisions produced phantom GPU reservations with no request-serving capacity.

Part of tracking issue #994.

---

## Root Cause

\`DirectActuator.scaleUp\` called \`PlacementManager.PlaceInstance()\` to reserve GPU slots, then returned. Seven steps required to make an instance live were entirely absent:
- \`NewInstanceSimulator\` + field initialisation
- \`TransitionTo(InstanceStateLoading)\`
- \`csp.AddInstance\` (registers with snapshot provider → routable)
- \`scheduleInstanceLoadedEvent\` (schedules Loading → Active)
- \`cs.instances = append\` + \`cs.inFlightRequests[id] = 0\`
- \`registerInstanceCacheQueryFn\` (precise prefix scoring)
- \`OnRequestDone\` callback wiring

---

## Fix

Extract \`addLiveInstance\` on \`ClusterSimulator\` — the canonical "add instance to a running cluster" path. Called by both \`NodeReadyEvent.Execute\` (deferred placement) and \`scaleUp\` (autoscaler direct placement).

\`scaleUp\` is responsible for \`PlaceInstance\`, building \`simCfg\` (GPU override + HWConfig + CostPerHour), and delegating the rest to \`addLiveInstance\`.

The startup path in \`NewClusterSimulator\` is structurally different (bulk \`NewCachedSnapshotProvider\` init) and is unchanged; a maintenance note in the method doc explains the asymmetry.

---

## Tests

- \`scale_up_creates_live_instance\` — after Apply(Delta=+1), exactly one InstanceSimulator exists in cs.instances, is in a startup state (Active with zero delay, Loading with non-zero delay), has pool-authoritative GPU, is registered with snapshotProvider, and has inFlightRequests=0
- \`scale_up_delta_2_creates_two_instances\` — Delta=+2 creates two instances, both registered
- \`scale_up_no_capacity_returns_error\` — when capacity is exhausted mid-loop, Apply returns error but the succeeded placement is preserved

---

## Test Plan

- [x] \`go test ./sim/cluster/...\` passes
- [x] \`go build ./...\` succeeds
- [x] All three new \`scale_up_*\` subtests pass
- [x] No regressions from \`NodeReadyEvent.Execute\` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)