### PR TITLE
fix(sim): reset TTFTSet on preemption so re-prefill updates FirstTokenTime

### DIFF
--- a/sim/batch_formation.go
+++ b/sim/batch_formation.go
@@ -231,7 +231,7 @@ func (v *VLLMBatchFormation) preemptForTokens(req *Request, numNewTokens int64, 
 			preemptedRequest.State = StateQueued
 			preemptedRequest.ProgressIndex = 0
 			preemptedRequest.ITL = nil
-			preemptedRequest.TTFTSet = false // re-prefill must update FirstTokenTime (#1122)
+			preemptedRequest.TTFTSet = false // lets the !TTFTSet guard in executeBatchStep fire on re-prefill, updating FirstTokenTime (#1122)
 			ctx.KVCache.ReleaseKVBlocks(preemptedRequest)
 			delete(ctx.ComputedTokens, preemptedRequest.ID)
 			ctx.WaitQ.PrependFront(preemptedRequest)

--- a/sim/batch_formation.go
+++ b/sim/batch_formation.go
@@ -231,6 +231,7 @@ func (v *VLLMBatchFormation) preemptForTokens(req *Request, numNewTokens int64, 
 			preemptedRequest.State = StateQueued
 			preemptedRequest.ProgressIndex = 0
 			preemptedRequest.ITL = nil
+			preemptedRequest.TTFTSet = false // re-prefill must update FirstTokenTime (#1122)
 			ctx.KVCache.ReleaseKVBlocks(preemptedRequest)
 			delete(ctx.ComputedTokens, preemptedRequest.ID)
 			ctx.WaitQ.PrependFront(preemptedRequest)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -672,10 +672,11 @@ func (sim *Simulator) executeBatchStep(now int64) int64 {
 			}
 		}
 		// !req.TTFTSet guard: fires once per prefill completion (including re-prefill after
-		// preemption). TTFTSet is reset to false on preemption (batch_formation.go) so that
-		// re-prefill overwrites FirstTokenTime with the correct post-preemption TTFT.
-		// TTFTSum double-counting is prevented by accumulating req.FirstTokenTime once at
-		// completion time in recordRequestCompletion, not inline here.
+		// preemption). TTFTSet is reset to false on preemption (batch_formation.go) so this
+		// block fires again on re-prefill, overwriting FirstTokenTime with the correct
+		// post-preemption TTFT. req.FirstTokenTime is a scalar assignment (not an
+		// accumulation), so overwriting it is safe. TTFTSum is not accumulated here;
+		// it is accumulated exactly once at completion time in recordRequestCompletion.
 		if req.ProgressIndex == util.Len64(req.InputTokens) && !req.TTFTSet {
 			req.TTFTSet = true
 			req.FirstTokenTime = now + currStepAdvance + sim.latencyModel.OutputTokenProcessingTime() - req.ArrivalTime

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -668,9 +668,11 @@ func (sim *Simulator) executeBatchStep(now int64) int64 {
 				req.ITL = append(req.ITL, currStepAdvance+sim.latencyModel.OutputTokenProcessingTime())
 			}
 		}
-		// !req.TTFTSet guard: fires exactly once per request lifetime.
-		// On preemption, ProgressIndex resets to 0 (batch_formation.go) but TTFTSet is
-		// preserved, preventing TTFT double-counting on re-prefill.
+		// !req.TTFTSet guard: fires once per prefill completion (including re-prefill after
+		// preemption). TTFTSet is reset to false on preemption (batch_formation.go) so that
+		// re-prefill overwrites FirstTokenTime with the correct post-preemption TTFT.
+		// TTFTSum double-counting is prevented by accumulating req.FirstTokenTime once at
+		// completion time in recordRequestCompletion, not inline here.
 		if req.ProgressIndex == util.Len64(req.InputTokens) && !req.TTFTSet {
 			req.TTFTSet = true
 			req.FirstTokenTime = now + currStepAdvance + sim.latencyModel.OutputTokenProcessingTime() - req.ArrivalTime

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -650,9 +650,12 @@ func (sim *Simulator) executeBatchStep(now int64) int64 {
 	// similar to vLLM's execute_model()
 	// Note: Per-request TTFT fields (FirstTokenTime, RequestTTFTs) are recorded inline
 	// because they are tightly coupled to the prefill/decode state transitions in this
-	// loop (scalar/map overwrites, safe across preemption). TTFTSum and TotalOutputTokens
-	// are computed at completion time in recordRequestCompletion to avoid double-counting
-	// when a preempted request re-runs from ProgressIndex=0.
+	// loop. Safety across preemption comes from the !req.TTFTSet guard below (TTFTSet is
+	// reset to false on preemption by batch_formation.go), not from overwrite idempotency —
+	// the guard ensures the block fires exactly once per prefill completion so FirstTokenTime
+	// always reflects the final re-prefill. TTFTSum and TotalOutputTokens are computed at
+	// completion time in recordRequestCompletion to avoid double-counting when a preempted
+	// request re-runs from ProgressIndex=0.
 	for _, req := range sim.RunningBatch.Requests {
 		if req.ProgressIndex < util.Len64(req.InputTokens) {
 			req.ProgressIndex = sim.reqNumComputedTokens[req.ID]

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2973,7 +2973,7 @@ func TestSimulator_TTFT_UpdatedAfterPreemption(t *testing.T) {
 	}
 
 	e2eB := s.Metrics.RequestE2Es["B"]
-	if e2eB < ttftB {
-		t.Errorf("E2E_B = %.0f < TTFT_B = %.0f: causality violated for preempted request", e2eB, ttftB)
+	if e2eB <= ttftB {
+		t.Errorf("E2E_B = %.0f <= TTFT_B = %.0f: expected E2E_B > TTFT_B for a request with 5 output tokens", e2eB, ttftB)
 	}
 }

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2963,6 +2963,9 @@ func TestSimulator_TTFT_UpdatedAfterPreemption(t *testing.T) {
 	if !okA || !okB {
 		t.Fatalf("missing TTFT entry: A=%v B=%v", okA, okB)
 	}
+	if ttftA <= 0 {
+		t.Errorf("TTFT_A = %.0f: A's TTFT should be positive (unaffected by B's preemption)", ttftA)
+	}
 
 	// B was preempted during decode and had to re-prefill after A finished.
 	// Its TTFT must reflect the re-prefill completion time, which is >> A's TTFT.

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -2906,3 +2906,74 @@ func TestTotalOutputTokens_Conservation_WithPreemption(t *testing.T) {
 			sim.Metrics.TotalOutputTokens, expected)
 	}
 }
+
+// TestSimulator_TTFT_UpdatedAfterPreemption verifies that TTFT reflects the re-prefill
+// completion time, not the original (pre-preemption) prefill time (#1122).
+//
+// GIVEN a 4-block KV cache that forces preemption of request B (32 tokens, 5 output)
+// while A (16 tokens, 5 output) continues decoding uninterrupted,
+// WHEN both complete after B's preemption and re-prefill,
+// THEN TTFT_B > TTFT_A (B's first token arrives later because it waited in queue and
+// re-prefilled after A finished — TTFTSet not reset on preemption would freeze TTFT_B
+// at the pre-preemption value, making it equal to TTFT_A).
+func TestSimulator_TTFT_UpdatedAfterPreemption(t *testing.T) {
+	cfg := SimConfig{
+		Horizon:             1_000_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(4, 16, 0, 0, 0, 0), // 4 blocks × 16 = 64 tokens: forces preemption
+		BatchConfig:         NewBatchConfig(256, 10_000, 0),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 1, 0}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(ModelConfig{}, HardwareCalib{}, "test", "H100", 1, "blackbox", 0),
+	}
+	s := mustNewSimulator(t, cfg)
+
+	// A (16 tokens) injected first → at front of WaitQ → stays in batch during decode.
+	// B (32 tokens) injected second → at tail of WaitQ → becomes tail of RunningBatch,
+	// gets preempted when decode needs a new KV block and none are free.
+	reqA := &Request{
+		ID:           "A",
+		ArrivalTime:  0,
+		InputTokens:  GenerateRandomTokenIDs(s.WorkloadRNG(), 16),
+		OutputTokens: make([]int, 5),
+		State:        StateQueued,
+	}
+	reqB := &Request{
+		ID:           "B",
+		ArrivalTime:  0,
+		InputTokens:  GenerateRandomTokenIDs(s.WorkloadRNG(), 32),
+		OutputTokens: make([]int, 5),
+		State:        StateQueued,
+	}
+	s.InjectArrival(reqA)
+	s.InjectArrival(reqB)
+
+	for s.HasPendingEvents() {
+		s.ProcessNextEvent()
+	}
+
+	if s.Metrics.PreemptionCount == 0 {
+		t.Fatal("precondition violated: expected at least one preemption — scenario does not exercise the bug path")
+	}
+	if s.Metrics.CompletedRequests != 2 {
+		t.Fatalf("expected both requests to complete, got %d completed", s.Metrics.CompletedRequests)
+	}
+
+	ttftA, okA := s.Metrics.RequestTTFTs["A"]
+	ttftB, okB := s.Metrics.RequestTTFTs["B"]
+	if !okA || !okB {
+		t.Fatalf("missing TTFT entry: A=%v B=%v", okA, okB)
+	}
+
+	// B was preempted during decode and had to re-prefill after A finished.
+	// Its TTFT must reflect the re-prefill completion time, which is >> A's TTFT.
+	// The bug (TTFTSet not reset) would leave TTFT_B == TTFT_A.
+	if ttftB <= ttftA {
+		t.Errorf("TTFT_B = %.0f, TTFT_A = %.0f: expected TTFT_B > TTFT_A because B was preempted and re-prefilled after A completed",
+			ttftB, ttftA)
+	}
+
+	e2eB := s.Metrics.RequestE2Es["B"]
+	if e2eB < ttftB {
+		t.Errorf("E2E_B = %.0f < TTFT_B = %.0f: causality violated for preempted request", e2eB, ttftB)
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: `TTFTSet` was never reset on preemption in `batch_formation.go`, so the `!req.TTFTSet` guard added in #1099 blocked re-prefill from updating `FirstTokenTime`. E2E and TTFT reflected the pre-preemption first run, missing all preemption wait time and re-prefill latency.
- **Fix**: Add `preemptedRequest.TTFTSet = false` alongside the existing `ProgressIndex = 0` and `ITL = nil` resets in `preemptForTokens`.
- **Test**: `TestSimulator_TTFT_UpdatedAfterPreemption` — 4-block KV cache forces preemption of B (32 tokens) while A (16 tokens) runs uninterrupted. Asserts `TTFT_B > TTFT_A` after both complete; the bug froze `TTFT_B == TTFT_A`.

Closes #1122

## Test plan

- [ ] `go test ./sim/... -run TestSimulator_TTFT_UpdatedAfterPreemption` passes
- [ ] `go test ./...` passes (all 10 packages)
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)