### PR TITLE
chore: ignore .claude/worktrees/ created by Claude Code EnterWorktree tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ actions-runner/
 # Convergence review state (session-local, not committed)
 .claude/convergence-state/
 
+# Claude Code worktrees (created by EnterWorktree tool, not committed)
+.claude/worktrees/
+
 # Superpowers specs/plans (agent-local, not committed)
 docs/superpowers/
 


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore`
- The Claude Code CLI's built-in `EnterWorktree` tool hardcodes `.claude/worktrees/` as the location for git worktrees it creates
- Without this entry the directory shows up as untracked in `git status` (visible in repo today)
- Placed alongside the existing `.claude/convergence-state/` entry for consistency

## Test plan

- [ ] Verify `git check-ignore -v .claude/worktrees/` reports the path as ignored after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)