### PR TITLE
fix(sim): prevent orphaned StepEvent cascade from TimeoutEvent batch-empty path

### DIFF
--- a/sim/event.go
+++ b/sim/event.go
@@ -163,12 +163,17 @@ func (e *TimeoutEvent) Execute(sim *Simulator) {
 			}
 		}
 		sim.RunningBatch.Requests = remaining
-		// If batch is now empty, clear state so the stale stepEvent doesn't
-		// fire Step() on an empty batch (which could crash in StepTime).
-		// This also enables the INV-8 guard below to reschedule if needed.
+		// If batch is now empty, clear RunningBatch. Do NOT nil sim.stepEvent:
+		// leaving it pointing to the already-scheduled StepEvent prevents the
+		// INV-8 guard below from creating a duplicate StepEvent at the current
+		// tick. At the same tick, StepEvents fire before TimeoutEvents (priority
+		// 2 < 5), so a newly-created StepEvent would pull a queued request and
+		// then its same-deadline TimeoutEvent would immediately time it out —
+		// cascading once per queued seed and leaving N orphaned StepEvents.
+		// The already-scheduled StepEvent fires at the correct future time and
+		// the Step() orphan guard handles the empty-batch case.
 		if len(remaining) == 0 {
 			sim.RunningBatch = nil
-			sim.stepEvent = nil
 		}
 	} else {
 		sim.WaitQ.Remove(e.Request)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -539,13 +539,15 @@ func (sim *Simulator) recordRequestCompletion(req *Request) {
 // Step simulates a single vllm step(): batch scheduling, model execution, mirroring, and completion.
 // Phases: (1) schedule batch, (2) execute prefill/decode, (2.5) mirror to CPU, (3) process completions, (4) schedule next step.
 //
-// Orphaned StepEvent guard: when a TimeoutEvent empties the RunningBatch and nils stepEvent,
-// a previously-scheduled StepEvent may still be in the heap. If the INV-8 guard also scheduled
-// a new StepEvent, two StepEvents fire at the same tick. The second finds RunningBatch nil and
-// WaitQ empty (already processed by the first). This guard prevents the phantom double-step.
+// Orphaned StepEvent guard: when a TimeoutEvent empties the RunningBatch it leaves
+// sim.stepEvent pointing to the already-scheduled StepEvent (preventing the cascade
+// described in #1096). If that StepEvent fires and finds nothing to do, clearing
+// sim.stepEvent here prevents future QueuedEvent INV-8 guards from seeing a stale
+// non-nil pointer and skipping their step-scheduling.
 func (sim *Simulator) Step(now int64) {
 	if sim.RunningBatch == nil && sim.WaitQ.Len() == 0 {
-		return // orphaned StepEvent — nothing to process
+		sim.stepEvent = nil
+		return
 	}
 	sim.scheduleBatch(now)
 	currStepAdvance := sim.executeBatchStep(now)

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -402,3 +402,107 @@ func TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock(t *testing.T) 
 		t.Errorf("SimEndedTime inflated: got %d µs, want < 500_000 µs", sim.Metrics.SimEndedTime)
 	}
 }
+
+// TestTimeout_CascadeDoesNotCreateOrphanedStepEvents verifies that simultaneous
+// TimeoutEvents for running requests do not trigger the INV-8 guard and cascade
+// into orphaned StepEvents (issue #1096).
+//
+// Without the fix, TimeoutEvent.Execute nil'd sim.stepEvent when emptying
+// RunningBatch. The INV-8 guard then created a new StepEvent at the current tick,
+// which (priority 2 < timeout priority 5) fired before remaining TimeoutEvents,
+// pulling a queued seed that was immediately timed out. Each iteration left an
+// orphaned StepEvent at the scheduled future tick. These orphans fired in lock-step
+// with subsequent legitimate StepEvents, processing the batch N+1 times per tick
+// and collapsing SimEndedTime by ~2x.
+//
+// GIVEN: 8 requests sharing the same arrival time; 6 with a short deadline (50ms),
+//
+//	2 with no deadline. KV cache: 4 blocks × 16 tokens, each request needs 2
+//	blocks (InputLen=16 fills block0; first decode token at PI=16 needs block1).
+//	This fits exactly 2 requests, leaving 6 to queue.
+//
+// WHEN: The simulation runs to completion.
+//
+// THEN: The 6 deadline requests time out, the 2 no-deadline requests complete
+//
+//	normally, and SimEndedTime reflects realistic per-step latency (~130ms),
+//	not collapsed cascade timing (~70ms).
+func TestTimeout_CascadeDoesNotCreateOrphanedStepEvents(t *testing.T) {
+	const (
+		deadlineTicks = int64(50_000) // 50ms — requests will not complete in time
+		stepTimeTicks = int64(10_000) // 10ms per step (alpha[0]=10000)
+		inputLen      = 16            // tokens per request — fills exactly 1 KV block (positions 0-15)
+		outputLen     = 8             // needs 1 decode block (positions 16-23); total 2 blocks
+		numDeadline   = 6             // requests that will time out
+		numSurviving  = 2             // requests with no deadline (will complete)
+		numRequests   = numDeadline + numSurviving
+	)
+	// KV cache: 4 blocks × 16 tokens.
+	// Each request needs 2 blocks (input block + first decode block), so 2 fit simultaneously.
+	// r0–r5 carry deadline=50ms; r6–r7 carry no deadline (Deadline==0 → no TimeoutEvent).
+	cfg := SimConfig{
+		Horizon:             500_000, // 500ms — well beyond the ~130ms expected completion
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(4, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(10, 10_000, 16),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{float64(stepTimeTicks), 0, 0}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	for i := 0; i < numRequests; i++ {
+		deadline := deadlineTicks
+		if i >= numDeadline {
+			deadline = 0
+		}
+		sim.InjectArrival(&Request{
+			ID:           fmt.Sprintf("r%d", i),
+			ArrivalTime:  0,
+			InputTokens:  make([]int, inputLen),
+			OutputTokens: make([]int, outputLen),
+			MaxOutputLen: outputLen,
+			State:        StateQueued,
+			Deadline:     deadline,
+		})
+	}
+	sim.Run()
+
+	// THEN: all deadline requests timed out, no-deadline requests completed.
+	if sim.Metrics.TimedOutRequests != numDeadline {
+		t.Errorf("TimedOutRequests: got %d, want %d", sim.Metrics.TimedOutRequests, numDeadline)
+	}
+	if sim.Metrics.CompletedRequests != numSurviving {
+		t.Errorf("CompletedRequests: got %d, want %d", sim.Metrics.CompletedRequests, numSurviving)
+	}
+
+	// INV-1: conservation across all terminal states.
+	total := sim.Metrics.CompletedRequests + sim.Metrics.TimedOutRequests +
+		sim.Metrics.StillQueued + sim.Metrics.StillRunning + sim.Metrics.DroppedUnservable
+	if total != numRequests {
+		t.Errorf("INV-1 violated: total %d != injected %d", total, numRequests)
+	}
+
+	// THEN: SimEndedTime must reflect realistic per-step latency for the surviving
+	// requests, not the collapsed timing caused by cascading orphaned StepEvents.
+	//
+	// With the fix: SimEndedTime ≈ 140ms (measured: 140,000 µs).
+	//   Cascade at t=50ms: r0/r1 timeout, r2–r5 queue timeout, r6/r7 survive.
+	//   Surviving requests admitted at ~t=60ms; 1 prefill + 7 decode = 8 steps
+	//   at 10ms/step → complete at t=140ms.
+	//
+	// Without the fix (cascade): SimEndedTime ≈ 100ms (measured: 100,000 µs).
+	//   Orphaned StepEvents fire alongside the legitimate ones, advancing the
+	//   surviving requests faster than real step timing allows, collapsing
+	//   SimEndedTime by ~30%.
+	const (
+		simEndedMin = int64(120_000) // 120ms: midpoint between fixed (140ms) and buggy (100ms)
+		simEndedMax = int64(250_000) // 250ms: generous upper bound for slow environments
+	)
+	if sim.Metrics.SimEndedTime < simEndedMin {
+		t.Errorf("SimEndedTime collapsed by cascade: got %d µs, want >= %d µs (orphaned StepEvents suspected)",
+			sim.Metrics.SimEndedTime, simEndedMin)
+	}
+	if sim.Metrics.SimEndedTime > simEndedMax {
+		t.Errorf("SimEndedTime too high: got %d µs, want <= %d µs", sim.Metrics.SimEndedTime, simEndedMax)
+	}
+}

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -496,7 +496,7 @@ func TestTimeout_CascadeDoesNotCreateOrphanedStepEvents(t *testing.T) {
 	//   SimEndedTime by ~30%.
 	const (
 		simEndedMin = int64(120_000) // 120ms: midpoint between fixed (140ms) and buggy (100ms)
-		simEndedMax = int64(250_000) // 250ms: generous upper bound for slow environments
+		simEndedMax = int64(200_000) // 200ms: 1.43× expected 140ms, catches step-time regressions
 	)
 	if sim.Metrics.SimEndedTime < simEndedMin {
 		t.Errorf("SimEndedTime collapsed by cascade: got %d µs, want >= %d µs (orphaned StepEvents suspected)",


### PR DESCRIPTION
## Summary

Fixes a DES event-ordering bug where simultaneous `TimeoutEvent`s for running requests cascade into N orphaned `StepEvent`s, collapsing `SimEndedTime` and inflating `tokens_per_sec` by up to ~33x at high concurrency.

**Root cause:** When `TimeoutEvent.Execute` emptied `RunningBatch`, it nil'd `sim.stepEvent`, orphaning the legitimate `StepEvent` already in the heap. The INV-8 work-conserving guard then created a *new* `StepEvent` at the current tick. Because `StepEvent` (priority 2) fires before `TimeoutEvent` (priority 5) at the same tick, this new event fired before the remaining `TimeoutEvent`s — pulling a queued request that was immediately timed out by its own deadline. Each cascade iteration left one orphaned `StepEvent` at the next legitimate step tick. These orphans fired in lock-step with subsequent legitimate `StepEvent`s, processing the batch N+1 times per tick and collapsing `SimEndedTime`.

**Fix:** Do not nil `sim.stepEvent` when `TimeoutEvent` empties `RunningBatch`. The already-scheduled `StepEvent` fires at the correct future time; the existing `Step()` orphan guard handles the empty-batch case. Also clear `sim.stepEvent` in the orphan guard to prevent a stale non-nil pointer from blocking future `QueuedEvent` INV-8 scheduling when all WaitQ requests time out before the orphaned `StepEvent` fires.

Closes #1096

## Behavioral Contracts

- **BC-1:** GIVEN simultaneous `TimeoutEvent`s at the same deadline tick for one running request and N queued requests, WHEN `TimeoutEvent` empties `RunningBatch`, THEN no new `StepEvent` is created at the current tick (the INV-8 guard does not fire because `sim.stepEvent` remains non-nil).
- **BC-2:** GIVEN an orphaned `StepEvent` that fires and finds `RunningBatch == nil` and `WaitQ.Len() == 0`, WHEN the `Step()` orphan guard returns early, THEN `sim.stepEvent` is cleared to nil so future `QueuedEvent` INV-8 guards can schedule normally.

## Antipattern Checklist

**Critical (correctness):**
- [x] No silent data loss — every error path returns error, panics, or increments counter (R1) — N/A: no new error paths
- [x] Struct construction sites audited for new fields (R4) — N/A: no new struct fields
- [x] Resource allocation loops rollback on mid-loop failure (R5) — N/A: no resource allocation changes
- [x] No `logrus.Fatalf` or `os.Exit` in `sim/` packages (R6) — N/A: no new log calls
- [x] Division by runtime-derived denominators guarded (R11) — N/A: no division
- [x] Unbounded retry/requeue loops have circuit breakers (R19) — N/A: no loops
- [x] No `range` over slices that can shrink during iteration (R21) — N/A: no range changes

**Important (quality):**
- [x] Map keys sorted before float accumulation or ordered output (R2) — N/A
- [x] Every new numeric parameter validated — CLI flags AND library constructors (R3) — N/A: no new parameters
- [x] Invariant tests alongside golden tests (R7) — new test asserts INV-1 conservation and SimEndedTime bounds
- [x] No exported mutable maps (R8) — N/A
- [x] `*float64` for YAML fields where zero is valid (R9) — N/A
- [x] YAML strict parsing with `KnownFields(true)` (R10) — N/A
- [x] New interfaces work for 2+ implementations (R13) — N/A: no interfaces
- [x] No method spans multiple module responsibilities (R14) — N/A
- [x] Routing scorer signals documented for freshness tier (R17) — N/A
- [x] CLI flag values not silently overwritten by defaults.yaml (R18) — N/A
- [x] Detectors and analyzers handle degenerate inputs (R20) — N/A
- [x] Pre-check estimates consistent with actual operation (R22) — N/A
- [x] Parallel code paths apply equivalent transformations (R23) — N/A

**Hygiene (maintenance):**
- [x] Golden dataset regenerated if output changed (R12) — N/A: no output format changes
- [x] Stale PR references resolved (R15) — N/A
- [x] Config params grouped by module (R16) — N/A

## Invariants

- [x] Request conservation: injected == completed + queued + running (INV-1) — verified by new test
- [x] Request lifecycle: queued -> running -> completed (INV-2) — unchanged
- [x] KV block conservation: allocated + free == total (INV-4) — unchanged
- [x] Causality: arrival <= schedule <= completion (INV-5) — unchanged
- [x] Clock monotonicity (INV-3) — unchanged
- [x] Work-conserving (INV-8) — fix prevents false-positive INV-8 triggers that caused the cascade; stale-pointer clear ensures INV-8 remains functional for future arrivals

## Test Plan

New test: `TestTimeout_CascadeDoesNotCreateOrphanedStepEvents` in `sim/timeout_test.go`

Scenario: 6 requests with a shared 50ms deadline + 2 requests with no deadline; KV cache constrained to force queueing. The deadline requests time out and trigger the cascade. The surviving requests are processed by the remaining `StepEvent`s.

Without the fix: `SimEndedTime` collapses to ~100ms (orphans process the batch faster than real step timing allows). With the fix: `SimEndedTime` is ~140ms (correct single-step-per-tick progression).

```bash
go test ./sim/... -run TestTimeout_CascadeDoesNotCreateOrphanedStepEvents -v
go test ./... -count=1
go vet ./...
```

All pass.

## Source

Fixes #1096