### PR TITLE
docs: add cross-repo feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cross_repo_feature.md
+++ b/.github/ISSUE_TEMPLATE/cross_repo_feature.md
@@ -1,6 +1,6 @@
 ---
 name: Cross-repo feature
-about: Port a feature or behavior from an external platform (llmd, gaie, vllm, sglang) into BLIS
+about: Port a feature or behavior from an external platform (llmd, gaie, vllm, sglang) into the simulator
 title: ''
 labels: 'enhancement, cross-repo'
 assignees: ''
@@ -39,18 +39,19 @@ GitHub permalinks are the preferred format — they encode repo, commit, file, a
 <!-- Paste as many permalinks as needed. Each must point to real code, not pseudocode. -->
 
 Permalink 1:
-`https://github.com/org/repo/blob/<commit-sha>/path/to/file.go#L42-L68`
+https://github.com/org/repo/blob/abc1234/path/to/file.go#L42-L68
 
 Permalink 2 (if applicable):
-`https://github.com/org/repo/blob/<commit-sha>/path/to/file.go#L100-L120`
+https://github.com/org/repo/blob/abc1234/path/to/file.py#L100-L120
 
-<!-- For non-GitHub repos, fall back to manual attribution with a pasted code block:
-Source: <repo>/<file>@<commit> (lines X-Y) -->
+<!-- For non-GitHub repos, fall back to manual attribution:
+Source: <repo>/<file>@<commit> (lines X-Y)
+followed by a fenced code block containing the actual source code. -->
 
 **Key behaviors to preserve**
 List the specific behaviors from the reference code that BLIS must match exactly:
-- [ ] Behavior 1 (reference: permalink 1, line N)
-- [ ] Behavior 2 (reference: permalink 2, line N)
+- [ ] Behavior 1 (reference: permalink 1)
+- [ ] Behavior 2 (reference: permalink 2)
 
 **Known intentional deviations**
 List any places where BLIS should deliberately differ from the reference, and why:

--- a/.github/ISSUE_TEMPLATE/cross_repo_feature.md
+++ b/.github/ISSUE_TEMPLATE/cross_repo_feature.md
@@ -1,0 +1,77 @@
+---
+name: Cross-repo feature
+about: Port a feature or behavior from an external platform (llmd, gaie, vllm, sglang) into BLIS
+title: ''
+labels: 'enhancement, cross-repo'
+assignees: ''
+
+---
+
+<!-- ⚠️ STOP — READ THIS BEFORE OPENING THIS ISSUE ⚠️
+
+This template is for features that replicate behavior from an external system
+(llmd, gaie, vllm, sglang, etc.) into the BLIS simulator.
+
+MANDATORY REQUIREMENT: You must have access to the actual source code of the
+reference implementation. Prose descriptions, documentation summaries, or
+second-hand explanations are NOT sufficient. If you cannot provide the real
+code, do not open this issue — ask for access first.
+
+AI AGENTS: If you are an AI agent opening this issue, you MUST read the
+actual source files from the reference repo and provide GitHub permalinks
+to the relevant code below. Do NOT paraphrase, summarize, or describe code
+from memory. If you do not have access to the source repo, STOP and ask
+the user to provide the code or grant access before proceeding.
+
+After assembling your code proofs, verify each permalink resolves to the
+code you cited. Ask yourself: "Are you absolutely sure these references
+are correct and complete?" Re-examine before submitting. -->
+
+**What external behavior are we replicating?**
+Name the system, component, and specific behavior (e.g., "llmd gateway GAIE admission saturation formula").
+
+**Reference implementation (MANDATORY)**
+
+Provide GitHub permalinks to the actual source code that defines the behavior being ported. Include ALL relevant code paths — main logic, edge cases, defaults, error handling.
+
+GitHub permalinks are the preferred format — they encode repo, commit, file, and lines in a single verifiable URL, and GitHub auto-renders them as code blocks.
+
+<!-- Paste as many permalinks as needed. Each must point to real code, not pseudocode. -->
+
+Permalink 1:
+`https://github.com/org/repo/blob/<commit-sha>/path/to/file.go#L42-L68`
+
+Permalink 2 (if applicable):
+`https://github.com/org/repo/blob/<commit-sha>/path/to/file.go#L100-L120`
+
+<!-- For non-GitHub repos, fall back to manual attribution with a pasted code block:
+Source: <repo>/<file>@<commit> (lines X-Y) -->
+
+**Key behaviors to preserve**
+List the specific behaviors from the reference code that BLIS must match exactly:
+- [ ] Behavior 1 (reference: permalink 1, line N)
+- [ ] Behavior 2 (reference: permalink 2, line N)
+
+**Known intentional deviations**
+List any places where BLIS should deliberately differ from the reference, and why:
+- Deviation 1: [what differs] — [why]
+
+**Target parity version**
+What version/commit of the external system are we targeting? (e.g., "llmd v0.8.2, commit abc1234")
+
+**Which components are affected?**
+- [ ] Core simulator (`sim/`)
+- [ ] Cluster simulation (`sim/cluster/`)
+- [ ] Workload generation (`sim/workload/`)
+- [ ] KV cache (`sim/kv/`)
+- [ ] Decision tracing (`sim/trace/`)
+- [ ] CLI (`cmd/`)
+- [ ] New package needed
+
+**Extension friction check**
+- How many files would need to change to add this? (Estimate)
+- Does this require a new interface, or can it extend an existing one?
+- Does this affect any invariants (conservation, causality, determinism)?
+
+**Relationship to existing work**
+Does this relate to any open issues, the macro plan, or a design document?

--- a/docs/plans/cross-repo-template-plan.md
+++ b/docs/plans/cross-repo-template-plan.md
@@ -1,0 +1,85 @@
+# Cross-Repo Feature Issue Template — Implementation Plan
+
+**Goal:** Add a GitHub issue template that requires code proofs (GitHub permalinks) when porting features from external repos into BLIS.
+**Source:** [#1053](https://github.com/inference-sim/inference-sim/issues/1053), [#1071](https://github.com/inference-sim/inference-sim/issues/1071)
+**Closes:** `Fixes #1053`
+**PR Size Tier:** Small (1 new template file, no Go code, no behavioral logic changes)
+
+## Behavioral Contracts
+
+BC-1: Cross-repo template available in GitHub issue picker
+- GIVEN a contributor opens "New Issue" on GitHub
+- WHEN they view the template picker
+- THEN they see a "Cross-repo feature" option with description "Port a feature or behavior from an external platform (llmd, gaie, vllm, sglang) into BLIS"
+
+BC-2: Template requires GitHub permalinks as code proofs
+- GIVEN a contributor selects the cross-repo feature template
+- WHEN they view the template body
+- THEN it contains a mandatory "Reference implementation" section that asks for GitHub permalinks to the exact source code lines
+
+BC-3: Template warns AI agents to verify their references
+- GIVEN an AI agent reads the template
+- WHEN it processes the HTML comment at the top
+- THEN it finds explicit instructions to: (1) provide GitHub permalinks, not paraphrased code, (2) verify each permalink resolves, and (3) ask itself "Are you absolutely sure these references are correct and complete?"
+
+## Tasks
+
+### Task 1: Create cross-repo feature issue template (BC-1, BC-2, BC-3)
+
+**Files:** create `.github/ISSUE_TEMPLATE/cross_repo_feature.md`
+
+**What to do:**
+
+Create the file `.github/ISSUE_TEMPLATE/cross_repo_feature.md` with this exact content:
+
+```yaml
+---
+name: Cross-repo feature
+about: Port a feature or behavior from an external platform (llmd, gaie, vllm, sglang) into BLIS
+title: ''
+labels: 'enhancement, cross-repo'
+assignees: ''
+
+---
+```
+
+Followed by the template body (in plain markdown, not inside a code fence). The template body must contain these sections in order:
+
+1. **HTML comment block at the top** — a STOP warning explaining:
+   - This template is for features replicating behavior from an external system
+   - MANDATORY: must have access to actual source code (no prose descriptions)
+   - AI AGENTS: must provide GitHub permalinks, not paraphrased code. Must verify each permalink resolves. Must ask: "Are you absolutely sure these references are correct and complete?" before submitting.
+
+2. **"What external behavior are we replicating?"** — asks for system, component, and specific behavior name.
+
+3. **"Reference implementation (MANDATORY)"** — explains GitHub permalinks are the preferred format. Provides placeholder permalink examples. Includes HTML comment about manual attribution fallback for non-GitHub repos.
+
+4. **"Key behaviors to preserve"** — checklist linking behaviors to specific permalink lines.
+
+5. **"Known intentional deviations"** — where BLIS should deliberately differ from the reference.
+
+6. **"Target parity version"** — which version/commit of the external system is targeted.
+
+7. **"Which components are affected?"** — same checklist as `feature_request.md` (Core sim, Cluster, Workload, KV cache, Trace, CLI, New package).
+
+8. **"Extension friction check"** — same as `feature_request.md` (files to change, new interface needed, invariant impact).
+
+9. **"Relationship to existing work"** — same as `feature_request.md`.
+
+**Style guide:** Match the formatting style of the existing templates (`feature_request.md`, `bug_report.md`). Use `**bold**` for section headers. Use `- [ ]` for checklists. Keep it concise.
+
+**Verify:** Open the raw file and confirm YAML frontmatter is valid (name, about, title, labels, assignees fields present). Confirm all 9 sections listed above are present.
+
+**Commit:** `docs: add cross-repo feature issue template (BC-1, BC-2, BC-3)`
+
+## Sanity Checklist
+
+- [ ] No Go code changes — this is a docs/template-only PR
+- [ ] No source-of-truth map entries need updating (issue templates are not tracked in the map)
+- [ ] CLAUDE.md does not reference issue templates in its file organization — no update needed
+- [ ] `project-structure.md` does not list `.github/ISSUE_TEMPLATE/` contents — no update needed
+- [ ] Template YAML frontmatter matches the format of existing templates (`feature_request.md`, `bug_report.md`)
+- [ ] Template labels field includes both `enhancement` and `cross-repo`
+- [ ] The `cross-repo` label may need to be created in the GitHub repo if it doesn't exist
+- [ ] No new antipattern rules apply (R1-R23 are for Go code)
+- [ ] mkdocs.yml does not need updating (issue templates are not part of the docs site)

--- a/docs/plans/cross-repo-template-plan.md
+++ b/docs/plans/cross-repo-template-plan.md
@@ -3,7 +3,7 @@
 **Goal:** Add a GitHub issue template that requires code proofs (GitHub permalinks) when porting features from external repos into BLIS.
 **Source:** [#1053](https://github.com/inference-sim/inference-sim/issues/1053), [#1071](https://github.com/inference-sim/inference-sim/issues/1071)
 **Closes:** `Fixes #1053`
-**PR Size Tier:** Small (1 new template file, no Go code, no behavioral logic changes)
+**PR Size Tier:** Small (1 new template file + this plan, no Go code, no behavioral logic changes)
 
 ## Behavioral Contracts
 


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/cross_repo_feature.md` — a dedicated issue template for features porting behavior from external repos (llmd, gaie, vllm, sglang) into BLIS
- Template requires **GitHub permalinks** as code proofs (mandatory, not optional)
- Includes AI agent instructions: provide permalinks (not paraphrased code), verify each resolves, and self-check with "Are you absolutely sure?"

## Behavioral Contracts

**BC-1: Template available in GitHub issue picker**
- GIVEN a contributor opens "New Issue"
- WHEN they view the template picker
- THEN they see "Cross-repo feature" with description about porting from external platforms

**BC-2: Template requires GitHub permalinks as code proofs**
- GIVEN a contributor selects the cross-repo feature template
- WHEN they view the template body
- THEN it contains a mandatory "Reference implementation" section requiring GitHub permalinks

**BC-3: Template warns AI agents to verify their references**
- GIVEN an AI agent reads the template
- WHEN it processes the HTML comment at the top
- THEN it finds instructions to provide permalinks, verify they resolve, and ask "Are you absolutely sure?"

## Test plan

- [ ] Verify template appears in GitHub issue picker after merge
- [ ] Verify YAML frontmatter renders correctly (name, about, labels)
- [ ] Verify `cross-repo` label is applied to issues using this template
- [ ] Verify HTML comment is hidden in rendered view but visible in edit mode

Fixes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)