### PR TITLE
fix(sim): lazy-cancel orphaned TimeoutEvents to prevent SimEndedTime inflation

### DIFF
--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -559,6 +559,7 @@ func (c *ClusterSimulator) Run() error {
 			}
 			entry.event.Execute(c)
 		} else {
+			prevClusterClock := c.clock
 			c.clock = instanceTime
 			if c.clock > c.config.Horizon {
 				break
@@ -572,7 +573,13 @@ func (c *ClusterSimulator) Run() error {
 			timedOutBefore := inst.Metrics().TimedOutRequests
 
 			ev := inst.ProcessNextEvent()
-			_ = ev // Event type no longer used for decrement
+
+			// If ProcessNextEvent() skipped a cancelled TimeoutEvent (lazy
+			// cancellation — inst.Clock was not advanced), restore c.clock.
+			// A no-op orphaned timeout must not advance the cluster clock.
+			if te, ok := ev.(*sim.TimeoutEvent); ok && te.Request.State == sim.StateCompleted {
+				c.clock = prevClusterClock
+			}
 
 			// Completion-based decrement (#463, BC-3, BC-7): InFlightRequests tracks the full
 			// dispatch-to-completion window. Decrement by the number of newly completed,

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2858,14 +2858,92 @@ func TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics(t *testi
 		t.Errorf("conservation: CompletedRequests(%d) + TimedOutRequests(%d) = %d, want 3",
 			m.CompletedRequests, m.TimedOutRequests, got)
 	}
-	// r1 completes after r0 (~12ms); SimEndedTime should reflect r1's completion,
-	// not r0/r1's orphaned 300s timeouts. Lower bound > 5_000 (past genuine timeout).
-	if m.SimEndedTime <= 5_000 {
-		t.Errorf("SimEndedTime too low: got %d µs, want > 5_000 µs", m.SimEndedTime)
+	// r1 completes after r0 (~12ms total); SimEndedTime should reflect r1's
+	// completion, not r0/r1's orphaned 300s timeouts.
+	// Lower bound > 10_000: r0 takes ~6ms and r1 runs after, so SimEndedTime
+	// must exceed 10ms — verifying both requests actually ran, not just r2's timeout.
+	if m.SimEndedTime <= 10_000 {
+		t.Errorf("SimEndedTime too low: got %d µs, want > 10_000 µs (r0+r1 must both complete)", m.SimEndedTime)
 	}
 	if m.SimEndedTime > 100_000 {
 		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < 100_000 µs",
 			m.SimEndedTime, float64(m.SimEndedTime)/1e6)
+	}
+}
+
+// TestClusterSimulator_PD_OrphanedTimeout_TimingNotInflated verifies that with
+// PD disaggregation, orphaned TimeoutEvents on the prefill instance do not
+// inflate per-request phase timestamps set by detectPrefillCompletions via
+// c.clock. If c.clock were not restored after a skipped orphaned timeout,
+// KVTransferStartedEvent.time and parent.PrefillCompleteTime could be set to
+// the orphaned timestamp (~300s) rather than the actual prefill completion time.
+//
+// Scenario: 4 requests through a 2P+2D cluster, each with a workload.DefaultTimeoutUs
+// deadline. All complete well before the deadline. Assert that PrefillCompleteTime,
+// TransferStartTime, and the causality chain are bounded by actual work time.
+func TestClusterSimulator_PD_OrphanedTimeout_TimingNotInflated(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	config.SimConfig.Horizon = 500_000_000 // 500s — beyond workload.DefaultTimeoutUs
+
+	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(42))
+	workloadRNG := rng.ForSubsystem(sim.SubsystemWorkload)
+
+	const n = 4
+	requests := make([]*sim.Request, n)
+	for i := 0; i < n; i++ {
+		arrivalTime := int64(i * 10_000)
+		requests[i] = &sim.Request{
+			ID:           fmt.Sprintf("pd_r%d", i),
+			ArrivalTime:  arrivalTime,
+			InputTokens:  sim.GenerateRandomTokenIDs(workloadRNG, 10),
+			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 5),
+			State:        sim.StateQueued,
+			MaxOutputLen: 5,
+			Deadline:     arrivalTime + workload.DefaultTimeoutUs,
+		}
+	}
+
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+	if m.CompletedRequests != n {
+		t.Fatalf("CompletedRequests: got %d, want %d", m.CompletedRequests, n)
+	}
+	if m.TimedOutRequests != 0 {
+		t.Errorf("TimedOutRequests: got %d, want 0", m.TimedOutRequests)
+	}
+
+	// Phase timestamps set by detectPrefillCompletions/detectDecodeCompletions
+	// use c.clock. If c.clock were not restored after an orphaned timeout skip,
+	// these would be inflated to ~300s. Assert all are bounded well below 1s.
+	const phaseThreshold = int64(1_000_000) // 1s
+	for _, parent := range cs.parentRequests {
+		if parent.PrefillCompleteTime > phaseThreshold {
+			t.Errorf("parent %s: PrefillCompleteTime inflated: %d µs (%.1fs), want < %d µs",
+				parent.ID, parent.PrefillCompleteTime, float64(parent.PrefillCompleteTime)/1e6, phaseThreshold)
+		}
+		if parent.TransferStartTime > phaseThreshold {
+			t.Errorf("parent %s: TransferStartTime inflated: %d µs (%.1fs), want < %d µs",
+				parent.ID, parent.TransferStartTime, float64(parent.TransferStartTime)/1e6, phaseThreshold)
+		}
+		// Causality: each phase must not precede the prior one.
+		chain := []struct {
+			name  string
+			value int64
+		}{
+			{"ArrivalTime", parent.ArrivalTime},
+			{"PrefillCompleteTime", parent.PrefillCompleteTime},
+			{"TransferStartTime", parent.TransferStartTime},
+			{"TransferCompleteTime", parent.TransferCompleteTime},
+			{"DecodeEnqueueTime", parent.DecodeEnqueueTime},
+		}
+		for i := 1; i < len(chain); i++ {
+			if chain[i].value < chain[i-1].value {
+				t.Errorf("parent %s causality: %s (%d) < %s (%d)",
+					parent.ID, chain[i].name, chain[i].value, chain[i-1].name, chain[i-1].value)
+			}
+		}
 	}
 }
 

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2883,7 +2883,7 @@ func TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics(t *testi
 // TransferStartTime, and the causality chain are bounded by actual work time.
 func TestClusterSimulator_PD_OrphanedTimeout_TimingNotInflated(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
-	config.SimConfig.Horizon = 500_000_000 // 500s — beyond workload.DefaultTimeoutUs
+	config.Horizon = 500_000_000 // 500s — beyond workload.DefaultTimeoutUs
 
 	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(42))
 	workloadRNG := rng.ForSubsystem(sim.SubsystemWorkload)

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2729,3 +2729,67 @@ func TestBatchRequestsNotSerialized(t *testing.T) {
 	}
 }
 
+// TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime verifies that
+// the cluster path's prevClusterClock save/restore (cluster.go) prevents orphaned
+// TimeoutEvents from inflating AggregatedMetrics().SimEndedTime. This is the
+// cluster-mode companion to TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime
+// in sim/timeout_test.go.
+//
+// Scenario: 5 requests complete quickly but each bears a 300s Deadline
+// (mimicking DefaultTimeoutUs). Without the c.clock restore in the cluster loop,
+// c.clock would advance to arrival+300s for the last request, inflating SimEndedTime.
+func TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
+	const deadline = int64(300_000_000) // 300s — mimics workload.DefaultTimeoutUs
+
+	config := DeploymentConfig{
+		SimConfig: sim.SimConfig{
+			Horizon:             500_000_000, // 500s — beyond the 300s deadline
+			Seed:                42,
+			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
+			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+		},
+		NumInstances: 2,
+	}
+
+	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(42))
+	workloadRNG := rng.ForSubsystem(sim.SubsystemWorkload)
+
+	requests := make([]*sim.Request, 5)
+	for i := 0; i < 5; i++ {
+		arrivalTime := int64(i * 100_000) // stagger arrivals by 100ms
+		requests[i] = &sim.Request{
+			ID:          fmt.Sprintf("r%d", i),
+			ArrivalTime: arrivalTime,
+			InputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 10),
+			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 5),
+			State:       sim.StateQueued,
+			MaxOutputLen: 5,
+			Deadline:    arrivalTime + deadline,
+		}
+	}
+
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+
+	if m.CompletedRequests != 5 {
+		t.Fatalf("CompletedRequests: got %d, want 5", m.CompletedRequests)
+	}
+	if m.TimedOutRequests != 0 {
+		t.Errorf("TimedOutRequests: got %d, want 0 (orphaned timeouts must not fire)", m.TimedOutRequests)
+	}
+
+	// SimEndedTime must reflect actual completion, not the last orphaned timeout.
+	// Last arrival at 400_000 µs; with beta=[1000,10,5] total execution is ~6ms,
+	// so SimEndedTime should be well under 1_000_000 µs (1s). The orphaned timeout
+	// would have placed it at 400_000 + 300_000_000 = ~300.4s without the fix.
+	const simEndedThreshold = int64(1_000_000) // 1s — 300× below orphaned timeout
+	if m.SimEndedTime > simEndedThreshold {
+		t.Errorf("SimEndedTime inflated by orphaned timeout in cluster path: got %d µs (%.1fs), want < %d µs",
+			m.SimEndedTime, float64(m.SimEndedTime)/1e6, simEndedThreshold)
+	}
+}
+

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2739,11 +2739,9 @@ func TestBatchRequestsNotSerialized(t *testing.T) {
 // (mimicking DefaultTimeoutUs). Without the c.clock restore in the cluster loop,
 // c.clock would advance to arrival+300s for the last request, inflating SimEndedTime.
 func TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
-	const deadline = int64(300_000_000) // 300s — mimics workload.DefaultTimeoutUs
-
 	config := DeploymentConfig{
 		SimConfig: sim.SimConfig{
-			Horizon:             500_000_000, // 500s — beyond the 300s deadline
+			Horizon:             500_000_000, // 500s — beyond workload.DefaultTimeoutUs (300s)
 			Seed:                42,
 			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
 			BatchConfig:         sim.NewBatchConfig(256, 2048, 0),
@@ -2760,13 +2758,13 @@ func TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.
 	for i := 0; i < 5; i++ {
 		arrivalTime := int64(i * 100_000) // stagger arrivals by 100ms
 		requests[i] = &sim.Request{
-			ID:          fmt.Sprintf("r%d", i),
-			ArrivalTime: arrivalTime,
-			InputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 10),
+			ID:           fmt.Sprintf("r%d", i),
+			ArrivalTime:  arrivalTime,
+			InputTokens:  sim.GenerateRandomTokenIDs(workloadRNG, 10),
 			OutputTokens: sim.GenerateRandomTokenIDs(workloadRNG, 5),
-			State:       sim.StateQueued,
+			State:        sim.StateQueued,
 			MaxOutputLen: 5,
-			Deadline:    arrivalTime + deadline,
+			Deadline:     arrivalTime + workload.DefaultTimeoutUs,
 		}
 	}
 
@@ -2783,13 +2781,91 @@ func TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.
 	}
 
 	// SimEndedTime must reflect actual completion, not the last orphaned timeout.
-	// Last arrival at 400_000 µs; with beta=[1000,10,5] total execution is ~6ms,
-	// so SimEndedTime should be well under 1_000_000 µs (1s). The orphaned timeout
-	// would have placed it at 400_000 + 300_000_000 = ~300.4s without the fix.
-	const simEndedThreshold = int64(1_000_000) // 1s — 300× below orphaned timeout
-	if m.SimEndedTime > simEndedThreshold {
-		t.Errorf("SimEndedTime inflated by orphaned timeout in cluster path: got %d µs (%.1fs), want < %d µs",
-			m.SimEndedTime, float64(m.SimEndedTime)/1e6, simEndedThreshold)
+	// Last arrival at 400_000 µs; with beta=[1000,10,5] per-request completion is ~6ms.
+	// Lower bound (> 400_000): last arrival advanced the clock past 400ms.
+	// Upper bound (< 1_000_000): 300× below workload.DefaultTimeoutUs; catches inflation.
+	if m.SimEndedTime <= 400_000 {
+		t.Errorf("SimEndedTime too low: got %d µs, want > 400_000 µs", m.SimEndedTime)
+	}
+	if m.SimEndedTime > 1_000_000 {
+		t.Errorf("SimEndedTime inflated by orphaned timeout in cluster path: got %d µs (%.1fs), want < 1_000_000 µs",
+			m.SimEndedTime, float64(m.SimEndedTime)/1e6)
+	}
+}
+
+// TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics verifies that
+// the lazy-cancellation guard skips only completed-request (orphaned) TimeoutEvents
+// and does not suppress genuine timeouts for still-queued requests.
+//
+// Scenario (1 instance, batch-size 1):
+//   - r0: arrives at 0, 300s deadline → completes normally (~6ms), orphaned timeout skipped
+//   - r1: arrives at 0, 300s deadline → queued behind r0, completes normally (~12ms), orphaned timeout skipped
+//   - r2: arrives at 0, 5000µs deadline → queued behind r0; r0 takes ~6ms so r2 times out while waiting
+//
+// Expected: CompletedRequests=2, TimedOutRequests=1, SimEndedTime reflects r1's
+// completion time (~12ms), not r0/r1's orphaned 300s timeouts.
+func TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics(t *testing.T) {
+	config := DeploymentConfig{
+		SimConfig: sim.SimConfig{
+			Horizon:             500_000_000,
+			Seed:                42,
+			KVCacheConfig:       sim.NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+			BatchConfig:         sim.NewBatchConfig(1, 2048, 0), // max 1 running — forces queuing
+			LatencyCoeffs:       sim.NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(sim.ModelConfig{}, sim.HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+		},
+		NumInstances: 1,
+	}
+
+	// r0 and r1 complete before their 300s deadline (orphaned TimeoutEvents).
+	// r2 has a 5000µs deadline — shorter than the time r0 takes to complete (~6ms),
+	// so r2 times out while queued. This verifies the guard uses State==StateCompleted
+	// (not a broader condition) and does not suppress genuine timeouts.
+	requests := []*sim.Request{
+		{
+			ID: "r0", ArrivalTime: 0,
+			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			State: sim.StateQueued, MaxOutputLen: 5,
+			Deadline: workload.DefaultTimeoutUs,
+		},
+		{
+			ID: "r1", ArrivalTime: 0,
+			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			State: sim.StateQueued, MaxOutputLen: 5,
+			Deadline: workload.DefaultTimeoutUs,
+		},
+		{
+			ID: "r2", ArrivalTime: 0,
+			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			State: sim.StateQueued, MaxOutputLen: 5,
+			Deadline: 5_000, // 5ms — r0 takes ~6ms, so r2 times out while queued
+		},
+	}
+
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+
+	if m.CompletedRequests != 2 {
+		t.Errorf("CompletedRequests: got %d, want 2", m.CompletedRequests)
+	}
+	if m.TimedOutRequests != 1 {
+		t.Errorf("TimedOutRequests: got %d, want 1 (r2 must genuinely time out)", m.TimedOutRequests)
+	}
+	// INV-1: 3 injected = 2 completed + 1 timed-out
+	if got := m.CompletedRequests + m.TimedOutRequests; got != 3 {
+		t.Errorf("conservation: CompletedRequests(%d) + TimedOutRequests(%d) = %d, want 3",
+			m.CompletedRequests, m.TimedOutRequests, got)
+	}
+	// r1 completes after r0 (~12ms); SimEndedTime should reflect r1's completion,
+	// not r0/r1's orphaned 300s timeouts. Lower bound > 5_000 (past genuine timeout).
+	if m.SimEndedTime <= 5_000 {
+		t.Errorf("SimEndedTime too low: got %d µs, want > 5_000 µs", m.SimEndedTime)
+	}
+	if m.SimEndedTime > 100_000 {
+		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < 100_000 µs",
+			m.SimEndedTime, float64(m.SimEndedTime)/1e6)
 	}
 }
 

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -203,6 +203,16 @@ func (sim *Simulator) PeekNextEventTime() int64 {
 func (sim *Simulator) ProcessNextEvent() Event {
 	entry := heap.Pop(&sim.eventQueue).(eventEntry)
 	ev := entry.event
+
+	// Lazy cancellation: a TimeoutEvent whose request already completed is an
+	// orphan — the real-world equivalent of a client cancelling its deadline
+	// timer when the response arrives. Skip it before advancing the clock so
+	// Finalize() captures SimEndedTime from the last real-work event, not from
+	// an orphaned no-op timeout 300s in the future.
+	if te, ok := ev.(*TimeoutEvent); ok && te.Request.State == StateCompleted {
+		return ev
+	}
+
 	sim.Clock = ev.Timestamp()
 	logrus.Debugf("[tick %07d] Executing %T", sim.Clock, ev)
 	ev.Execute(sim)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -200,6 +200,12 @@ func (sim *Simulator) PeekNextEventTime() int64 {
 // pending-request tracking) without maintaining fragile before/after heuristics.
 // Caller MUST check HasPendingEvents() first. Panics on empty queue.
 // Does NOT check horizon — caller is responsible.
+//
+// Special case — lazy cancellation: if the popped event is a TimeoutEvent for a
+// request that has already completed (State == StateCompleted), the event is
+// returned immediately without advancing Clock or calling Execute(). This models
+// real-world client behavior where a deadline timer is cancelled the moment a
+// response arrives, preventing orphaned timeouts from inflating SimEndedTime.
 func (sim *Simulator) ProcessNextEvent() Event {
 	entry := heap.Pop(&sim.eventQueue).(eventEntry)
 	ev := entry.event

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -281,3 +281,47 @@ func TestTimeout_PreemptThenTimeout_SafeNoOp(t *testing.T) {
 			completed, queued, running, dropped, timedOut, sum, injected)
 	}
 }
+
+// TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime verifies that a
+// completed request's orphaned TimeoutEvent does not advance the simulation
+// clock. The real-world equivalent: a client cancels its deadline timer when
+// the response arrives.
+//
+// Scenario: one request completes quickly, but its Deadline is 300s in the
+// future. Without lazy cancellation, SimEndedTime would be ~300s (the orphaned
+// timeout fires and advances the clock). With the fix, SimEndedTime reflects
+// the actual completion time.
+func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             500_000_000, // 500s — well beyond the 300s deadline
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	r1 := &Request{
+		ID: "r1", ArrivalTime: 0,
+		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		State: StateQueued, MaxOutputLen: 5,
+		Deadline: 300_000_000, // 300s — mimics DefaultTimeoutUs
+	}
+
+	sim.InjectArrival(r1)
+	sim.Run()
+
+	if r1.State != StateCompleted {
+		t.Fatalf("r1 state: got %s, want %s", r1.State, StateCompleted)
+	}
+
+	// SimEndedTime must reflect actual work completion, not the orphaned timeout.
+	// With beta0=1000, beta1=10, beta2=5 and a small request, completion is well
+	// under 1s (1_000_000 µs). If SimEndedTime exceeds 1s, the orphaned timeout
+	// inflated the clock.
+	if sim.Metrics.SimEndedTime > 1_000_000 {
+		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < 1_000_000 µs (1s)",
+			sim.Metrics.SimEndedTime, float64(sim.Metrics.SimEndedTime)/1e6)
+	}
+}

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -348,9 +348,10 @@ func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
 }
 
 // TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock verifies that
-// N > 1 completed requests each with an orphaned timeout do not inflate
-// SimEndedTime. A loop bug where sim.Run() exits after the first non-advancing
-// pop would leave later orphaned timeouts unprocessed; this test catches that.
+// N > 1 completed requests each with an orphaned timeout do not cumulatively
+// inflate SimEndedTime. Each orphaned pop must be skipped without advancing
+// sim.Clock, so draining N orphaned timeouts leaves Clock at the last
+// real-work timestamp rather than the last orphaned timestamp.
 func TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock(t *testing.T) {
 	cfg := SimConfig{
 		Horizon:             500_000_000,

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -315,13 +315,23 @@ func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
 	if r1.State != StateCompleted {
 		t.Fatalf("r1 state: got %s, want %s", r1.State, StateCompleted)
 	}
+	// INV-1: the skipped orphaned timeout must not corrupt conservation counters.
+	if sim.Metrics.CompletedRequests != 1 {
+		t.Errorf("CompletedRequests: got %d, want 1", sim.Metrics.CompletedRequests)
+	}
+	if sim.Metrics.TimedOutRequests != 0 {
+		t.Errorf("TimedOutRequests: got %d, want 0 (orphaned timeout must not count as timed-out)", sim.Metrics.TimedOutRequests)
+	}
 
 	// SimEndedTime must reflect actual work completion, not the orphaned timeout.
-	// With beta0=1000, beta1=10, beta2=5 and a small request, completion is well
-	// under 1s (1_000_000 µs). If SimEndedTime exceeds 1s, the orphaned timeout
-	// inflated the clock.
-	if sim.Metrics.SimEndedTime > 1_000_000 {
-		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < 1_000_000 µs (1s)",
-			sim.Metrics.SimEndedTime, float64(sim.Metrics.SimEndedTime)/1e6)
+	// With beta=[1000,10,5] (µs), 1 prefill step + 5 decode steps:
+	//   prefill  ≈ beta0 + beta1*10 = 1100 µs
+	//   decode×5 ≈ 5 × (beta0 + beta1*1 + beta2*1) ≈ 5×1015 = 5075 µs
+	//   total    ≈ 6175 µs — well under 100_000 µs threshold
+	// If SimEndedTime exceeds the threshold, the orphaned 300s timeout inflated Clock.
+	const simEndedThreshold = 100_000 // 100 ms — 3000× above expected, 3000× below orphaned timeout
+	if sim.Metrics.SimEndedTime > simEndedThreshold {
+		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < %d µs",
+			sim.Metrics.SimEndedTime, float64(sim.Metrics.SimEndedTime)/1e6, simEndedThreshold)
 	}
 }

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -2,8 +2,13 @@ package sim
 
 import (
 	"container/heap"
+	"fmt"
 	"testing"
 )
+
+// testDefaultTimeoutUs mirrors workload.DefaultTimeoutUs (300s).
+// Cannot import workload directly — that package imports sim (circular).
+const testDefaultTimeoutUs = 300_000_000
 
 // TestEventQueue_SameTimestamp_PriorityOrder verifies BC-12: at equal timestamps,
 // events fire in priority order (lower priority number first).
@@ -306,7 +311,7 @@ func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
 		ID: "r1", ArrivalTime: 0,
 		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
 		State: StateQueued, MaxOutputLen: 5,
-		Deadline: 300_000_000, // 300s — mimics DefaultTimeoutUs
+		Deadline: testDefaultTimeoutUs,
 	}
 
 	sim.InjectArrival(r1)
@@ -324,14 +329,75 @@ func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
 	}
 
 	// SimEndedTime must reflect actual work completion, not the orphaned timeout.
-	// With beta=[1000,10,5] (µs), 1 prefill step + 5 decode steps:
-	//   prefill  ≈ beta0 + beta1*10 = 1100 µs
-	//   decode×5 ≈ 5 × (beta0 + beta1*1 + beta2*1) ≈ 5×1015 = 5075 µs
-	//   total    ≈ 6175 µs — well under 100_000 µs threshold
-	// If SimEndedTime exceeds the threshold, the orphaned 300s timeout inflated Clock.
+	// With beta=[1000,10,5] (µs), beta0=base, beta1=cache-miss tokens (prefill only),
+	// beta2=decode tokens. For 10 inputs + 5 outputs:
+	//   prefill  = beta0 + beta1*10 = 1000 + 100 = 1100 µs
+	//   decode×5 = 5 × (beta0 + beta2*1) = 5 × 1005 = 5025 µs
+	//   total    ≈ 6125 µs
+	// Lower bound (> 5_000): catches a regression where Clock is never advanced.
+	// Upper bound (< 100_000): 3000× below testDefaultTimeoutUs, catches clock inflation.
+	if sim.Metrics.SimEndedTime <= 5_000 {
+		t.Errorf("SimEndedTime too low: got %d µs, want > 5_000 µs (Clock must advance for real work)",
+			sim.Metrics.SimEndedTime)
+	}
 	const simEndedThreshold = 100_000 // 100 ms — 3000× above expected, 3000× below orphaned timeout
 	if sim.Metrics.SimEndedTime > simEndedThreshold {
 		t.Errorf("SimEndedTime inflated by orphaned timeout: got %d µs (%.1fs), want < %d µs",
 			sim.Metrics.SimEndedTime, float64(sim.Metrics.SimEndedTime)/1e6, simEndedThreshold)
+	}
+}
+
+// TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock verifies that
+// N > 1 completed requests each with an orphaned timeout do not inflate
+// SimEndedTime. A loop bug where sim.Run() exits after the first non-advancing
+// pop would leave later orphaned timeouts unprocessed; this test catches that.
+func TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             500_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(10000, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(256, 2048, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{1000, 10, 5}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	const n = 3
+	requests := make([]*Request, n)
+	for i := 0; i < n; i++ {
+		arrivalTime := int64(i * 50_000) // stagger by 50ms
+		requests[i] = &Request{
+			ID:           fmt.Sprintf("r%d", i),
+			ArrivalTime:  arrivalTime,
+			InputTokens:  make([]int, 10),
+			OutputTokens: make([]int, 5),
+			State:        StateQueued,
+			MaxOutputLen: 5,
+			Deadline:     arrivalTime + testDefaultTimeoutUs,
+		}
+		sim.InjectArrival(requests[i])
+	}
+	sim.Run()
+
+	for i, r := range requests {
+		if r.State != StateCompleted {
+			t.Errorf("requests[%d] state: got %s, want %s", i, r.State, StateCompleted)
+		}
+	}
+	// INV-1: n completed, 0 timed-out
+	if sim.Metrics.CompletedRequests != n {
+		t.Errorf("CompletedRequests: got %d, want %d", sim.Metrics.CompletedRequests, n)
+	}
+	if sim.Metrics.TimedOutRequests != 0 {
+		t.Errorf("TimedOutRequests: got %d, want 0", sim.Metrics.TimedOutRequests)
+	}
+	// Last arrival at 100_000 µs; after processing all 3 requests SimEndedTime
+	// should be > 100_000 (last arrival advanced the clock) and well under
+	// testDefaultTimeoutUs (orphaned timeouts are all skipped).
+	if sim.Metrics.SimEndedTime <= 100_000 {
+		t.Errorf("SimEndedTime too low: got %d µs, want > 100_000 µs", sim.Metrics.SimEndedTime)
+	}
+	if sim.Metrics.SimEndedTime > 500_000 {
+		t.Errorf("SimEndedTime inflated: got %d µs, want < 500_000 µs", sim.Metrics.SimEndedTime)
 	}
 }


### PR DESCRIPTION
## Summary
- Applies lazy cancellation at pop-time in `ProcessNextEvent()`: skips a `TimeoutEvent` whose request already completed **before** advancing `sim.Clock`, so `Finalize()` captures `SimEndedTime` from the last real-work event instead of an orphaned no-op timeout 300s in the future
- Patches two sites: `sim/simulator.go` (single-instance path) and `sim/cluster/cluster.go` (cluster path — saves/restores `c.clock` when a cancelled timeout is skipped)
- Adds behavioral test `TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime` verifying SimEndedTime reflects actual completion time, not the orphaned deadline
- Existing `StateCompleted` guard in `TimeoutEvent.Execute()` (`event.go:140`) preserved as defence-in-depth

## Test plan
- [x] `go test ./sim/... -run TestTimeout` — all timeout tests pass including new test
- [x] `go test ./...` — full suite passes with no regressions
- [x] `go vet ./...` — clean

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)