### PR TITLE
feat(workload): configurable think-time distribution for blis replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,12 @@ go build -o blis main.go
   --rate 10 --num-requests 100 --output-tokens 2048 --min-tokens 2048 \
   --trace-header trace.yaml --trace-data trace.csv
 
+# Observe closed-loop with lognormal think-time distribution (requires --concurrency)
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --concurrency 10 --num-requests 100 \
+  --think-time-dist "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" \
+  --trace-header trace.yaml --trace-data trace.csv
+
 # Observe with ITL (inter-token latency) recording for streaming requests
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
   --workload chatbot --rate 10 --num-requests 100 \

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -52,6 +52,7 @@ var (
 	observeRttMs               float64
 	observeConcurrency         int
 	observeThinkTimeMs         int
+	observeThinkTimeDist       string
 	observeWorkload            string
 	observeDefaultsFilePath    string
 	observeRecordITL           bool
@@ -128,7 +129,8 @@ func init() {
 	observeCmd.Flags().Int64Var(&observeHorizon, "horizon", 0, "Observation horizon in microseconds (0 = from spec or unlimited)")
 	observeCmd.Flags().IntVar(&observeNumRequests, "num-requests", 0, "Maximum requests to generate (0 = from spec or unlimited; differs from blis run default of 100)")
 	observeCmd.Flags().IntVar(&observeConcurrency, "concurrency", 0, "Number of concurrent virtual users (closed-loop, mutually exclusive with --rate)")
-	observeCmd.Flags().IntVar(&observeThinkTimeMs, "think-time-ms", 0, "Think time in ms between response and next request (concurrency mode)")
+	observeCmd.Flags().IntVar(&observeThinkTimeMs, "think-time-ms", 0, "Think time in ms between response and next request (concurrency mode; mutually exclusive with --think-time-dist)")
+	observeCmd.Flags().StringVar(&observeThinkTimeDist, "think-time-dist", "", `Think-time distribution spec for closed-loop observe (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" or "constant:value=500ms"). Mutually exclusive with --think-time-ms. Requires --concurrency.`)
 
 	// Distribution synthesis flags — same names AND defaults as blis run.
 	// Default values are defined in root.go (distDefaults const block).
@@ -243,6 +245,23 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	if observeThinkTimeMs < 0 {
 		logrus.Fatalf("--think-time-ms must be >= 0, got %d", observeThinkTimeMs)
 	}
+	if cmd.Flags().Changed("think-time-ms") && cmd.Flags().Changed("think-time-dist") {
+		logrus.Fatalf("--think-time-ms and --think-time-dist are mutually exclusive")
+	}
+	if observeThinkTimeDist != "" && observeConcurrency <= 0 {
+		logrus.Fatalf("--think-time-dist requires --concurrency")
+	}
+
+	// Resolve think-time distribution sampler (nil when --think-time-dist is not set;
+	// --think-time-ms is applied via DistributionParams.ThinkTimeMs below).
+	var observeThinkTimeSampler workload.LengthSampler
+	if cmd.Flags().Changed("think-time-dist") {
+		var err error
+		observeThinkTimeSampler, err = workload.ParseThinkTimeDist(observeThinkTimeDist)
+		if err != nil {
+			logrus.Fatalf("--think-time-dist: %v", err)
+		}
+	}
 
 	// BC-14: Numeric flag validation (R3)
 	if observeMaxConcur <= 0 {
@@ -348,6 +367,13 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	logrus.Infof("Generated %d requests", len(wl.Requests))
 	if len(wl.Sessions) > 0 {
 		logrus.Infof("Generated %d session blueprints (closed-loop)", len(wl.Sessions))
+	}
+
+	// Apply --think-time-dist sampler to all session blueprints (overrides constant ThinkTimeUs).
+	if observeThinkTimeSampler != nil {
+		for i := range wl.Sessions {
+			wl.Sessions[i].ThinkTimeSampler = observeThinkTimeSampler
+		}
 	}
 
 	if len(wl.Requests) == 0 {

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -370,11 +370,7 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	}
 
 	// Apply --think-time-dist sampler to all session blueprints (overrides constant ThinkTimeUs).
-	if observeThinkTimeSampler != nil {
-		for i := range wl.Sessions {
-			wl.Sessions[i].ThinkTimeSampler = observeThinkTimeSampler
-		}
-	}
+	applyThinkTimeSampler(wl.Sessions, observeThinkTimeSampler)
 
 	if len(wl.Requests) == 0 {
 		logrus.Warn("No requests generated — writing empty trace")
@@ -982,4 +978,15 @@ func buildPrefixStrings(groups map[string]int, seed int64, tokensPerWord float64
 		prefixLengths[group] = length
 	}
 	return prefixes, prefixLengths
+}
+
+// applyThinkTimeSampler sets s on every blueprint in sessions.
+// No-op when s is nil. Extracted for unit testability.
+func applyThinkTimeSampler(sessions []workload.SessionBlueprint, s workload.LengthSampler) {
+	if s == nil {
+		return
+	}
+	for i := range sessions {
+		sessions[i].ThinkTimeSampler = s
+	}
 }

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -1692,3 +1692,56 @@ func TestSend_UnconstrainedOutput_MaxTokensNeverBelowMinTokens(t *testing.T) {
 	}
 }
 
+func TestObserveCmd_ThinkTimeDist_FlagExists(t *testing.T) {
+	f := observeCmd.Flags().Lookup("think-time-dist")
+	if f == nil {
+		t.Fatal("missing expected flag --think-time-dist on observeCmd")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--think-time-dist default: got %q, want %q (empty — no default distribution)", f.DefValue, "")
+	}
+}
+
+// TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied verifies that when a
+// LengthSampler is provided, it is set on all session blueprints.
+// This exercises the override loop in runObserve (the inner logic, not the full command).
+func TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied(t *testing.T) {
+	sampler, err := workload.ParseThinkTimeDist("constant:value=500ms")
+	if err != nil {
+		t.Fatalf("ParseThinkTimeDist: %v", err)
+	}
+
+	spec := workload.SynthesizeFromDistribution(workload.DistributionParams{
+		Concurrency:        2,
+		ThinkTimeMs:        100,
+		NumRequests:        4,
+		PromptTokensMean:   64,
+		PromptTokensStdDev: 0,
+		PromptTokensMin:    64,
+		PromptTokensMax:    64,
+		OutputTokensMean:   16,
+		OutputTokensStdDev: 0,
+		OutputTokensMin:    16,
+		OutputTokensMax:    16,
+	})
+	wl, err := workload.GenerateWorkload(spec, 1<<60, 4)
+	if err != nil {
+		t.Fatalf("GenerateWorkload: %v", err)
+	}
+	if len(wl.Sessions) == 0 {
+		t.Skip("no sessions generated — cannot test blueprint override")
+	}
+
+	// Apply sampler (mirrors the loop in runObserve)
+	for i := range wl.Sessions {
+		wl.Sessions[i].ThinkTimeSampler = sampler
+	}
+
+	// Invariant: all blueprints now have the sampler set
+	for i, bp := range wl.Sessions {
+		if bp.ThinkTimeSampler == nil {
+			t.Errorf("blueprint[%d]: ThinkTimeSampler is nil after override", i)
+		}
+	}
+}
+

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -1702,10 +1702,9 @@ func TestObserveCmd_ThinkTimeDist_FlagExists(t *testing.T) {
 	}
 }
 
-// TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied verifies that when a
-// LengthSampler is provided, it is set on all session blueprints.
-// This exercises the override loop in runObserve (the inner logic, not the full command).
-func TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied(t *testing.T) {
+// TestApplyThinkTimeSampler_SetsOnAllBlueprints verifies that applyThinkTimeSampler
+// (the production helper called by runObserve) sets the sampler on every blueprint.
+func TestApplyThinkTimeSampler_SetsOnAllBlueprints(t *testing.T) {
 	sampler, err := workload.ParseThinkTimeDist("constant:value=500ms")
 	if err != nil {
 		t.Fatalf("ParseThinkTimeDist: %v", err)
@@ -1724,7 +1723,7 @@ func TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied(t *testing.T) {
 		OutputTokensMin:    16,
 		OutputTokensMax:    16,
 	})
-	wl, err := workload.GenerateWorkload(spec, 1<<60, 4)
+	wl, err := workload.GenerateWorkload(spec, 1_000_000, 4)
 	if err != nil {
 		t.Fatalf("GenerateWorkload: %v", err)
 	}
@@ -1732,15 +1731,36 @@ func TestObserveCmd_ThinkTimeDist_BlueprintOverrideApplied(t *testing.T) {
 		t.Skip("no sessions generated — cannot test blueprint override")
 	}
 
-	// Apply sampler (mirrors the loop in runObserve)
-	for i := range wl.Sessions {
-		wl.Sessions[i].ThinkTimeSampler = sampler
-	}
+	applyThinkTimeSampler(wl.Sessions, sampler)
 
-	// Invariant: all blueprints now have the sampler set
 	for i, bp := range wl.Sessions {
 		if bp.ThinkTimeSampler == nil {
-			t.Errorf("blueprint[%d]: ThinkTimeSampler is nil after override", i)
+			t.Errorf("blueprint[%d]: ThinkTimeSampler is nil after applyThinkTimeSampler", i)
+		}
+	}
+}
+
+// TestApplyThinkTimeSampler_NilSamplerIsNoOp verifies that passing nil leaves
+// existing ThinkTimeSampler values unchanged.
+func TestApplyThinkTimeSampler_NilSamplerIsNoOp(t *testing.T) {
+	spec := workload.SynthesizeFromDistribution(workload.DistributionParams{
+		Concurrency: 2, NumRequests: 4,
+		PromptTokensMean: 64, PromptTokensMin: 64, PromptTokensMax: 64,
+		OutputTokensMean: 16, OutputTokensMin: 16, OutputTokensMax: 16,
+	})
+	wl, err := workload.GenerateWorkload(spec, 1_000_000, 4)
+	if err != nil {
+		t.Fatalf("GenerateWorkload: %v", err)
+	}
+	if len(wl.Sessions) == 0 {
+		t.Skip("no sessions generated")
+	}
+
+	applyThinkTimeSampler(wl.Sessions, nil)
+
+	for i, bp := range wl.Sessions {
+		if bp.ThinkTimeSampler != nil {
+			t.Errorf("blueprint[%d]: ThinkTimeSampler unexpectedly set after nil applyThinkTimeSampler", i)
 		}
 	}
 }

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -25,6 +25,7 @@ var (
 	replayTraceOutput string // File prefix for TraceV2 re-export (<prefix>.yaml + <prefix>.csv)
 	replaySessionMode string
 	replayThinkTimeMs int
+	replayThinkTimeDist string // distribution spec for think time (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s")
 )
 
 var replayCmd = &cobra.Command{
@@ -89,6 +90,30 @@ Example:
 		if replayThinkTimeMs > 0 && replaySessionMode != "closed-loop" {
 			logrus.Fatalf("--think-time-ms requires --session-mode closed-loop")
 		}
+		if replayThinkTimeDist != "" && replaySessionMode != "closed-loop" {
+			logrus.Fatalf("--think-time-dist requires --session-mode closed-loop")
+		}
+		if cmd.Flags().Changed("think-time-ms") && cmd.Flags().Changed("think-time-dist") {
+			logrus.Fatalf("--think-time-ms and --think-time-dist are mutually exclusive")
+		}
+
+		// Resolve think-time sampler: --think-time-dist takes the general distribution;
+		// --think-time-ms is a convenience alias for constant:<N>ms.
+		// Neither → nil (derive per-session think time from trace arrival gaps).
+		var thinkTimeSampler workload.LengthSampler
+		if cmd.Flags().Changed("think-time-dist") {
+			var err error
+			thinkTimeSampler, err = workload.ParseThinkTimeDist(replayThinkTimeDist)
+			if err != nil {
+				logrus.Fatalf("--think-time-dist: %v", err)
+			}
+		} else if replayThinkTimeMs > 0 {
+			var err error
+			thinkTimeSampler, err = workload.ParseThinkTimeDist(fmt.Sprintf("constant:value=%dms", replayThinkTimeMs))
+			if err != nil {
+				logrus.Fatalf("--think-time-ms: %v", err)
+			}
+		}
 
 		// Build requests from trace — mode selects pre-baked vs closed-loop (BC-8, BC-9)
 		var requests []*sim.Request
@@ -97,12 +122,11 @@ Example:
 			// Closed-loop: inject only round-0 requests; SessionManager drives follow-ups.
 			// Compute the preliminary horizon from trace records directly (O(n)) so we can
 			// call LoadTraceV2SessionBlueprints exactly once with correct parameters.
-			thinkTimeUs := int64(replayThinkTimeMs) * 1000
 			replayHorizonPrelim := computeHorizonFromMaxArrival(maxInjectedArrivalTimeUs(traceData))
 			if cmd.Flags().Changed("horizon") {
 				replayHorizonPrelim = simulationHorizon
 			}
-			r0Requests, blueprints, bErr := workload.LoadTraceV2SessionBlueprints(traceData, seed, thinkTimeUs, replayHorizonPrelim)
+			r0Requests, blueprints, bErr := workload.LoadTraceV2SessionBlueprints(traceData, seed, thinkTimeSampler, replayHorizonPrelim)
 			if bErr != nil {
 				logrus.Fatalf("Failed to build session blueprints from trace: %v", bErr)
 			}
@@ -350,7 +374,8 @@ func init() {
 	replayCmd.Flags().StringVar(&resultsPath, "results-path", "", "File to write []SimResult JSON (request_id, ttft_us, e2e_us, input_tokens, output_tokens) for blis calibrate consumption.")
 	replayCmd.Flags().StringVar(&replayTraceOutput, "trace-output", "", "Export replay results as TraceV2 files (<prefix>.yaml + <prefix>.csv); header mode is \"replayed\"")
 	replayCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", `Session replay mode: "fixed" (pre-baked arrivals from trace) or "closed-loop" (load-adaptive follow-ups via SessionManager)`)
-	replayCmd.Flags().IntVar(&replayThinkTimeMs, "think-time-ms", 0, "Override think time between session rounds in milliseconds (0 = derive from trace inter-round arrival gaps, which include prior-round service time — use this flag to supply the actual client-side think time; requires --session-mode closed-loop)")
+	replayCmd.Flags().IntVar(&replayThinkTimeMs, "think-time-ms", 0, "Override think time between session rounds in milliseconds (0 = derive from trace inter-round arrival gaps; mutually exclusive with --think-time-dist; requires --session-mode closed-loop)")
+	replayCmd.Flags().StringVar(&replayThinkTimeDist, "think-time-dist", "", `Think-time distribution spec for closed-loop replay (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" or "constant:value=500ms"). Mutually exclusive with --think-time-ms. Requires --session-mode closed-loop.`)
 	rootCmd.AddCommand(replayCmd)
 }
 

--- a/sim/workload/distribution.go
+++ b/sim/workload/distribution.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"math/rand"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // LengthSampler generates token count samples.
@@ -75,6 +77,39 @@ func (s *ParetoLogNormalSampler) Sample(rng *rand.Rand) int {
 		return 1
 	}
 	result := int(math.Round(val))
+	if result < 1 {
+		return 1
+	}
+	return result
+}
+
+// LognormalSampler produces lognormally-distributed samples.
+// X = exp(mu + sigma*Z), where Z ~ N(0,1).
+// mu and sigma are the mean and std dev of ln(X) — the caller selects the
+// natural unit (tokens for length distributions; µs for think-time distributions,
+// with mu adjusted by ln(1e6) to shift from seconds to µs).
+// Optional min/max clamp (0 = no bound). Output is always >= 1.
+type LognormalSampler struct {
+	mu, sigma float64
+	min, max  int // 0 = no bound; applied after rounding
+}
+
+func (s *LognormalSampler) Sample(rng *rand.Rand) int {
+	z := rng.NormFloat64()
+	val := math.Exp(s.mu + s.sigma*z)
+	if math.IsInf(val, 0) || math.IsNaN(val) {
+		if s.min > 0 {
+			return s.min
+		}
+		return 1
+	}
+	result := int(math.Round(val))
+	if s.min > 0 && result < s.min {
+		result = s.min
+	}
+	if s.max > 0 && result > s.max {
+		result = s.max
+	}
 	if result < 1 {
 		return 1
 	}
@@ -214,6 +249,22 @@ func NewLengthSampler(spec DistSpec) (LengthSampler, error) {
 			mixWeight: spec.Params["mix_weight"],
 		}, nil
 
+	case "lognormal":
+		if err := requireParam(spec.Params, "mu", "sigma"); err != nil {
+			return nil, err
+		}
+		s := &LognormalSampler{
+			mu:    spec.Params["mu"],
+			sigma: spec.Params["sigma"],
+		}
+		if v, ok := spec.Params["min"]; ok {
+			s.min = int(v)
+		}
+		if v, ok := spec.Params["max"]; ok {
+			s.max = int(v)
+		}
+		return s, nil
+
 	case "constant":
 		if err := requireParam(spec.Params, "value"); err != nil {
 			return nil, err
@@ -242,5 +293,135 @@ func NewLengthSampler(spec DistSpec) (LengthSampler, error) {
 
 	default:
 		return nil, fmt.Errorf("unknown distribution type %q", spec.Type)
+	}
+}
+
+// ParseThinkTimeDist parses a think-time distribution spec string into a LengthSampler
+// that produces values in microseconds.
+//
+// Supported formats:
+//
+//	lognormal:mu=2.0,sigma=0.6
+//	lognormal:mu=2.0,sigma=0.6,min=3s,max=30s
+//	constant:value=500ms
+//
+// For lognormal, mu and sigma parameterize ln(X) where X is in seconds.
+// The sampler internally adjusts mu by ln(1e6) so output is in microseconds.
+// min/max accept time suffixes s, ms, us; bare numbers are treated as milliseconds.
+// For constant, value accepts the same time suffixes.
+func ParseThinkTimeDist(spec string) (LengthSampler, error) {
+	colon := strings.IndexByte(spec, ':')
+	if colon < 0 {
+		return nil, fmt.Errorf("think-time-dist must have format type:key=value,...; got %q", spec)
+	}
+	distType := spec[:colon]
+	params, err := parseKVParams(spec[colon+1:])
+	if err != nil {
+		return nil, fmt.Errorf("think-time-dist %q: %w", distType, err)
+	}
+
+	switch distType {
+	case "lognormal":
+		muStr, ok := params["mu"]
+		if !ok {
+			return nil, fmt.Errorf("think-time-dist lognormal requires parameter \"mu\"")
+		}
+		sigmaStr, ok := params["sigma"]
+		if !ok {
+			return nil, fmt.Errorf("think-time-dist lognormal requires parameter \"sigma\"")
+		}
+		mu, err := strconv.ParseFloat(muStr, 64)
+		if err != nil {
+			return nil, fmt.Errorf("think-time-dist lognormal: invalid mu %q: %w", muStr, err)
+		}
+		sigma, err := strconv.ParseFloat(sigmaStr, 64)
+		if err != nil {
+			return nil, fmt.Errorf("think-time-dist lognormal: invalid sigma %q: %w", sigmaStr, err)
+		}
+		// mu/sigma are in log-space of seconds; shift to µs: mu_us = mu_s + ln(1e6)
+		muUs := mu + math.Log(1e6)
+		s := &LognormalSampler{mu: muUs, sigma: sigma}
+		if v, ok := params["min"]; ok {
+			minUs, err := parseTimeToMicros(v)
+			if err != nil {
+				return nil, fmt.Errorf("think-time-dist lognormal: invalid min %q: %w", v, err)
+			}
+			s.min = int(minUs)
+		}
+		if v, ok := params["max"]; ok {
+			maxUs, err := parseTimeToMicros(v)
+			if err != nil {
+				return nil, fmt.Errorf("think-time-dist lognormal: invalid max %q: %w", v, err)
+			}
+			s.max = int(maxUs)
+		}
+		return s, nil
+
+	case "constant":
+		valStr, ok := params["value"]
+		if !ok {
+			return nil, fmt.Errorf("think-time-dist constant requires parameter \"value\"")
+		}
+		valueUs, err := parseTimeToMicros(valStr)
+		if err != nil {
+			return nil, fmt.Errorf("think-time-dist constant: invalid value %q: %w", valStr, err)
+		}
+		return &ConstantSampler{value: int(valueUs)}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported think-time-dist type %q; supported: lognormal, constant", distType)
+	}
+}
+
+// parseKVParams splits "k=v,k=v,..." into a map. Empty string returns empty map.
+func parseKVParams(s string) (map[string]string, error) {
+	result := make(map[string]string)
+	if strings.TrimSpace(s) == "" {
+		return result, nil
+	}
+	for _, kv := range strings.Split(s, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("invalid parameter %q: expected key=value", kv)
+		}
+		result[kv[:eq]] = kv[eq+1:]
+	}
+	return result, nil
+}
+
+// parseTimeToMicros converts a time string to microseconds.
+// Supported suffixes: s (seconds), ms (milliseconds), us (microseconds).
+// Bare numbers (no suffix) are treated as milliseconds.
+func parseTimeToMicros(s string) (int64, error) {
+	switch {
+	case strings.HasSuffix(s, "us"):
+		v, err := strconv.ParseFloat(strings.TrimSuffix(s, "us"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v), nil
+	case strings.HasSuffix(s, "ms"):
+		v, err := strconv.ParseFloat(strings.TrimSuffix(s, "ms"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v * 1_000), nil
+	case strings.HasSuffix(s, "s"):
+		v, err := strconv.ParseFloat(strings.TrimSuffix(s, "s"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v * 1_000_000), nil
+	default:
+		// bare number → milliseconds (consistent with --think-time-ms convention)
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(v * 1_000), nil
 	}
 }

--- a/sim/workload/distribution.go
+++ b/sim/workload/distribution.go
@@ -334,9 +334,15 @@ func ParseThinkTimeDist(spec string) (LengthSampler, error) {
 		if err != nil {
 			return nil, fmt.Errorf("think-time-dist lognormal: invalid mu %q: %w", muStr, err)
 		}
+		if math.IsNaN(mu) || math.IsInf(mu, 0) {
+			return nil, fmt.Errorf("think-time-dist lognormal: mu must be a finite number, got %q", muStr)
+		}
 		sigma, err := strconv.ParseFloat(sigmaStr, 64)
 		if err != nil {
 			return nil, fmt.Errorf("think-time-dist lognormal: invalid sigma %q: %w", sigmaStr, err)
+		}
+		if math.IsNaN(sigma) || math.IsInf(sigma, 0) || sigma <= 0 {
+			return nil, fmt.Errorf("think-time-dist lognormal: sigma must be a finite positive number, got %q", sigmaStr)
 		}
 		// mu/sigma are in log-space of seconds; shift to µs: mu_us = mu_s + ln(1e6)
 		muUs := mu + math.Log(1e6)
@@ -354,6 +360,9 @@ func ParseThinkTimeDist(spec string) (LengthSampler, error) {
 				return nil, fmt.Errorf("think-time-dist lognormal: invalid max %q: %w", v, err)
 			}
 			s.max = int(maxUs)
+		}
+		if s.min > 0 && s.max > 0 && s.min > s.max {
+			return nil, fmt.Errorf("think-time-dist lognormal: min (%d µs) must be <= max (%d µs)", s.min, s.max)
 		}
 		return s, nil
 
@@ -374,6 +383,7 @@ func ParseThinkTimeDist(spec string) (LengthSampler, error) {
 }
 
 // parseKVParams splits "k=v,k=v,..." into a map. Empty string returns empty map.
+// Duplicate keys are rejected to prevent silent user-intent loss (R1).
 func parseKVParams(s string) (map[string]string, error) {
 	result := make(map[string]string)
 	if strings.TrimSpace(s) == "" {
@@ -388,7 +398,11 @@ func parseKVParams(s string) (map[string]string, error) {
 		if eq < 0 {
 			return nil, fmt.Errorf("invalid parameter %q: expected key=value", kv)
 		}
-		result[kv[:eq]] = kv[eq+1:]
+		key := kv[:eq]
+		if _, exists := result[key]; exists {
+			return nil, fmt.Errorf("invalid parameter string: duplicate key %q", key)
+		}
+		result[key] = kv[eq+1:]
 	}
 	return result, nil
 }
@@ -396,11 +410,21 @@ func parseKVParams(s string) (map[string]string, error) {
 // parseTimeToMicros converts a time string to microseconds.
 // Supported suffixes: s (seconds), ms (milliseconds), us (microseconds).
 // Bare numbers (no suffix) are treated as milliseconds.
+// Negative and non-finite values are rejected (R3).
 func parseTimeToMicros(s string) (int64, error) {
+	validateFiniteNonNegative := func(v float64, raw string) error {
+		if v < 0 || math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("time value must be a non-negative finite number, got %q", raw)
+		}
+		return nil
+	}
 	switch {
 	case strings.HasSuffix(s, "us"):
 		v, err := strconv.ParseFloat(strings.TrimSuffix(s, "us"), 64)
 		if err != nil {
+			return 0, err
+		}
+		if err := validateFiniteNonNegative(v, s); err != nil {
 			return 0, err
 		}
 		return int64(v), nil
@@ -409,10 +433,16 @@ func parseTimeToMicros(s string) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
+		if err := validateFiniteNonNegative(v, s); err != nil {
+			return 0, err
+		}
 		return int64(v * 1_000), nil
 	case strings.HasSuffix(s, "s"):
 		v, err := strconv.ParseFloat(strings.TrimSuffix(s, "s"), 64)
 		if err != nil {
+			return 0, err
+		}
+		if err := validateFiniteNonNegative(v, s); err != nil {
 			return 0, err
 		}
 		return int64(v * 1_000_000), nil
@@ -420,6 +450,9 @@ func parseTimeToMicros(s string) (int64, error) {
 		// bare number → milliseconds (consistent with --think-time-ms convention)
 		v, err := strconv.ParseFloat(s, 64)
 		if err != nil {
+			return 0, err
+		}
+		if err := validateFiniteNonNegative(v, s); err != nil {
 			return 0, err
 		}
 		return int64(v * 1_000), nil

--- a/sim/workload/distribution_test.go
+++ b/sim/workload/distribution_test.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"math"
 	"math/rand"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -304,6 +305,197 @@ func TestSequenceSampler_EmptyValues(t *testing.T) {
 	got := s.Sample(nil)
 	if got != 1 {
 		t.Errorf("empty sampler: got %d, want 1", got)
+	}
+}
+
+// --- LognormalSampler tests ---
+
+// TestLognormalSampler_MeanMatchesParams verifies BC-1:
+// E[X] = exp(mu + sigma²/2); empirical mean within 10%.
+func TestLognormalSampler_MeanMatchesParams(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	mu, sigma := 6.0, 0.5
+	s := &LognormalSampler{mu: mu, sigma: sigma}
+	expectedMean := math.Exp(mu + sigma*sigma/2)
+
+	n := 50_000
+	sum := 0
+	for i := 0; i < n; i++ {
+		sum += s.Sample(rng)
+	}
+	got := float64(sum) / float64(n)
+	if math.Abs(got-expectedMean)/expectedMean > 0.10 {
+		t.Errorf("lognormal mean = %.1f, want ≈ %.1f (within 10%%)", got, expectedMean)
+	}
+}
+
+// TestLognormalSampler_ClampedToRange verifies BC-2: all samples within [min, max].
+func TestLognormalSampler_ClampedToRange(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	s := &LognormalSampler{mu: 6.0, sigma: 2.0, min: 100, max: 2000}
+	for i := 0; i < 10_000; i++ {
+		v := s.Sample(rng)
+		if v < 100 || v > 2000 {
+			t.Errorf("sample %d: %d outside [100, 2000]", i, v)
+			break
+		}
+	}
+}
+
+// TestLognormalSampler_AlwaysPositive verifies that samples are always >= 1.
+func TestLognormalSampler_AlwaysPositive(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	s := &LognormalSampler{mu: 0.0, sigma: 0.1}
+	for i := 0; i < 10_000; i++ {
+		if v := s.Sample(rng); v < 1 {
+			t.Errorf("sample %d: got %d, want >= 1", i, v)
+			break
+		}
+	}
+}
+
+// TestLognormalSampler_ViaNewLengthSampler verifies the factory path.
+func TestLognormalSampler_ViaNewLengthSampler(t *testing.T) {
+	s, err := NewLengthSampler(DistSpec{
+		Type:   "lognormal",
+		Params: map[string]float64{"mu": 6.0, "sigma": 0.5, "min": 50, "max": 5000},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 1000; i++ {
+		v := s.Sample(rng)
+		if v < 50 || v > 5000 {
+			t.Errorf("sample %d: %d outside [50, 5000]", i, v)
+			break
+		}
+	}
+}
+
+// TestNewLengthSampler_Lognormal_MissingMu_ReturnsError verifies required param check.
+func TestNewLengthSampler_Lognormal_MissingMu_ReturnsError(t *testing.T) {
+	_, err := NewLengthSampler(DistSpec{
+		Type:   "lognormal",
+		Params: map[string]float64{"sigma": 0.5},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing mu")
+	}
+	if !strings.Contains(err.Error(), "mu") {
+		t.Errorf("error %q should mention \"mu\"", err.Error())
+	}
+}
+
+// --- ParseThinkTimeDist tests ---
+
+// TestParseThinkTimeDist_Lognormal_ProducesCorrectRange verifies BC-3:
+// samples fall within [min, max] and represent µs values.
+func TestParseThinkTimeDist_Lognormal_ProducesCorrectRange(t *testing.T) {
+	s, err := ParseThinkTimeDist("lognormal:mu=2.0,sigma=0.6,min=3s,max=30s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(42))
+	const minUs = 3_000_000
+	const maxUs = 30_000_000
+	for i := 0; i < 10_000; i++ {
+		v := s.Sample(rng)
+		if v < minUs || v > maxUs {
+			t.Errorf("sample %d: %d µs outside [%d, %d]", i, v, minUs, maxUs)
+			break
+		}
+	}
+}
+
+// TestParseThinkTimeDist_Lognormal_MedianMatchesExpected verifies the µs conversion:
+// mu=2.0 in seconds → median ≈ exp(2.0)*1e6 µs ≈ 7,389,056 µs.
+func TestParseThinkTimeDist_Lognormal_MedianMatchesExpected(t *testing.T) {
+	s, err := ParseThinkTimeDist("lognormal:mu=2.0,sigma=0.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(42))
+	// With small sigma, empirical median ≈ exp(mu_us) = exp(2.0+ln(1e6)) µs = exp(2.0)*1e6 µs
+	expectedMedianUs := math.Exp(2.0) * 1e6
+	n := 50_000
+	samples := make([]int, n)
+	for i := range samples {
+		samples[i] = s.Sample(rng)
+	}
+	// Sort and take middle
+	sortedSamples := make([]int, n)
+	copy(sortedSamples, samples)
+	sort.Ints(sortedSamples)
+	median := float64(sortedSamples[n/2])
+	if math.Abs(median-expectedMedianUs)/expectedMedianUs > 0.05 {
+		t.Errorf("lognormal median = %.0f µs, want ≈ %.0f µs (within 5%%)", median, expectedMedianUs)
+	}
+}
+
+// TestParseThinkTimeDist_Constant_Ms verifies BC-4: constant:value=500ms → 500_000 µs.
+func TestParseThinkTimeDist_Constant_Ms(t *testing.T) {
+	s, err := ParseThinkTimeDist("constant:value=500ms")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 10; i++ {
+		if got := s.Sample(rng); got != 500_000 {
+			t.Errorf("sample %d: got %d µs, want 500000 µs", i, got)
+		}
+	}
+}
+
+// TestParseThinkTimeDist_Constant_S verifies constant:value=2s → 2_000_000 µs.
+func TestParseThinkTimeDist_Constant_S(t *testing.T) {
+	s, err := ParseThinkTimeDist("constant:value=2s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.Sample(nil); got != 2_000_000 {
+		t.Errorf("got %d µs, want 2000000 µs", got)
+	}
+}
+
+// TestParseThinkTimeDist_Constant_Us verifies constant:value=100us → 100 µs.
+func TestParseThinkTimeDist_Constant_Us(t *testing.T) {
+	s, err := ParseThinkTimeDist("constant:value=100us")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.Sample(nil); got != 100 {
+		t.Errorf("got %d µs, want 100 µs", got)
+	}
+}
+
+// TestParseThinkTimeDist_InvalidType_ReturnsError verifies unknown type is rejected.
+func TestParseThinkTimeDist_InvalidType_ReturnsError(t *testing.T) {
+	_, err := ParseThinkTimeDist("uniform:min=1s,max=10s")
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+	if !strings.Contains(err.Error(), "uniform") {
+		t.Errorf("error %q should mention type name", err.Error())
+	}
+}
+
+// TestParseThinkTimeDist_MissingColon_ReturnsError verifies format validation.
+func TestParseThinkTimeDist_MissingColon_ReturnsError(t *testing.T) {
+	_, err := ParseThinkTimeDist("lognormal-mu=2.0")
+	if err == nil {
+		t.Fatal("expected error for missing colon")
+	}
+}
+
+// TestParseThinkTimeDist_MissingMu_ReturnsError verifies required param for lognormal.
+func TestParseThinkTimeDist_MissingMu_ReturnsError(t *testing.T) {
+	_, err := ParseThinkTimeDist("lognormal:sigma=0.6")
+	if err == nil {
+		t.Fatal("expected error for missing mu")
+	}
+	if !strings.Contains(err.Error(), "mu") {
+		t.Errorf("error %q should mention \"mu\"", err.Error())
 	}
 }
 

--- a/sim/workload/distribution_test.go
+++ b/sim/workload/distribution_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
 )
 
 func TestGaussianSampler_MeanMatchesParam(t *testing.T) {
@@ -496,6 +498,103 @@ func TestParseThinkTimeDist_MissingMu_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mu") {
 		t.Errorf("error %q should mention \"mu\"", err.Error())
+	}
+}
+
+// TestParseThinkTimeDist_Constant_BareNumber verifies that bare numbers (no suffix)
+// are treated as milliseconds — the same convention as --think-time-ms.
+func TestParseThinkTimeDist_Constant_BareNumber(t *testing.T) {
+	s, err := ParseThinkTimeDist("constant:value=500")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := s.Sample(nil); got != 500_000 {
+		t.Errorf("bare number: got %d µs, want 500000 µs (500ms)", got)
+	}
+}
+
+// TestParseThinkTimeDist_Lognormal_MinZero verifies that min=0 is treated as
+// "no lower bound" (s.min sentinel), not as an active clamp.
+// All samples must be >= 1 (the floor) and <= max when max is set.
+func TestParseThinkTimeDist_Lognormal_MinZero(t *testing.T) {
+	s, err := ParseThinkTimeDist("lognormal:mu=2.0,sigma=0.5,min=0s,max=30s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(99))
+	maxUs := 30_000_000
+	for i := 0; i < 1000; i++ {
+		v := s.Sample(rng)
+		if v < 1 {
+			t.Errorf("sample %d: got %d, want >= 1", i, v)
+		}
+		if v > maxUs {
+			t.Errorf("sample %d: got %d, want <= %d (30s)", i, v, maxUs)
+		}
+	}
+}
+
+// TestParseThinkTimeDist_ValidationErrors verifies that invalid inputs are
+// rejected with errors rather than silently producing degenerate samplers.
+func TestParseThinkTimeDist_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{"negative time value", "constant:value=-5s", "non-negative"},
+		{"infinite time value", "constant:value=Infs", "non-negative finite"},
+		{"lognormal infinite mu", "lognormal:mu=+Inf,sigma=0.6", "finite"},
+		{"lognormal NaN sigma", "lognormal:mu=2.0,sigma=NaN", "finite positive"},
+		{"lognormal negative sigma", "lognormal:mu=2.0,sigma=-0.5", "finite positive"},
+		{"lognormal zero sigma", "lognormal:mu=2.0,sigma=0", "finite positive"},
+		{"lognormal min > max", "lognormal:mu=2.0,sigma=0.6,min=30s,max=3s", "min"},
+		{"duplicate key", "lognormal:mu=2.0,sigma=0.6,mu=5.0", "duplicate key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseThinkTimeDist(tt.spec)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.spec)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseThinkTimeDist_Lognormal_INV10_SessionCausality verifies that the
+// lognormal sampler always returns a positive think time, preserving INV-10:
+// round[N+1].ArrivalTime >= round[N].CompletionTime + ThinkTimeUs.
+func TestParseThinkTimeDist_Lognormal_INV10_SessionCausality(t *testing.T) {
+	s, err := ParseThinkTimeDist("lognormal:mu=2.0,sigma=0.6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sm := NewSessionManager([]SessionBlueprint{{
+		SessionID:        "inv10-test",
+		MaxRounds:        3,
+		ThinkTimeSampler: s,
+		RNG:              rand.New(rand.NewSource(42)),
+		InputSampler:     &constantSampler{value: 10},
+		OutputSampler:    &constantSampler{value: 5},
+		Horizon:          1_000_000_000,
+	}})
+	req0 := &sim.Request{
+		ID: "r0", SessionID: "inv10-test", RoundIndex: 0,
+		State: sim.StateCompleted, ProgressIndex: 15,
+		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+	}
+	completionTick := int64(100_000)
+	follow := sm.OnComplete(req0, completionTick)
+	if len(follow) != 1 {
+		t.Fatalf("expected 1 follow-up, got %d", len(follow))
+	}
+	// INV-10: follow-up arrival must be >= completion + think time (>= 1 µs)
+	if follow[0].ArrivalTime < completionTick+1 {
+		t.Errorf("INV-10 violated: follow-up arrival %d < completion %d + 1",
+			follow[0].ArrivalTime, completionTick)
 	}
 }
 

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -79,15 +79,17 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 // Returns round-0 requests (plus all non-session requests) for initial injection,
 // and blueprints for the SessionManager.
 //
-// thinkTimeOverrideUs > 0: use constant think time for all sessions.
-// thinkTimeOverrideUs == 0: derive per-round think time from trace arrival gaps.
-//   NOTE: gap-derived think time = ArrivalTimeUs[i] - ArrivalTimeUs[i-1], which
-//   equals (service_time[i-1] + client_think_time) when the trace was produced by
-//   blis observe. It is NOT pure client think time. Use thinkTimeOverrideUs (i.e.
-//   --think-time-ms) to supply the actual client-side think time when replaying an
-//   observe-generated trace with accurate inter-round spacing.
+// thinkTimeSampler != nil: use this sampler for all sessions' think-time draws.
+// thinkTimeSampler == nil: derive per-round think time from trace arrival gaps.
+//
+//	NOTE: gap-derived think time = ArrivalTimeUs[i] - ArrivalTimeUs[i-1], which
+//	equals (service_time[i-1] + client_think_time) when the trace was produced by
+//	blis observe. It is NOT pure client think time. Pass a sampler built via
+//	ParseThinkTimeDist to supply the actual client-side think time when replaying
+//	an observe-generated trace with accurate inter-round spacing.
+//
 // horizon <= 0: defaults to math.MaxInt64.
-func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeOverrideUs int64, horizon int64) ([]*sim.Request, []SessionBlueprint, error) {
+func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler LengthSampler, horizon int64) ([]*sim.Request, []SessionBlueprint, error) {
 	if trace == nil || len(trace.Records) == 0 {
 		return nil, nil, fmt.Errorf("empty trace")
 	}
@@ -159,11 +161,10 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeOverrideU
 			outputSeq[i] = rec.OutputTokens
 		}
 
-		// Build think time: override or derive from inter-round arrival gaps
-		var thinkTimeSampler LengthSampler
-		var thinkTimeUs int64
-		if thinkTimeOverrideUs > 0 {
-			thinkTimeUs = thinkTimeOverrideUs
+		// Build think time: use provided sampler or derive from inter-round arrival gaps.
+		var sessionThinkTimeSampler LengthSampler
+		if thinkTimeSampler != nil {
+			sessionThinkTimeSampler = thinkTimeSampler // stateless: safe to share across sessions
 		} else if len(rounds) > 1 {
 			thinkTimes := make([]int, len(rounds)-1)
 			for i := 1; i < len(rounds); i++ {
@@ -176,7 +177,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeOverrideU
 				}
 				thinkTimes[i-1] = int(gap)
 			}
-			thinkTimeSampler = &SequenceSampler{values: thinkTimes}
+			sessionThinkTimeSampler = &SequenceSampler{values: thinkTimes}
 		}
 
 		// Per-session RNG for deterministic token ID generation (INV-6)
@@ -227,8 +228,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeOverrideU
 			SessionID:        sessionID,
 			ClientID:         r0.ClientID,
 			MaxRounds:        len(rounds),
-			ThinkTimeUs:      thinkTimeUs,
-			ThinkTimeSampler: thinkTimeSampler,
+			ThinkTimeSampler: sessionThinkTimeSampler,
 			Horizon:          horizon,
 			InputSampler:     &SequenceSampler{values: inputSeq[1:]},  // rounds 1..N
 			OutputSampler:    &SequenceSampler{values: outputSeq[1:]}, // rounds 1..N

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -121,7 +121,7 @@ func TestLoadTraceV2SessionBlueprints_GroupsBySession(t *testing.T) {
 		},
 	}
 
-	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestLoadTraceV2SessionBlueprints_NonSessionPassThrough(t *testing.T) {
 		},
 	}
 
-	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestLoadTraceV2SessionBlueprints_ThinkTimeFromTrace(t *testing.T) {
 		},
 	}
 
-	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestLoadTraceV2SessionBlueprints_SingleRoundSession(t *testing.T) {
 		},
 	}
 
-	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,6 +228,9 @@ func TestLoadTraceV2SessionBlueprints_SingleRoundSession(t *testing.T) {
 }
 
 func TestLoadTraceV2SessionBlueprints_OverrideThinkTime(t *testing.T) {
+	// GIVEN a 2-round session and a ConstantSampler providing 500ms think time
+	// WHEN blueprints are built
+	// THEN the session's ThinkTimeSampler returns 500_000 µs on every call
 	trace := &TraceV2{
 		Records: []TraceRecord{
 			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0},
@@ -235,17 +238,19 @@ func TestLoadTraceV2SessionBlueprints_OverrideThinkTime(t *testing.T) {
 		},
 	}
 
-	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 500_000, 0)
+	sampler := &ConstantSampler{value: 500_000}
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, sampler, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	bp := blueprints[0]
-	if bp.ThinkTimeSampler != nil {
-		t.Error("expected nil ThinkTimeSampler when override provided")
+	if bp.ThinkTimeSampler == nil {
+		t.Fatal("expected ThinkTimeSampler to be set when sampler provided")
 	}
-	if bp.ThinkTimeUs != 500_000 {
-		t.Errorf("ThinkTimeUs = %d, want 500000", bp.ThinkTimeUs)
+	got := bp.ThinkTimeSampler.Sample(nil)
+	if got != 500_000 {
+		t.Errorf("ThinkTimeSampler.Sample() = %d, want 500000 µs", got)
 	}
 }
 
@@ -260,7 +265,7 @@ func TestLoadTraceV2SessionBlueprints_NonMonotoneGapClamped(t *testing.T) {
 		},
 	}
 
-	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -285,7 +290,7 @@ func TestLoadTraceV2SessionBlueprints_NonConsecutiveRoundIndex_Error(t *testing.
 		},
 	}
 
-	_, _, err := LoadTraceV2SessionBlueprints(trace, 42, 0, 0)
+	_, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err == nil {
 		t.Fatal("expected error for non-consecutive round indices, got nil")
 	}


### PR DESCRIPTION
## Summary

- Adds `LognormalSampler` to `sim/workload/distribution.go` — a new `LengthSampler` backend registered as `"lognormal"` in `NewLengthSampler`, usable for both token-length and think-time distributions
- Adds `ParseThinkTimeDist` — parses `type:key=value,...` spec strings (e.g. `lognormal:mu=2.0,sigma=0.6,min=3s,max=30s`) into a `LengthSampler` that produces µs values; supports `s`/`ms`/`us` time suffixes
- Adds `--think-time-dist` flag to `blis replay` for full distribution control; `--think-time-ms` remains as a convenience alias for `constant:<N>ms`
- Updates `LoadTraceV2SessionBlueprints` signature: `thinkTimeOverrideUs int64` → `thinkTimeSampler LengthSampler` (nil = derive from trace gaps)

## Test plan

- [ ] `TestLognormalSampler_MeanMatchesParams` — empirical mean ≈ exp(µ + σ²/2) within 10%
- [ ] `TestLognormalSampler_ClampedToRange` — all samples in [min, max]
- [ ] `TestParseThinkTimeDist_Lognormal_ProducesCorrectRange` — µs values in [3M, 30M] for `min=3s,max=30s`
- [ ] `TestParseThinkTimeDist_Lognormal_MedianMatchesExpected` — median ≈ exp(2.0)×10⁶ µs within 5%
- [ ] `TestParseThinkTimeDist_Constant_Ms/S/Us` — time suffix conversion
- [ ] All existing replay blueprint tests updated and passing (`go test ./...` green)
- [ ] `golangci-lint run ./...` clean

Fixes #1070 

🤖 Generated with [Claude Code](https://claude.com/claude-code)