### PR TITLE
fix(sim): prevent TotalOutputTokens double-count after preemption

### DIFF
--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -490,6 +490,16 @@ func (sim *Simulator) recordRequestCompletion(req *Request) {
 	// would cause the request to vanish from conservation accounting entirely.
 	sim.Metrics.CompletedRequests++
 
+	// Count decode tokens at completion time, not inline during each decode step.
+	// Inline counting double-counts when a request is preempted (ProgressIndex reset
+	// to 0) and re-runs: tokens from the aborted run are counted a second time.
+	// At completion: PI = InputLen + OutputLen - 1 (normal) or maxModelLen - 1 (capped),
+	// so PI - InputLen is always the exact number of decode tokens generated.
+	decodeTokens := int(req.ProgressIndex) - len(req.InputTokens)
+	if decodeTokens > 0 {
+		sim.Metrics.TotalOutputTokens += decodeTokens
+	}
+
 	var itlSum int64
 	for _, v := range req.ITL {
 		itlSum += v
@@ -644,7 +654,6 @@ func (sim *Simulator) executeBatchStep(now int64) int64 {
 			// Also prevents phantom tokens from token budget exhaustion (pre-existing edge case).
 			if req.NumNewTokens > 0 {
 				req.ProgressIndex++
-				sim.Metrics.TotalOutputTokens++
 				req.ITL = append(req.ITL, currStepAdvance+sim.latencyModel.OutputTokenProcessingTime())
 			}
 		}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -494,9 +494,10 @@ func (sim *Simulator) recordRequestCompletion(req *Request) {
 	// Inline counting double-counts when a request is preempted (ProgressIndex reset
 	// to 0) and re-runs: tokens from the aborted run are counted a second time.
 	// At completion: PI = InputLen + OutputLen - 1 (normal) or maxModelLen - 1 (capped),
-	// so PI - InputLen is always the exact number of decode tokens generated.
+	// so PI - InputLen counts decode-step increments (= OutputLen - 1; the first output
+	// token is generated at prefill completion, not as a decode-step increment).
 	decodeTokens := int(req.ProgressIndex) - len(req.InputTokens)
-	if decodeTokens > 0 {
+	if decodeTokens > 0 { // zero-output-token requests complete with PI == InputLen → decodeTokens == 0
 		sim.Metrics.TotalOutputTokens += decodeTokens
 	}
 

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -640,8 +640,10 @@ func (sim *Simulator) executeBatchStep(now int64) int64 {
 
 	// Subprocess: Model Execution - this could be prefill or decode depending on the request.
 	// similar to vLLM's execute_model()
-	// Note: TotalOutputTokens++ and TTFT metrics are recorded inline (not extracted to helpers)
-	// because they are tightly coupled to the prefill/decode state transitions in this loop.
+	// Note: TTFT metrics are recorded inline because they are tightly coupled to the
+	// prefill/decode state transitions in this loop. TotalOutputTokens is computed at
+	// completion time in recordRequestCompletion (not inline) to avoid double-counting
+	// tokens when a preempted request re-runs from ProgressIndex=0.
 	for _, req := range sim.RunningBatch.Requests {
 		if req.ProgressIndex < util.Len64(req.InputTokens) {
 			req.ProgressIndex = sim.reqNumComputedTokens[req.ID]

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2598,3 +2598,79 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 			got, simClock, clusterTime)
 	}
 }
+
+// TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption verifies that
+// TotalOutputTokens is not inflated when a request is preempted and re-runs.
+//
+// Scenario: 4 KV blocks × 16 tokens/block = 64 total capacity.
+// B (32 input, 5 output) injected first → head of running batch.
+// A (16 input, 5 output) injected second → tail of running batch (eviction candidate).
+//
+// Token slices use distinct non-zero values to prevent prefix-cache sharing
+// between A and B, ensuring separate block allocations.
+//
+// Block layout at peak concurrency (before B's second decode):
+//   B: block0(B-input-0..15) + block1(B-input-16..31) + block2(B-decode-0) = 3 blocks
+//   A: block3(A-input-0..15) = 1 block (decode needs new block when block3 is full)
+//
+// B's second decode step (PI=33) needs a 4th block for its output token; all 4
+// blocks are taken at that point, so A (tail) is evicted.  A is re-queued with
+// ProgressIndex=0, re-prefills, and eventually completes normally.
+//
+// Without the fix: TotalOutputTokens counts A's pre-eviction decode step AND
+// A's full post-eviction run (one extra).
+// With the fix: TotalOutputTokens = 8 (4 per request: PI_final - InputLen).
+func TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption(t *testing.T) {
+	// beta=[0,1,0]: StepTime = cacheMissTokens (min 1 µs).
+	// Decode steps cost 0 µs → clamped to 1; prefill costs inputTokens µs.
+	cfg := SimConfig{
+		Horizon:             1_000_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(4, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(10, 10_000, 16),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 1, 0}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+	}
+	s := mustNewSimulator(t, cfg)
+
+	// Distinct non-zero token slices prevent prefix-cache sharing between A and B.
+	bInput := make([]int, 32)
+	for i := range bInput {
+		bInput[i] = i + 1
+	}
+	aInput := make([]int, 16)
+	for i := range aInput {
+		aInput[i] = 1000 + i
+	}
+
+	// B injected first → WaitQ front → running batch head (index 0), never evicted.
+	// A injected second → running batch tail (index 1), eviction candidate.
+	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]int, 5)})
+	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]int, 5)})
+
+	for s.HasPendingEvents() {
+		s.ProcessNextEvent()
+	}
+
+	// Both requests must complete; verify preemption was exercised.
+	if s.Metrics.PreemptionCount == 0 {
+		t.Fatal("precondition violated: expected at least one preemption, got 0 — scenario does not test the bug")
+	}
+
+	// At normal completion: PI_final = InputLen + OutputLen - 1.
+	// decode tokens per request = PI_final - InputLen = OutputLen - 1 = 4.
+	// Total = 4 (B) + 4 (A) = 8.
+	want := 8
+	got := s.Metrics.TotalOutputTokens
+	if got != want {
+		t.Errorf("TotalOutputTokens = %d, want %d (extra %d indicates double-count after preemption)",
+			got, want, got-want)
+	}
+
+	// INV-1: all requests must be accounted for.
+	total := s.Metrics.CompletedRequests + s.Metrics.StillQueued + s.Metrics.StillRunning +
+		s.Metrics.DroppedUnservable + s.Metrics.TimedOutRequests
+	if total != 2 {
+		t.Errorf("INV-1 violated: accounted = %d, want 2", total)
+	}
+}

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2609,13 +2609,14 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 // Token slices use distinct non-zero values to prevent prefix-cache sharing
 // between A and B, ensuring separate block allocations.
 //
-// Block layout at peak concurrency (before B's second decode):
+// Block layout at peak concurrency (after B's first prefill chunk + A's full prefill):
 //   B: block0(B-input-0..15) + block1(B-input-16..31) + block2(B-decode-0) = 3 blocks
-//   A: block3(A-input-0..15) = 1 block (decode needs new block when block3 is full)
+//   A: block3(A-input-0..15) = 1 block (block3 is full after prefill)
 //
-// B's second decode step (PI=33) needs a 4th block for its output token; all 4
-// blocks are taken at that point, so A (tail) is evicted.  A is re-queued with
-// ProgressIndex=0, re-prefills, and eventually completes normally.
+// The eviction is triggered by A, not B: when A needs its first decode token at
+// position 16, block3 (covering positions 0-15) is full and all 4 blocks are
+// occupied by B (3) + A (1).  A is at the batch tail, so A is evicted, re-queued
+// with ProgressIndex=0, re-prefills, and eventually completes normally.
 //
 // Without the fix: TotalOutputTokens counts A's pre-eviction decode step AND
 // A's full post-eviction run (one extra).

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2609,14 +2609,13 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 // Token slices use distinct non-zero values to prevent prefix-cache sharing
 // between A and B, ensuring separate block allocations.
 //
-// Block layout at peak concurrency (after B's first prefill chunk + A's full prefill):
-//   B: block0(B-input-0..15) + block1(B-input-16..31) + block2(B-decode-0) = 3 blocks
-//   A: block3(A-input-0..15) = 1 block (block3 is full after prefill)
+// Block layout at peak concurrency (after B's second prefill chunk + A's full prefill + A's first decode):
+//   B: block0(B-input-0..15) + block2(B-input-16..31) = 2 blocks
+//   A: block1(A-input-0..15) + block3(A-decode-0)     = 2 blocks
 //
-// The eviction is triggered by A, not B: when A needs its first decode token at
-// position 16, block3 (covering positions 0-15) is full and all 4 blocks are
-// occupied by B (3) + A (1).  A is at the batch tail, so A is evicted, re-queued
-// with ProgressIndex=0, re-prefills, and eventually completes normally.
+// The eviction is triggered by B, not A: when B needs its first decode token (step 3),
+// all 4 blocks are occupied by B (2) + A (2).  A is at the batch tail, so A is evicted,
+// re-queued with ProgressIndex=0, re-prefills, and eventually completes normally.
 //
 // Without the fix: TotalOutputTokens counts A's pre-eviction decode step AND
 // A's full post-eviction run (one extra).


### PR DESCRIPTION
## Summary

Closes #1091

- **Root cause**: `TotalOutputTokens++` was incremented inline during every decode step in `executeBatchStep`. When a request was preempted its `ProgressIndex` was reset to 0, causing all decode tokens from the aborted run to be counted again when the request re-ran.
- **Fix**: Remove the inline `TotalOutputTokens++` and instead compute decode tokens once at completion time in `recordRequestCompletion` using `ProgressIndex - len(InputTokens)`, which equals the exact number of decode tokens generated regardless of preemption history.
- **Test**: `TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption` — two requests with distinct token content (to prevent prefix-cache sharing), 4 KV blocks tight enough to force A's eviction after one decode step. Asserts `PreemptionCount > 0` (precondition) and `TotalOutputTokens == 8` (4 per request). Fails with the old code (returns 9), passes with the fix.

## Test plan

- [x] New failing test `TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption` added and confirmed to fail before fix (returns 9, wants 8)
- [x] Fix applied; test now passes
- [x] `go test ./...` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)