### PR TITLE
docs(calibrate): update guide for workload-level aggregate metrics

### DIFF
--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -232,6 +232,7 @@ Compares real observed latencies (from `blis observe`) against simulator predict
 | `--warmup-requests` | `int` | `-1` | Requests to exclude from comparison (-1 = use trace header value, 0 = include all) |
 | `--network-rtt-us` | `int64` | `-1` | Network RTT in microseconds added to sim-side latencies (-1 = use trace header value) |
 | `--network-bandwidth-mbps` | `float64` | `0` | Network bandwidth in Mbps for upload/download delay (0 = no delay) |
+| `--itl-data` | `string` | `""` | Path to ITL CSV from `blis observe --record-itl` to include ITL metric in the calibration report |
 
 !!! info "Sentinel defaults"
     The `--warmup-requests` and `--network-rtt-us` flags use `-1` as a sentinel meaning "read the value from the trace header." This allows the calibration to automatically use the warmup count and RTT recorded during observation. Pass `0` explicitly to override (include all requests or apply no RTT correction).
@@ -248,40 +249,75 @@ The calibration report JSON contains four sections:
   "warm_up_excluded": 5,
   "matched_pairs": 95,
   "token_mismatches": 2,
+  "itl_dropped": 3,
   "duration": "2m30s"
 }
 ```
 
 - `matched_pairs`: Requests matched by ID between trace and sim results
 - `token_mismatches`: Pairs where observed and simulated token counts differ (indicates potential data quality issues)
+- `itl_dropped`: ITL chunks dropped due to missing request pairing (only present when `--itl-data` is supplied)
 
-**`metrics`** — Per-metric comparison (TTFT and E2E latency):
+**`metrics`** — Per-metric comparison. Keys are `ttft`, `e2e`, and (if `--itl-data` was supplied) `itl`. Each entry has two sub-objects and a top-level `count`:
 
 ```json
 {
   "ttft": {
-    "RealP50": 1234.5,
-    "SimP50": 1200.0,
-    "RealP99": 4567.8,
-    "SimP99": 4500.0,
-    "MAPE": 0.05,
-    "PearsonR": 0.95,
-    "BiasDirection": "over-predict",
-    "Quality": "good",
-    "Count": 95
+    "workload_level": {
+      "real_mean": 1534.2,
+      "sim_mean": 1498.0,
+      "mean_error": -36.2,
+      "mean_percent_error": 0.024,
+      "real_median": 1234.5,
+      "sim_median": 1200.0,
+      "median_error": -34.5,
+      "median_percent_error": 0.028,
+      "real_p50": 1234.5,
+      "sim_p50": 1200.0,
+      "real_p90": 3200.0,
+      "sim_p90": 3150.0,
+      "real_p95": 4000.0,
+      "sim_p95": 3950.0,
+      "real_p99": 4567.8,
+      "sim_p99": 4500.0
+    },
+    "request_level": {
+      "mape": 0.05,
+      "pearson_r": 0.95,
+      "bias_direction": "under-predict",
+      "quality": "good"
+    },
+    "count": 95
   },
   "e2e": { ... }
 }
 ```
 
+The report uses two levels of analysis because they catch different problems. **Workload-level** aggregates (mean, median, percentiles) reveal systematic bias — the simulator consistently over- or under-predicting. **Request-level** prediction quality (MAPE, Pearson) captures per-request variance — how tightly the simulator tracks individual latencies regardless of any overall offset.
+
+**`workload_level` fields:**
+
 | Field | Meaning |
 |-------|---------|
-| `RealP50/P90/P95/P99` | Real (observed) latency percentiles in microseconds |
-| `SimP50/P90/P95/P99` | Simulated latency percentiles in microseconds |
-| `MAPE` | Mean Absolute Percentage Error (lower is better) |
-| `PearsonR` | Pearson correlation coefficient (closer to 1.0 is better) |
-| `BiasDirection` | `over-predict`, `under-predict`, or `neutral` |
-| `Quality` | Rating: `excellent`, `good`, `fair`, or `poor` |
+| `real_mean` / `sim_mean` | Arithmetic mean of observed / simulated latencies (µs) |
+| `mean_error` | `sim_mean - real_mean` — positive = over-predict, negative = under-predict |
+| `mean_percent_error` | `|mean_error| / real_mean` — absolute relative error on the mean |
+| `real_median` / `sim_median` | Median latency aliased from P50 (µs) |
+| `median_error` | `sim_median - real_median` |
+| `median_percent_error` | `|median_error| / real_median` |
+| `real_p50/p90/p95/p99` | Real (observed) latency percentiles (µs) |
+| `sim_p50/p90/p95/p99` | Simulated latency percentiles (µs) |
+
+**`request_level` fields:**
+
+| Field | Meaning |
+|-------|---------|
+| `mape` | Mean Absolute Percentage Error across matched request pairs (lower is better) |
+| `pearson_r` | Pearson correlation coefficient (closer to 1.0 is better) |
+| `bias_direction` | `over-predict`, `under-predict`, or `neutral` |
+| `quality` | Rating: `excellent`, `good`, `fair`, or `poor` |
+
+**Top-level:** `count` — number of matched request pairs used for this metric.
 
 **`config_match`** — Tracks which simulator config parameters matched the observed server config (currently reports `matched` and `defaulted` arrays).
 
@@ -369,10 +405,13 @@ cat calibration.json | python3 -m json.tool
 
 Look for:
 
-- **MAPE < 0.10** and **Quality = "good" or "excellent"** → simulator is well-calibrated for this workload
-- **BiasDirection = "over-predict"** → simulator latencies are higher than reality (conservative)
-- **BiasDirection = "under-predict"** → simulator latencies are lower than reality (optimistic — may need latency model tuning)
-- **High token_mismatches** → data quality issue; check if the server truncated outputs
+- **`request_level.mape` < 0.10** and **`request_level.quality` = `"good"` or `"excellent"`** → simulator tracks individual request latencies well
+- **`workload_level.mean_percent_error` < 0.05** → no systematic bias; mean prediction is within 5% of reality
+- **`request_level.bias_direction` = `"over-predict"`** → simulator latencies are higher than reality (conservative)
+- **`request_level.bias_direction` = `"under-predict"`** → simulator latencies are lower than reality (optimistic — may need latency model tuning)
+- **High `token_mismatches`** → data quality issue; check if the server truncated outputs
+
+Low MAPE with high `mean_percent_error` indicates high per-request variance but no systematic offset. High `mean_percent_error` with low MAPE is unusual and suggests a distributional shift rather than a per-request accuracy problem.
 
 If calibration quality is poor, try:
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -105,6 +105,8 @@ Four input modes are available. At least one must be provided per invocation:
 | `--min-tokens` | `int` | `0` | Set `min_tokens` in request body; requests server to generate at least N tokens before EOS. Set equal to `--output-tokens` for exact output length control (0 = omit). Compatible with `--unconstrained-output`: `min_tokens` is still sent, `max_tokens` is still omitted |
 | `--rtt-ms` | `float64` | `0` | Measured network round-trip time in milliseconds |
 | `--defaults-filepath` | `string` | `"defaults.yaml"` | Path to `defaults.yaml` containing preset definitions (preset mode only) |
+| `--record-itl` | `bool` | `false` | Record per-chunk timestamps for ITL calibration (streaming only; use with `--itl-output`) |
+| `--itl-output` | `string` | `""` | Output path for ITL CSV file (default: `<trace-data>.itl.csv` when `--record-itl` is set) |
 
 ### Distribution Synthesis Flags
 
@@ -256,7 +258,7 @@ The calibration report JSON contains four sections:
 
 - `matched_pairs`: Requests matched by ID between trace and sim results
 - `token_mismatches`: Pairs where observed and simulated token counts differ (indicates potential data quality issues)
-- `itl_dropped`: ITL chunks dropped due to missing request pairing (only present when `--itl-data` is supplied)
+- `itl_dropped`: Requests dropped from ITL computation because all inter-chunk deltas were negative (clock skew); only present when greater than 0
 
 **`metrics`** — Per-metric comparison. Keys are `ttft`, `e2e`, and (if `--itl-data` was supplied) `itl`. Each entry has two sub-objects and a top-level `count`:
 
@@ -411,7 +413,7 @@ Look for:
 - **`request_level.bias_direction` = `"under-predict"`** → simulator latencies are lower than reality (optimistic — may need latency model tuning)
 - **High `token_mismatches`** → data quality issue; check if the server truncated outputs
 
-Low MAPE with high `mean_percent_error` indicates high per-request variance but no systematic offset. High `mean_percent_error` with low MAPE is unusual and suggests a distributional shift rather than a per-request accuracy problem.
+Low MAPE with high `mean_percent_error` indicates low per-request variance but a systematic offset — the simulator is consistently biased in one direction on every request. High MAPE with high `mean_percent_error` suggests widespread per-request inaccuracy with an additional systematic component; consider switching latency models.
 
 If calibration quality is poor, try:
 


### PR DESCRIPTION
## Summary

The `docs/guide/observe-replay-calibrate.md` guide was not updated when PR #1093 restructured the calibration report JSON. This PR closes that documentation gap.

**What was stale:**
- JSON example used PascalCase flat keys (`MAPE`, `RealP50`, `Quality`, etc.) — the actual output uses snake_case nested under `workload_level` and `request_level`
- Field table was missing all 8 new aggregate fields (`real_mean`, `sim_mean`, `mean_error`, `mean_percent_error`, `real_median`, `sim_median`, `median_error`, `median_percent_error`)
- `--itl-data` flag was undocumented
- `itl_dropped` field in `trace_info` was missing from the example
- "Interpret results" guidance referenced bare `MAPE`/`Quality` instead of `request_level.mape`/`request_level.quality`

**What changed:**
- Fix JSON example to show the real nested `workload_level`/`request_level` structure with snake_case keys
- Split field table into separate `workload_level` and `request_level` tables covering all fields
- Add explanation of why the two-level split exists (systematic bias detection vs per-request variance)
- Update "Interpret results" guidance to use canonical field paths and add `workload_level.mean_percent_error` as a complementary diagnostic signal
- Add `--itl-data` to the flags table
- Add `itl_dropped` to the `trace_info` JSON example

## Test plan

- [x] `go test ./...` passes (docs-only change)
- [x] Verified no remaining PascalCase field references in the calibrate section
- [x] JSON example matches actual `MetricComparison` struct JSON tags in `sim/workload/calibrate.go`

Closes #1103. Follow-up to #1093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)