### PR TITLE
fix(workload): skip empty dict windows in ServeGen converter

### DIFF
--- a/sim/workload/servegen.go
+++ b/sim/workload/servegen.go
@@ -282,9 +282,12 @@ func loadServeGenDataset(path string, sgConfig *ServeGenDataSpec) (map[int]float
 			outputPDFStr != "" && outputPDFStr != "{}" {
 			break
 		}
+		// Log skipped windows for debugging (common in real ServeGen data warm-up periods)
+		logrus.Debugf("loadServeGenDataset: skipping window %q: input=%q output=%q (empty dict or missing)", k, inputPDFStr, outputPDFStr)
 	}
 
-	if inputPDFStr == "" || outputPDFStr == "" {
+	if inputPDFStr == "" || inputPDFStr == "{}" ||
+		outputPDFStr == "" || outputPDFStr == "{}" {
 		return nil, nil, fmt.Errorf("no valid PDF windows found in dataset")
 	}
 

--- a/sim/workload/servegen.go
+++ b/sim/workload/servegen.go
@@ -276,7 +276,10 @@ func loadServeGenDataset(path string, sgConfig *ServeGenDataSpec) (map[int]float
 		}
 		inputPDFStr = window["input_tokens"]
 		outputPDFStr = window["output_tokens"]
-		if inputPDFStr != "" && outputPDFStr != "" {
+		// Skip empty dicts (represented as "{}" string) and truly empty strings
+		// Matches ServeGen Python library behavior (clientpool.py:166-168)
+		if inputPDFStr != "" && inputPDFStr != "{}" &&
+			outputPDFStr != "" && outputPDFStr != "{}" {
 			break
 		}
 	}

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -141,13 +141,15 @@ func TestParseServeGenTrace_NonNumericFields_SkippedAndWarned(t *testing.T) {
 // TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid tests that the loader
 // skips time windows with empty PDF dictionaries (serialized as "{}") and finds the first
 // window with actual traffic data, matching ServeGen Python library behavior.
+// Keys are chosen for lexicographic sort order ("100" < "200" < "300") to ensure
+// asymmetric partial-empty windows (window 200: input="{}", output=valid) are evaluated.
 func TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid(t *testing.T) {
 	// GIVEN a dataset with empty dict windows followed by a valid window
 	dir := t.TempDir()
 	datasetJSON := `{
-		"0": {"input_tokens": "{}", "output_tokens": "{}"},
-		"600": {"input_tokens": "{}", "output_tokens": "{50: 1.0}"},
-		"1200": {"input_tokens": "{100: 0.5, 200: 0.5}", "output_tokens": "{50: 0.7, 100: 0.3}"}
+		"100": {"input_tokens": "{}", "output_tokens": "{}"},
+		"200": {"input_tokens": "{}", "output_tokens": "{50: 1.0}"},
+		"300": {"input_tokens": "{100: 0.5, 200: 0.5}", "output_tokens": "{50: 0.7, 100: 0.3}"}
 	}`
 	path := filepath.Join(dir, "dataset.json")
 	require.NoError(t, os.WriteFile(path, []byte(datasetJSON), 0644))
@@ -155,10 +157,11 @@ func TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid(t *testing.T) {
 	// WHEN loading the dataset
 	inputPDF, outputPDF, err := loadServeGenDataset(path, &ServeGenDataSpec{})
 
-	// THEN the function succeeds and uses the first valid window (timestamp 1200)
+	// THEN the function succeeds and uses the first valid window (timestamp 300)
+	// Windows 100 (both empty) and 200 (input empty, output valid) are skipped
 	require.NoError(t, err, "should skip empty dict windows and find valid window")
-	assert.Len(t, inputPDF, 2, "input PDF should have 2 bins from window 1200")
-	assert.Len(t, outputPDF, 2, "output PDF should have 2 bins from window 1200")
+	assert.Len(t, inputPDF, 2, "input PDF should have 2 bins from window 300")
+	assert.Len(t, outputPDF, 2, "output PDF should have 2 bins from window 300")
 	assert.Equal(t, 0.5, inputPDF[100])
 	assert.Equal(t, 0.5, inputPDF[200])
 	assert.Equal(t, 0.7, outputPDF[50])

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -167,6 +167,33 @@ func TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid(t *testing.T) {
 	assert.Equal(t, 0.3, outputPDF[100])
 }
 
+// TestLoadServeGenDataset_OutputEmptyDictWindow_Skipped tests the mirror asymmetric case:
+// when the output field is "{}" but input is valid, the window is correctly skipped.
+// This independently verifies the outputPDFStr != "{}" clause of the break condition.
+func TestLoadServeGenDataset_OutputEmptyDictWindow_Skipped(t *testing.T) {
+	// GIVEN a dataset with output="{}" followed by a valid window
+	dir := t.TempDir()
+	datasetJSON := `{
+		"100": {"input_tokens": "{100: 1.0}", "output_tokens": "{}"},
+		"200": {"input_tokens": "{100: 0.5, 200: 0.5}", "output_tokens": "{50: 0.7, 100: 0.3}"}
+	}`
+	path := filepath.Join(dir, "dataset.json")
+	require.NoError(t, os.WriteFile(path, []byte(datasetJSON), 0644))
+
+	// WHEN loading the dataset
+	inputPDF, outputPDF, err := loadServeGenDataset(path, &ServeGenDataSpec{})
+
+	// THEN the function succeeds and uses the first valid window (timestamp 200)
+	// Window 100 (input valid, output empty) is skipped
+	require.NoError(t, err, "should skip window with output={}")
+	assert.Len(t, inputPDF, 2, "input PDF should have 2 bins from window 200")
+	assert.Len(t, outputPDF, 2, "output PDF should have 2 bins from window 200")
+	assert.Equal(t, 0.5, inputPDF[100])
+	assert.Equal(t, 0.5, inputPDF[200])
+	assert.Equal(t, 0.7, outputPDF[50])
+	assert.Equal(t, 0.3, outputPDF[100])
+}
+
 // TestLoadServeGenDataset_AllEmptyDictWindows_ReturnsError tests that when ALL windows
 // contain empty dicts ("{}"), the loader returns the correct "no valid PDF windows" error
 // rather than falling through to the parser with misleading "empty PDF dictionary" error.
@@ -174,9 +201,9 @@ func TestLoadServeGenDataset_AllEmptyDictWindows_ReturnsError(t *testing.T) {
 	// GIVEN a dataset where every window has empty dicts
 	dir := t.TempDir()
 	datasetJSON := `{
-		"0": {"input_tokens": "{}", "output_tokens": "{}"},
-		"600": {"input_tokens": "{}", "output_tokens": "{}"},
-		"1200": {"input_tokens": "{}", "output_tokens": "{}"}
+		"100": {"input_tokens": "{}", "output_tokens": "{}"},
+		"200": {"input_tokens": "{}", "output_tokens": "{}"},
+		"300": {"input_tokens": "{}", "output_tokens": "{}"}
 	}`
 	path := filepath.Join(dir, "dataset.json")
 	require.NoError(t, os.WriteFile(path, []byte(datasetJSON), 0644))

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -161,6 +161,30 @@ func TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid(t *testing.T) {
 	assert.Len(t, outputPDF, 2, "output PDF should have 2 bins from window 1200")
 	assert.Equal(t, 0.5, inputPDF[100])
 	assert.Equal(t, 0.5, inputPDF[200])
+	assert.Equal(t, 0.7, outputPDF[50])
+	assert.Equal(t, 0.3, outputPDF[100])
+}
+
+// TestLoadServeGenDataset_AllEmptyDictWindows_ReturnsError tests that when ALL windows
+// contain empty dicts ("{}"), the loader returns the correct "no valid PDF windows" error
+// rather than falling through to the parser with misleading "empty PDF dictionary" error.
+func TestLoadServeGenDataset_AllEmptyDictWindows_ReturnsError(t *testing.T) {
+	// GIVEN a dataset where every window has empty dicts
+	dir := t.TempDir()
+	datasetJSON := `{
+		"0": {"input_tokens": "{}", "output_tokens": "{}"},
+		"600": {"input_tokens": "{}", "output_tokens": "{}"},
+		"1200": {"input_tokens": "{}", "output_tokens": "{}"}
+	}`
+	path := filepath.Join(dir, "dataset.json")
+	require.NoError(t, os.WriteFile(path, []byte(datasetJSON), 0644))
+
+	// WHEN loading the dataset
+	_, _, err := loadServeGenDataset(path, &ServeGenDataSpec{})
+
+	// THEN the function returns an error indicating no valid windows were found
+	require.Error(t, err, "should fail when all windows are empty dicts")
+	assert.Contains(t, err.Error(), "no valid PDF windows", "error should indicate no valid windows, not parser error")
 }
 
 // JSON keys that are not valid floats are skipped with a warning.

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -137,7 +137,6 @@ func TestParseServeGenTrace_NonNumericFields_SkippedAndWarned(t *testing.T) {
 	assert.Contains(t, buf.String(), "2 rows", "should warn about 2 skipped rows")
 }
 
-// TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning verifies BC-3.
 // TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid tests that the loader
 // skips time windows with empty PDF dictionaries (serialized as "{}") and finds the first
 // window with actual traffic data, matching ServeGen Python library behavior.
@@ -190,6 +189,7 @@ func TestLoadServeGenDataset_AllEmptyDictWindows_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "no valid PDF windows", "error should indicate no valid windows, not parser error")
 }
 
+// TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning verifies BC-3.
 // JSON keys that are not valid floats are skipped with a warning.
 // When ALL keys are non-numeric, the function returns an error after warning.
 func TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning(t *testing.T) {

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -138,6 +138,31 @@ func TestParseServeGenTrace_NonNumericFields_SkippedAndWarned(t *testing.T) {
 }
 
 // TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning verifies BC-3.
+// TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid tests that the loader
+// skips time windows with empty PDF dictionaries (serialized as "{}") and finds the first
+// window with actual traffic data, matching ServeGen Python library behavior.
+func TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid(t *testing.T) {
+	// GIVEN a dataset with empty dict windows followed by a valid window
+	dir := t.TempDir()
+	datasetJSON := `{
+		"0": {"input_tokens": "{}", "output_tokens": "{}"},
+		"600": {"input_tokens": "{}", "output_tokens": "{50: 1.0}"},
+		"1200": {"input_tokens": "{100: 0.5, 200: 0.5}", "output_tokens": "{50: 0.7, 100: 0.3}"}
+	}`
+	path := filepath.Join(dir, "dataset.json")
+	require.NoError(t, os.WriteFile(path, []byte(datasetJSON), 0644))
+
+	// WHEN loading the dataset
+	inputPDF, outputPDF, err := loadServeGenDataset(path, &ServeGenDataSpec{})
+
+	// THEN the function succeeds and uses the first valid window (timestamp 1200)
+	require.NoError(t, err, "should skip empty dict windows and find valid window")
+	assert.Len(t, inputPDF, 2, "input PDF should have 2 bins from window 1200")
+	assert.Len(t, outputPDF, 2, "output PDF should have 2 bins from window 1200")
+	assert.Equal(t, 0.5, inputPDF[100])
+	assert.Equal(t, 0.5, inputPDF[200])
+}
+
 // JSON keys that are not valid floats are skipped with a warning.
 // When ALL keys are non-numeric, the function returns an error after warning.
 func TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1111 — ServeGen converter now correctly skips inactive time windows serialized as `"{}"` (empty dict string).

## Root Cause

Official ServeGen traces contain inactive time windows as `"{}"` (2-character string, not empty). The converter's check `if inputPDFStr != ""` was insufficient, causing `parseServeGenPDF` to fail with "empty PDF dictionary".

## Fix

Added explicit check for `"{}"` in addition to empty strings, matching the official ServeGen Python library (clientpool.py:166-168).

**GIVEN** a ServeGen dataset with empty dict windows (`"{}"`) followed by valid windows  
**WHEN** loading the dataset  
**THEN** the converter skips empty windows and uses the first valid window

## Testing

- ✅ New test: `TestLoadServeGenDataset_EmptyDictWindows_SkippedUntilValid` verifies skip behavior
- ✅ Existing test: `TestParseServeGenPDF_EmptyDict_ReturnsError` confirms `"{}"` is rejected by parser
- ✅ All workload tests pass (`go test ./sim/workload/...`)
- ✅ Full test suite passes (`go test ./...`)

## Verification

Tested with official ServeGen data:
```bash
git clone https://github.com/ModelStudio-AI/ServeGen.git
./blis convert servegen --path ServeGen/data/language/m-mid
# Previously: FATA[0000] ServeGen conversion failed: parsing input PDF: empty PDF dictionary
# Now: Success (skips empty windows, finds first valid data)
```