### PR TITLE
fix(cmd): validate distribution params in concurrency mode (R3)

### DIFF
--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -295,6 +295,11 @@ func runObserve(cmd *cobra.Command, _ []string) {
 		spec.Seed = observeSeed
 	} else {
 		// Distribution or concurrency synthesis
+		// R3: Validate distribution token bounds before synthesis.
+		if msg := validateDistributionParams(observePromptMin, observePromptMax, observeOutputMin, observeOutputMax,
+			observePromptStdDev, observeOutputStdDev, observePromptTokens, observeOutputTokens); msg != "" {
+			logrus.Fatalf("%s", msg)
+		}
 		spec = workload.SynthesizeFromDistribution(workload.DistributionParams{
 			Rate:               observeRate,
 			Concurrency:        observeConcurrency,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -260,6 +260,44 @@ var rootCmd = &cobra.Command{
 	Short: "BLIS — Blackbox Inference Simulator for LLM serving systems",
 }
 
+// validateDistributionParams checks token distribution bounds common to both the
+// concurrency and distribution synthesis paths (R3). Returns a non-empty error
+// string if any parameter violates a bound, empty string if all are valid.
+// Extracted for unit testability (R14).
+func validateDistributionParams(promptMin, promptMax, outputMin, outputMax, promptStdev, outputStdev, promptMean, outputMean int) string {
+	if promptMin < 1 {
+		return fmt.Sprintf("--prompt-tokens-min must be >= 1, got %d", promptMin)
+	}
+	if promptMax < 1 {
+		return fmt.Sprintf("--prompt-tokens-max must be >= 1, got %d", promptMax)
+	}
+	if outputMin < 1 {
+		return fmt.Sprintf("--output-tokens-min must be >= 1, got %d", outputMin)
+	}
+	if outputMax < 1 {
+		return fmt.Sprintf("--output-tokens-max must be >= 1, got %d", outputMax)
+	}
+	if promptStdev < 0 {
+		return fmt.Sprintf("--prompt-tokens-stdev must be >= 0, got %d", promptStdev)
+	}
+	if outputStdev < 0 {
+		return fmt.Sprintf("--output-tokens-stdev must be >= 0, got %d", outputStdev)
+	}
+	if promptMin > promptMax {
+		return fmt.Sprintf("--prompt-tokens-min (%d) must be <= --prompt-tokens-max (%d)", promptMin, promptMax)
+	}
+	if outputMin > outputMax {
+		return fmt.Sprintf("--output-tokens-min (%d) must be <= --output-tokens-max (%d)", outputMin, outputMax)
+	}
+	if promptMean > promptMax || promptMean < promptMin || promptStdev > promptMax || promptStdev < promptMin {
+		return "prompt-tokens and prompt-tokens-stdev should be in range [prompt-tokens-min, prompt-tokens-max]"
+	}
+	if outputMean > outputMax || outputMean < outputMin || outputStdev > outputMax || outputStdev < outputMin {
+		return "output-tokens and output-tokens-stdev should be in range [output-tokens-min, output-tokens-max]"
+	}
+	return ""
+}
+
 // allZeros reports whether all values in the coefficients slice are 0 (default).
 func allZeros(values []float64) bool {
 	for _, v := range values {
@@ -1283,6 +1321,11 @@ var runCmd = &cobra.Command{
 			// If the user did not explicitly set it, leave it at 0 (unbounded) and
 			// require --horizon to bound the run. The existing unbounded-generation
 			// guard will fire with a clear message if neither is provided.
+			// R3: Validate distribution token bounds (shared with distribution mode).
+			if msg := validateDistributionParams(promptTokensMin, promptTokensMax, outputTokensMin, outputTokensMax,
+				promptTokensStdev, outputTokensStdev, promptTokensMean, outputTokensMean); msg != "" {
+				logrus.Fatalf("%s", msg)
+			}
 			concurrencyNumRequests := 0
 			if cmd.Flags().Changed("num-requests") {
 				concurrencyNumRequests = numRequests
@@ -1301,36 +1344,10 @@ var runCmd = &cobra.Command{
 			if rate <= 0 || math.IsNaN(rate) || math.IsInf(rate, 0) {
 				logrus.Fatalf("--rate must be a finite value > 0, got %v", rate)
 			}
-			// R3: Standalone validation for distribution token bounds (BC-1, BC-2)
-			if promptTokensMin < 1 {
-				logrus.Fatalf("--prompt-tokens-min must be >= 1, got %d", promptTokensMin)
-			}
-			if promptTokensMax < 1 {
-				logrus.Fatalf("--prompt-tokens-max must be >= 1, got %d", promptTokensMax)
-			}
-			if outputTokensMin < 1 {
-				logrus.Fatalf("--output-tokens-min must be >= 1, got %d", outputTokensMin)
-			}
-			if outputTokensMax < 1 {
-				logrus.Fatalf("--output-tokens-max must be >= 1, got %d", outputTokensMax)
-			}
-			if promptTokensStdev < 0 {
-				logrus.Fatalf("--prompt-tokens-stdev must be >= 0, got %d", promptTokensStdev)
-			}
-			if outputTokensStdev < 0 {
-				logrus.Fatalf("--output-tokens-stdev must be >= 0, got %d", outputTokensStdev)
-			}
-			if promptTokensMin > promptTokensMax {
-				logrus.Fatalf("--prompt-tokens-min (%d) must be <= --prompt-tokens-max (%d)", promptTokensMin, promptTokensMax)
-			}
-			if outputTokensMin > outputTokensMax {
-				logrus.Fatalf("--output-tokens-min (%d) must be <= --output-tokens-max (%d)", outputTokensMin, outputTokensMax)
-			}
-			if promptTokensMean > promptTokensMax || promptTokensMean < promptTokensMin || promptTokensStdev > promptTokensMax || promptTokensStdev < promptTokensMin {
-				logrus.Fatalf("prompt-tokens and prompt-tokens-stdev should be in range [prompt-tokens-min, prompt-tokens-max]")
-			}
-			if outputTokensMean > outputTokensMax || outputTokensMean < outputTokensMin || outputTokensStdev > outputTokensMax || outputTokensStdev < outputTokensMin {
-				logrus.Fatalf("output-tokens and output-tokens-stdev should be in range [output-tokens-min, output-tokens-max]")
+			// R3: Validate distribution token bounds (shared with concurrency mode).
+			if msg := validateDistributionParams(promptTokensMin, promptTokensMax, outputTokensMin, outputTokensMax,
+				promptTokensStdev, outputTokensStdev, promptTokensMean, outputTokensMean); msg != "" {
+				logrus.Fatalf("%s", msg)
 			}
 			spec = workload.SynthesizeFromDistribution(workload.DistributionParams{
 				Rate: rate, NumRequests: numRequests, PrefixTokens: prefixTokens,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -294,6 +294,156 @@ func TestPrintPDMetrics_NilPD_ProducesNoOutput(t *testing.T) {
 	assert.Empty(t, buf.String(), "printPDMetrics with nil pd must produce no output")
 }
 
+// TestValidateDistributionParams verifies the behavioral contract of the extracted
+// distribution-parameter validation helper (R3, R14).
+//
+// Contract: validateDistributionParams returns an empty string for valid inputs and
+// a non-empty string describing the violation for any invalid input.
+//
+// GIVEN distribution token parameters
+// WHEN validateDistributionParams is called
+// THEN it returns empty string iff all parameters satisfy the bounds invariants
+func TestValidateDistributionParams(t *testing.T) {
+	// valid baseline — all defaults from the shared constants
+	const (
+		validMin    = defaultPromptMin
+		validMax    = defaultPromptMax
+		validMean   = defaultPromptMean
+		validStdev  = defaultPromptStdev
+		validOMin   = defaultOutputMin
+		validOMax   = defaultOutputMax
+		validOMean  = defaultOutputMean
+		validOStdev = defaultOutputStdev
+	)
+
+	tests := []struct {
+		name      string
+		promptMin int
+		promptMax int
+		outputMin int
+		outputMax int
+		promptStdev int
+		outputStdev int
+		promptMean  int
+		outputMean  int
+		wantErr     bool
+	}{
+		{
+			name:        "valid defaults produce no error",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: false,
+		},
+		{
+			name:        "prompt-tokens-min zero is rejected",
+			promptMin: 0, promptMax: validMax,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "prompt-tokens-min negative is rejected",
+			promptMin: -5, promptMax: validMax,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "prompt-tokens-max zero is rejected",
+			promptMin: validMin, promptMax: 0,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "output-tokens-min zero is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: 0, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "output-tokens-max zero is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: validOMin, outputMax: 0,
+			promptStdev: validStdev, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "negative prompt stdev is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: -1, outputStdev: validOStdev,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "negative output stdev is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: validStdev, outputStdev: -1,
+			promptMean: validMean, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "prompt min greater than max is rejected",
+			promptMin: 500, promptMax: 100,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: 50, outputStdev: validOStdev,
+			promptMean: 100, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "output min greater than max is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: 500, outputMax: 100,
+			promptStdev: validStdev, outputStdev: 50,
+			promptMean: validMean, outputMean: 100,
+			wantErr: true,
+		},
+		{
+			name:        "prompt mean above max is rejected",
+			promptMin: 10, promptMax: 100,
+			outputMin: validOMin, outputMax: validOMax,
+			promptStdev: 10, outputStdev: validOStdev,
+			promptMean: 200, outputMean: validOMean,
+			wantErr: true,
+		},
+		{
+			name:        "output mean below min is rejected",
+			promptMin: validMin, promptMax: validMax,
+			outputMin: 100, outputMax: 500,
+			promptStdev: validStdev, outputStdev: 50,
+			promptMean: validMean, outputMean: 50,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validateDistributionParams(
+				tc.promptMin, tc.promptMax,
+				tc.outputMin, tc.outputMax,
+				tc.promptStdev, tc.outputStdev,
+				tc.promptMean, tc.outputMean,
+			)
+			if tc.wantErr && got == "" {
+				t.Errorf("expected a non-empty error string, got empty")
+			}
+			if !tc.wantErr && got != "" {
+				t.Errorf("expected no error, got %q", got)
+			}
+		})
+	}
+}
+
 // TestRunCmdDistributionDefaults_NoHardcodedLiterals verifies that none of the distDefaults
 // constant values appear as hardcoded literals in root.go's distribution flag IntVar calls
 // (BC-2: single source of truth).


### PR DESCRIPTION
## Summary

Closes #872.

- Extracts a `validateDistributionParams` helper (R14) in `cmd/root.go` that validates all ten distribution-token bounds: `min >= 1`, `max >= 1`, `stdev >= 0`, `min <= max`, and `mean/stdev in [min, max]`.
- Calls the helper in `blis run`'s concurrency-mode path before `SynthesizeFromDistribution` — the missing gap reported in #872.
- Replaces the equivalent inline block in `blis run`'s distribution-mode path with the same call (DRY, parity).
- Calls the helper in `blis observe`'s distribution/concurrency synthesis `else`-branch for cross-path parity.
- Adds 12 table-driven BDD unit tests covering all error conditions and the happy path.

## Root cause

`cmd/root.go` had the R3 distribution validation only inside the `workloadType == "distribution"` branch (lines 1304–1333). The `concurrency > 0` branch called `SynthesizeFromDistribution` with the same parameters but no bounds checks. The fix hoists the shared checks into an extracted, testable helper.

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] `go vet ./...` — no diagnostics
- [ ] `TestValidateDistributionParams` — 12 sub-tests covering every bound, including the previously unguarded negative-min case from the issue (`--concurrency 4 --prompt-tokens-min -5`)
- [ ] Existing distribution-path tests continue to pass (no behavioral change for valid inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)