### PR TITLE
feat(observe): add --min-tokens flag for exact output length control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ go build -o blis main.go
   --max-concurrency 32 --unconstrained-output \
   --trace-header trace.yaml --trace-data trace.csv
 
-# Observe with exact output length control (min_tokens=output_tokens forces vLLM to suppress EOS)
+# Observe with exact output length control (min_tokens=output_tokens defers EOS to target length; vLLM/compatible servers only)
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
   --rate 10 --num-requests 100 --output-tokens 2048 --min-tokens 2048 \
   --trace-header trace.yaml --trace-data trace.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ go build -o blis main.go
   --max-concurrency 32 --unconstrained-output \
   --trace-header trace.yaml --trace-data trace.csv
 
+# Observe with exact output length control (min_tokens=output_tokens forces vLLM to suppress EOS)
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --rate 10 --num-requests 100 --output-tokens 2048 --min-tokens 2048 \
+  --trace-header trace.yaml --trace-data trace.csv
+
 # Observe with ITL (inter-token latency) recording for streaming requests
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
   --workload chatbot --rate 10 --num-requests 100 \

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -245,8 +245,13 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 		if choice, ok := choices[0].(map[string]interface{}); ok {
 			if fr, ok := choice["finish_reason"].(string); ok {
 				record.FinishReason = fr
-				if (fr == "length" || fr == "abort") && minTokens == 0 {
+				// "length" is expected when min_tokens == max_tokens; suppress noise.
+				// "abort" is a server error (OOM, preemption) regardless of min_tokens.
+				if fr == "length" && minTokens == 0 {
 					logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, fr)
+				}
+				if fr == "abort" {
+					logrus.Warnf("observe: request %d finish_reason=%q (server aborted request; timing data unreliable)", record.RequestID, fr)
 				}
 			}
 		}
@@ -318,9 +323,13 @@ func (c *RealClient) handleStreamingResponse(resp *http.Response, record *Reques
 		}
 	}
 
-	// Warn on problematic finish_reason values (suppress when min_tokens is set: length is expected)
-	if (record.FinishReason == "length" || record.FinishReason == "abort") && minTokens == 0 {
+	// "length" is expected when min_tokens == max_tokens; suppress noise.
+	// "abort" is a server error (OOM, preemption) regardless of min_tokens.
+	if record.FinishReason == "length" && minTokens == 0 {
 		logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, record.FinishReason)
+	}
+	if record.FinishReason == "abort" {
+		logrus.Warnf("observe: request %d finish_reason=%q (server aborted request; timing data unreliable)", record.RequestID, record.FinishReason)
 	}
 
 	return record, nil

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -64,6 +64,7 @@ type PendingRequest struct {
 	PrefixLength    int
 	Prompt          string
 	Unconstrained   bool
+	MinTokens       int
 	DeadlineUs      int64
 }
 
@@ -110,6 +111,11 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 		body["max_tokens"] = math.MaxInt32
 	}
 	// chat + unconstrained: omit max_tokens entirely (server uses model default)
+
+	if req.MinTokens > 0 {
+		body["min_tokens"] = req.MinTokens
+	}
+
 	// Set prompt/messages and endpoint based on API format.
 	var endpoint string
 	switch c.apiFormat {

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultMaxOutputTokens = 2048
+
 // RealClient sends requests to an OpenAI-compatible inference server.
 type RealClient struct {
 	baseURL    string
@@ -100,10 +102,10 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 	if !req.Unconstrained {
 		maxTokens := req.MaxOutputTokens
 		if maxTokens < 0 {
-			logrus.Warnf("PendingRequest.MaxOutputTokens is negative (%d), using default 2048", maxTokens)
+			logrus.Warnf("PendingRequest.MaxOutputTokens is negative (%d), using default %d", maxTokens, defaultMaxOutputTokens)
 		}
 		if maxTokens <= 0 {
-			maxTokens = 2048
+			maxTokens = defaultMaxOutputTokens
 		}
 		body["max_tokens"] = maxTokens
 	} else if c.apiFormat == "completions" {
@@ -184,7 +186,7 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 	if !req.Unconstrained {
 		effectiveMax = req.MaxOutputTokens
 		if effectiveMax <= 0 {
-			effectiveMax = 2048
+			effectiveMax = defaultMaxOutputTokens
 		}
 	} else if c.apiFormat == "completions" {
 		effectiveMax = math.MaxInt32
@@ -195,6 +197,23 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 		return c.handleStreamingResponse(resp, record, req.MinTokens, effectiveMax)
 	}
 	return c.handleNonStreamingResponse(resp, record, req.MinTokens, effectiveMax)
+}
+
+// warnOnFinishReason emits diagnostic warnings for notable finish_reason values.
+// It suppresses the "length" truncation warning in exact-length mode (min_tokens >= max_tokens),
+// always warns on "abort" (server-side error regardless of intent), and warns when
+// finish_reason="stop" but outputTokens < minTokens (silent min_tokens non-support detection).
+func warnOnFinishReason(requestID int, finishReason string, minTokens, effectiveMax, outputTokens int) {
+	exactLengthMode := minTokens > 0 && effectiveMax > 0 && minTokens >= effectiveMax
+	if finishReason == "length" && !exactLengthMode {
+		logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", requestID, finishReason)
+	}
+	if finishReason == "abort" {
+		logrus.Warnf("observe: request %d finish_reason=%q (server aborted request; timing data unreliable)", requestID, finishReason)
+	}
+	if minTokens > 0 && finishReason == "stop" && outputTokens > 0 && outputTokens < minTokens {
+		logrus.Warnf("observe: request %d generated %d tokens (< min_tokens=%d); server may not support min_tokens", requestID, outputTokens, minTokens)
+	}
 }
 
 // firstByteReader wraps an io.Reader and captures the timestamp when the first byte is received.
@@ -257,22 +276,11 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 		if choice, ok := choices[0].(map[string]interface{}); ok {
 			if fr, ok := choice["finish_reason"].(string); ok {
 				record.FinishReason = fr
-				// Suppress "length" warning only in exact-length mode (min_tokens >= max_tokens):
-				// vLLM stops at max_tokens as intended. If min_tokens < max_tokens, truncation
-				// is still unexpected and should be flagged.
-				// "abort" is a server error (preemption, client disconnect, engine cancellation)
-				// — always warn regardless of min_tokens.
-				exactLengthMode := minTokens > 0 && effectiveMax > 0 && minTokens >= effectiveMax
-				if fr == "length" && !exactLengthMode {
-					logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, fr)
-				}
-				if fr == "abort" {
-					logrus.Warnf("observe: request %d finish_reason=%q (server aborted request; timing data unreliable)", record.RequestID, fr)
-				}
 			}
 		}
 	}
 
+	warnOnFinishReason(record.RequestID, record.FinishReason, minTokens, effectiveMax, record.OutputTokens)
 	return record, nil
 }
 
@@ -339,19 +347,7 @@ func (c *RealClient) handleStreamingResponse(resp *http.Response, record *Reques
 		}
 	}
 
-	// Suppress "length" warning only in exact-length mode (min_tokens >= max_tokens):
-	// vLLM stops at max_tokens as intended. If min_tokens < max_tokens, truncation
-	// is still unexpected and should be flagged.
-	// "abort" is a server error (preemption, client disconnect, engine cancellation)
-	// — always warn regardless of min_tokens.
-	exactLengthMode := minTokens > 0 && effectiveMax > 0 && minTokens >= effectiveMax
-	if record.FinishReason == "length" && !exactLengthMode {
-		logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, record.FinishReason)
-	}
-	if record.FinishReason == "abort" {
-		logrus.Warnf("observe: request %d finish_reason=%q (server aborted request; timing data unreliable)", record.RequestID, record.FinishReason)
-	}
-
+	warnOnFinishReason(record.RequestID, record.FinishReason, minTokens, effectiveMax, record.OutputTokens)
 	return record, nil
 }
 

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -180,9 +180,9 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 	}
 
 	if req.Streaming {
-		return c.handleStreamingResponse(resp, record)
+		return c.handleStreamingResponse(resp, record, req.MinTokens)
 	}
-	return c.handleNonStreamingResponse(resp, record)
+	return c.handleNonStreamingResponse(resp, record, req.MinTokens)
 }
 
 // firstByteReader wraps an io.Reader and captures the timestamp when the first byte is received.
@@ -199,7 +199,7 @@ func (f *firstByteReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *RequestRecord) (*RequestRecord, error) {
+func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *RequestRecord, minTokens int) (*RequestRecord, error) {
 	// Wrap body to capture first-byte timing (BC-2).
 	// Note: for non-streaming HTTP, real servers send the entire response after generation
 	// completes, so FirstChunkTimeUs approximates "server finished + transfer started,"
@@ -245,7 +245,7 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 		if choice, ok := choices[0].(map[string]interface{}); ok {
 			if fr, ok := choice["finish_reason"].(string); ok {
 				record.FinishReason = fr
-				if fr == "length" || fr == "abort" {
+				if (fr == "length" || fr == "abort") && minTokens == 0 {
 					logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, fr)
 				}
 			}
@@ -255,7 +255,7 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 	return record, nil
 }
 
-func (c *RealClient) handleStreamingResponse(resp *http.Response, record *RequestRecord) (*RequestRecord, error) {
+func (c *RealClient) handleStreamingResponse(resp *http.Response, record *RequestRecord, minTokens int) (*RequestRecord, error) {
 	scanner := bufio.NewScanner(resp.Body)
 	chunkCount := 0
 	var lastUsage map[string]interface{}
@@ -318,8 +318,8 @@ func (c *RealClient) handleStreamingResponse(resp *http.Response, record *Reques
 		}
 	}
 
-	// Warn on problematic finish_reason values
-	if record.FinishReason == "length" || record.FinishReason == "abort" {
+	// Warn on problematic finish_reason values (suppress when min_tokens is set: length is expected)
+	if (record.FinishReason == "length" || record.FinishReason == "abort") && minTokens == 0 {
 		logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, record.FinishReason)
 	}
 

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -179,10 +179,22 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 		return record, nil
 	}
 
-	if req.Streaming {
-		return c.handleStreamingResponse(resp, record, req.MinTokens)
+	// Compute effective max_tokens for warning suppression in handlers.
+	effectiveMax := 0
+	if !req.Unconstrained {
+		effectiveMax = req.MaxOutputTokens
+		if effectiveMax <= 0 {
+			effectiveMax = 2048
+		}
+	} else if c.apiFormat == "completions" {
+		effectiveMax = math.MaxInt32
 	}
-	return c.handleNonStreamingResponse(resp, record, req.MinTokens)
+	// unconstrained chat: effectiveMax=0 (no max_tokens sent; warn on length if it occurs)
+
+	if req.Streaming {
+		return c.handleStreamingResponse(resp, record, req.MinTokens, effectiveMax)
+	}
+	return c.handleNonStreamingResponse(resp, record, req.MinTokens, effectiveMax)
 }
 
 // firstByteReader wraps an io.Reader and captures the timestamp when the first byte is received.
@@ -199,7 +211,7 @@ func (f *firstByteReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *RequestRecord, minTokens int) (*RequestRecord, error) {
+func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *RequestRecord, minTokens, effectiveMax int) (*RequestRecord, error) {
 	// Wrap body to capture first-byte timing (BC-2).
 	// Note: for non-streaming HTTP, real servers send the entire response after generation
 	// completes, so FirstChunkTimeUs approximates "server finished + transfer started,"
@@ -245,9 +257,13 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 		if choice, ok := choices[0].(map[string]interface{}); ok {
 			if fr, ok := choice["finish_reason"].(string); ok {
 				record.FinishReason = fr
-				// "length" is expected when min_tokens == max_tokens; suppress noise.
-				// "abort" is a server error (OOM, preemption) regardless of min_tokens.
-				if fr == "length" && minTokens == 0 {
+				// Suppress "length" warning only in exact-length mode (min_tokens >= max_tokens):
+				// vLLM stops at max_tokens as intended. If min_tokens < max_tokens, truncation
+				// is still unexpected and should be flagged.
+				// "abort" is a server error (preemption, client disconnect, engine cancellation)
+				// — always warn regardless of min_tokens.
+				exactLengthMode := minTokens > 0 && effectiveMax > 0 && minTokens >= effectiveMax
+				if fr == "length" && !exactLengthMode {
 					logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, fr)
 				}
 				if fr == "abort" {
@@ -260,7 +276,7 @@ func (c *RealClient) handleNonStreamingResponse(resp *http.Response, record *Req
 	return record, nil
 }
 
-func (c *RealClient) handleStreamingResponse(resp *http.Response, record *RequestRecord, minTokens int) (*RequestRecord, error) {
+func (c *RealClient) handleStreamingResponse(resp *http.Response, record *RequestRecord, minTokens, effectiveMax int) (*RequestRecord, error) {
 	scanner := bufio.NewScanner(resp.Body)
 	chunkCount := 0
 	var lastUsage map[string]interface{}
@@ -323,9 +339,13 @@ func (c *RealClient) handleStreamingResponse(resp *http.Response, record *Reques
 		}
 	}
 
-	// "length" is expected when min_tokens == max_tokens; suppress noise.
-	// "abort" is a server error (OOM, preemption) regardless of min_tokens.
-	if record.FinishReason == "length" && minTokens == 0 {
+	// Suppress "length" warning only in exact-length mode (min_tokens >= max_tokens):
+	// vLLM stops at max_tokens as intended. If min_tokens < max_tokens, truncation
+	// is still unexpected and should be flagged.
+	// "abort" is a server error (preemption, client disconnect, engine cancellation)
+	// — always warn regardless of min_tokens.
+	exactLengthMode := minTokens > 0 && effectiveMax > 0 && minTokens >= effectiveMax
+	if record.FinishReason == "length" && !exactLengthMode {
 		logrus.Warnf("observe: request %d finish_reason=%q (output may be truncated)", record.RequestID, record.FinishReason)
 	}
 	if record.FinishReason == "abort" {

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -142,7 +142,7 @@ func init() {
 	observeCmd.Flags().IntVar(&observePrefixTokens, "prefix-tokens", 0, "Shared prefix token count (distribution mode)")
 	observeCmd.Flags().StringVar(&observeAPIFormat, "api-format", "completions", "API format: 'completions' (/v1/completions) or 'chat' (/v1/chat/completions)")
 	observeCmd.Flags().BoolVar(&observeUnconstrainedOutput, "unconstrained-output", false, "Do not set max_tokens (let server decide output length)")
-	observeCmd.Flags().IntVar(&observeMinTokens, "min-tokens", 0, "Set min_tokens in request body (forces server to generate at least N tokens before EOS; 0 = omit field)")
+	observeCmd.Flags().IntVar(&observeMinTokens, "min-tokens", 0, "Set min_tokens in request body (requests server to generate at least N tokens before EOS; 0 = omit field)")
 	observeCmd.Flags().Float64Var(&observeRttMs, "rtt-ms", 0, "Measured network round-trip time in milliseconds (recorded in trace header)")
 
 	// ITL recording (optional, opt-in)

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -79,8 +79,10 @@ API format: Use --api-format=chat for servers that expose /v1/chat/completions
 which uses /v1/completions with a "prompt" field.
 
 Output control: Use --unconstrained-output to let the server decide output length
-(omits max_tokens for chat, sends large value for completions). Default constrains
-output to the workload spec's sampled MaxOutputTokens.
+(omits max_tokens for chat, sends large value for completions). Use --min-tokens N
+to force the server to generate at least N tokens before EOS (set equal to
+--output-tokens for exact token counts). Default constrains output to the workload
+spec's sampled MaxOutputTokens.
 
 Network calibration: Use --rtt-ms to record measured network round-trip time
 in the trace header for calibration normalization.
@@ -333,6 +335,19 @@ func runObserve(cmd *cobra.Command, _ []string) {
 
 	if len(wl.Requests) == 0 {
 		logrus.Warn("No requests generated — writing empty trace")
+	}
+
+	// Warn if --min-tokens exceeds max_tokens for any request: vLLM rejects such requests.
+	if observeMinTokens > 0 && !observeUnconstrainedOutput {
+		mismatch := 0
+		for _, r := range wl.Requests {
+			if observeMinTokens > r.MaxOutputLen {
+				mismatch++
+			}
+		}
+		if mismatch > 0 {
+			logrus.Warnf("--min-tokens=%d exceeds max_tokens for %d/%d requests; those requests will likely be rejected by the server", observeMinTokens, mismatch, len(wl.Requests))
+		}
 	}
 
 	// Enable streaming on all requests when --record-itl is set (BC-6)

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -256,6 +256,9 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	if observeRttMs < 0 || math.IsNaN(observeRttMs) || math.IsInf(observeRttMs, 0) {
 		logrus.Fatalf("--rtt-ms must be a finite value >= 0, got %v", observeRttMs)
 	}
+	if observeMinTokens < 0 {
+		logrus.Fatalf("--min-tokens must be >= 0, got %d", observeMinTokens)
+	}
 
 	// Generate workload
 	var spec *workload.WorkloadSpec

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -343,6 +343,9 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	// Warn if --min-tokens exceeds the effective max_tokens for any request.
 	if observeMinTokens > 0 && !observeUnconstrainedOutput {
 		if n := countMinTokensMismatch(observeMinTokens, wl.Requests); n > 0 {
+			if n == len(wl.Requests) {
+				logrus.Fatalf("--min-tokens=%d exceeds max_tokens for all %d requests; all requests will be rejected by the server", observeMinTokens, n)
+			}
 			logrus.Warnf("--min-tokens=%d exceeds max_tokens for %d/%d requests; those requests will likely be rejected by the server", observeMinTokens, n, len(wl.Requests))
 		}
 	}
@@ -723,7 +726,7 @@ func countMinTokensMismatch(minTokens int, requests []*sim.Request) int {
 	for _, r := range requests {
 		effectiveMax := r.MaxOutputLen
 		if effectiveMax <= 0 {
-			effectiveMax = 2048
+			effectiveMax = defaultMaxOutputTokens
 		}
 		if minTokens > effectiveMax {
 			n++

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -81,8 +81,8 @@ which uses /v1/completions with a "prompt" field.
 Output control: Use --unconstrained-output to let the server decide output length
 (omits max_tokens for chat, sends large value for completions). Use --min-tokens N
 to force the server to generate at least N tokens before EOS (set equal to
---output-tokens with --output-tokens-stdev 0 for exact token counts). Default constrains output to the workload
-spec's sampled MaxOutputTokens.
+--output-tokens with --output-tokens-stdev 0 for exact token counts).
+Default constrains output to the workload spec's sampled MaxOutputTokens.
 
 Network calibration: Use --rtt-ms to record measured network round-trip time
 in the trace header for calibration normalization.

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -81,7 +81,7 @@ which uses /v1/completions with a "prompt" field.
 Output control: Use --unconstrained-output to let the server decide output length
 (omits max_tokens for chat, sends large value for completions). Use --min-tokens N
 to force the server to generate at least N tokens before EOS (set equal to
---output-tokens for exact token counts). Default constrains output to the workload
+--output-tokens with --output-tokens-stdev 0 for exact token counts). Default constrains output to the workload
 spec's sampled MaxOutputTokens.
 
 Network calibration: Use --rtt-ms to record measured network round-trip time
@@ -142,7 +142,7 @@ func init() {
 	observeCmd.Flags().IntVar(&observePrefixTokens, "prefix-tokens", 0, "Shared prefix token count (distribution mode)")
 	observeCmd.Flags().StringVar(&observeAPIFormat, "api-format", "completions", "API format: 'completions' (/v1/completions) or 'chat' (/v1/chat/completions)")
 	observeCmd.Flags().BoolVar(&observeUnconstrainedOutput, "unconstrained-output", false, "Do not set max_tokens (let server decide output length)")
-	observeCmd.Flags().IntVar(&observeMinTokens, "min-tokens", 0, "Set min_tokens in request body (forces server to generate at least N tokens before EOS)")
+	observeCmd.Flags().IntVar(&observeMinTokens, "min-tokens", 0, "Set min_tokens in request body (forces server to generate at least N tokens before EOS; 0 = omit field)")
 	observeCmd.Flags().Float64Var(&observeRttMs, "rtt-ms", 0, "Measured network round-trip time in milliseconds (recorded in trace header)")
 
 	// ITL recording (optional, opt-in)
@@ -340,16 +340,10 @@ func runObserve(cmd *cobra.Command, _ []string) {
 		logrus.Warn("No requests generated — writing empty trace")
 	}
 
-	// Warn if --min-tokens exceeds max_tokens for any request: vLLM rejects such requests.
+	// Warn if --min-tokens exceeds the effective max_tokens for any request.
 	if observeMinTokens > 0 && !observeUnconstrainedOutput {
-		mismatch := 0
-		for _, r := range wl.Requests {
-			if observeMinTokens > r.MaxOutputLen {
-				mismatch++
-			}
-		}
-		if mismatch > 0 {
-			logrus.Warnf("--min-tokens=%d exceeds max_tokens for %d/%d requests; those requests will likely be rejected by the server", observeMinTokens, mismatch, len(wl.Requests))
+		if n := countMinTokensMismatch(observeMinTokens, wl.Requests); n > 0 {
+			logrus.Warnf("--min-tokens=%d exceeds max_tokens for %d/%d requests; those requests will likely be rejected by the server", observeMinTokens, n, len(wl.Requests))
 		}
 	}
 
@@ -719,6 +713,23 @@ func adaptForSessionManager(original *sim.Request, record *RequestRecord) *sim.R
 	}
 
 	return adapted
+}
+
+// countMinTokensMismatch returns the number of requests whose effective max_tokens
+// is less than minTokens. Mirrors Send()'s MaxOutputTokens<=0 → 2048 fallback so
+// the warning fires only for requests that will actually be rejected.
+func countMinTokensMismatch(minTokens int, requests []*sim.Request) int {
+	n := 0
+	for _, r := range requests {
+		effectiveMax := r.MaxOutputLen
+		if effectiveMax <= 0 {
+			effectiveMax = 2048
+		}
+		if minTokens > effectiveMax {
+			n++
+		}
+	}
+	return n
 }
 
 // tokensToPrompt converts token IDs into a diverse prompt string using

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -56,6 +56,7 @@ var (
 	observeDefaultsFilePath    string
 	observeRecordITL           bool
 	observeITLOutput           string
+	observeMinTokens           int
 )
 
 var observeCmd = &cobra.Command{
@@ -139,6 +140,7 @@ func init() {
 	observeCmd.Flags().IntVar(&observePrefixTokens, "prefix-tokens", 0, "Shared prefix token count (distribution mode)")
 	observeCmd.Flags().StringVar(&observeAPIFormat, "api-format", "completions", "API format: 'completions' (/v1/completions) or 'chat' (/v1/chat/completions)")
 	observeCmd.Flags().BoolVar(&observeUnconstrainedOutput, "unconstrained-output", false, "Do not set max_tokens (let server decide output length)")
+	observeCmd.Flags().IntVar(&observeMinTokens, "min-tokens", 0, "Set min_tokens in request body (forces server to generate at least N tokens before EOS)")
 	observeCmd.Flags().Float64Var(&observeRttMs, "rtt-ms", 0, "Measured network round-trip time in milliseconds (recorded in trace header)")
 
 	// ITL recording (optional, opt-in)
@@ -408,7 +410,7 @@ func runObserve(cmd *cobra.Command, _ []string) {
 
 	// Run orchestrator
 	startTime := time.Now()
-	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, observeNoStreaming, observeMaxConcur, observeWarmup, prefixes, prefixLengths, observeUnconstrainedOutput, observeRecordITL, tokensPerWord)
+	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, observeNoStreaming, observeMaxConcur, observeWarmup, prefixes, prefixLengths, observeUnconstrainedOutput, observeMinTokens, observeRecordITL, tokensPerWord)
 	logrus.Infof("Observation wall-clock time: %.3fs", time.Since(startTime).Seconds())
 
 	// Export trace (BC-4)
@@ -483,6 +485,7 @@ func runObserveOrchestrator(
 	prefixes map[string]string,
 	prefixLengths map[string]int,
 	unconstrained bool,
+	minTokens int,
 	recordITL bool,
 	tokensPerWord float64,
 ) {
@@ -540,7 +543,7 @@ func runObserveOrchestrator(
 		defer wg.Done()
 		defer func() { <-semaphore }() // release concurrency slot
 
-		pending := requestToPending(req, idx, noStreaming, unconstrained, prefixes, prefixLengths, tokensPerWord)
+		pending := requestToPending(req, idx, noStreaming, unconstrained, minTokens, prefixes, prefixLengths, tokensPerWord)
 		record, sendErr := client.Send(ctx, pending)
 		if sendErr != nil {
 			logrus.Warnf("request %d: Send returned error: %v", idx, sendErr)
@@ -726,7 +729,7 @@ func tokensToPrompt(tokens []int, wordCount int) string {
 // see buildPrefixStrings). Both may be nil if no prefix groups exist.
 // tokensPerWord is the calibrated ratio from calibratePrefixTokenRatio; it scales
 // word count so the server tokenizes the prompt to approximately len(InputTokens) tokens.
-func requestToPending(req *sim.Request, reqIndex int, noStreaming, unconstrained bool, prefixes map[string]string, prefixLengths map[string]int, tokensPerWord float64) *PendingRequest {
+func requestToPending(req *sim.Request, reqIndex int, noStreaming, unconstrained bool, minTokens int, prefixes map[string]string, prefixLengths map[string]int, tokensPerWord float64) *PendingRequest {
 	// Scale token count to word count using calibrated ratio (BC-3, BC-6).
 	if tokensPerWord <= 0 {
 		tokensPerWord = 1.0
@@ -776,6 +779,7 @@ func requestToPending(req *sim.Request, reqIndex int, noStreaming, unconstrained
 		PrefixLength:    req.PrefixLength,
 		Prompt:          prompt,
 		Unconstrained:   unconstrained,
+		MinTokens:       minTokens,
 		DeadlineUs:      req.Deadline,
 	}
 }

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -148,7 +148,7 @@ func TestObserveOrchestrator_OpenLoop_ConservationAndConcurrency(t *testing.T) {
 
 	// WHEN dispatching with max-concurrency 2 and 0 warmup
 	ctx := context.Background()
-	runObserveOrchestrator(ctx, client, recorder, nil, requests, false, 2, 0, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(ctx, client, recorder, nil, requests, false, 2, 0, nil, nil, false, 0, false, 1.0)
 
 	// THEN: BC-6 conservation: all 5 requests recorded
 	records := recorder.Records()
@@ -215,7 +215,7 @@ func TestObserveOrchestrator_SessionFollowUp_GeneratesRound2(t *testing.T) {
 	sessionMgr := workload.NewSessionManager(wl.Sessions)
 
 	ctx := context.Background()
-	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, false, 10, 0, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, false, 10, 0, nil, nil, false, 0, false, 1.0)
 
 	records := recorder.Records()
 	if len(records) < 2 {
@@ -282,7 +282,7 @@ func TestObserveOrchestrator_SessionError_CancelsSession(t *testing.T) {
 	sessionMgr := workload.NewSessionManager(wl.Sessions)
 
 	ctx := context.Background()
-	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, false, 10, 0, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, false, 10, 0, nil, nil, false, 0, false, 1.0)
 
 	records := recorder.Records()
 	for _, r := range records {
@@ -314,7 +314,7 @@ func TestObserveOrchestrator_WarmupExclusion(t *testing.T) {
 
 	client := NewRealClient(server.URL, "", "test-model", "vllm")
 	recorder := &Recorder{}
-	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 2, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 2, nil, nil, false, 0, false, 1.0)
 
 	records := recorder.Records()
 	if len(records) != 3 {
@@ -342,7 +342,7 @@ func TestObserveOrchestrator_WarmupExceedsTotal(t *testing.T) {
 
 	client := NewRealClient(server.URL, "", "test-model", "vllm")
 	recorder := &Recorder{}
-	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 5, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 5, nil, nil, false, 0, false, 1.0)
 
 	records := recorder.Records()
 	if len(records) != 0 {
@@ -381,7 +381,7 @@ func TestObserveOrchestrator_RecordITL_CapturesChunkTimestamps(t *testing.T) {
 
 	client := NewRealClient(server.URL, "", "test-model", "vllm")
 	recorder := &Recorder{}
-	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, true, 1.0)
+	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, 0, true, 1.0)
 
 	// THEN ITL records are captured
 	itlRecords := recorder.ITLRecords()
@@ -422,7 +422,7 @@ func TestObserveOrchestrator_TimestampOrdering(t *testing.T) {
 
 	client := NewRealClient(server.URL, "", "test-model", "vllm")
 	recorder := &Recorder{}
-	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, 0, false, 1.0)
 
 	records := recorder.Records()
 	if len(records) != 1 {
@@ -462,7 +462,7 @@ func TestObserveOrchestrator_TraceV2RoundTrip(t *testing.T) {
 
 	client := NewRealClient(server.URL, "", "test-model", "vllm")
 	recorder := &Recorder{}
-	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, false, 1.0)
+	runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 10, 0, nil, nil, false, 0, false, 1.0)
 
 	headerPath := filepath.Join(t.TempDir(), "header.yaml")
 	dataPath := filepath.Join(t.TempDir(), "data.csv")
@@ -520,7 +520,7 @@ func TestObserveOrchestrator_ErrorStormDrain(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 5, 0, nil, nil, false, false, 1.0)
+		runObserveOrchestrator(context.Background(), client, recorder, nil, requests, false, 5, 0, nil, nil, false, 0, false, 1.0)
 		close(done)
 	}()
 
@@ -564,7 +564,7 @@ func TestObserveOrchestrator_ContextCancellation(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runObserveOrchestrator(ctx, client, recorder, nil, requests, false, 2, 0, nil, nil, false, false, 1.0)
+		runObserveOrchestrator(ctx, client, recorder, nil, requests, false, 2, 0, nil, nil, false, 0, false, 1.0)
 		close(done)
 	}()
 
@@ -667,7 +667,7 @@ func TestRequestToPending_PrependsPrefixString(t *testing.T) {
 		PrefixLength: 64,
 	}
 
-	pending := requestToPending(req, 0, false, false, prefixes, prefixLengths, 1.0)
+	pending := requestToPending(req, 0, false, false, 0, prefixes, prefixLengths, 1.0)
 
 	// PrefixGroup and PrefixLength propagated to PendingRequest
 	if pending.PrefixGroup != "shared" {
@@ -693,7 +693,7 @@ func TestRequestToPending_PrependsPrefixString(t *testing.T) {
 		ID:          "test2",
 		InputTokens: []int{5, 15, 25, 35, 45, 55, 65, 75, 85, 95},
 	}
-	pendingNoPrefix := requestToPending(reqNoPrefix, 1, false, false, prefixes, prefixLengths, 1.0)
+	pendingNoPrefix := requestToPending(reqNoPrefix, 1, false, false, 0, prefixes, prefixLengths, 1.0)
 	// Without prefix group, prompt should not start with the group prefix string
 	if strings.HasPrefix(pendingNoPrefix.Prompt, "alpha bravo charlie ") {
 		t.Error("request without prefix group should not have prefix group's prefix string")
@@ -713,17 +713,17 @@ func TestRequestToPending_UsesPerRequestStreaming(t *testing.T) {
 	}
 
 	// BC-1 / BC-3: without global override, per-request value propagates
-	p1 := requestToPending(streamingReq, 0, false, false, nil, nil, 1.0)
+	p1 := requestToPending(streamingReq, 0, false, false, 0, nil, nil, 1.0)
 	if !p1.Streaming {
 		t.Error("expected Streaming=true for streaming request when noStreaming=false")
 	}
-	p2 := requestToPending(nonStreamingReq, 1, false, false, nil, nil, 1.0)
+	p2 := requestToPending(nonStreamingReq, 1, false, false, 0, nil, nil, 1.0)
 	if p2.Streaming {
 		t.Error("expected Streaming=false for non-streaming request when noStreaming=false")
 	}
 
 	// BC-2: --no-streaming overrides per-request value to false
-	p3 := requestToPending(streamingReq, 2, true, false, nil, nil, 1.0)
+	p3 := requestToPending(streamingReq, 2, true, false, 0, nil, nil, 1.0)
 	if p3.Streaming {
 		t.Error("expected Streaming=false when noStreaming=true overrides req.Streaming=true")
 	}
@@ -860,7 +860,7 @@ func TestRequestToPending_SuffixUsesTokenCountNotWordCount(t *testing.T) {
 		InputTokens: suffixTokens,
 		PrefixGroup: "scaled",
 	}
-	pending := requestToPending(req, 0, false, false, prefixes, prefixLengths, 1.0)
+	pending := requestToPending(req, 0, false, false, 0, prefixes, prefixLengths, 1.0)
 
 	// Suffix should have 100 words (200 total tokens - 100 prefix tokens at ratio 1.0),
 	// NOT 150 (which would happen if word count leaked into prefixLengths)
@@ -883,8 +883,8 @@ func TestRequestToPending_NoPrefixDiversePrompt(t *testing.T) {
 	}
 
 	// tokensPerWord=1.0 for direct word-to-token mapping
-	p1 := requestToPending(req1, 0, false, false, nil, nil, 1.0)
-	p2 := requestToPending(req2, 1, false, false, nil, nil, 1.0)
+	p1 := requestToPending(req1, 0, false, false, 0, nil, nil, 1.0)
+	p2 := requestToPending(req2, 1, false, false, 0, nil, nil, 1.0)
 
 	// BC-2: different token IDs -> different prompts
 	if p1.Prompt == p2.Prompt {
@@ -914,7 +914,7 @@ func TestRequestToPending_WordCountScaledByTokensPerWord(t *testing.T) {
 		InputTokens: tokens,
 	}
 
-	pending := requestToPending(req, 0, false, false, nil, nil, 2.0)
+	pending := requestToPending(req, 0, false, false, 0, nil, nil, 2.0)
 	words := strings.Fields(pending.Prompt)
 	if len(words) != 50 {
 		t.Errorf("word count = %d, want 50 (100 tokens / 2.0 tokensPerWord)", len(words))
@@ -932,7 +932,7 @@ func TestRequestToPending_UnknownPrefixGroupFallback(t *testing.T) {
 		InputTokens: []int{3, 17, 42, 88, 61},
 		PrefixGroup: "unknownGroup",
 	}
-	pending := requestToPending(req, 0, false, false, prefixes, prefixLengths, 1.0)
+	pending := requestToPending(req, 0, false, false, 0, prefixes, prefixLengths, 1.0)
 
 	if strings.Contains(pending.Prompt, "hello") {
 		t.Error("unknown prefix group fallback should use vocabulary words, not 'hello'")
@@ -1019,7 +1019,7 @@ func TestRequestToPending_WordCountClampedToOne(t *testing.T) {
 		ID:          "tiny",
 		InputTokens: []int{42},
 	}
-	pending := requestToPending(req, 0, false, false, nil, nil, 2.0)
+	pending := requestToPending(req, 0, false, false, 0, nil, nil, 2.0)
 	words := strings.Fields(pending.Prompt)
 	if len(words) != 1 {
 		t.Errorf("word count = %d, want 1 (clamped minimum)", len(words))
@@ -1065,6 +1065,61 @@ func TestObserveCmd_UnconstrainedOutputFlag_Exists(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("--unconstrained-output default: got %q, want %q", f.DefValue, "false")
+	}
+}
+
+func TestObserveCmd_MinTokensFlag_Exists(t *testing.T) {
+	f := observeCmd.Flags().Lookup("min-tokens")
+	if f == nil {
+		t.Fatal("missing expected flag --min-tokens")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("--min-tokens default: got %q, want %q", f.DefValue, "0")
+	}
+}
+
+func TestRequestToPending_MinTokensPropagated(t *testing.T) {
+	req := &sim.Request{
+		ID:          "min-tok",
+		InputTokens: make([]int, 5),
+	}
+	p := requestToPending(req, 0, false, false, 128, nil, nil, 1.0)
+	if p.MinTokens != 128 {
+		t.Errorf("MinTokens = %d, want 128", p.MinTokens)
+	}
+}
+
+func TestSend_MinTokensInBody(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"text": "ok", "finish_reason": "length"},
+			},
+			"usage": map[string]interface{}{"completion_tokens": 10, "prompt_tokens": 5},
+		})
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm")
+
+	// min_tokens > 0: included in body
+	req := &PendingRequest{Prompt: "hello", MaxOutputTokens: 256, MinTokens: 128}
+	_, _ = client.Send(context.Background(), req)
+	if v, ok := receivedBody["min_tokens"]; !ok {
+		t.Error("min_tokens not found in request body")
+	} else if int(v.(float64)) != 128 {
+		t.Errorf("min_tokens = %v, want 128", v)
+	}
+
+	// min_tokens = 0: omitted from body
+	receivedBody = nil
+	req2 := &PendingRequest{Prompt: "hello", MaxOutputTokens: 256, MinTokens: 0}
+	_, _ = client.Send(context.Background(), req2)
+	if _, ok := receivedBody["min_tokens"]; ok {
+		t.Error("min_tokens should be omitted when 0")
 	}
 }
 

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -1123,6 +1123,63 @@ func TestSend_MinTokensInBody(t *testing.T) {
 	}
 }
 
+func TestCountMinTokensMismatch(t *testing.T) {
+	makeReqs := func(maxLens ...int) []*sim.Request {
+		reqs := make([]*sim.Request, len(maxLens))
+		for i, m := range maxLens {
+			reqs[i] = &sim.Request{MaxOutputLen: m}
+		}
+		return reqs
+	}
+
+	tests := []struct {
+		name      string
+		minTokens int
+		requests  []*sim.Request
+		want      int
+	}{
+		{
+			name:      "minTokens=0 skips check",
+			minTokens: 0,
+			requests:  makeReqs(100, 200),
+			want:      0,
+		},
+		{
+			name:      "no mismatch",
+			minTokens: 100,
+			requests:  makeReqs(200, 300, 400),
+			want:      0,
+		},
+		{
+			name:      "some mismatch",
+			minTokens: 150,
+			requests:  makeReqs(100, 200, 300),
+			want:      1,
+		},
+		{
+			name:      "MaxOutputLen=0 uses 2048 fallback, no mismatch",
+			minTokens: 100,
+			requests:  makeReqs(0, 0),
+			want:      0,
+		},
+		{
+			name:      "MaxOutputLen=0 uses 2048 fallback, triggers mismatch",
+			minTokens: 3000,
+			requests:  makeReqs(0, 4000),
+			want:      1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countMinTokensMismatch(tc.minTokens, tc.requests)
+			if got != tc.want {
+				t.Errorf("countMinTokensMismatch(%d, ...) = %d, want %d", tc.minTokens, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestObserveDistributionDefaults_MatchRunDefaults verifies that observeCmd's eight
 // distribution flag defaults are identical to runCmd's defaults (BC-1).
 //

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -1139,7 +1139,7 @@ func TestCountMinTokensMismatch(t *testing.T) {
 		want      int
 	}{
 		{
-			name:      "minTokens=0 skips check",
+			name:      "minTokens=0 never exceeds effective max",
 			minTokens: 0,
 			requests:  makeReqs(100, 200),
 			want:      0,
@@ -1167,6 +1167,12 @@ func TestCountMinTokensMismatch(t *testing.T) {
 			minTokens: 3000,
 			requests:  makeReqs(0, 4000),
 			want:      1,
+		},
+		{
+			name:      "minTokens equal to effectiveMax is not a mismatch",
+			minTokens: 2048,
+			requests:  makeReqs(0), // effectiveMax=2048, minTokens=2048: not strictly greater
+			want:      0,
 		},
 	}
 

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -648,9 +648,8 @@ func TestRealClient_GIEHeaders_OmittedWhenDefault(t *testing.T) {
 }
 
 // TestSend_AbortAlwaysWarns verifies that finish_reason="abort" produces a warning
-// regardless of MinTokens, since abort is a server-side error, not expected behavior.
-// (finish_reason="length" is suppressed when MinTokens>0 because vLLM stops at
-// max_tokens with length when min_tokens==max_tokens — that is expected.)
+// regardless of MinTokens, since abort is a server-side error (preemption, client
+// disconnect, engine cancellation), not expected behavior.
 func TestSend_AbortAlwaysWarns(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -704,8 +703,8 @@ func TestSend_AbortAlwaysWarns(t *testing.T) {
 }
 
 // TestSend_LengthSuppressedWithMinTokens verifies that finish_reason="length" does NOT
-// produce a warning (i.e., no record-level side effect) when MinTokens > 0, because
-// vLLM stops at max_tokens with finish_reason="length" in the canonical min_tokens==max_tokens case.
+// produce a warning in exact-length mode (MinTokens == MaxOutputTokens), because
+// vLLM stops at max_tokens as intended in the canonical min_tokens==max_tokens case.
 func TestSend_LengthSuppressedWithMinTokens(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -755,6 +754,115 @@ func TestSend_LengthSuppressedWithMinTokens(t *testing.T) {
 				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
 			}
 		})
+	}
+}
+
+// TestSend_MinTokens_ChatFormat verifies that min_tokens is included in the request body
+// for the chat API format, not just the completions format.
+func TestSend_MinTokens_ChatFormat(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "ok"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]interface{}{"completion_tokens": 10, "prompt_tokens": 5},
+		})
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm", WithAPIFormat("chat"))
+
+	req := &PendingRequest{Prompt: "hello", MaxOutputTokens: 256, MinTokens: 64}
+	_, _ = client.Send(context.Background(), req)
+	if v, ok := receivedBody["min_tokens"]; !ok {
+		t.Error("min_tokens not found in chat API request body")
+	} else if int(v.(float64)) != 64 {
+		t.Errorf("min_tokens = %v, want 64", v)
+	}
+}
+
+// TestSend_LengthWarnsWhenMinTokensNotSet verifies that the original truncation warning
+// behaviour is preserved: finish_reason="length" without --min-tokens still fires.
+func TestSend_LengthWarnsWhenMinTokensNotSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		streaming bool
+	}{
+		{"non-streaming", false},
+		{"streaming", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.streaming {
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Fatal("expected http.Flusher")
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":50}}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+					flusher.Flush()
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"choices": []map[string]interface{}{
+							{"text": "ok", "finish_reason": "length"},
+						},
+						"usage": map[string]interface{}{"completion_tokens": 50, "prompt_tokens": 5},
+					})
+				}
+			}))
+			defer server.Close()
+
+			client := NewRealClient(server.URL, "", "test-model", "vllm")
+			// MinTokens=0: truncation warning must still fire.
+			record, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
+				Prompt: "hello", MaxOutputTokens: 256, MinTokens: 0,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if record.FinishReason != "length" {
+				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
+			}
+		})
+	}
+}
+
+// TestSend_LengthWarnsWhenMinTokensBelowMax verifies that the truncation warning fires
+// when min_tokens is set but below max_tokens — the output might still be truncated.
+func TestSend_LengthWarnsWhenMinTokensBelowMax(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"text": "ok", "finish_reason": "length"},
+			},
+			"usage": map[string]interface{}{"completion_tokens": 50, "prompt_tokens": 5},
+		})
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm")
+	// MinTokens=10, MaxOutputTokens=256: not exact-length mode, warning must fire.
+	record, err := client.Send(context.Background(), &PendingRequest{
+		RequestID: 1, InputTokens: 5, Streaming: false,
+		Prompt: "hello", MaxOutputTokens: 256, MinTokens: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.FinishReason != "length" {
+		t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
 	}
 }
 

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -647,6 +647,117 @@ func TestRealClient_GIEHeaders_OmittedWhenDefault(t *testing.T) {
 	}
 }
 
+// TestSend_AbortAlwaysWarns verifies that finish_reason="abort" produces a warning
+// regardless of MinTokens, since abort is a server-side error, not expected behavior.
+// (finish_reason="length" is suppressed when MinTokens>0 because vLLM stops at
+// max_tokens with length when min_tokens==max_tokens — that is expected.)
+func TestSend_AbortAlwaysWarns(t *testing.T) {
+	tests := []struct {
+		name      string
+		streaming bool
+	}{
+		{"non-streaming", false},
+		{"streaming", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.streaming {
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Fatal("expected http.Flusher")
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"abort\"}]}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3}}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+					flusher.Flush()
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"choices": []map[string]interface{}{
+							{"text": "ok", "finish_reason": "abort"},
+						},
+						"usage": map[string]interface{}{"completion_tokens": 3, "prompt_tokens": 5},
+					})
+				}
+			}))
+			defer server.Close()
+
+			client := NewRealClient(server.URL, "", "test-model", "vllm")
+			// MinTokens > 0: abort must still propagate to the record.
+			record, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
+				Prompt: "hello", MaxOutputTokens: 128, MinTokens: 128,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if record.FinishReason != "abort" {
+				t.Errorf("FinishReason = %q, want %q (abort must not be suppressed by MinTokens)", record.FinishReason, "abort")
+			}
+		})
+	}
+}
+
+// TestSend_LengthSuppressedWithMinTokens verifies that finish_reason="length" does NOT
+// produce a warning (i.e., no record-level side effect) when MinTokens > 0, because
+// vLLM stops at max_tokens with finish_reason="length" in the canonical min_tokens==max_tokens case.
+func TestSend_LengthSuppressedWithMinTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		streaming bool
+	}{
+		{"non-streaming", false},
+		{"streaming", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.streaming {
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Fatal("expected http.Flusher")
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":128}}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+					flusher.Flush()
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"choices": []map[string]interface{}{
+							{"text": "ok", "finish_reason": "length"},
+						},
+						"usage": map[string]interface{}{"completion_tokens": 128, "prompt_tokens": 5},
+					})
+				}
+			}))
+			defer server.Close()
+
+			client := NewRealClient(server.URL, "", "test-model", "vllm")
+			record, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
+				Prompt: "hello", MaxOutputTokens: 128, MinTokens: 128,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// FinishReason is still recorded correctly — only the warn is suppressed.
+			if record.FinishReason != "length" {
+				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
+			}
+		})
+	}
+}
+
 func TestRecorder_RecordITL_StreamingRequest(t *testing.T) {
 	// GIVEN a recorder and chunk timestamps
 	rec := &Recorder{}

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -7,9 +7,51 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
+
+// testLogHook captures logrus warn/error entries for test assertions.
+type testLogHook struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (h *testLogHook) Levels() []logrus.Level {
+	return []logrus.Level{logrus.WarnLevel, logrus.ErrorLevel}
+}
+
+func (h *testLogHook) Fire(e *logrus.Entry) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.entries = append(h.entries, e.Message)
+	return nil
+}
+
+func (h *testLogHook) hasEntry(substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, msg := range h.entries {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// installLogHook replaces logrus hooks for the test duration and returns the hook.
+func installLogHook(t *testing.T) *testLogHook {
+	t.Helper()
+	h := &testLogHook{}
+	orig := logrus.StandardLogger().Hooks
+	logrus.StandardLogger().Hooks = logrus.LevelHooks{}
+	logrus.AddHook(h)
+	t.Cleanup(func() { logrus.StandardLogger().Hooks = orig })
+	return h
+}
 
 func TestRealClient_NonStreaming_RecordsTokenCounts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -661,6 +703,7 @@ func TestSend_AbortAlwaysWarns(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tc.streaming {
 					flusher, ok := w.(http.Flusher)
@@ -687,7 +730,7 @@ func TestSend_AbortAlwaysWarns(t *testing.T) {
 			defer server.Close()
 
 			client := NewRealClient(server.URL, "", "test-model", "vllm")
-			// MinTokens > 0: abort must still propagate to the record.
+			// MinTokens > 0: abort must still produce a warning.
 			record, err := client.Send(context.Background(), &PendingRequest{
 				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
 				Prompt: "hello", MaxOutputTokens: 128, MinTokens: 128,
@@ -697,6 +740,9 @@ func TestSend_AbortAlwaysWarns(t *testing.T) {
 			}
 			if record.FinishReason != "abort" {
 				t.Errorf("FinishReason = %q, want %q (abort must not be suppressed by MinTokens)", record.FinishReason, "abort")
+			}
+			if !hook.hasEntry("server aborted request") {
+				t.Error("expected abort warning to be logged, but no matching entry found")
 			}
 		})
 	}
@@ -716,6 +762,7 @@ func TestSend_LengthSuppressedWithMinTokens(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tc.streaming {
 					flusher, ok := w.(http.Flusher)
@@ -752,6 +799,9 @@ func TestSend_LengthSuppressedWithMinTokens(t *testing.T) {
 			// FinishReason is still recorded correctly — only the warn is suppressed.
 			if record.FinishReason != "length" {
 				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
+			}
+			if hook.hasEntry("output may be truncated") {
+				t.Error("expected no truncation warning in exact-length mode, but warning was logged")
 			}
 		})
 	}
@@ -797,6 +847,7 @@ func TestSend_LengthWarnsWhenMinTokensNotSet(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tc.streaming {
 					flusher, ok := w.(http.Flusher)
@@ -834,6 +885,9 @@ func TestSend_LengthWarnsWhenMinTokensNotSet(t *testing.T) {
 			if record.FinishReason != "length" {
 				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
 			}
+			if !hook.hasEntry("output may be truncated") {
+				t.Error("expected truncation warning to be logged, but no matching entry found")
+			}
 		})
 	}
 }
@@ -841,28 +895,167 @@ func TestSend_LengthWarnsWhenMinTokensNotSet(t *testing.T) {
 // TestSend_LengthWarnsWhenMinTokensBelowMax verifies that the truncation warning fires
 // when min_tokens is set but below max_tokens — the output might still be truncated.
 func TestSend_LengthWarnsWhenMinTokensBelowMax(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"choices": []map[string]interface{}{
-				{"text": "ok", "finish_reason": "length"},
-			},
-			"usage": map[string]interface{}{"completion_tokens": 50, "prompt_tokens": 5},
-		})
-	}))
-	defer server.Close()
-
-	client := NewRealClient(server.URL, "", "test-model", "vllm")
-	// MinTokens=10, MaxOutputTokens=256: not exact-length mode, warning must fire.
-	record, err := client.Send(context.Background(), &PendingRequest{
-		RequestID: 1, InputTokens: 5, Streaming: false,
-		Prompt: "hello", MaxOutputTokens: 256, MinTokens: 10,
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name      string
+		streaming bool
+	}{
+		{"non-streaming", false},
+		{"streaming", true},
 	}
-	if record.FinishReason != "length" {
-		t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.streaming {
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Fatal("expected http.Flusher")
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":50}}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+					flusher.Flush()
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"choices": []map[string]interface{}{
+							{"text": "ok", "finish_reason": "length"},
+						},
+						"usage": map[string]interface{}{"completion_tokens": 50, "prompt_tokens": 5},
+					})
+				}
+			}))
+			defer server.Close()
+
+			client := NewRealClient(server.URL, "", "test-model", "vllm")
+			// MinTokens=10, MaxOutputTokens=256: not exact-length mode, warning must fire.
+			record, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
+				Prompt: "hello", MaxOutputTokens: 256, MinTokens: 10,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if record.FinishReason != "length" {
+				t.Errorf("FinishReason = %q, want %q", record.FinishReason, "length")
+			}
+			if !hook.hasEntry("output may be truncated") {
+				t.Error("expected truncation warning to be logged, but no matching entry found")
+			}
+		})
+	}
+}
+
+// TestSend_StopWarnsWhenBelowMinTokens verifies that finish_reason="stop" with
+// outputTokens < minTokens triggers the "server may not support min_tokens" warning.
+// This detects servers that silently ignore the min_tokens parameter.
+func TestSend_StopWarnsWhenBelowMinTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		streaming bool
+	}{
+		{"non-streaming", false},
+		{"streaming", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.streaming {
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Fatal("expected http.Flusher")
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":5}}\n\n")
+					flusher.Flush()
+					_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+					flusher.Flush()
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"choices": []map[string]interface{}{
+							{"text": "ok", "finish_reason": "stop"},
+						},
+						"usage": map[string]interface{}{"completion_tokens": 5, "prompt_tokens": 5},
+					})
+				}
+			}))
+			defer server.Close()
+
+			client := NewRealClient(server.URL, "", "test-model", "vllm")
+			// minTokens=128 but server returns only 5 tokens with stop: silent non-support.
+			_, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: tc.streaming,
+				Prompt: "hello", MaxOutputTokens: 256, MinTokens: 128,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !hook.hasEntry("server may not support min_tokens") {
+				t.Error("expected min_tokens non-support warning, but no matching entry found")
+			}
+		})
+	}
+}
+
+// TestSend_Unconstrained_MinTokensStop_Warns verifies that the stop+outputTokens<minTokens
+// warning fires even in unconstrained mode (both completions and chat formats).
+func TestSend_Unconstrained_MinTokensStop_Warns(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiFormat string
+	}{
+		{"completions", "completions"},
+		{"chat", "chat"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := installLogHook(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				var choices interface{}
+				if tc.apiFormat == "chat" {
+					choices = []map[string]interface{}{
+						{"message": map[string]string{"content": "ok"}, "finish_reason": "stop"},
+					}
+				} else {
+					choices = []map[string]interface{}{
+						{"text": "ok", "finish_reason": "stop"},
+					}
+				}
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"choices": choices,
+					"usage":   map[string]interface{}{"completion_tokens": 5, "prompt_tokens": 5},
+				})
+			}))
+			defer server.Close()
+
+			opts := []RealClientOption{}
+			if tc.apiFormat == "chat" {
+				opts = append(opts, WithAPIFormat("chat"))
+			}
+			client := NewRealClient(server.URL, "", "test-model", "vllm", opts...)
+			// Unconstrained + minTokens=128, server returns only 5 tokens: silent non-support.
+			_, err := client.Send(context.Background(), &PendingRequest{
+				RequestID: 1, InputTokens: 5, Streaming: false,
+				Prompt: "hello", Unconstrained: true, MinTokens: 128,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !hook.hasEntry("server may not support min_tokens") {
+				t.Error("expected min_tokens non-support warning, but no matching entry found")
+			}
+		})
 	}
 }
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -102,6 +102,7 @@ Four input modes are available. At least one must be provided per invocation:
 | `--think-time-ms` | `int` | `0` | Think time in ms between response and next request (concurrency mode only) |
 | `--api-format` | `string` | `"completions"` | API format: `completions` or `chat` |
 | `--unconstrained-output` | `bool` | `false` | Do not set `max_tokens` (let server decide output length) |
+| `--min-tokens` | `int` | `0` | Set `min_tokens` in request body; forces server to generate at least N tokens before EOS. Set equal to `--output-tokens` for exact output length control (0 = omit) |
 | `--rtt-ms` | `float64` | `0` | Measured network round-trip time in milliseconds |
 | `--defaults-filepath` | `string` | `"defaults.yaml"` | Path to `defaults.yaml` containing preset definitions (preset mode only) |
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -102,7 +102,7 @@ Four input modes are available. At least one must be provided per invocation:
 | `--think-time-ms` | `int` | `0` | Think time in ms between response and next request (concurrency mode only) |
 | `--api-format` | `string` | `"completions"` | API format: `completions` or `chat` |
 | `--unconstrained-output` | `bool` | `false` | Do not set `max_tokens` (let server decide output length) |
-| `--min-tokens` | `int` | `0` | Set `min_tokens` in request body; forces server to generate at least N tokens before EOS. Set equal to `--output-tokens` for exact output length control (0 = omit) |
+| `--min-tokens` | `int` | `0` | Set `min_tokens` in request body; requests server to generate at least N tokens before EOS. Set equal to `--output-tokens` for exact output length control (0 = omit). Compatible with `--unconstrained-output`: `min_tokens` is still sent, `max_tokens` is still omitted |
 | `--rtt-ms` | `float64` | `0` | Measured network round-trip time in milliseconds |
 | `--defaults-filepath` | `string` | `"defaults.yaml"` | Path to `defaults.yaml` containing preset definitions (preset mode only) |
 


### PR DESCRIPTION
## Summary

- Add `--min-tokens` flag to `blis observe` that sets `min_tokens` in the HTTP request body, forcing vLLM (and compatible servers) to generate at least N tokens before allowing EOS
- When set equal to `--output-tokens`, this gives exact OSL control from the client side for deterministic benchmarks
- Default is 0 (omitted from request body), preserving current behavior

Closes https://github.com/inference-sim/inference-sim/issues/1066

## Test plan

- [x] `TestObserveCmd_MinTokensFlag_Exists` — flag registered with correct default
- [x] `TestRequestToPending_MinTokensPropagated` — value flows through to PendingRequest
- [x] `TestSend_MinTokensInBody` — included in HTTP body when > 0, omitted when 0
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)