### PR TITLE
fix(workload): per-phase rate normalization for phased workloads

### DIFF
--- a/docs/guide/workloads.md
+++ b/docs/guide/workloads.md
@@ -433,6 +433,37 @@ cohorts:
 
 > **Note:** Do not combine `spike` (which creates a short lifecycle window) with multi-turn `reasoning` (which generates rounds seconds apart). Rounds whose arrival times fall outside the spike window are silently filtered by the lifecycle window filter. Use diurnal or drain patterns — or no lifecycle modifier — with multi-turn cohorts.
 
+### Phased Workloads
+
+Use lifecycle windows to model workloads that change over time — for example, switching between prompt types or scaling request rates across stages.
+
+```yaml
+aggregate_rate: 40        # Target rate during each active phase
+clients:
+  - id: "summarization"
+    rate_fraction: 0.7
+    lifecycle:
+      windows:
+        - { start_us: 0, end_us: 50000000 }          # Active 0–50s
+    # ... arrival, distributions
+  - id: "qa"
+    rate_fraction: 0.3
+    lifecycle:
+      windows:
+        - { start_us: 0, end_us: 50000000 }          # Active 0–50s
+    # ... arrival, distributions
+  - id: "contentgen"
+    rate_fraction: 1.0
+    lifecycle:
+      windows:
+        - { start_us: 50000000, end_us: 100000000 }  # Active 50–100s
+    # ... arrival, distributions
+```
+
+Rate fractions are normalized **per-phase**: during 0–50s the co-active fractions are 0.7 + 0.3 = 1.0, so summarization gets 28 req/s and qa gets 12 req/s. During 50–100s, contentgen's fraction (1.0) is the only one active and gets the full 40 req/s. Clients without lifecycle windows are "always-on" and overlap with every phase.
+
+See [Lifecycle Normalization](../reference/workload-spec.md#lifecycle-normalization) for details.
+
 ## Advanced Features
 
 ### Multimodal Requests

--- a/docs/reference/workload-spec.md
+++ b/docs/reference/workload-spec.md
@@ -158,6 +158,8 @@ Each phase's fractions are normalized independently: A gets `40 × 0.7/1.0 = 28 
 
 Without per-phase normalization, the global sum would be 2.0, and every client's rate would be halved.
 
+**Limitation:** Always-on clients compute a single rate using co-active sums across all phases they overlap with. When an always-on client coexists with multiple non-overlapping phased clients, per-phase totals may be less than `aggregate_rate`. For predictable results, use either all-phased or all-always-on clients.
+
 ## Multimodal Specification
 
 Configures multimodal request generation (used in the `multimodal` field of Client Specification). Each distribution follows the same [Distribution Specification](#distribution-specification) format.

--- a/docs/reference/workload-spec.md
+++ b/docs/reference/workload-spec.md
@@ -29,7 +29,7 @@ Each entry in the `clients` list defines a traffic source:
 | `tenant_id` | string | No | Tenant identifier |
 | `slo_class` | string | No | SLO tier: `critical`, `standard`, `sheddable`, `batch`, `background`, or empty |
 | `model` | string | No | Model name override (for multi-model workloads) |
-| `rate_fraction` | float64 | **Yes** | Fraction of `aggregate_rate` for this client (must be positive) |
+| `rate_fraction` | float64 | **Yes** | Fraction of `aggregate_rate` for this client (must be positive). When lifecycle windows are present, fractions are normalized per-phase (see [Lifecycle Normalization](#lifecycle-normalization)) |
 | `arrival` | object | **Yes** | Arrival process configuration |
 | `input_distribution` | object | **Yes** | Input token length distribution |
 | `output_distribution` | object | **Yes** | Output token length distribution |
@@ -142,6 +142,21 @@ Activity window configuration for clients (used in the `lifecycle` field of Clie
 |-------|------|-------------|
 | `start_us` | int64 | Window start time in microseconds |
 | `end_us` | int64 | Window end time in microseconds |
+
+### Lifecycle Normalization
+
+When clients have lifecycle windows, `rate_fraction` values are normalized **per-phase** rather than globally. For each client, the simulator sums the `rate_fraction` of all **co-active** clients (those whose lifecycle windows overlap) and divides by that sum. This ensures `aggregate_rate` is achieved during every active phase.
+
+Clients without lifecycle windows are "always-on" and are counted as co-active with every phase.
+
+**Example:** A two-phase workload with `aggregate_rate: 40`:
+
+- Phase 1 (0–50s): clients A (`rate_fraction: 0.7`) and B (`rate_fraction: 0.3`)
+- Phase 2 (50–100s): client C (`rate_fraction: 1.0`)
+
+Each phase's fractions are normalized independently: A gets `40 × 0.7/1.0 = 28 req/s`, B gets `40 × 0.3/1.0 = 12 req/s`, C gets `40 × 1.0/1.0 = 40 req/s`. Both phases produce the full 40 req/s.
+
+Without per-phase normalization, the global sum would be 2.0, and every client's rate would be halved.
 
 ## Multimodal Specification
 

--- a/sim/workload/client.go
+++ b/sim/workload/client.go
@@ -10,22 +10,81 @@ import (
 
 const defaultPrefixLength = 50
 
-// normalizeRateFractions normalizes client rate fractions to sum to 1.0.
-// Returns per-client rates in requests/microsecond.
+// normalizeRateFractions normalizes client rate fractions and returns per-client
+// rates in requests/microsecond.
+//
+// When no client has lifecycle windows, fractions are normalized globally (sum to 1.0).
+// When lifecycle windows are present, fractions are normalized per-phase: each
+// client's fraction is divided by the sum of fractions of all co-active clients
+// (those whose lifecycle windows overlap). This ensures aggregate_rate is achieved
+// during every active phase, not diluted by clients in non-overlapping phases.
+//
+// Clients without lifecycle windows are "always-on" and overlap with everything.
 func normalizeRateFractions(clients []ClientSpec, aggregateRate float64) []float64 {
-	totalFraction := 0.0
+	// Fast path: no lifecycle windows → global normalization (original behavior).
+	hasLifecycle := false
 	for i := range clients {
-		totalFraction += clients[i].RateFraction
+		if clients[i].Lifecycle != nil && len(clients[i].Lifecycle.Windows) > 0 {
+			hasLifecycle = true
+			break
+		}
 	}
-	if totalFraction == 0 {
-		return make([]float64, len(clients))
+
+	if !hasLifecycle {
+		totalFraction := 0.0
+		for i := range clients {
+			totalFraction += clients[i].RateFraction
+		}
+		if totalFraction == 0 {
+			return make([]float64, len(clients))
+		}
+		rates := make([]float64, len(clients))
+		for i := range clients {
+			rates[i] = aggregateRate * (clients[i].RateFraction / totalFraction) / 1e6
+		}
+		return rates
 	}
+
+	// Lifecycle-aware path: normalize each client's fraction by the sum of
+	// fractions of all co-active clients (clients whose windows overlap).
 	rates := make([]float64, len(clients))
 	for i := range clients {
-		normalizedFraction := clients[i].RateFraction / totalFraction
-		rates[i] = aggregateRate * normalizedFraction / 1e6 // convert req/sec to req/µs
+		if clients[i].RateFraction <= 0 {
+			continue
+		}
+		coActiveSum := 0.0
+		for j := range clients {
+			if clients[j].RateFraction <= 0 {
+				continue
+			}
+			if windowsOverlap(clients[i].Lifecycle, clients[j].Lifecycle) {
+				coActiveSum += clients[j].RateFraction
+			}
+		}
+		if coActiveSum == 0 {
+			continue
+		}
+		rates[i] = aggregateRate * (clients[i].RateFraction / coActiveSum) / 1e6
 	}
 	return rates
+}
+
+// windowsOverlap reports whether two clients' lifecycle windows overlap.
+// A nil or empty lifecycle means "always on" — overlaps with everything.
+func windowsOverlap(a, b *LifecycleSpec) bool {
+	aOn := a == nil || len(a.Windows) == 0
+	bOn := b == nil || len(b.Windows) == 0
+	if aOn || bOn {
+		return true
+	}
+	for _, wa := range a.Windows {
+		for _, wb := range b.Windows {
+			if wa.StartUs < wb.EndUs && wb.StartUs < wa.EndUs {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // generatePrefixTokens creates shared prefix token sequences per prefix group.

--- a/sim/workload/client.go
+++ b/sim/workload/client.go
@@ -20,6 +20,13 @@ const defaultPrefixLength = 50
 // during every active phase, not diluted by clients in non-overlapping phases.
 //
 // Clients without lifecycle windows are "always-on" and overlap with everything.
+//
+// Limitation: always-on clients compute a single rate using co-active sums across
+// ALL phases they overlap with. When combined with multiple non-overlapping phased
+// clients, the always-on client's rate is diluted by the union of all phases, so
+// per-phase totals may be less than aggregate_rate. A fully phase-aware algorithm
+// (computing separate rates per discrete time interval) would fix this but is
+// significantly more complex.
 func normalizeRateFractions(clients []ClientSpec, aggregateRate float64) []float64 {
 	// Fast path: no lifecycle windows → global normalization (original behavior).
 	hasLifecycle := false

--- a/sim/workload/client_test.go
+++ b/sim/workload/client_test.go
@@ -1,0 +1,133 @@
+package workload
+
+import (
+	"math"
+	"testing"
+)
+
+func TestNormalizeRateFractions(t *testing.T) {
+	const aggregateRate = 100.0 // 100 req/s
+	const toReqPerUs = 1e6     // multiply rate (req/µs) to get req/s
+
+	tests := []struct {
+		name    string
+		clients []ClientSpec
+		// wantRates are expected rates in req/s (we multiply the returned req/µs by 1e6)
+		wantRates []float64
+	}{
+		{
+			name: "BC-4: no lifecycle windows — global normalization",
+			clients: []ClientSpec{
+				{ID: "a", RateFraction: 0.7},
+				{ID: "b", RateFraction: 0.3},
+			},
+			wantRates: []float64{70.0, 30.0}, // 100 * 0.7, 100 * 0.3
+		},
+		{
+			name: "BC-4: global normalization with non-unit sum",
+			clients: []ClientSpec{
+				{ID: "a", RateFraction: 7.0},
+				{ID: "b", RateFraction: 3.0},
+			},
+			wantRates: []float64{70.0, 30.0}, // normalized: 7/10=0.7, 3/10=0.3
+		},
+		{
+			name: "BC-1: non-overlapping phases — each phase at aggregate_rate",
+			clients: []ClientSpec{
+				{ID: "p1a", RateFraction: 0.7, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 0, EndUs: 50_000_000}},
+				}},
+				{ID: "p1b", RateFraction: 0.3, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 0, EndUs: 50_000_000}},
+				}},
+				{ID: "p2", RateFraction: 1.0, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 50_000_000, EndUs: 100_000_000}},
+				}},
+			},
+			// Phase 1 coActiveSum = 0.7+0.3 = 1.0 → rates unchanged
+			// Phase 2 coActiveSum = 1.0 → rate unchanged
+			wantRates: []float64{70.0, 30.0, 100.0},
+		},
+		{
+			name: "BC-2: sub-1.0 fraction solo phase — normalized to full rate",
+			clients: []ClientSpec{
+				{ID: "solo", RateFraction: 0.7, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 0, EndUs: 50_000_000}},
+				}},
+			},
+			// coActiveSum = 0.7, rate = 100 * 0.7/0.7 = 100
+			wantRates: []float64{100.0},
+		},
+		{
+			name: "BC-3: always-on + phased mix",
+			clients: []ClientSpec{
+				{ID: "always", RateFraction: 0.5}, // no lifecycle = always-on
+				{ID: "phased", RateFraction: 0.5, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 0, EndUs: 50_000_000}},
+				}},
+			},
+			// Both overlap (always-on overlaps everything)
+			// coActiveSum for both = 0.5 + 0.5 = 1.0
+			wantRates: []float64{50.0, 50.0},
+		},
+		{
+			name: "edge: all zero fractions",
+			clients: []ClientSpec{
+				{ID: "a", RateFraction: 0},
+				{ID: "b", RateFraction: 0},
+			},
+			wantRates: []float64{0, 0},
+		},
+		{
+			name: "edge: single client no lifecycle",
+			clients: []ClientSpec{
+				{ID: "only", RateFraction: 1.0},
+			},
+			wantRates: []float64{100.0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rates := normalizeRateFractions(tt.clients, aggregateRate)
+			if len(rates) != len(tt.wantRates) {
+				t.Fatalf("got %d rates, want %d", len(rates), len(tt.wantRates))
+			}
+			for i, got := range rates {
+				gotReqPerSec := got * toReqPerUs
+				want := tt.wantRates[i]
+				if math.Abs(gotReqPerSec-want) > 0.01 {
+					t.Errorf("client %d (%s): rate = %.4f req/s, want %.4f req/s",
+						i, tt.clients[i].ID, gotReqPerSec, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWindowsOverlap(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b *LifecycleSpec
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"a nil b has windows", nil, &LifecycleSpec{Windows: []ActiveWindow{{0, 100}}}, true},
+		{"a has windows b nil", &LifecycleSpec{Windows: []ActiveWindow{{0, 100}}}, nil, true},
+		{"a empty windows", &LifecycleSpec{}, &LifecycleSpec{Windows: []ActiveWindow{{0, 100}}}, true},
+		{"overlapping", &LifecycleSpec{Windows: []ActiveWindow{{0, 100}}}, &LifecycleSpec{Windows: []ActiveWindow{{50, 150}}}, true},
+		{"adjacent no overlap", &LifecycleSpec{Windows: []ActiveWindow{{0, 100}}}, &LifecycleSpec{Windows: []ActiveWindow{{100, 200}}}, false},
+		{"disjoint", &LifecycleSpec{Windows: []ActiveWindow{{0, 50}}}, &LifecycleSpec{Windows: []ActiveWindow{{100, 200}}}, false},
+		{"multi-window one overlaps", &LifecycleSpec{Windows: []ActiveWindow{{0, 50}, {200, 300}}}, &LifecycleSpec{Windows: []ActiveWindow{{250, 350}}}, true},
+		{"multi-window none overlap", &LifecycleSpec{Windows: []ActiveWindow{{0, 50}, {200, 250}}}, &LifecycleSpec{Windows: []ActiveWindow{{100, 150}}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := windowsOverlap(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("windowsOverlap = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sim/workload/client_test.go
+++ b/sim/workload/client_test.go
@@ -71,6 +71,24 @@ func TestNormalizeRateFractions(t *testing.T) {
 			wantRates: []float64{50.0, 50.0},
 		},
 		{
+			name: "known-limitation: always-on + two non-overlapping phases — per-phase total < aggregate_rate",
+			clients: []ClientSpec{
+				{ID: "always", RateFraction: 0.5}, // always-on, overlaps both phases
+				{ID: "p1", RateFraction: 0.5, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 0, EndUs: 50_000_000}},
+				}},
+				{ID: "p2", RateFraction: 0.5, Lifecycle: &LifecycleSpec{
+					Windows: []ActiveWindow{{StartUs: 50_000_000, EndUs: 100_000_000}},
+				}},
+			},
+			// always-on coActiveSum = 0.5+0.5+0.5 = 1.5 → rate = 100*0.5/1.5 ≈ 33.33
+			// p1 coActiveSum = 0.5+0.5 = 1.0 → rate = 100*0.5/1.0 = 50
+			// p2 coActiveSum = 0.5+0.5 = 1.0 → rate = 100*0.5/1.0 = 50
+			// Per-phase total ≈ 83.33, not 100. This is a known limitation of
+			// per-client normalization; a fully phase-aware algorithm would fix it.
+			wantRates: []float64{100.0 / 3, 50.0, 50.0},
+		},
+		{
 			name: "edge: all zero fractions",
 			clients: []ClientSpec{
 				{ID: "a", RateFraction: 0},

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -111,7 +111,9 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 		clientSeed := workloadRNG.Int63()
 		clientRNG := newRandFromSeed(clientSeed)
 
-		// Create samplers
+		// Create samplers.
+		// When CustomSamplerFactory is set, clientRate is only used for the
+		// skip guard above (line 106); the factory overrides the actual arrival rate.
 		var arrivalSampler ArrivalSampler
 		if client.CustomSamplerFactory != nil {
 			// Derive sub-RNG for factory with single entropy draw from clientRNG.

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -2589,3 +2589,130 @@ func TestGenerateRequests_LifecycleWindow_NoHang(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateRequests_PhasedWorkload_CorrectRatePerPhase(t *testing.T) {
+	// BC-1: Two non-overlapping phases with different fractions, each should
+	// produce requests at the full aggregate_rate during its active window.
+	// Phase 1: 0-50s, clients a (0.7) + b (0.3) → 40 req/s total
+	// Phase 2: 50-100s, client c (1.0) → 40 req/s total
+	const aggregateRate = 40.0
+	const phase1End = 50_000_000   // 50s in µs
+	const phase2End = 100_000_000  // 100s in µs
+
+	spec := &WorkloadSpec{
+		Version:       "2",
+		Seed:          42,
+		AggregateRate: aggregateRate,
+		Clients: []ClientSpec{
+			{
+				ID: "p1a", RateFraction: 0.7,
+				Arrival:    ArrivalSpec{Process: "poisson"},
+				InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+				OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+				Lifecycle:  &LifecycleSpec{Windows: []ActiveWindow{{StartUs: 0, EndUs: phase1End}}},
+			},
+			{
+				ID: "p1b", RateFraction: 0.3,
+				Arrival:    ArrivalSpec{Process: "poisson"},
+				InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+				OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+				Lifecycle:  &LifecycleSpec{Windows: []ActiveWindow{{StartUs: 0, EndUs: phase1End}}},
+			},
+			{
+				ID: "p2", RateFraction: 1.0,
+				Arrival:    ArrivalSpec{Process: "poisson"},
+				InputDist:  DistSpec{Type: "constant", Params: map[string]float64{"value": 100}},
+				OutputDist: DistSpec{Type: "constant", Params: map[string]float64{"value": 50}},
+				Lifecycle:  &LifecycleSpec{Windows: []ActiveWindow{{StartUs: phase1End, EndUs: phase2End}}},
+			},
+		},
+	}
+
+	requests, err := GenerateRequests(spec, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Count requests per phase.
+	var phase1Count, phase2Count int
+	for _, req := range requests {
+		if req.ArrivalTime < phase1End {
+			phase1Count++
+		} else if req.ArrivalTime < phase2End {
+			phase2Count++
+		}
+	}
+
+	// Expected: ~40 req/s × 50s = ~2000 requests per phase.
+	// Accept ±15% tolerance for Poisson variance.
+	wantPerPhase := aggregateRate * 50.0 // 2000
+	for _, tc := range []struct {
+		name  string
+		count int
+	}{
+		{"phase1", phase1Count},
+		{"phase2", phase2Count},
+	} {
+		ratio := float64(tc.count) / wantPerPhase
+		if ratio < 0.85 || ratio > 1.15 {
+			t.Errorf("%s: got %d requests, want ~%.0f (ratio=%.2f, outside ±15%%)",
+				tc.name, tc.count, wantPerPhase, ratio)
+		}
+	}
+}
+
+func TestGenerateRequests_InferencePerfMultiStage_CorrectRatePerStage(t *testing.T) {
+	// BC-5: inference-perf multi-stage produces correct rate per stage via
+	// CustomSamplerFactory, independent of normalizeRateFractions.
+	ipSpec := &InferencePerfSpec{
+		Stages: []StageSpec{
+			{Rate: 8.0, Duration: 30},
+			{Rate: 20.0, Duration: 30},
+		},
+		SharedPrefix: &SharedPrefixSpec{
+			NumUniqueSystemPrompts:  1,
+			NumUsersPerSystemPrompt: 2,
+			SystemPromptLen:         10,
+			QuestionLen:             100,
+			OutputLen:               50,
+		},
+	}
+
+	expanded, err := ExpandInferencePerfSpec(ipSpec, 42)
+	if err != nil {
+		t.Fatalf("expansion error: %v", err)
+	}
+
+	requests, err := GenerateRequests(expanded, math.MaxInt64, 0)
+	if err != nil {
+		t.Fatalf("generation error: %v", err)
+	}
+
+	// Stage 1: 0-30s at 8 req/s → ~240 requests
+	// Stage 2: 30-60s at 20 req/s → ~600 requests
+	stage1End := int64(30_000_000) // 30s in µs
+	stage2End := int64(60_000_000) // 60s in µs
+	var stage1Count, stage2Count int
+	for _, req := range requests {
+		if req.ArrivalTime < stage1End {
+			stage1Count++
+		} else if req.ArrivalTime < stage2End {
+			stage2Count++
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		got  int
+		want float64
+	}{
+		{"stage1", stage1Count, 8.0 * 30},
+		{"stage2", stage2Count, 20.0 * 30},
+	} {
+		ratio := float64(tc.got) / tc.want
+		if ratio < 0.80 || ratio > 1.20 {
+			t.Errorf("%s: got %d requests, want ~%.0f (ratio=%.2f, outside ±20%%)",
+				tc.name, tc.got, tc.want, ratio)
+		}
+	}
+}

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -213,17 +213,14 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 		// Each stage's N*M clients are active only during that stage's window
 		// and emit at that stage's rate.
 		//
-		// Math: aggregateRate = sum(stageRates), rateFraction = stageRate/numClientsPerStage.
-		// After normalization, each client's rate = stageRate/numClientsPerStage.
-		// During a stage, N*M clients are active → total rate = stageRate.
+		// Each client uses a CustomSamplerFactory with a Poisson sampler at the
+		// exact per-client rate (stage.Rate / numClients), bypassing fraction
+		// normalization entirely. This avoids interaction with per-phase
+		// normalization in normalizeRateFractions.
 		//
-		// NOTE: Multi-stage workloads use Poisson (not NormalizedExponentialSampler).
-		// Rationale: NormalizedExponentialSampler pre-generates intervals spanning the
-		// full workload duration, but per-stage clients are only active during their
-		// stage's window (a subset of the full duration). This mismatch would waste
-		// intervals or require complex windowing. Poisson generates incrementally
-		// during the active window, matching the per-stage lifecycle architecture.
-		// See BC-4 in plan for full details.
+		// RateFraction is set to 1.0 as a dummy (must be positive to pass the
+		// clientRate <= 0 skip check in generator.go). The factory overrides
+		// the normalized rate.
 		windows := stagesToWindows(spec.Stages)
 
 		for _, stage := range spec.Stages {
@@ -232,7 +229,10 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 
 		clients = make([]ClientSpec, 0, numClientsPerStage*len(spec.Stages))
 		for s, stage := range spec.Stages {
-			rateFraction := stage.Rate / float64(numClientsPerStage)
+			perClientRate := stage.Rate / float64(numClientsPerStage) / 1e6 // req/µs
+			factory := func(rng *rand.Rand) ArrivalSampler {
+				return &PoissonSampler{rateMicros: perClientRate}
+			}
 			stageLifecycle := &LifecycleSpec{
 				Windows: []ActiveWindow{windows[s]},
 			}
@@ -257,37 +257,39 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 						clientIdx++
 
 						clients = append(clients, ClientSpec{
-							ID:           clientID,
-							TenantID:     prefixGroup,
-							SLOClass:     "standard",
-							RateFraction: rateFraction,
-							Arrival:      ArrivalSpec{Process: "poisson"},
-							InputDist:    inputDist,
-							OutputDist:   outputDist,
-							PrefixGroup:  prefixGroup,
-							PrefixLength: sp.SystemPromptLen,
-							Reasoning:    reasoning,
-							Lifecycle:    stageLifecycle,
+							ID:                  clientID,
+							TenantID:            prefixGroup,
+							SLOClass:            "standard",
+							RateFraction:         1.0,
+							Arrival:              ArrivalSpec{Process: "poisson"},
+							CustomSamplerFactory: factory,
+							InputDist:            inputDist,
+							OutputDist:           outputDist,
+							PrefixGroup:          prefixGroup,
+							PrefixLength:         sp.SystemPromptLen,
+							Reasoning:            reasoning,
+							Lifecycle:            stageLifecycle,
 						})
 					}
 				}
 			} else {
-				// Non-multi-turn multi-stage: use Poisson
+				// Non-multi-turn multi-stage: use Poisson via CustomSamplerFactory
 				for p := 0; p < sp.NumUniqueSystemPrompts; p++ {
 					prefixGroup := fmt.Sprintf("prompt-%d", p)
 					for u := 0; u < sp.NumUsersPerSystemPrompt; u++ {
 						clientID := fmt.Sprintf("stage-%d-prompt-%d-user-%d", s, p, u)
 						clients = append(clients, ClientSpec{
-							ID:           clientID,
-							TenantID:     prefixGroup,
-							SLOClass:     "standard",
-							RateFraction: rateFraction,
-							Arrival:      ArrivalSpec{Process: "poisson"},
-							InputDist:    inputDist,
-							OutputDist:   outputDist,
-							PrefixGroup:  prefixGroup,
-							PrefixLength: sp.SystemPromptLen,
-							Lifecycle:    stageLifecycle,
+							ID:                  clientID,
+							TenantID:            prefixGroup,
+							SLOClass:            "standard",
+							RateFraction:         1.0,
+							Arrival:              ArrivalSpec{Process: "poisson"},
+							CustomSamplerFactory: factory,
+							InputDist:            inputDist,
+							OutputDist:           outputDist,
+							PrefixGroup:          prefixGroup,
+							PrefixLength:         sp.SystemPromptLen,
+							Lifecycle:            stageLifecycle,
 						})
 					}
 				}

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -2,6 +2,8 @@ package workload
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1478,9 +1480,9 @@ func TestExpandInferencePerfSpec_SingleStage_NormalizedDeterministic(t *testing.
 	}
 }
 
-func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
-	// BC-4: Multi-stage expansion still uses Poisson arrival (for now).
-	// Verify that clients have Arrival field set (not CustomSamplerFactory).
+func TestExpandInferencePerfSpec_MultiStage_CustomSamplerFactory(t *testing.T) {
+	// BC-5: Multi-stage expansion uses CustomSamplerFactory with Poisson at exact
+	// per-client rate, bypassing fraction normalization.
 	ipSpec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 8.0, Duration: 10},
@@ -1502,12 +1504,28 @@ func TestExpandInferencePerfSpec_MultiStage_KeepsPoisson(t *testing.T) {
 	if len(expanded.Clients) != 2 {
 		t.Fatalf("client count = %d, want 2", len(expanded.Clients))
 	}
+	wantRates := []float64{8.0, 20.0} // stage rates with 1 client per stage
 	for i, client := range expanded.Clients {
 		if client.Arrival.Process != "poisson" {
 			t.Errorf("client %d: arrival process = %q, want poisson", i, client.Arrival.Process)
 		}
-		if client.CustomSamplerFactory != nil {
-			t.Errorf("client %d: CustomSamplerFactory should be nil (using Poisson)", i)
+		if client.CustomSamplerFactory == nil {
+			t.Fatalf("client %d: CustomSamplerFactory should be set", i)
+		}
+		// Verify the factory produces a sampler at the correct rate by sampling IATs.
+		rng := rand.New(rand.NewSource(99))
+		sampler := client.CustomSamplerFactory(rng)
+		// Sample enough IATs to estimate the rate within ±20%.
+		var totalIAT int64
+		n := 10000
+		for j := 0; j < n; j++ {
+			totalIAT += sampler.SampleIAT(rng)
+		}
+		avgIATus := float64(totalIAT) / float64(n)
+		estimatedRate := 1e6 / avgIATus // convert µs IAT to req/s
+		want := wantRates[i]
+		if math.Abs(estimatedRate-want)/want > 0.20 {
+			t.Errorf("client %d: estimated rate = %.2f req/s, want ~%.2f req/s (±20%%)", i, estimatedRate, want)
 		}
 	}
 }

--- a/testdata/roofline_goldendataset.json
+++ b/testdata/roofline_goldendataset.json
@@ -41,14 +41,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 142986343,
-        "ttft_mean_ms": 28.036537843137257,
-        "ttft_p90_ms": 75.521,
+        "ttft_sum_us": 165629225,
+        "ttft_mean_ms": 32.47631862745098,
+        "ttft_p90_ms": 89.672,
         "ttft_p99_ms": 158.903,
-        "e2e_mean_ms": 944.6026382352942,
+        "e2e_mean_ms": 1013.1004780392157,
         "e2e_p90_ms": 1749.715,
         "e2e_p99_ms": 1749.715,
-        "itl_mean_ms": 3.7107939287131857
+        "itl_mean_ms": 3.970138297213622
       }
     },
     {
@@ -90,14 +90,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 562814766,
-        "ttft_mean_ms": 62.534974000000005,
-        "ttft_p90_ms": 146.534,
-        "ttft_p99_ms": 166.775,
-        "e2e_mean_ms": 1445.7567813333333,
-        "e2e_p90_ms": 1743.657,
-        "e2e_p99_ms": 1825.876,
-        "itl_mean_ms": 5.622852875338753
+        "ttft_sum_us": 489396563,
+        "ttft_mean_ms": 54.37739588888889,
+        "ttft_p90_ms": 131.2325000000015,
+        "ttft_p99_ms": 170.079,
+        "e2e_mean_ms": 1313.780413888889,
+        "e2e_p90_ms": 1744.391,
+        "e2e_p99_ms": 1744.391,
+        "itl_mean_ms": 5.119524463414634
       }
     },
     {
@@ -139,14 +139,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 1711761870,
-        "ttft_mean_ms": 190.19576333333333,
-        "ttft_p90_ms": 410.024,
+        "ttft_sum_us": 1696128560,
+        "ttft_mean_ms": 188.4587288888889,
+        "ttft_p90_ms": 384.588,
         "ttft_p99_ms": 424.898,
-        "e2e_mean_ms": 2104.335259777778,
+        "e2e_mean_ms": 2086.2536181111113,
         "e2e_p90_ms": 2312.299,
-        "e2e_p99_ms": 3661.883750000001,
-        "itl_mean_ms": 7.781054863595303
+        "e2e_p99_ms": 3113.92708,
+        "itl_mean_ms": 7.7146133708220415
       }
     },
     {
@@ -233,14 +233,14 @@
         "completed_requests": 16800,
         "total_input_tokens": 9189600,
         "total_output_tokens": 4166400,
-        "ttft_sum_us": 3651397346,
-        "ttft_mean_ms": 217.3450801190476,
-        "ttft_p90_ms": 411.249,
-        "ttft_p99_ms": 493.587,
-        "e2e_mean_ms": 2346.472362857143,
-        "e2e_p90_ms": 2800.18,
-        "e2e_p99_ms": 3807.441,
-        "itl_mean_ms": 8.619948513109698
+        "ttft_sum_us": 3541552904,
+        "ttft_mean_ms": 210.80672047619046,
+        "ttft_p90_ms": 411.367,
+        "ttft_p99_ms": 421.458,
+        "e2e_mean_ms": 2319.288849702381,
+        "e2e_p90_ms": 2801.814,
+        "e2e_p99_ms": 3790.926,
+        "itl_mean_ms": 8.536364895652593
       }
     },
     {
@@ -372,14 +372,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 2869376505,
-        "ttft_mean_ms": 562.622844117647,
-        "ttft_p90_ms": 1106.794,
-        "ttft_p99_ms": 1177.023,
-        "e2e_mean_ms": 2850.3926449019605,
-        "e2e_p90_ms": 3141.027,
-        "e2e_p99_ms": 4057.2552700000015,
-        "itl_mean_ms": 9.262225914106534
+        "ttft_sum_us": 2597633309,
+        "ttft_mean_ms": 509.33986450980393,
+        "ttft_p90_ms": 954.236,
+        "ttft_p99_ms": 1120.023,
+        "e2e_mean_ms": 2766.4214243137253,
+        "e2e_p90_ms": 3133.327,
+        "e2e_p99_ms": 3133.3923999999997,
+        "itl_mean_ms": 9.137982023497658
       }
     },
     {
@@ -421,14 +421,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 4935174041,
-        "ttft_mean_ms": 548.3526712222223,
+        "ttft_sum_us": 5163442369,
+        "ttft_mean_ms": 573.7158187777777,
         "ttft_p90_ms": 1074.595,
-        "ttft_p99_ms": 1172.4555100000025,
-        "e2e_mean_ms": 3069.011061222222,
-        "e2e_p90_ms": 3223.6956000000005,
-        "e2e_p99_ms": 4412.60767,
-        "itl_mean_ms": 10.246578821138211
+        "ttft_p99_ms": 1102.133,
+        "e2e_mean_ms": 3123.743917777778,
+        "e2e_p90_ms": 3279.618,
+        "e2e_p99_ms": 4405.91568,
+        "itl_mean_ms": 10.36596788211382
       }
     },
     {
@@ -470,14 +470,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 325899325,
-        "ttft_mean_ms": 63.90182843137255,
-        "ttft_p90_ms": 195.2814,
-        "ttft_p99_ms": 328.936,
-        "e2e_mean_ms": 836.13399,
+        "ttft_sum_us": 448561113,
+        "ttft_mean_ms": 87.9531594117647,
+        "ttft_p90_ms": 259.34200000000004,
+        "ttft_p99_ms": 342.743,
+        "e2e_mean_ms": 916.7256603921569,
         "e2e_p90_ms": 1190.078,
         "e2e_p99_ms": 1190.078,
-        "itl_mean_ms": 3.126445998253552
+        "itl_mean_ms": 3.3553542549813447
       }
     },
     {
@@ -519,14 +519,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 3226511475,
-        "ttft_mean_ms": 358.501275,
+        "ttft_sum_us": 3010374457,
+        "ttft_mean_ms": 334.4860507777778,
         "ttft_p90_ms": 675.613,
         "ttft_p99_ms": 747.436,
-        "e2e_mean_ms": 2356.4846262222222,
-        "e2e_p90_ms": 2455.58,
-        "e2e_p99_ms": 3357.484380000001,
-        "itl_mean_ms": 8.121883541553748
+        "e2e_mean_ms": 2281.997979888889,
+        "e2e_p90_ms": 2445.296,
+        "e2e_p99_ms": 3376.57606,
+        "itl_mean_ms": 7.916715158988257
       }
     },
     {
@@ -613,14 +613,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 2262432963,
-        "ttft_mean_ms": 443.61430647058825,
-        "ttft_p90_ms": 986.332,
-        "ttft_p99_ms": 1180.055750000007,
-        "e2e_mean_ms": 2881.71704,
-        "e2e_p90_ms": 3159.683,
-        "e2e_p99_ms": 4387.571,
-        "itl_mean_ms": 9.870861269349845
+        "ttft_sum_us": 2041895784,
+        "ttft_mean_ms": 400.37172235294116,
+        "ttft_p90_ms": 929.785,
+        "ttft_p99_ms": 1072.886,
+        "e2e_mean_ms": 2787.578059215686,
+        "e2e_p90_ms": 3161.484,
+        "e2e_p99_ms": 3169.8976599999996,
+        "itl_mean_ms": 9.664802983249979
       }
     },
     {
@@ -705,7 +705,7 @@
         "total_output_tokens": 1737600,
         "ttft_sum_us": 31127971,
         "ttft_mean_ms": 25.939975833333335,
-        "ttft_p90_ms": 26.929000000000006,
+        "ttft_p90_ms": 26.929000000000002,
         "ttft_p99_ms": 62.339,
         "e2e_mean_ms": 6547.379883333334,
         "e2e_p90_ms": 7035.1229,

--- a/testdata/trained_physics_iter29.json
+++ b/testdata/trained_physics_iter29.json
@@ -58,14 +58,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 278003676,
-        "ttft_mean_ms": 54.510524705882354,
-        "ttft_p90_ms": 64.30810000000001,
-        "ttft_p99_ms": 68.05506000000001,
-        "e2e_mean_ms": 6266.126684705882,
-        "e2e_p90_ms": 6602.2344,
-        "e2e_p99_ms": 6705.10462,
-        "itl_mean_ms": 25.145097813765183
+        "ttft_sum_us": 277874535,
+        "ttft_mean_ms": 54.48520294117647,
+        "ttft_p90_ms": 64.6493,
+        "ttft_p99_ms": 68.246,
+        "e2e_mean_ms": 6300.223331568628,
+        "e2e_p90_ms": 6580.7341,
+        "e2e_p99_ms": 6691.79635,
+        "itl_mean_ms": 25.283243435738665
       }
     },
     {
@@ -107,14 +107,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 499729650,
-        "ttft_mean_ms": 55.52551666666667,
-        "ttft_p90_ms": 65.9966,
-        "ttft_p99_ms": 69.45903,
-        "e2e_mean_ms": 6515.546669666666,
-        "e2e_p90_ms": 6780.811199999999,
-        "e2e_p99_ms": 6840.521,
-        "itl_mean_ms": 26.257090052845527
+        "ttft_sum_us": 503513216,
+        "ttft_mean_ms": 55.94591288888889,
+        "ttft_p90_ms": 66.2069,
+        "ttft_p99_ms": 69.58429,
+        "e2e_mean_ms": 6521.736675555555,
+        "e2e_p90_ms": 6772.7626,
+        "e2e_p99_ms": 6836.95305,
+        "itl_mean_ms": 26.280543750677506
       }
     },
     {
@@ -156,14 +156,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 285259473,
-        "ttft_mean_ms": 31.695497,
-        "ttft_p90_ms": 36.603,
-        "ttft_p99_ms": 42.85512,
-        "e2e_mean_ms": 2494.186436333333,
-        "e2e_p90_ms": 3202.5683,
-        "e2e_p99_ms": 3632.50088,
-        "itl_mean_ms": 10.00696723306233
+        "ttft_sum_us": 288780804,
+        "ttft_mean_ms": 32.086756,
+        "ttft_p90_ms": 37.395300000000006,
+        "ttft_p99_ms": 44.382,
+        "e2e_mean_ms": 2516.742652,
+        "e2e_p90_ms": 3218.5341000000003,
+        "e2e_p99_ms": 3812.0654,
+        "itl_mean_ms": 10.097068682926828
       }
     },
     {
@@ -250,14 +250,14 @@
         "completed_requests": 16800,
         "total_input_tokens": 9189600,
         "total_output_tokens": 4166400,
-        "ttft_sum_us": 609439992,
-        "ttft_mean_ms": 36.27619,
-        "ttft_p90_ms": 43.7603,
-        "ttft_p99_ms": 50.934009999999994,
-        "e2e_mean_ms": 3095.5977995238095,
-        "e2e_p90_ms": 4179.469700000001,
-        "e2e_p99_ms": 4439.56205,
-        "itl_mean_ms": 12.382771698476962
+        "ttft_sum_us": 625417751,
+        "ttft_mean_ms": 37.22724708333334,
+        "ttft_p90_ms": 45.855,
+        "ttft_p99_ms": 52.710429999999995,
+        "e2e_mean_ms": 3102.4585885714287,
+        "e2e_p90_ms": 4158.4286999999995,
+        "e2e_p99_ms": 4300.0943,
+        "itl_mean_ms": 12.406697738818199
       }
     },
     {
@@ -389,14 +389,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 258630842,
-        "ttft_mean_ms": 50.71192980392157,
-        "ttft_p90_ms": 70.271,
-        "ttft_p99_ms": 93.371,
-        "e2e_mean_ms": 4433.453591176471,
-        "e2e_p90_ms": 4607.165,
-        "e2e_p99_ms": 4649.138,
-        "itl_mean_ms": 17.74074761689291
+        "ttft_sum_us": 241839027,
+        "ttft_mean_ms": 47.41941705882353,
+        "ttft_p90_ms": 55.524,
+        "ttft_p99_ms": 77.519,
+        "e2e_mean_ms": 4375.513172941176,
+        "e2e_p90_ms": 4484.7274,
+        "e2e_p99_ms": 4537.20935,
+        "itl_mean_ms": 17.519501035960943
       }
     },
     {
@@ -438,14 +438,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 604411508,
-        "ttft_mean_ms": 67.15683422222223,
-        "ttft_p90_ms": 119.301,
-        "ttft_p99_ms": 157.512,
-        "e2e_mean_ms": 4566.275003777778,
-        "e2e_p90_ms": 4698.3409,
-        "e2e_p99_ms": 4839.406,
-        "itl_mean_ms": 18.28593971364047
+        "ttft_sum_us": 647501040,
+        "ttft_mean_ms": 71.94456,
+        "ttft_p90_ms": 133.518,
+        "ttft_p99_ms": 156.427,
+        "e2e_mean_ms": 4582.169323666667,
+        "e2e_p90_ms": 4694.0546,
+        "e2e_p99_ms": 4822.09291,
+        "itl_mean_ms": 18.3310884701897
       }
     },
     {
@@ -487,14 +487,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 133543553,
-        "ttft_mean_ms": 26.18501039215686,
-        "ttft_p90_ms": 28.808,
-        "ttft_p99_ms": 29.82808,
-        "e2e_mean_ms": 1635.2134350980393,
-        "e2e_p90_ms": 1681.441,
-        "e2e_p99_ms": 1745.4671,
-        "itl_mean_ms": 6.511139371278876
+        "ttft_sum_us": 133517082,
+        "ttft_mean_ms": 26.17982,
+        "ttft_p90_ms": 28.7232,
+        "ttft_p99_ms": 30.229,
+        "e2e_mean_ms": 1626.6830668627451,
+        "e2e_p90_ms": 1669.2038,
+        "e2e_p99_ms": 1731.42632,
+        "itl_mean_ms": 6.476624481225688
       }
     },
     {
@@ -536,14 +536,14 @@
         "completed_requests": 9000,
         "total_input_tokens": 5094000,
         "total_output_tokens": 2223000,
-        "ttft_sum_us": 353698720,
-        "ttft_mean_ms": 39.299857777777774,
-        "ttft_p90_ms": 47.791,
-        "ttft_p99_ms": 66.601,
-        "e2e_mean_ms": 3177.2461804444447,
-        "e2e_p90_ms": 3465.1335999999997,
-        "e2e_p99_ms": 3584.1342799999998,
-        "itl_mean_ms": 12.752720823848238
+        "ttft_sum_us": 366760203,
+        "ttft_mean_ms": 40.75113366666667,
+        "ttft_p90_ms": 52.508,
+        "ttft_p99_ms": 72.861,
+        "e2e_mean_ms": 3253.5968766666665,
+        "e2e_p90_ms": 3529.3412,
+        "e2e_p99_ms": 3700.58455,
+        "itl_mean_ms": 13.057190012195122
       }
     },
     {
@@ -584,7 +584,7 @@
         "ttft_sum_us": 200165993,
         "ttft_mean_ms": 27.800832361111112,
         "ttft_p90_ms": 30.9356,
-        "ttft_p99_ms": 35.239180000000005,
+        "ttft_p99_ms": 35.23918,
         "e2e_mean_ms": 1720.1092315277779,
         "e2e_p90_ms": 1748.8048999999999,
         "e2e_p99_ms": 1773.592,
@@ -630,14 +630,14 @@
         "completed_requests": 5100,
         "total_input_tokens": 2789700,
         "total_output_tokens": 1264800,
-        "ttft_sum_us": 237418787,
-        "ttft_mean_ms": 46.55270333333333,
-        "ttft_p90_ms": 55.51,
-        "ttft_p99_ms": 74.628,
-        "e2e_mean_ms": 4242.510950196078,
-        "e2e_p90_ms": 4414.6623,
-        "e2e_p99_ms": 4473.622,
-        "itl_mean_ms": 16.984539460982774
+        "ttft_sum_us": 233328193,
+        "ttft_mean_ms": 45.750626078431374,
+        "ttft_p90_ms": 53.647,
+        "ttft_p99_ms": 68.9783,
+        "e2e_mean_ms": 4188.407154901961,
+        "e2e_p90_ms": 4294.356,
+        "e2e_p99_ms": 4421.8221,
+        "itl_mean_ms": 16.768743031674205
       }
     },
     {


### PR DESCRIPTION
## Summary

- **Per-phase normalization**: `normalizeRateFractions` now normalizes each client's `rate_fraction` by the sum of co-active clients (overlapping lifecycle windows) instead of the global sum. Clients without lifecycle windows are always-on and overlap with every phase.
- **inference-perf multi-stage bypass**: Multi-stage clients now use `CustomSamplerFactory` with Poisson at the exact per-client rate, bypassing fraction normalization entirely.
- Golden datasets regenerated due to RNG sequence shift from `CustomSamplerFactory` sub-RNG allocation.

Fixes #1144

## Test plan

- [x] Unit tests for `normalizeRateFractions` (7 cases: BC-1..4 + edge cases)
- [x] Unit tests for `windowsOverlap` (9 cases)
- [x] Updated `TestExpandInferencePerfSpec_MultiStage_CustomSamplerFactory` — verifies factory produces correct per-stage rate
- [x] Integration test: phased workload produces correct aggregate rate per phase (±15%)
- [x] Integration test: inference-perf multi-stage produces correct rate per stage (±20%)
- [x] Golden datasets updated (`-update-golden`) and verified
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)