### PR TITLE
docs: remove stale crossmodel/trained-roofline references

### DIFF
--- a/cmd/simconfig_shared_test.go
+++ b/cmd/simconfig_shared_test.go
@@ -132,10 +132,6 @@ func TestReplayCmd_SourceContainsNoInlineBackendBlocks(t *testing.T) {
 	// THEN they must not be present (indicates delegation to resolveLatencyConfig)
 	assert.NotContains(t, content, `if backend == "roofline" {`,
 		"replay.go must not contain inline roofline resolution block; use resolveLatencyConfig(cmd)")
-	assert.NotContains(t, content, `if backend == "crossmodel" {`,
-		"replay.go must not contain inline crossmodel resolution block; use resolveLatencyConfig(cmd)")
-	assert.NotContains(t, content, `if backend == "trained-roofline" {`,
-		"replay.go must not contain inline trained-roofline resolution block; use resolveLatencyConfig(cmd)")
 }
 
 // TestReplayCmd_SourceContainsNoPolicyInlineBlocks verifies replay.go delegates

--- a/sim/latency_model.go
+++ b/sim/latency_model.go
@@ -1,10 +1,9 @@
 package sim
 
 // LatencyModel estimates execution times for the DES step loop.
-// Five implementations exist in sim/latency/: BlackboxLatencyModel (alpha/beta regression),
-// RooflineLatencyModel (analytical FLOPs/bandwidth), CrossModelLatencyModel (physics-informed
-// cross-model), TrainedRooflineLatencyModel (roofline basis functions × learned corrections),
-// and TrainedPhysicsModel (physics-informed basis functions with architecture-aware MoE scaling).
+// Three implementations exist in sim/latency/: BlackboxLatencyModel (alpha/beta regression),
+// RooflineLatencyModel (analytical FLOPs/bandwidth), and TrainedPhysicsModel (physics-informed
+// basis functions with architecture-aware MoE scaling).
 // All time estimates are in microseconds (ticks).
 type LatencyModel interface {
 	// StepTime estimates the duration of one batch step given the running batch.


### PR DESCRIPTION
Fixes #1102

## Summary

Removes remaining documentation and test references to the deprecated `crossmodel` and `trained-roofline` backends that were removed in #1094.

## Changes

- **`sim/latency_model.go`**: Updated `LatencyModel` interface documentation to list only the three active implementations:
  - `BlackboxLatencyModel` (alpha/beta regression)
  - `RooflineLatencyModel` (analytical FLOPs/bandwidth)
  - `TrainedPhysicsModel` (physics-informed basis functions with MoE scaling)
  
- **`cmd/simconfig_shared_test.go`**: Removed test assertions that checked for inline backend resolution strings for the removed backends. These assertions were checking for code patterns that can never appear since the backends were removed.

## What Was Kept

Regression tests that verify the removed backends produce clear error messages remain in:
- `sim/latency/latency_test.go` - `TestNewLatencyModel_RemovedBackendError`
- `sim/bundle_test.go` - Tests for policy bundle validation

These serve as guards to ensure deprecated backend names stay rejected with helpful error messages.

## Testing

- ✅ `go test ./cmd/... -run TestReplayCmd_SourceContainsNoInlineBackendBlocks` - Modified test passes
- ✅ `go test ./sim/latency/...` - All latency tests pass including removed backend error tests

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>