### PR TITLE
fix(workload): break generator loop when past last lifecycle window

### DIFF
--- a/docs/plans/fix-1131-lifecycle-window-hang-plan.md
+++ b/docs/plans/fix-1131-lifecycle-window-hang-plan.md
@@ -100,7 +100,7 @@ if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
 And apply the same fix to the multi-session reasoning loop (line ~222):
 
 ```go
-// Check lifecycle windows (bug fix: reasoning path was missing this)
+// Check lifecycle windows
 if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
 	if currentTime >= lastWindowEndUs(client.Lifecycle) {
 		break

--- a/docs/plans/fix-1131-lifecycle-window-hang-plan.md
+++ b/docs/plans/fix-1131-lifecycle-window-hang-plan.md
@@ -1,0 +1,298 @@
+# Fix Lifecycle Window Hang Implementation Plan
+
+**Goal:** Prevent workload generation from hanging when lifecycle windows are used without an explicit horizon.
+**Source:** [GitHub Issue #1131](https://github.com/inference-sim/inference-sim/issues/1131)
+**Closes:** `Fixes #1131`
+
+## Behavioral Contracts
+
+**BC-1: Early exit when past all lifecycle windows (standard client path)**
+- GIVEN a client with `lifecycle.windows` and the default `horizon=math.MaxInt64`
+- WHEN `currentTime` exceeds the last window's `EndUs`
+- THEN the generator stops producing requests for that client in bounded time (no hang)
+
+**BC-2: Early exit when past all lifecycle windows (multi-session reasoning path)**
+- GIVEN a multi-session reasoning client with `lifecycle.windows` and `horizon=math.MaxInt64`
+- WHEN `currentTime` exceeds the last window's `EndUs`
+- THEN the generator stops producing requests for that client in bounded time (no hang)
+
+**BC-3: Gap windows still work**
+- GIVEN a client with multiple non-contiguous lifecycle windows (e.g., `[0, 1s)` and `[3s, 4s)`)
+- WHEN generating requests with a horizon that covers all windows
+- THEN requests are produced in both windows, with no requests in the gap between them
+
+**BC-4: Behavioral equivalence with explicit horizon**
+- GIVEN a client with lifecycle windows ending at time T
+- WHEN generating with `horizon=MaxInt64` (implicit) versus `horizon=2*T` (explicit, well beyond last window)
+- THEN both produce the same requests (same count, same arrival times)
+
+## Tasks
+
+### Task 1: Add `lastWindowEndUs` helper and early-exit test (BC-1, BC-4)
+
+**Files:** modify `sim/workload/generator.go`, modify `sim/workload/generator_test.go`
+
+**Test:**
+
+Add a table-driven test `TestGenerateRequests_LifecycleWindow_NoHang` that exercises:
+- A single client with one lifecycle window `[0, 5_000_000)`, `horizon=math.MaxInt64`, `num_requests=0` (unlimited). Asserts: (a) the function returns without hanging (enforced by the test runner's timeout), (b) all returned requests have `ArrivalTime < 5_000_000`, (c) at least 1 request is produced.
+
+```go
+func TestGenerateRequests_LifecycleWindow_NoHang(t *testing.T) {
+	// BC-1: Generator must exit in bounded time when lifecycle windows
+	// end well before MaxInt64 horizon. Before the fix, this hangs forever.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "phase1", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 256, "std_dev": 64, "min": 64, "max": 512}},
+			OutputDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 128, "std_dev": 64, "min": 32, "max": 512}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 5_000_000}},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	for i, req := range requests {
+		if req.ArrivalTime >= 5_000_000 {
+			t.Errorf("request %d: ArrivalTime=%d outside window [0, 5000000)", i, req.ArrivalTime)
+		}
+	}
+}
+```
+
+**Impl:**
+
+Add a `lastWindowEndUs` helper function to `generator.go`:
+
+```go
+// lastWindowEndUs returns the maximum EndUs across all lifecycle windows.
+func lastWindowEndUs(lifecycle *LifecycleSpec) int64 {
+	var maxEnd int64
+	for _, w := range lifecycle.Windows {
+		if w.EndUs > maxEnd {
+			maxEnd = w.EndUs
+		}
+	}
+	return maxEnd
+}
+```
+
+Then modify the standard client loop (line ~284) to break instead of continuing when past all windows:
+
+```go
+// Check lifecycle windows
+if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
+	if currentTime >= lastWindowEndUs(client.Lifecycle) {
+		break
+	}
+	continue
+}
+```
+
+And apply the same fix to the multi-session reasoning loop (line ~222):
+
+```go
+// Check lifecycle windows (bug fix: reasoning path was missing this)
+if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
+	if currentTime >= lastWindowEndUs(client.Lifecycle) {
+		break
+	}
+	continue
+}
+```
+
+**Verify:** `go test ./sim/workload/... -run TestGenerateRequests_LifecycleWindow_NoHang -timeout 30s`
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `fix(workload): break generator loop when past last lifecycle window (BC-1, BC-2)`
+
+### Task 2: Multi-window gap test (BC-3)
+
+**Files:** modify `sim/workload/generator_test.go`
+
+**Test:**
+
+Add `TestGenerateRequests_LifecycleWindow_MultipleWindows` verifying requests appear in both windows but not in the gap:
+
+```go
+func TestGenerateRequests_LifecycleWindow_MultipleWindows(t *testing.T) {
+	// BC-3: Multiple non-contiguous windows must all produce requests,
+	// with no requests in gaps between windows.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 50.0,
+		Clients: []ClientSpec{{
+			ID: "multi-win", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{
+					{StartUs: 0, EndUs: 1_000_000},          // window 1: [0, 1s)
+					{StartUs: 3_000_000, EndUs: 4_000_000},  // window 2: [3s, 4s)
+				},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected requests")
+	}
+
+	var inWindow1, inWindow2 int
+	for i, req := range requests {
+		arrTime := req.ArrivalTime
+		inW1 := arrTime >= 0 && arrTime < 1_000_000
+		inW2 := arrTime >= 3_000_000 && arrTime < 4_000_000
+		if !inW1 && !inW2 {
+			t.Errorf("request %d: ArrivalTime=%d outside all windows", i, req.ArrivalTime)
+		}
+		if inW1 {
+			inWindow1++
+		}
+		if inW2 {
+			inWindow2++
+		}
+	}
+	if inWindow1 == 0 {
+		t.Error("no requests in window 1 [0, 1s)")
+	}
+	if inWindow2 == 0 {
+		t.Error("no requests in window 2 [3s, 4s)")
+	}
+}
+```
+
+Note: The `break` in Task 1 only fires when past ALL windows. For multiple windows, `lastWindowEndUs` returns the max end (4s in this case), so the loop keeps running through the gap (IAT samples skip past it via `continue`) and produces requests in window 2. The `break` only fires once `currentTime >= 4_000_000`.
+
+**Impl:** No production code changes needed. This test validates that the Task 1 fix correctly handles multi-window gaps.
+
+**Verify:** `go test ./sim/workload/... -run TestGenerateRequests_LifecycleWindow_MultipleWindows -timeout 30s`
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `test(workload): add multi-window gap coverage for lifecycle early exit (BC-3)`
+
+### Task 3: Behavioral equivalence test (BC-4)
+
+**Files:** modify `sim/workload/generator_test.go`
+
+**Test:**
+
+Add `TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon` verifying that implicit `MaxInt64` horizon and explicit large horizon produce identical results:
+
+```go
+func TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon(t *testing.T) {
+	// BC-4: MaxInt64 horizon must produce the same requests as an explicit
+	// horizon well beyond the last window. This proves the early-exit is
+	// a pure optimization, not a behavioral change.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "equiv", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 256, "std_dev": 64, "min": 64, "max": 512}},
+			OutputDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 128, "std_dev": 64, "min": 32, "max": 512}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 5_000_000}},
+			},
+		}},
+	}
+
+	// Run with MaxInt64 (the fix path)
+	r1, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("MaxInt64 horizon: %v", err)
+	}
+
+	// Run with explicit horizon well beyond the window (10s > 5s window)
+	r2, err := GenerateRequests(spec, 10_000_000, 0)
+	if err != nil {
+		t.Fatalf("explicit horizon: %v", err)
+	}
+
+	// Same count and arrival times (INV-6: determinism given same seed)
+	if len(r1) != len(r2) {
+		t.Fatalf("request count: MaxInt64=%d, explicit=%d", len(r1), len(r2))
+	}
+	for i := range r1 {
+		if r1[i].ArrivalTime != r2[i].ArrivalTime {
+			t.Errorf("request %d: arrival %d vs %d", i, r1[i].ArrivalTime, r2[i].ArrivalTime)
+			break
+		}
+	}
+}
+```
+
+**Impl:** No production code changes needed.
+
+**Verify:** `go test ./sim/workload/... -run TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon -timeout 30s`
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `test(workload): add equivalence test for lifecycle early exit (BC-4)`
+
+### Task 4: Multi-session reasoning path hang test (BC-2)
+
+**Files:** modify `sim/workload/generator_test.go`
+
+**Test:**
+
+Add `TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang` covering the reasoning multi-session loop:
+
+```go
+func TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang(t *testing.T) {
+	// BC-2: Multi-session reasoning path must also exit when past all windows.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "reason-lc", TenantID: "t1", SLOClass: "standard", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 25}},
+			Reasoning: &ReasoningSpec{
+				ReasonRatioDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 0}},
+				MultiTurn:       &MultiTurnSpec{MaxRounds: 3, ThinkTimeUs: 50_000, ContextGrowth: "accumulate"},
+			},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 2_000_000}},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	for i, req := range requests {
+		if req.ArrivalTime >= 2_000_000 {
+			t.Errorf("request %d: ArrivalTime=%d outside window [0, 2000000)", i, req.ArrivalTime)
+		}
+	}
+}
+```
+
+**Impl:** Already done in Task 1 (both loops were fixed together).
+
+**Verify:** `go test ./sim/workload/... -run TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang -timeout 30s`
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `test(workload): add reasoning multi-session lifecycle hang test (BC-2)`
+
+## Sanity Checklist
+
+- [x] **R1 (silent continue):** The `continue` is preserved for in-gap timestamps; `break` added only past the last window end. No data is silently discarded.
+- [x] **R2 (determinism, INV-6):** No map iteration, no new non-determinism. BC-4 explicitly verifies deterministic equivalence.
+- [x] **R4 (canonical constructors):** No new structs or struct fields. Only a new free function `lastWindowEndUs`.
+- [x] **R7 (golden values):** No golden values — all tests assert behavioral invariants (arrival times within windows, bounded termination, equivalence).
+- [x] **R12 (behavioral tests):** All four tests assert observable behavior (arrival time bounds, count > 0, equivalence). No structural assertions.
+- [x] **INV-6 (determinism):** BC-4 test verifies identical output for same seed.
+- [x] **Regression:** Existing lifecycle tests (`TestGenerateRequests_SingleSession_LifecycleWindowRoundSuppression`, `TestGenerateRequests_ReasoningClient_RespectsLifecycleWindows`) continue to pass unchanged.
+- [x] **No new interfaces/types/CLI flags.**
+- [x] **No documentation changes needed:** This is a bug fix for internal generator behavior, not a user-facing feature change. Lifecycle windows and horizon flag are already documented.

--- a/docs/plans/fix-1131-lifecycle-window-hang-plan.md
+++ b/docs/plans/fix-1131-lifecycle-window-hang-plan.md
@@ -6,22 +6,22 @@
 
 ## Behavioral Contracts
 
-**BC-1: Early exit when past all lifecycle windows (standard client path)**
+**BC-1131-1: Early exit when past all lifecycle windows (standard client path)**
 - GIVEN a client with `lifecycle.windows` and the default `horizon=math.MaxInt64`
 - WHEN `currentTime` exceeds the last window's `EndUs`
 - THEN the generator stops producing requests for that client in bounded time (no hang)
 
-**BC-2: Early exit when past all lifecycle windows (multi-session reasoning path)**
+**BC-1131-2: Early exit when past all lifecycle windows (multi-session reasoning path)**
 - GIVEN a multi-session reasoning client with `lifecycle.windows` and `horizon=math.MaxInt64`
 - WHEN `currentTime` exceeds the last window's `EndUs`
 - THEN the generator stops producing requests for that client in bounded time (no hang)
 
-**BC-3: Gap windows still work**
+**BC-1131-3: Gap windows still work**
 - GIVEN a client with multiple non-contiguous lifecycle windows (e.g., `[0, 1s)` and `[3s, 4s)`)
 - WHEN generating requests with a horizon that covers all windows
 - THEN requests are produced in both windows, with no requests in the gap between them
 
-**BC-4: Behavioral equivalence with explicit horizon**
+**BC-1131-4: Behavioral equivalence with explicit horizon**
 - GIVEN a client with lifecycle windows ending at time T
 - WHEN generating with `horizon=MaxInt64` (implicit) versus `horizon=2*T` (explicit, well beyond last window)
 - THEN both produce the same requests (same count, same arrival times)
@@ -39,7 +39,7 @@ Add a table-driven test `TestGenerateRequests_LifecycleWindow_NoHang` that exerc
 
 ```go
 func TestGenerateRequests_LifecycleWindow_NoHang(t *testing.T) {
-	// BC-1: Generator must exit in bounded time when lifecycle windows
+	// BC-1131-1: Generator must exit in bounded time when lifecycle windows
 	// end well before MaxInt64 horizon. Before the fix, this hangs forever.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 10.0,
@@ -123,7 +123,7 @@ Add `TestGenerateRequests_LifecycleWindow_MultipleWindows` verifying requests ap
 
 ```go
 func TestGenerateRequests_LifecycleWindow_MultipleWindows(t *testing.T) {
-	// BC-3: Multiple non-contiguous windows must all produce requests,
+	// BC-1131-3: Multiple non-contiguous windows must all produce requests,
 	// with no requests in gaps between windows.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 50.0,
@@ -190,7 +190,7 @@ Add `TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon` verifyi
 
 ```go
 func TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon(t *testing.T) {
-	// BC-4: MaxInt64 horizon must produce the same requests as an explicit
+	// BC-1131-4: MaxInt64 horizon must produce the same requests as an explicit
 	// horizon well beyond the last window. This proves the early-exit is
 	// a pure optimization, not a behavioral change.
 	spec := &WorkloadSpec{
@@ -247,7 +247,7 @@ Add `TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang` covering the re
 
 ```go
 func TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang(t *testing.T) {
-	// BC-2: Multi-session reasoning path must also exit when past all windows.
+	// BC-1131-2: Multi-session reasoning path must also exit when past all windows.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 10.0,
 		Clients: []ClientSpec{{

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -220,6 +220,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				}
 				// Check lifecycle windows (bug fix: reasoning path was missing this)
 				if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
+					if currentTime >= lastWindowEndUs(client.Lifecycle) {
+						break
+					}
 					continue
 				}
 				reasoningReqs, err := GenerateReasoningRequests(
@@ -282,6 +285,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 
 			// Check lifecycle windows
 			if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
+				if currentTime >= lastWindowEndUs(client.Lifecycle) {
+					break
+				}
 				continue
 			}
 
@@ -666,6 +672,17 @@ func isInActiveWindow(timeUs int64, lifecycle *LifecycleSpec) bool {
 		}
 	}
 	return false
+}
+
+// lastWindowEndUs returns the maximum EndUs across all lifecycle windows.
+func lastWindowEndUs(lifecycle *LifecycleSpec) int64 {
+	var maxEnd int64
+	for _, w := range lifecycle.Windows {
+		if w.EndUs > maxEnd {
+			maxEnd = w.EndUs
+		}
+	}
+	return maxEnd
 }
 
 // newRandFromSeed creates a new *rand.Rand from a seed (avoids importing math/rand in callers).

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -218,7 +218,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				if currentTime >= horizon {
 					break
 				}
-				// Check lifecycle windows (bug fix: reasoning path was missing this)
+				// Check lifecycle windows
 				if client.Lifecycle != nil && !isInActiveWindow(currentTime, client.Lifecycle) {
 					if currentTime >= lastWindowEndUs(client.Lifecycle) {
 						break

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -675,6 +675,7 @@ func isInActiveWindow(timeUs int64, lifecycle *LifecycleSpec) bool {
 }
 
 // lastWindowEndUs returns the maximum EndUs across all lifecycle windows.
+// Returns 0 if Windows is empty; callers must ensure the lifecycle is validated.
 func lastWindowEndUs(lifecycle *LifecycleSpec) int64 {
 	var maxEnd int64
 	for _, w := range lifecycle.Windows {

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -2438,3 +2438,154 @@ func TestGenerateWorkload_ZeroSessionClosedLoopClient_EmitsWarning(t *testing.T)
 		t.Errorf("expected 0 sessions (no requests generated), got %d", len(gw.Sessions))
 	}
 }
+
+func TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang(t *testing.T) {
+	// BC-2: Multi-session reasoning path must also exit when past all windows.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "reason-lc", TenantID: "t1", SLOClass: "standard", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 25}},
+			Reasoning: &ReasoningSpec{
+				ReasonRatioDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 0}},
+				MultiTurn:       &MultiTurnSpec{MaxRounds: 3, ThinkTimeUs: 50_000, ContextGrowth: "accumulate"},
+			},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 2_000_000}},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	for i, req := range requests {
+		if req.ArrivalTime >= 2_000_000 {
+			t.Errorf("request %d: ArrivalTime=%d outside window [0, 2000000)", i, req.ArrivalTime)
+		}
+	}
+}
+
+func TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon(t *testing.T) {
+	// BC-4: MaxInt64 horizon must produce the same requests as an explicit
+	// horizon well beyond the last window. This proves the early-exit is
+	// a pure optimization, not a behavioral change.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "equiv", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 256, "std_dev": 64, "min": 64, "max": 512}},
+			OutputDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 128, "std_dev": 64, "min": 32, "max": 512}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 5_000_000}},
+			},
+		}},
+	}
+
+	// Run with MaxInt64 (the fix path)
+	r1, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("MaxInt64 horizon: %v", err)
+	}
+
+	// Run with explicit horizon well beyond the window (10s > 5s window)
+	r2, err := GenerateRequests(spec, 10_000_000, 0)
+	if err != nil {
+		t.Fatalf("explicit horizon: %v", err)
+	}
+
+	// Same count and arrival times (INV-6: determinism given same seed)
+	if len(r1) != len(r2) {
+		t.Fatalf("request count: MaxInt64=%d, explicit=%d", len(r1), len(r2))
+	}
+	for i := range r1 {
+		if r1[i].ArrivalTime != r2[i].ArrivalTime {
+			t.Errorf("request %d: arrival %d vs %d", i, r1[i].ArrivalTime, r2[i].ArrivalTime)
+			break
+		}
+	}
+}
+
+func TestGenerateRequests_LifecycleWindow_MultipleWindows(t *testing.T) {
+	// BC-3: Multiple non-contiguous windows must all produce requests,
+	// with no requests in gaps between windows.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 50.0,
+		Clients: []ClientSpec{{
+			ID: "multi-win", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{
+					{StartUs: 0, EndUs: 1_000_000},         // window 1: [0, 1s)
+					{StartUs: 3_000_000, EndUs: 4_000_000}, // window 2: [3s, 4s)
+				},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected requests")
+	}
+
+	var inWindow1, inWindow2 int
+	for i, req := range requests {
+		arrTime := req.ArrivalTime
+		inW1 := arrTime >= 0 && arrTime < 1_000_000
+		inW2 := arrTime >= 3_000_000 && arrTime < 4_000_000
+		if !inW1 && !inW2 {
+			t.Errorf("request %d: ArrivalTime=%d outside all windows", i, req.ArrivalTime)
+		}
+		if inW1 {
+			inWindow1++
+		}
+		if inW2 {
+			inWindow2++
+		}
+	}
+	if inWindow1 == 0 {
+		t.Error("no requests in window 1 [0, 1s)")
+	}
+	if inWindow2 == 0 {
+		t.Error("no requests in window 2 [3s, 4s)")
+	}
+}
+
+func TestGenerateRequests_LifecycleWindow_NoHang(t *testing.T) {
+	// BC-1: Generator must exit in bounded time when lifecycle windows
+	// end well before MaxInt64 horizon. Before the fix, this hangs forever.
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 42, AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "phase1", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 256, "std_dev": 64, "min": 64, "max": 512}},
+			OutputDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 128, "std_dev": 64, "min": 32, "max": 512}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 0, EndUs: 5_000_000}},
+			},
+		}},
+	}
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	for i, req := range requests {
+		if req.ArrivalTime >= 5_000_000 {
+			t.Errorf("request %d: ArrivalTime=%d outside window [0, 5000000)", i, req.ArrivalTime)
+		}
+	}
+}

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -2440,7 +2440,7 @@ func TestGenerateWorkload_ZeroSessionClosedLoopClient_EmitsWarning(t *testing.T)
 }
 
 func TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang(t *testing.T) {
-	// BC-2: Multi-session reasoning path must also exit when past all windows.
+	// BC-1131-2: Multi-session reasoning path must also exit when past all windows.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 10.0,
 		Clients: []ClientSpec{{
@@ -2472,7 +2472,7 @@ func TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang(t *testing.T) {
 }
 
 func TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon(t *testing.T) {
-	// BC-4: MaxInt64 horizon must produce the same requests as an explicit
+	// BC-1131-4: MaxInt64 horizon must produce the same requests as an explicit
 	// horizon well beyond the last window. This proves the early-exit is
 	// a pure optimization, not a behavioral change.
 	spec := &WorkloadSpec{
@@ -2513,7 +2513,7 @@ func TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon(t *testi
 }
 
 func TestGenerateRequests_LifecycleWindow_MultipleWindows(t *testing.T) {
-	// BC-3: Multiple non-contiguous windows must all produce requests,
+	// BC-1131-3: Multiple non-contiguous windows must all produce requests,
 	// with no requests in gaps between windows.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 50.0,
@@ -2562,7 +2562,7 @@ func TestGenerateRequests_LifecycleWindow_MultipleWindows(t *testing.T) {
 }
 
 func TestGenerateRequests_LifecycleWindow_NoHang(t *testing.T) {
-	// BC-1: Generator must exit in bounded time when lifecycle windows
+	// BC-1131-1: Generator must exit in bounded time when lifecycle windows
 	// end well before MaxInt64 horizon. Before the fix, this hangs forever.
 	spec := &WorkloadSpec{
 		Version: "2", Seed: 42, AggregateRate: 10.0,

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -352,7 +352,8 @@ func validateClient(c *ClientSpec, idx int) error {
 	if c.Reasoning != nil && c.Reasoning.MultiTurn != nil && c.Reasoning.MultiTurn.MaxRounds < 1 {
 		return fmt.Errorf("%s: reasoning.multi_turn.max_rounds must be >= 1, got %d", prefix, c.Reasoning.MultiTurn.MaxRounds)
 	}
-	// Validate lifecycle windows (#1131: empty/degenerate windows cause silent zero-request generation)
+	// Validate lifecycle windows (#1131): empty or degenerate windows would cause
+	// the generator to loop indefinitely against a MaxInt64 horizon.
 	if c.Lifecycle != nil {
 		if len(c.Lifecycle.Windows) == 0 {
 			return fmt.Errorf("%s: lifecycle specified with no windows", prefix)

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -352,6 +352,20 @@ func validateClient(c *ClientSpec, idx int) error {
 	if c.Reasoning != nil && c.Reasoning.MultiTurn != nil && c.Reasoning.MultiTurn.MaxRounds < 1 {
 		return fmt.Errorf("%s: reasoning.multi_turn.max_rounds must be >= 1, got %d", prefix, c.Reasoning.MultiTurn.MaxRounds)
 	}
+	// Validate lifecycle windows (#1131: empty/degenerate windows cause silent zero-request generation)
+	if c.Lifecycle != nil {
+		if len(c.Lifecycle.Windows) == 0 {
+			return fmt.Errorf("%s: lifecycle specified with no windows", prefix)
+		}
+		for j, w := range c.Lifecycle.Windows {
+			if w.StartUs < 0 {
+				return fmt.Errorf("%s: lifecycle.windows[%d] has negative start_us (%d)", prefix, j, w.StartUs)
+			}
+			if w.EndUs <= w.StartUs {
+				return fmt.Errorf("%s: lifecycle.windows[%d] has end_us (%d) <= start_us (%d)", prefix, j, w.EndUs, w.StartUs)
+			}
+		}
+	}
 	return nil
 }
 

--- a/sim/workload/spec_test.go
+++ b/sim/workload/spec_test.go
@@ -646,6 +646,61 @@ func TestValidate_NegativeConcurrency_Rejects(t *testing.T) {
 	}
 }
 
+func TestValidate_LifecycleNoWindows_Rejects(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "2", AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "bad", RateFraction: 1.0,
+			Arrival:   ArrivalSpec{Process: "poisson"},
+			InputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			Lifecycle:  &LifecycleSpec{Windows: []ActiveWindow{}},
+		}},
+	}
+	err := spec.Validate()
+	if err == nil {
+		t.Error("expected error for lifecycle with no windows")
+	}
+}
+
+func TestValidate_LifecycleNegativeStartUs_Rejects(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "2", AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "bad", RateFraction: 1.0,
+			Arrival:   ArrivalSpec{Process: "poisson"},
+			InputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: -1, EndUs: 1_000_000}},
+			},
+		}},
+	}
+	err := spec.Validate()
+	if err == nil {
+		t.Error("expected error for lifecycle window with negative start_us")
+	}
+}
+
+func TestValidate_LifecycleEndUsNotGreaterThanStartUs_Rejects(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "2", AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "bad", RateFraction: 1.0,
+			Arrival:   ArrivalSpec{Process: "poisson"},
+			InputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+			OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{{StartUs: 1_000_000, EndUs: 1_000_000}},
+			},
+		}},
+	}
+	err := spec.Validate()
+	if err == nil {
+		t.Error("expected error for lifecycle window with end_us == start_us")
+	}
+}
+
 func TestValidate_NegativeThinkTimeUs_Rejects(t *testing.T) {
 	spec := &WorkloadSpec{
 		Version:  "2",


### PR DESCRIPTION
## Summary

- **Bug:** Workload generation hangs indefinitely when `lifecycle.windows` is used without an explicit `--horizon`. The generator loops from `currentTime` to `math.MaxInt64` with only a `continue` (no `break`) once past the last window's `EndUs`.
- **Fix:** Add `lastWindowEndUs()` helper and early `break` in both the standard client loop and multi-session reasoning loop when `currentTime >= max(window.EndUs)`.
- **Tests:** Four behavioral tests — hang prevention (both loops), multi-window gap correctness, and equivalence with explicit horizon.

## Behavioral Contracts

**BC-1:** GIVEN a client with `lifecycle.windows` and `horizon=MaxInt64`, WHEN `currentTime` exceeds the last window's `EndUs`, THEN the generator stops in bounded time.

**BC-2:** GIVEN a multi-session reasoning client with `lifecycle.windows` and `horizon=MaxInt64`, WHEN `currentTime` exceeds the last window's `EndUs`, THEN the generator stops in bounded time.

**BC-3:** GIVEN multiple non-contiguous lifecycle windows, WHEN generating requests, THEN requests are produced in all windows with no requests in gaps.

**BC-4:** GIVEN lifecycle windows ending at time T, WHEN comparing `horizon=MaxInt64` vs `horizon=2*T`, THEN both produce identical requests (pure optimization, not behavioral change).

## Test plan

- [x] `TestGenerateRequests_LifecycleWindow_NoHang` — BC-1: standard path terminates
- [x] `TestGenerateRequests_ReasoningMultiSession_LifecycleNoHang` — BC-2: reasoning path terminates
- [x] `TestGenerateRequests_LifecycleWindow_MultipleWindows` — BC-3: gap windows produce requests in both windows
- [x] `TestGenerateRequests_LifecycleWindow_EquivalentWithExplicitHorizon` — BC-4: determinism equivalence
- [x] Existing lifecycle tests pass unchanged (regression check)
- [x] Full `go test ./sim/workload/...` passes
- [x] `go build ./...` clean

Fixes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)