### PR TITLE
ci: handle test timeout for golden dataset tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,10 +22,54 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "cluster (heavy)"
+            packages: "./sim/cluster"
+            timeout: "15m"
+          - name: "core packages"
+            packages: "./sim ./sim/kv ./sim/trace"
+            timeout: "10m"
+          - name: "latency models"
+            packages: "./sim/latency"
+            timeout: "10m"
+          - name: "workload & cmd"
+            packages: "./sim/workload ./cmd"
+            timeout: "10m"
+          - name: "root & internals"
+            packages: ". ./sim/internal/..."
+            timeout: "5m"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Test ${{ matrix.name }}
+        run: go test -v -timeout ${{ matrix.timeout }} ${{ matrix.packages }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
       - name: Lint
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.9.0
-
-      - name: Test
-        run: go test -v ./...


### PR DESCRIPTION
## Problem

`TestTrainedPhysics_GoldenDataset` consistently times out in CI after 10 minutes but passes locally in ~68 seconds. The test runs 15 model simulations in parallel, which hits resource contention on GitHub Actions shared runners.

## Solution

**Split tests across parallel runners using GitHub Actions matrix strategy** with tailored timeouts:

```yaml
strategy:
  fail-fast: false
  matrix:
    include:
      - name: "cluster (heavy)"
        packages: "./sim/cluster"
        timeout: "15m"
      - name: "core packages"
        packages: "./sim ./sim/kv ./sim/trace"
        timeout: "10m"
      - name: "latency models"
        packages: "./sim/latency"
        timeout: "10m"
      - name: "workload & cmd"
        packages: "./sim/workload ./cmd"
        timeout: "10m"
      - name: "root & internals"
        packages: ". ./sim/internal/..."
        timeout: "5m"
```

## Benefits

✅ **Faster total time**: ~15m wall-clock (was 20m+ serial)  
✅ **True parallelism**: 5 concurrent runners  
✅ **Right-sized timeouts**: cluster gets 15m, lightweight tests get 5m  
✅ **Fail-fast disabled**: All test groups complete even if one fails  
✅ **Isolation**: Heavy `sim/cluster` tests don't compete with other packages

## Why This Approach?

1. ❌ **Simple timeout increase (20m)** → Still slow, wastes CI time
2. ❌ **Splitting test files** → Maintains test structure, avoids refactoring
3. ✅ **Matrix parallelization** → **Actual speedup**, optimal resource usage

## Testing

The CI run on this PR will validate the matrix strategy works correctly.

Fixes #1082