### PR TITLE
fix(workload): peak-overlap normalization for lifecycle-windowed clients (#1144)

### DIFF
--- a/sim/workload/client.go
+++ b/sim/workload/client.go
@@ -1,7 +1,9 @@
 package workload
 
 import (
+	"math"
 	"math/rand"
+	"sort"
 
 	"github.com/inference-sim/inference-sim/sim"
 )
@@ -10,22 +12,90 @@ import (
 
 const defaultPrefixLength = 50
 
-// normalizeRateFractions normalizes client rate fractions to sum to 1.0.
+// normalizeRateFractions normalizes client rate fractions so that, at any
+// point in simulated time, the sum of rates of the clients active at that
+// moment equals aggregateRate. The normalization divisor is the maximum
+// RateFraction sum across all moments — i.e. across the peak-concurrency
+// phase — not the unconditional sum across every client.
+//
+// This matters when clients declare non-overlapping lifecycle windows. For a
+// two-phase workload where phase 1 uses fractions 0.7+0.3 and phase 2 uses
+// 1.0, the unconditional sum is 2.0 and halves every rate, producing ~half
+// the intended aggregateRate during each phase (issue #1144). Using the
+// max-overlap sum (1.0) keeps each phase at aggregateRate.
+//
 // Returns per-client rates in requests/microsecond.
 func normalizeRateFractions(clients []ClientSpec, aggregateRate float64) []float64 {
-	totalFraction := 0.0
-	for i := range clients {
-		totalFraction += clients[i].RateFraction
-	}
-	if totalFraction == 0 {
+	divisor := maxOverlappingFractionSum(clients)
+	if divisor == 0 {
 		return make([]float64, len(clients))
 	}
 	rates := make([]float64, len(clients))
 	for i := range clients {
-		normalizedFraction := clients[i].RateFraction / totalFraction
-		rates[i] = aggregateRate * normalizedFraction / 1e6 // convert req/sec to req/µs
+		rates[i] = aggregateRate * (clients[i].RateFraction / divisor) / 1e6
 	}
 	return rates
+}
+
+// maxOverlappingFractionSum sweeps the client lifecycle timeline and returns
+// the largest RateFraction sum over any sub-interval. Clients without a
+// Lifecycle spec are treated as active from t=0 to t=+∞. If no client is
+// ever active (or all fractions are zero) the function returns 0 — callers
+// are expected to short-circuit in that case.
+func maxOverlappingFractionSum(clients []ClientSpec) float64 {
+	type event struct {
+		t     int64
+		delta float64
+	}
+	events := make([]event, 0, 2*len(clients))
+	hasUnbounded := false
+	unboundedSum := 0.0
+	for i := range clients {
+		frac := clients[i].RateFraction
+		if frac == 0 {
+			continue
+		}
+		if clients[i].Lifecycle == nil || len(clients[i].Lifecycle.Windows) == 0 {
+			hasUnbounded = true
+			unboundedSum += frac
+			continue
+		}
+		for _, w := range clients[i].Lifecycle.Windows {
+			if w.EndUs <= w.StartUs {
+				continue
+			}
+			events = append(events, event{t: w.StartUs, delta: frac})
+			events = append(events, event{t: w.EndUs, delta: -frac})
+		}
+	}
+	if len(events) == 0 {
+		return unboundedSum
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].t != events[j].t {
+			return events[i].t < events[j].t
+		}
+		// Windows are half-open [start, end). At a tied instant where
+		// one window ends and another begins, process the removal first
+		// so back-to-back phases do not falsely register a moment of
+		// concurrent overlap.
+		return events[i].delta < events[j].delta
+	})
+	active := unboundedSum
+	peak := unboundedSum
+	if hasUnbounded && peak == 0 {
+		peak = 0
+	}
+	for _, e := range events {
+		active += e.delta
+		if active > peak {
+			peak = active
+		}
+	}
+	if math.IsNaN(peak) || peak < 0 {
+		return 0
+	}
+	return peak
 }
 
 // generatePrefixTokens creates shared prefix token sequences per prefix group.

--- a/sim/workload/client_test.go
+++ b/sim/workload/client_test.go
@@ -1,0 +1,108 @@
+package workload
+
+import (
+	"math"
+	"testing"
+)
+
+// floatsClose is a small helper used by the rate-normalization tests.
+func floatsClose(a, b, eps float64) bool { return math.Abs(a-b) <= eps }
+
+// TestNormalizeRateFractions_SingleUnboundedGroup preserves the historical
+// behaviour: when every client is active for the full run, the aggregate
+// rate is split proportionally by RateFraction.
+func TestNormalizeRateFractions_SingleUnboundedGroup(t *testing.T) {
+	clients := []ClientSpec{
+		{ID: "a", RateFraction: 0.7},
+		{ID: "b", RateFraction: 0.3},
+	}
+	// aggregateRate = 40 req/s => total should be 40 * 1e-6 req/µs.
+	rates := normalizeRateFractions(clients, 40)
+	want := []float64{28.0 / 1e6, 12.0 / 1e6}
+	for i := range clients {
+		if !floatsClose(rates[i], want[i], 1e-12) {
+			t.Errorf("client %s: rate = %g, want %g", clients[i].ID, rates[i], want[i])
+		}
+	}
+}
+
+// TestNormalizeRateFractions_NonOverlappingPhases is the scenario from
+// issue #1144. Phase 1 (clients A+B, windows 0-50s, fractions 0.7+0.3)
+// and Phase 2 (client C alone, 50-100s, fraction 1.0) do not overlap —
+// the peak-overlap sum is 1.0 and the per-phase rates must total
+// aggregateRate, not aggregateRate/2.
+func TestNormalizeRateFractions_NonOverlappingPhases(t *testing.T) {
+	clients := []ClientSpec{
+		{
+			ID:           "phase1-A",
+			RateFraction: 0.7,
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 0, EndUs: 50_000_000},
+			}},
+		},
+		{
+			ID:           "phase1-B",
+			RateFraction: 0.3,
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 0, EndUs: 50_000_000},
+			}},
+		},
+		{
+			ID:           "phase2",
+			RateFraction: 1.0,
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 50_000_000, EndUs: 100_000_000},
+			}},
+		},
+	}
+	rates := normalizeRateFractions(clients, 40)
+	want := []float64{28.0 / 1e6, 12.0 / 1e6, 40.0 / 1e6}
+	for i := range clients {
+		if !floatsClose(rates[i], want[i], 1e-12) {
+			t.Errorf("client %s: rate = %g, want %g", clients[i].ID, rates[i], want[i])
+		}
+	}
+}
+
+// TestNormalizeRateFractions_OverlappingWindows keeps the old normalization
+// when lifecycle windows do overlap: the concurrent sum of active
+// fractions must not exceed aggregateRate, so the divisor is the peak.
+func TestNormalizeRateFractions_OverlappingWindows(t *testing.T) {
+	clients := []ClientSpec{
+		{
+			ID:           "a",
+			RateFraction: 0.5,
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 0, EndUs: 80_000_000},
+			}},
+		},
+		{
+			ID:           "b",
+			RateFraction: 0.5,
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 20_000_000, EndUs: 100_000_000},
+			}},
+		},
+	}
+	// Peak overlap (both active 20-80s) sums to 1.0, so each client
+	// should run at aggregateRate/2 when overlapping.
+	rates := normalizeRateFractions(clients, 40)
+	want := []float64{20.0 / 1e6, 20.0 / 1e6}
+	for i := range clients {
+		if !floatsClose(rates[i], want[i], 1e-12) {
+			t.Errorf("client %s: rate = %g, want %g", clients[i].ID, rates[i], want[i])
+		}
+	}
+}
+
+// TestNormalizeRateFractions_ZeroAggregate yields zero rates without panicking.
+func TestNormalizeRateFractions_ZeroAggregate(t *testing.T) {
+	clients := []ClientSpec{
+		{ID: "a", RateFraction: 0},
+		{ID: "b", RateFraction: 0},
+	}
+	rates := normalizeRateFractions(clients, 40)
+	if len(rates) != 2 || rates[0] != 0 || rates[1] != 0 {
+		t.Errorf("expected [0 0], got %v", rates)
+	}
+}

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -52,7 +52,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 		// ground truth. A user-specified aggregate_rate would silently scale
 		// all per-stage rates by the wrong factor.
 		if spec.AggregateRate > 0 && spec.AggregateRate != expanded.AggregateRate {
-			logrus.Warnf("overriding aggregate_rate %.2f with sum of stage rates %.2f",
+			logrus.Warnf("overriding aggregate_rate %.2f with peak stage rate %.2f",
 				spec.AggregateRate, expanded.AggregateRate)
 		}
 		spec.AggregateRate = expanded.AggregateRate

--- a/sim/workload/inference_perf.go
+++ b/sim/workload/inference_perf.go
@@ -77,8 +77,10 @@ func validateInferencePerfSpec(spec *InferencePerfSpec) error {
 //
 // Single-stage: N*M clients with no lifecycle windows, aggregateRate = stage rate.
 // Multi-stage: N*M clients per stage, each active only during its stage's window.
-// aggregateRate = sum of stage rates; each client's rateFraction = stageRate / (N*M).
-// This ensures each stage emits at its configured rate during its time window.
+// aggregateRate = peak stage rate (stages don't overlap); each client's
+// rateFraction = stageRate / (N*M). The peak-overlap normalization in
+// normalizeRateFractions then yields per-client rate = stageRate/(N*M), so
+// each stage emits exactly at its configured rate during its window.
 //
 // Returns error if the spec is invalid.
 func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec, error) {
@@ -226,8 +228,16 @@ func ExpandInferencePerfSpec(spec *InferencePerfSpec, seed int64) (*WorkloadSpec
 		// See BC-4 in plan for full details.
 		windows := stagesToWindows(spec.Stages)
 
+		// aggregateRate is the peak concurrent rate across all active
+		// clients. Multi-stage inference_perf has non-overlapping stage
+		// windows, so the peak is the single largest stage rate; pairing
+		// that with the per-stage rateFraction gives each client its
+		// intended stage rate after normalizeRateFractions divides by
+		// the peak-overlap fraction sum (issue #1144).
 		for _, stage := range spec.Stages {
-			aggregateRate += stage.Rate
+			if stage.Rate > aggregateRate {
+				aggregateRate = stage.Rate
+			}
 		}
 
 		clients = make([]ClientSpec, 0, numClientsPerStage*len(spec.Stages))

--- a/sim/workload/inference_perf_test.go
+++ b/sim/workload/inference_perf_test.go
@@ -417,9 +417,11 @@ func TestExpandInferencePerfSpec_TwoStages_PerStageClients(t *testing.T) {
 }
 
 func TestExpandInferencePerfSpec_TwoStages_AggregateRate(t *testing.T) {
-	// BC-2: aggregate rate is sum of stage rates (not time-weighted average).
-	// Each stage's clients emit at the stage rate during their window;
-	// aggregateRate = sum ensures normalizeRateFractions produces correct per-client rates.
+	// BC-2: aggregate rate is the peak concurrent rate across stages
+	// (i.e. the largest single-stage rate), not the sum. Stage windows
+	// are non-overlapping, so per-stage clients emit at their stage
+	// rate during the stage's window after the peak-overlap
+	// normalization in normalizeRateFractions (issue #1144).
 	spec := &InferencePerfSpec{
 		Stages: []StageSpec{
 			{Rate: 8.0, Duration: 600},
@@ -437,8 +439,8 @@ func TestExpandInferencePerfSpec_TwoStages_AggregateRate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Sum of stage rates: 8.0 + 20.0 = 28.0
-	expectedRate := 28.0
+	// Peak stage rate: max(8.0, 20.0) = 20.0
+	expectedRate := 20.0
 	if ws.AggregateRate != expectedRate {
 		t.Errorf("aggregate rate = %f, want %f", ws.AggregateRate, expectedRate)
 	}
@@ -493,9 +495,9 @@ func TestExpandInferencePerfSpec_ThreeStages_PerStageClients(t *testing.T) {
 	if len(ws.Clients) != 3 {
 		t.Fatalf("client count = %d, want 3 (1 per stage)", len(ws.Clients))
 	}
-	// aggregateRate = 5 + 10 + 15 = 30
-	if ws.AggregateRate != 30.0 {
-		t.Errorf("aggregate rate = %f, want 30.0", ws.AggregateRate)
+	// aggregateRate = max(5, 10, 15) = 15 (peak stage rate).
+	if ws.AggregateRate != 15.0 {
+		t.Errorf("aggregate rate = %f, want 15.0", ws.AggregateRate)
 	}
 
 	// Each client has exactly one lifecycle window matching its stage
@@ -1031,7 +1033,7 @@ func TestGenerateRequests_InferencePerfSpec_AggregateRateOverridden(t *testing.T
 	spec := &WorkloadSpec{
 		Version:       "2",
 		Seed:          42,
-		AggregateRate: 10.0, // wrong — should be 28.0 (sum of stage rates)
+		AggregateRate: 10.0, // wrong — should be 20.0 (peak stage rate)
 		InferencePerf: ipSpec,
 	}
 	horizon := int64(10_000_000) // 10 seconds
@@ -1039,9 +1041,9 @@ func TestGenerateRequests_InferencePerfSpec_AggregateRateOverridden(t *testing.T
 	if err != nil {
 		t.Fatalf("generation error: %v", err)
 	}
-	// After expansion, AggregateRate must be overridden to sum of stage rates.
-	if spec.AggregateRate != 28.0 {
-		t.Errorf("AggregateRate = %f, want 28.0 (sum of 8+20)", spec.AggregateRate)
+	// After expansion, AggregateRate must be overridden to the peak stage rate.
+	if spec.AggregateRate != 20.0 {
+		t.Errorf("AggregateRate = %f, want 20.0 (peak of 8, 20)", spec.AggregateRate)
 	}
 }
 


### PR DESCRIPTION
## Summary

`normalizeRateFractions` summed `RateFraction` across every client and used that sum as the divisor, which halved the effective aggregate rate whenever clients had non-overlapping lifecycle windows. A two-phase workload with phase-1 fractions 0.7+0.3 and phase-2 fraction 1.0 ran at ~20 QPS instead of the specified 40 QPS.

This PR changes the normalization divisor to the maximum `RateFraction` sum over any sub-interval of simulated time, computed by an event-sweep over all lifecycle windows. Clients without a `Lifecycle` spec are treated as always-active, which preserves the existing behaviour when no windows are configured (the peak equals the unconditional sum).

Windows are half-open `[start, end)`: removals are processed before additions at tied instants so that back-to-back phases do not falsely register a moment of overlap.

`inference_perf` multi-stage expansion is updated in lock-step: `aggregateRate` is now the peak stage rate (not the sum), which combined with the peak-overlap normalization keeps per-client and per-stage rates exactly at their configured values. BC-2 tests and the override warning message are updated to match.

Fixes #1144

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./sim/workload/ -count=1\` (new TestNormalizeRateFractions_* cases)
- [x] \`go test ./sim/cluster/ -run TestTrainedPhysics_GoldenDataset -count=1\` (golden dataset still matches)
- [x] \`go test ./... -count=1 -timeout 600s\` (all packages green)