### PR TITLE
fix: resolve merge conflict and add Shape/Scale fields to ArrivalSpec

### DIFF
--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2947,3 +2947,60 @@ func TestClusterSimulator_PD_OrphanedTimeout_TimingNotInflated(t *testing.T) {
 	}
 }
 
+// TestClusterSimulator_ProjectPDMetrics_NoOpWhenEmpty is the definitive evidence test
+// for issue #962. It runs a single-instance (non-PD) simulation, captures TTFT values,
+// then directly calls projectPDMetrics() (bypassing the poolsConfigured guard) and
+// verifies that TTFT values are byte-identical before and after.
+//
+// If projectPDMetrics corrupted non-PD metrics, TTFTs would differ after the call.
+// This test proves the internal guard (len(parentRequests)==0) already prevents corruption.
+func TestClusterSimulator_ProjectPDMetrics_NoOpWhenEmpty(t *testing.T) {
+	config := newTestDeploymentConfig(1) // single instance, no PD
+	requests := newTestRequests(5)
+
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	metrics := cs.AggregatedMetrics()
+
+	// Snapshot TTFT values before calling projectPDMetrics directly
+	ttftBefore := make(map[string]float64, len(metrics.RequestTTFTs))
+	for k, v := range metrics.RequestTTFTs {
+		ttftBefore[k] = v
+	}
+
+	// Print TTFT values for evidence
+	t.Logf("parentRequests count: %d", len(cs.parentRequests))
+	t.Logf("poolsConfigured: %v", cs.poolsConfigured())
+	for reqID, ttft := range metrics.RequestTTFTs {
+		t.Logf("BEFORE projectPDMetrics: %s TTFT = %.2f us (%.4f ms)", reqID, ttft, ttft/1000)
+	}
+
+	// Directly call projectPDMetrics WITHOUT the poolsConfigured guard
+	cs.projectPDMetrics()
+
+	// Compare TTFT values after the call
+	for reqID, ttft := range metrics.RequestTTFTs {
+		t.Logf("AFTER  projectPDMetrics: %s TTFT = %.2f us (%.4f ms)", reqID, ttft, ttft/1000)
+	}
+
+	// Verify no change
+	if len(metrics.RequestTTFTs) != len(ttftBefore) {
+		t.Errorf("TTFT map size changed: before=%d, after=%d", len(ttftBefore), len(metrics.RequestTTFTs))
+	}
+	for reqID, before := range ttftBefore {
+		after, ok := metrics.RequestTTFTs[reqID]
+		if !ok {
+			t.Errorf("TTFT for %s disappeared after projectPDMetrics", reqID)
+			continue
+		}
+		if before != after {
+			t.Errorf("TTFT for %s changed: before=%.2f, after=%.2f (diff=%.2f)", reqID, before, after, after-before)
+		}
+	}
+	for reqID := range metrics.RequestTTFTs {
+		if _, ok := ttftBefore[reqID]; !ok {
+			t.Errorf("new TTFT key %s appeared after projectPDMetrics", reqID)
+		}
+	}
+}

--- a/sim/workload/servegen.go
+++ b/sim/workload/servegen.go
@@ -76,6 +76,8 @@ type serveGenTraceRow struct {
 	rate         float64
 	cv           float64
 	pattern      string // "Gamma", "Weibull", or empty
+	shapeParam   float64
+	scaleParam   float64
 }
 
 // loadServeGenData loads ServeGen data files and populates the spec's Clients list.
@@ -159,6 +161,11 @@ func loadServeGenChunk(chunkID, tracePath, datasetPath string, sgConfig *ServeGe
 			arrivalSpec.Process = process
 			cv := bestRow.cv
 			arrivalSpec.CV = &cv
+			// Store MLE-fitted parameters from ServeGen trace columns 5-6
+			shape := bestRow.shapeParam
+			scale := bestRow.scaleParam
+			arrivalSpec.Shape = &shape
+			arrivalSpec.Scale = &scale
 		}
 	}
 
@@ -227,11 +234,26 @@ func parseServeGenTrace(path string) ([]serveGenTraceRow, error) {
 		}
 		pattern := strings.TrimSpace(record[3])
 
+		// Parse shape and scale parameters (columns 5-6)
+		var shapeParam, scaleParam float64
+		if len(record) >= 6 {
+			shape, shapeErr := strconv.ParseFloat(strings.TrimSpace(record[4]), 64)
+			scale, scaleErr := strconv.ParseFloat(strings.TrimSpace(record[5]), 64)
+			if shapeErr != nil || scaleErr != nil {
+				logrus.Debugf("parseServeGenTrace: row at t=%.0f has non-numeric shape/scale, falling back to 0", startTime)
+			} else {
+				shapeParam = shape
+				scaleParam = scale
+			}
+		}
+
 		rows = append(rows, serveGenTraceRow{
 			startTimeSec: startTime,
 			rate:         rate,
 			cv:           cv,
 			pattern:      pattern,
+			shapeParam:   shapeParam,
+			scaleParam:   scaleParam,
 		})
 	}
 	if skippedRows > 0 {

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -165,6 +165,141 @@ func TestLoadServeGenDataset_NonNumericKey_SkippedWithWarning(t *testing.T) {
 	assert.Contains(t, buf.String(), "metadata", "should warn about non-numeric key 'metadata'")
 }
 
+func TestParseServeGenTrace_WithShapeScale(t *testing.T) {
+	// GIVEN a trace CSV with 6 columns including shape/scale
+	tmpfile, err := os.CreateTemp("", "trace-*.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	// Write test data with high CV and fitted shape/scale
+	content := "199200,22.46,173.81,Weibull,0.0575,0.000573\n"
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	// WHEN parsing the trace
+	rows, err := parseServeGenTrace(tmpfile.Name())
+
+	// THEN shape and scale are parsed correctly
+	if err != nil {
+		t.Fatalf("parseServeGenTrace failed: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.cv != 173.81 {
+		t.Errorf("expected cv=173.81, got %f", row.cv)
+	}
+	if row.shapeParam != 0.0575 {
+		t.Errorf("expected shapeParam=0.0575, got %f", row.shapeParam)
+	}
+	if row.scaleParam != 0.000573 {
+		t.Errorf("expected scaleParam=0.000573, got %f", row.scaleParam)
+	}
+}
+
+func TestParseServeGenTrace_FourColumnsBackwardCompat(t *testing.T) {
+	// GIVEN a trace CSV with only 4 columns (no shape/scale)
+	dir := t.TempDir()
+	csvContent := "0,1.5,2.5,Gamma\n600,0.8,1.2,Weibull\n"
+	path := filepath.Join(dir, "trace.csv")
+	require.NoError(t, os.WriteFile(path, []byte(csvContent), 0644))
+
+	// WHEN parsing the trace
+	rows, err := parseServeGenTrace(path)
+
+	// THEN both rows are parsed successfully
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	// AND shapeParam and scaleParam default to zero for both rows
+	assert.Equal(t, float64(0), rows[0].shapeParam, "4-column row should have shapeParam=0")
+	assert.Equal(t, float64(0), rows[0].scaleParam, "4-column row should have scaleParam=0")
+	assert.Equal(t, float64(0), rows[1].shapeParam, "4-column row should have shapeParam=0")
+	assert.Equal(t, float64(0), rows[1].scaleParam, "4-column row should have scaleParam=0")
+
+	// AND the core fields are parsed correctly
+	assert.InDelta(t, 1.5, rows[0].rate, 0.001)
+	assert.InDelta(t, 2.5, rows[0].cv, 0.001)
+	assert.Equal(t, "Gamma", rows[0].pattern)
+}
+
+func TestParseServeGenTrace_BadShapeScale_FallsBackToZero(t *testing.T) {
+	// GIVEN a trace CSV with 6 columns where columns 5-6 are non-numeric
+	dir := t.TempDir()
+	csvContent := "0,1.0,2.5,Gamma,BAD,BAD\n"
+	path := filepath.Join(dir, "trace.csv")
+	require.NoError(t, os.WriteFile(path, []byte(csvContent), 0644))
+
+	// WHEN parsing the trace
+	rows, err := parseServeGenTrace(path)
+
+	// THEN the row is still parsed (not skipped)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "row with bad shape/scale should not be skipped")
+
+	// AND shapeParam and scaleParam fall back to zero
+	assert.Equal(t, float64(0), rows[0].shapeParam, "bad shape should fall back to 0")
+	assert.Equal(t, float64(0), rows[0].scaleParam, "bad scale should fall back to 0")
+
+	// AND core fields are still parsed correctly
+	assert.InDelta(t, 1.0, rows[0].rate, 0.001)
+	assert.InDelta(t, 2.5, rows[0].cv, 0.001)
+	assert.Equal(t, "Gamma", rows[0].pattern)
+}
+
+func TestLoadServeGenChunk_PopulatesShapeScale(t *testing.T) {
+	// GIVEN a ServeGen chunk with high CV and fitted parameters
+	traceDir, err := os.MkdirTemp("", "servegen-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(traceDir)
+
+	// Write trace file
+	tracePath := filepath.Join(traceDir, "chunk-0-trace.csv")
+	traceContent := "0,22.46,173.81,Weibull,0.0575,0.000573\n"
+	if err := os.WriteFile(tracePath, []byte(traceContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write dataset file
+	datasetPath := filepath.Join(traceDir, "chunk-0-dataset.json")
+	datasetContent := `{"0": {"input_tokens": "{256: 1.0}", "output_tokens": "{100: 1.0}"}}`
+	if err := os.WriteFile(datasetPath, []byte(datasetContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sgConfig := &ServeGenDataSpec{}
+
+	// WHEN loading the chunk
+	client, err := loadServeGenChunk("0", tracePath, datasetPath, sgConfig)
+
+	// THEN ArrivalSpec contains shape and scale
+	if err != nil {
+		t.Fatalf("loadServeGenChunk failed: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.Arrival.Process != "weibull" {
+		t.Errorf("expected process=weibull, got %s", client.Arrival.Process)
+	}
+	if client.Arrival.CV == nil || *client.Arrival.CV != 173.81 {
+		t.Errorf("expected cv=173.81, got %v", client.Arrival.CV)
+	}
+	if client.Arrival.Shape == nil || *client.Arrival.Shape != 0.0575 {
+		t.Errorf("expected shape=0.0575, got %v", client.Arrival.Shape)
+	}
+	if client.Arrival.Scale == nil || *client.Arrival.Scale != 0.000573 {
+		t.Errorf("expected scale=0.000573, got %v", client.Arrival.Scale)
+	}
+}
+
 func TestServeGenDataLoading_SyntheticDataset_ProducesClients(t *testing.T) {
 	dir := t.TempDir()
 	// Create chunk-0-trace.csv

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -143,6 +143,8 @@ type ClientSpec struct {
 type ArrivalSpec struct {
 	Process string   `yaml:"process"`
 	CV      *float64 `yaml:"cv,omitempty"`
+	Shape   *float64 `yaml:"shape,omitempty"`
+	Scale   *float64 `yaml:"scale,omitempty"`
 }
 
 // DistSpec parameterizes a token length distribution.


### PR DESCRIPTION
## Summary
- Resolve merge conflict in `cluster_test.go` — keep the `TestClusterSimulator_ProjectPDMetrics_NoOpWhenEmpty` evidence test for issue #962
- Add missing `Shape` and `Scale` fields to `ArrivalSpec` struct in `spec.go` — required by the staged `servegen.go` changes that propagate MLE-fitted distribution parameters from ServeGen trace columns 5-6

## Test plan
- [x] `go test ./...` passes all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)