### PR TITLE
fix(sim): preemption log storm and StepTime idle request inflation (#963)

### DIFF
--- a/sim/kv/cache.go
+++ b/sim/kv/cache.go
@@ -218,7 +218,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 
 		// Cannot allocate enough KV cache blocks
 		if numNewBlocks > kvc.countFreeBlocks() {
-			logrus.Warnf("KV cache full: cannot allocate %d new blocks for req %s", numNewBlocks, req.ID)
+			logrus.Debugf("KV cache full: cannot allocate %d new blocks for req %s", numNewBlocks, req.ID)
 			return false
 		}
 	} else {

--- a/sim/kv/cache_test.go
+++ b/sim/kv/cache_test.go
@@ -1,9 +1,12 @@
 package kv
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -714,6 +717,39 @@ func TestAllocateKVBlocks_ChunkedPrefill_NoPhantomBlocks(t *testing.T) {
 			t.Errorf("block %d has empty Tokens (phantom block)", blk.ID)
 		}
 	}
+}
+
+// BC-1 (#963): AllocateKVBlocks failure must not produce Warn-level output.
+// vLLM proof: kv_cache_manager.py:334-336 returns None silently.
+func TestAllocateKVBlocks_Failure_NoWarnOutput(t *testing.T) {
+	// GIVEN a KV cache with 1 block (16 tokens) that is fully occupied
+	kvc := NewKVCacheState(1, 16)
+	filler := &sim.Request{
+		ID:          "filler",
+		InputTokens: make([]int, 16),
+	}
+	ok := kvc.AllocateKVBlocks(filler, 0, 16, nil)
+	require.True(t, ok, "setup: filler allocation must succeed")
+
+	// Capture log output at Warn level
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.WarnLevel)
+	defer func() {
+		logrus.SetOutput(os.Stderr)
+		logrus.SetLevel(logrus.InfoLevel)
+	}()
+
+	// WHEN a second request tries to allocate and fails
+	victim := &sim.Request{
+		ID:          "victim",
+		InputTokens: make([]int, 16),
+	}
+	ok = kvc.AllocateKVBlocks(victim, 0, 16, nil)
+
+	// THEN allocation fails but no Warn-level output is produced
+	assert.False(t, ok, "allocation must fail (cache full)")
+	assert.Empty(t, buf.String(), "no Warn-level log output expected (BC-1: vLLM returns None silently)")
 }
 
 func TestKVCacheState_SnapshotCachedBlocksFn_FrozenView(t *testing.T) {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -587,8 +587,22 @@ func (sim *Simulator) scheduleBatch(now int64) {
 // executeBatchStep handles Phase 2: model execution (prefill + decode) for all requests
 // in the running batch. Returns the step time advance in ticks.
 func (sim *Simulator) executeBatchStep(now int64) int64 {
-	// Estimate step time via LatencyModel (blackbox or roofline, selected at construction)
-	currStepAdvance := sim.latencyModel.StepTime(sim.RunningBatch.Requests)
+	// Match vLLM's scheduled_running_reqs: only requests that were allocated
+	// tokens by FormBatch participate in the forward pass latency computation.
+	// Requests with NumNewTokens=0 (past Phase 1 break point, token budget
+	// exhaustion, or MaxModelLen boundary) retain their KV blocks and remain
+	// in RunningBatch for the next step, but do not contribute to this step's
+	// compute time. See vllm/v1/core/sched/scheduler.py scheduled_running_reqs.
+	// Note: scheduled may be empty when all requests are idle (e.g., after
+	// Phase 1 preemption cascade). All StepTime backends handle empty batches
+	// correctly (return >= 1), and the max(1, ...) floor below guarantees INV-3.
+	scheduled := make([]*Request, 0, len(sim.RunningBatch.Requests))
+	for _, req := range sim.RunningBatch.Requests {
+		if req.NumNewTokens > 0 {
+			scheduled = append(scheduled, req)
+		}
+	}
+	currStepAdvance := sim.latencyModel.StepTime(scheduled)
 
 	// Add transfer latency from CPU→GPU reloads (0 for single-tier)
 	currStepAdvance += sim.KVCache.ConsumePendingTransferLatency()

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -23,6 +23,110 @@ func (m *fixedOverheadModel) QueueingTime(req *Request) int64      { return 0 }
 func (m *fixedOverheadModel) OutputTokenProcessingTime() int64     { return 0 }
 func (m *fixedOverheadModel) PostDecodeFixedOverhead() int64       { return m.overhead }
 
+// spyLatencyModel records the batch passed to StepTime for inspection.
+// Used by BC-2/BC-3 tests to verify idle request filtering.
+type spyLatencyModel struct {
+	lastBatch []*Request
+}
+
+func (m *spyLatencyModel) StepTime(batch []*Request) int64 {
+	m.lastBatch = batch
+	return 1
+}
+func (m *spyLatencyModel) QueueingTime(req *Request) int64  { return 0 }
+func (m *spyLatencyModel) OutputTokenProcessingTime() int64 { return 0 }
+func (m *spyLatencyModel) PostDecodeFixedOverhead() int64   { return 0 }
+
+// BC-2 (#963): StepTime receives only requests with NumNewTokens > 0.
+// vLLM proof: scheduler.py:870 adds to scheduled_running_reqs only on
+// successful allocation; scheduler.py:1236-1242 builds SchedulerOutput
+// from scheduled_running_reqs, NOT self.running.
+func TestExecuteBatchStep_FiltersIdleRequests_BC2(t *testing.T) {
+	// GIVEN a running batch with 3 requests: 2 active (NumNewTokens > 0), 1 idle (NumNewTokens = 0)
+	spy := &spyLatencyModel{}
+	cfg := SimConfig{
+		KVCacheConfig: NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:   NewBatchConfig(256, 2048, 0),
+		Seed:          42,
+	}
+	kvStore := MustNewKVStoreFromConfig(cfg.KVCacheConfig)
+	s, err := NewSimulator(cfg, kvStore, spy)
+	if err != nil {
+		t.Fatalf("NewSimulator: %v", err)
+	}
+
+	active1 := &Request{ID: "active1", InputTokens: make([]int, 32), OutputTokens: make([]int, 10),
+		ProgressIndex: 32, NumNewTokens: 1, State: StateRunning}
+	active2 := &Request{ID: "active2", InputTokens: make([]int, 16), OutputTokens: make([]int, 5),
+		ProgressIndex: 16, NumNewTokens: 1, State: StateRunning}
+	idle := &Request{ID: "idle", InputTokens: make([]int, 64), OutputTokens: make([]int, 20),
+		ProgressIndex: 64, NumNewTokens: 0, State: StateRunning}
+
+	s.RunningBatch = &Batch{Requests: []*Request{active1, active2, idle}}
+	s.reqNumComputedTokens = map[string]int64{
+		"active1": 32, "active2": 16, "idle": 64,
+	}
+
+	// WHEN executeBatchStep runs
+	s.executeBatchStep(0)
+
+	// THEN StepTime was called with only the 2 active requests (BC-2)
+	if len(spy.lastBatch) != 2 {
+		t.Fatalf("StepTime must receive only active requests, got %d", len(spy.lastBatch))
+	}
+	ids := map[string]bool{}
+	for _, r := range spy.lastBatch {
+		ids[r.ID] = true
+	}
+	if !ids["active1"] || !ids["active2"] {
+		t.Errorf("StepTime batch missing active requests: got %v", ids)
+	}
+	if ids["idle"] {
+		t.Errorf("StepTime batch should NOT contain idle request")
+	}
+}
+
+// BC-3 (#963): Idle requests persist in RunningBatch after executeBatchStep.
+func TestExecuteBatchStep_IdleRequestsPersist_BC3(t *testing.T) {
+	// GIVEN a running batch with 1 active and 1 idle request
+	spy := &spyLatencyModel{}
+	cfg := SimConfig{
+		KVCacheConfig: NewKVCacheConfig(1000, 16, 0, 0, 0, 0),
+		BatchConfig:   NewBatchConfig(256, 2048, 0),
+		Seed:          42,
+	}
+	kvStore := MustNewKVStoreFromConfig(cfg.KVCacheConfig)
+	s, err := NewSimulator(cfg, kvStore, spy)
+	if err != nil {
+		t.Fatalf("NewSimulator: %v", err)
+	}
+
+	active := &Request{ID: "active", InputTokens: make([]int, 32), OutputTokens: make([]int, 10),
+		ProgressIndex: 32, NumNewTokens: 1, State: StateRunning}
+	idle := &Request{ID: "idle", InputTokens: make([]int, 64), OutputTokens: make([]int, 20),
+		ProgressIndex: 64, NumNewTokens: 0, State: StateRunning}
+
+	s.RunningBatch = &Batch{Requests: []*Request{active, idle}}
+	s.reqNumComputedTokens = map[string]int64{"active": 32, "idle": 64}
+
+	// WHEN executeBatchStep runs
+	s.executeBatchStep(0)
+
+	// THEN both requests are still in RunningBatch (idle was not dropped) (BC-3)
+	if len(s.RunningBatch.Requests) != 2 {
+		t.Fatalf("idle requests must persist in RunningBatch, got %d requests", len(s.RunningBatch.Requests))
+	}
+	found := false
+	for _, r := range s.RunningBatch.Requests {
+		if r.ID == "idle" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("idle request was dropped from RunningBatch (BC-3 violation)")
+	}
+}
+
 // BC-1: Simulator.PostDecodeFixedOverhead() delegates to the underlying LatencyModel.
 func TestSimulator_PostDecodeFixedOverhead_DelegatesToModel(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Downgrade `AllocateKVBlocks` failure log from `Warn` to `Debug`, matching vLLM's silent `return None` (`kv_cache_manager.py:334-336`)
- Filter idle requests (`NumNewTokens=0`) from `StepTime` computation, matching vLLM's `scheduled_running_reqs` pattern (`scheduler.py:870,1236-1242`)

## Behavioral Contracts

**BC-1: Silent allocation failure**
- GIVEN `AllocateKVBlocks` is called when the KV cache has insufficient free blocks
- WHEN the allocation check fails
- THEN the function returns `false` without producing any `Warn`-level log output

**BC-2: StepTime receives only active requests**
- GIVEN a running batch with mixed active (`NumNewTokens > 0`) and idle (`NumNewTokens = 0`) requests
- WHEN `executeBatchStep` computes step duration
- THEN `StepTime` is called with only the active requests

**BC-3: Idle requests persist in RunningBatch**
- GIVEN idle requests exist in `RunningBatch` after `FormBatch`
- WHEN `executeBatchStep` and `processCompletions` run
- THEN idle requests remain in `RunningBatch` for the next step

**BC-4: Determinism preserved**
- GIVEN any simulation configuration and seed
- WHEN the simulation runs before and after this change
- THEN completion metrics are identical (INV-6)

## Testing

- `TestAllocateKVBlocks_Failure_NoWarnOutput` — captures logrus output, verifies no Warn on allocation failure
- `TestExecuteBatchStep_FiltersIdleRequests_BC2` — spy model verifies only active requests reach `StepTime`
- `TestExecuteBatchStep_IdleRequestsPersist_BC3` — verifies idle requests are not dropped from batch
- Full suite: `go test ./... -count=1` all pass, `golangci-lint run ./...` 0 issues

## Known Limitation

This PR does NOT fix the Phase 2 head-of-line deadlock identified by @susiejojo ([comment](https://github.com/inference-sim/inference-sim/issues/963#issuecomment-4261128669)). That is tracked in #1061.

## Discovered Issues

- #1061 — Phase 2 head-of-line deadlock when front WaitQ request cannot allocate KV blocks
- #1062 — TTFT recording lacks TTFTSet guard (pre-existing, found during convergence review)

Fixes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)