### PR TITLE
fix(cluster): invert PD routing order to decode-first, eliminate second routing decision

### DIFF
--- a/docs/contributing/standards/invariants.md
+++ b/docs/contributing/standards/invariants.md
@@ -160,9 +160,9 @@ Invariants are properties that must hold at all times during and after simulatio
 
 **Statement:** For every disaggregated request, `decode_enqueue_time >= kv_transfer_completion_time`. A decode sub-request must not be enqueued before its KV transfer completes.
 
-**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_RequestCompletesFullPath` checks DecodeEnqueueTime >= TransferCompleteTime for every parent request. Runtime defensive check in `DecodeRoutingEvent.Execute()`.
+**Verification:** `sim/cluster/disaggregation_test.go` — `TestDisaggregation_RequestCompletesFullPath` checks DecodeEnqueueTime >= TransferCompleteTime for every parent request. Runtime defensive check in `KVTransferCompletedEvent.Execute()`.
 
-**Evidence:** By event priority ordering: KVTransferCompletedEvent (priority 6) schedules DecodeRoutingEvent (priority 7) at the same timestamp. DecodeEnqueueTime is set in DecodeRoutingEvent which fires after transfer completion.
+**Evidence:** Both `TransferCompleteTime` and `DecodeEnqueueTime` are set in `KVTransferCompletedEvent.Execute()` at the same simulation tick (`e.time`), so the invariant holds by construction.
 
 ### INV-PD-2: Pool Exclusivity
 

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -413,7 +413,7 @@ func (e *DisaggregationDecisionEvent) Execute(cs *ClusterSimulator) {
 		if warmUpCount > 0 && len(decodeInst.WarmUpRequestIDs()) < warmUpCount {
 			decodeInst.RecordWarmUpRequest(e.request.ID)
 		}
-		decodeInst.InjectRequestOnline(e.request, e.time)
+		decodeInst.InjectRequestOnline(e.request, e.time+cs.routingLatency)
 		cs.notifyDisaggregationObserver(e.request, decodeDecision.TargetInstance)
 		return
 	}

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -14,7 +14,7 @@ import (
 // These are separate from sim.Event and processed by ClusterSimulator's control plane.
 type ClusterEvent interface {
 	Timestamp() int64
-	Priority() int // 0=Arrival, 1=Admission, 2=Routing, 3=Disaggregation, 4-7=PD, 8=ScalingTick, 9=ScaleActuation
+	Priority() int // 0=Arrival, 1=Admission, 2=Routing, 3=Disaggregation, 4-6=PD, 8=ScalingTick, 9=ScaleActuation
 	Execute(*ClusterSimulator)
 }
 
@@ -327,36 +327,101 @@ type DisaggregationDecisionEvent struct {
 func (e *DisaggregationDecisionEvent) Timestamp() int64 { return e.time }
 func (e *DisaggregationDecisionEvent) Priority() int     { return 3 }
 
-// Execute calls the disaggregation decider and bifurcates the request flow.
-// disaggregate=true: splits request into prefill sub-request, schedules PrefillRoutingEvent.
-// disaggregate=false: schedules standard RoutingDecisionEvent (unchanged path).
+// Execute implements the llm-d decode-first routing order:
+// 1. Select a decode pod first (via decode pool routing).
+// 2. Decide disaggregation with the decode pod known.
+// 3a. disaggregate=false: inject directly to the selected decode pod.
+// 3b. disaggregate=true: store decode pod in ParentRequest upfront, route prefill,
+//
+//	KV-transfer, then inject directly to the pre-selected decode pod (no second
+//	routing decision).
 func (e *DisaggregationDecisionEvent) Execute(cs *ClusterSimulator) {
-	decision := cs.disaggregationDecider.Decide(e.request)
-	logrus.Debugf("[cluster] req %s: disaggregate=%v", e.request.ID, decision.Disaggregate)
+	// Step 1: route to decode pool first (llm-d parity: decode pod always selected first).
+	filteredSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
+	if len(filteredSnapshots) == 0 {
+		logrus.Warnf("[cluster] req %s: no routable instances in decode pool — request rejected at routing", e.request.ID)
+		cs.routingRejections++
+		return
+	}
+	state := &sim.RouterState{Snapshots: filteredSnapshots, Clock: cs.clock}
+	policy := cs.decodeRoutingPolicy
+	if policy == nil {
+		policy = cs.routingPolicy
+	}
+	decodeDecision := policy.Route(e.request, state)
+	logrus.Debugf("[cluster] req %s: decode pod pre-selected → %s", e.request.ID, decodeDecision.TargetInstance)
 
-	// Record disaggregation decision if tracing is enabled (BC-PD-17)
+	// Step 2: disaggregation decision with decode pod known.
+	disaggDecision := cs.disaggregationDecider.Decide(e.request)
+	logrus.Debugf("[cluster] req %s: disaggregate=%v", e.request.ID, disaggDecision.Disaggregate)
+
+	// Record disaggregation decision if tracing is enabled (BC-PD-17).
 	if cs.trace != nil {
 		cs.trace.RecordDisaggregation(trace.DisaggregationRecord{
 			RequestID:    e.request.ID,
 			Clock:        cs.clock,
-			Disaggregate: decision.Disaggregate,
+			Disaggregate: disaggDecision.Disaggregate,
 		})
 	}
 
-	if !decision.Disaggregate {
-		// Local path: standard routing (unchanged)
-		heap.Push(&cs.clusterEvents, clusterEventEntry{
-			event: &RoutingDecisionEvent{
-				time:    e.time + cs.routingLatency,
-				request: e.request,
-			},
-			seqID: cs.nextSeqID(),
-		})
+	// Find the target decode instance object (used in both paths below).
+	var decodeInst *InstanceSimulator
+	for _, inst := range cs.instances {
+		if string(inst.ID()) == decodeDecision.TargetInstance {
+			decodeInst = inst
+			break
+		}
+	}
+	if decodeInst == nil {
+		// R6: routing policy must return a valid target from the provided snapshot set.
+		panic(fmt.Sprintf("DisaggregationDecisionEvent: invalid decode TargetInstance %q returned by routing policy", decodeDecision.TargetInstance))
+	}
+
+	if !disaggDecision.Disaggregate {
+		// Step 3a: local path — inject directly to the selected decode pod.
+		// This fixes P3: non-disaggregated requests are now routed exclusively to the decode
+		// pool, not to all instances via buildRouterState().
+		e.request.AssignedInstance = decodeDecision.TargetInstance
+		if decodeDecision.Priority != 0 {
+			e.request.Priority = decodeDecision.Priority
+		}
+
+		// Record standard routing trace for BC-TRACE-COMPAT: consumers (e.g.
+		// TestPDTrace_NeverDecider_WithPools) expect len(tr.Routings) == numRequests.
+		if cs.trace != nil {
+			record := trace.RoutingRecord{
+				RequestID:      e.request.ID,
+				Clock:          cs.clock,
+				ChosenInstance: decodeDecision.TargetInstance,
+				Reason:         decodeDecision.Reason,
+				Scores:         copyScores(decodeDecision.Scores),
+			}
+			if cs.trace.Config.CounterfactualK > 0 {
+				record.Candidates, record.Regret = computeCounterfactual(
+					decodeDecision.TargetInstance, decodeDecision.Scores,
+					filteredSnapshots, cs.trace.Config.CounterfactualK,
+				)
+			}
+			cs.trace.RecordRouting(record)
+		}
+
+		cs.inFlightRequests[decodeDecision.TargetInstance]++
+		if cs.tenantTracker != nil {
+			cs.tenantTracker.OnStart(e.request.TenantID)
+		}
+		warmUpCount := cs.config.InstanceLifecycle.WarmUpRequestCount
+		if warmUpCount > 0 && len(decodeInst.WarmUpRequestIDs()) < warmUpCount {
+			decodeInst.RecordWarmUpRequest(e.request.ID)
+		}
+		decodeInst.InjectRequestOnline(e.request, e.time)
+		cs.notifyDisaggregationObserver(e.request, decodeDecision.TargetInstance)
 		return
 	}
 
-	// Disaggregated path: split request and route to prefill pool
+	// Step 3b: disaggregated path — decode pod pre-selected, route prefill next.
+	// This fixes P1: decode pod is stored upfront in ParentRequest before prefill routing.
 	parent := NewParentRequest(e.request, cs.config.BlockSizeTokens)
+	parent.DecodeInstanceID = InstanceID(decodeDecision.TargetInstance)
 	cs.parentRequests[parent.ID] = parent
 
 	// Create prefill sub-request: same input, no output (completes after prefill).

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -1797,11 +1797,12 @@ func TestDisaggregation_DecodeInstancePreSelected(t *testing.T) {
 	mustRun(t, cs)
 
 	// THEN: every parent request has a non-empty DecodeInstanceID in the decode pool,
-	// and the instance is actually in the decode pool (not prefill)
-	if len(cs.parentRequests) == 0 {
+	// and the instance is actually in the decode pool (not prefill).
+	parents := cs.ParentRequests()
+	if len(parents) == 0 {
 		t.Fatal("expected disaggregated parent requests, got none")
 	}
-	for _, parent := range cs.parentRequests {
+	for _, parent := range parents {
 		if parent.DecodeInstanceID == "" {
 			t.Errorf("parent %s: DecodeInstanceID is empty — decode instance was not pre-selected", parent.ID)
 			continue

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -1747,3 +1747,109 @@ func TestDisaggregation_PD_SessionManager_ContextAccumulation(t *testing.T) {
 	// INV-1 conservation
 	assertINV1Conservation(t, metrics, 2, "PD SessionManager context accumulation")
 }
+
+// TestDisaggregation_NonDisaggRoutedToDecodePoolOnly verifies P3 fix: when PDDecider="never"
+// (no disaggregation), all requests must be routed exclusively to decode pool instances.
+// Before the fix, DisaggregationDecisionEvent scheduled RoutingDecisionEvent which called
+// buildRouterState() including ALL instances (prefill + decode).
+func TestDisaggregation_NonDisaggRoutedToDecodePoolOnly(t *testing.T) {
+	// GIVEN: pool topology configured but disaggregation never triggered
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	config.PDDecider = "never"
+	const numRequests = 8
+	requests := newTestRequests(numRequests)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// WHEN: simulation runs
+	mustRun(t, cs)
+
+	// THEN: every routed request is assigned to a decode-pool instance
+	for _, req := range requests {
+		if req.AssignedInstance == "" {
+			continue // not yet routed (e.g., still queued at horizon) — skip
+		}
+		role, ok := cs.poolMembership[req.AssignedInstance]
+		if !ok {
+			t.Errorf("req %s assigned to instance %q which has no pool membership", req.ID, req.AssignedInstance)
+			continue
+		}
+		if role != PoolRoleDecode {
+			t.Errorf("req %s assigned to instance %q (role=%v), want PoolRoleDecode — non-disaggregated requests must not land on prefill pods",
+				req.ID, req.AssignedInstance, role)
+		}
+	}
+
+	// INV-1 conservation still holds
+	assertINV1Conservation(t, cs.AggregatedMetrics(), numRequests, "non-disagg decode-only routing")
+}
+
+// TestDisaggregation_DecodeInstancePreSelected verifies P1 fix: the decode instance is
+// selected during DisaggregationDecisionEvent (before prefill routing), not after KV transfer.
+// Before the fix, DecodeInstanceID was set by DecodeRoutingEvent after KV transfer completed.
+func TestDisaggregation_DecodeInstancePreSelected(t *testing.T) {
+	// GIVEN: always-disaggregate pool topology
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	const numRequests = 5
+	requests := newTestRequests(numRequests)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// WHEN: simulation runs
+	mustRun(t, cs)
+
+	// THEN: every parent request has a non-empty DecodeInstanceID in the decode pool,
+	// and the instance is actually in the decode pool (not prefill)
+	if len(cs.parentRequests) == 0 {
+		t.Fatal("expected disaggregated parent requests, got none")
+	}
+	for _, parent := range cs.parentRequests {
+		if parent.DecodeInstanceID == "" {
+			t.Errorf("parent %s: DecodeInstanceID is empty — decode instance was not pre-selected", parent.ID)
+			continue
+		}
+		role, ok := cs.poolMembership[string(parent.DecodeInstanceID)]
+		if !ok {
+			t.Errorf("parent %s: DecodeInstanceID %q not in pool membership", parent.ID, parent.DecodeInstanceID)
+			continue
+		}
+		if role != PoolRoleDecode {
+			t.Errorf("parent %s: DecodeInstanceID %q has role=%v, want PoolRoleDecode",
+				parent.ID, parent.DecodeInstanceID, role)
+		}
+	}
+}
+
+// TestDisaggregation_NoDecodeRoutingEvent verifies P2 fix: no DecodeRoutingRecord is emitted
+// in the trace because the second routing decision (DecodeRoutingEvent) is eliminated.
+// The decode pod is pre-selected at DisaggregationDecisionEvent time; KVTransferCompletedEvent
+// injects directly to the pre-selected pod.
+func TestDisaggregation_NoDecodeRoutingEvent(t *testing.T) {
+	// GIVEN: always-disaggregate with trace enabled
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	config.TraceLevel = "decisions"
+	const numRequests = 4
+	requests := newTestRequests(numRequests)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// WHEN: simulation runs
+	mustRun(t, cs)
+
+	// THEN: no DecodeRoutingRecord emitted (no second routing decision)
+	tr := cs.Trace()
+	if tr == nil {
+		t.Fatal("expected non-nil trace with trace-level decisions")
+	}
+	if len(tr.DecodeRoutings) != 0 {
+		t.Errorf("expected 0 DecodeRoutingRecords (decode pod pre-selected, no second routing), got %d",
+			len(tr.DecodeRoutings))
+	}
+	// Disaggregation, prefill routing, and KV transfers still recorded
+	if len(tr.Disaggregations) != numRequests {
+		t.Errorf("expected %d disaggregation records, got %d", numRequests, len(tr.Disaggregations))
+	}
+	if len(tr.PrefillRoutings) != numRequests {
+		t.Errorf("expected %d prefill routing records, got %d", numRequests, len(tr.PrefillRoutings))
+	}
+	if len(tr.KVTransfers) != numRequests {
+		t.Errorf("expected %d KV transfer records, got %d", numRequests, len(tr.KVTransfers))
+	}
+}

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -340,7 +340,7 @@ func (i *InstanceSimulator) AllocateTransferredKV(req *sim.Request) bool {
 // Bypasses the normal ArrivalEvent → QueuedEvent → EnqueueRequest chain to avoid
 // the oversized-request guard (KV already allocated) and TotalInputTokens double-counting.
 // Registers request in metrics and directly enqueues into wait queue.
-// clusterTime is the cluster clock at the time of injection (from DecodeRoutingEvent).
+// clusterTime is the cluster clock at the time of injection (from KVTransferCompletedEvent).
 func (i *InstanceSimulator) InjectDecodeOnline(req *sim.Request, clusterTime int64) {
 	i.sim.Metrics.Requests[req.ID] = sim.NewRequestMetrics(req, float64(req.ArrivalTime)/1e6)
 	i.sim.EnqueueDecodeSubRequest(req, clusterTime)

--- a/sim/cluster/parent_request.go
+++ b/sim/cluster/parent_request.go
@@ -9,7 +9,7 @@ type ParentRequest struct {
 	OriginalRequest *sim.Request // Pointer to the original request (for metadata)
 	PrefillSubReqID string
 	DecodeSubReqID  string
-	DecodeSubReq    *sim.Request // Pointer to the decode sub-request (set by DecodeRoutingEvent)
+	DecodeSubReq    *sim.Request // Pointer to the decode sub-request (set by KVTransferCompletedEvent)
 	NumKVBlocks     int64        // KV blocks to transfer (ceil(inputLen / blockSize))
 
 	// Phase timestamps (microseconds). Zero means phase not yet reached.
@@ -26,7 +26,7 @@ type ParentRequest struct {
 	//     that projectPDMetrics() computes the same client-visible E2E as non-PD
 	//     recordRequestCompletion (issue #846). For roofline (overhead=0), equals
 	//     the raw cluster clock tick.
-	//   - Dropped at decode KV allocation: set to the DecodeRoutingEvent time (the
+	//   - Dropped at decode KV allocation: set to the KVTransferCompletedEvent time (the
 	//     point when the drop was detected). Since decode never ran, this reflects
 	//     the drop-detection time, not a decode completion time.
 	//     Use DecodeInstanceID == "" to distinguish dropped requests.
@@ -34,7 +34,9 @@ type ParentRequest struct {
 	//     timeout detection time. The session is cancelled via sessionCallback.
 	CompletionTime int64
 
-	// Instance assignment
+	// Instance assignment.
+	// DecodeInstanceID is set upfront at DisaggregationDecisionEvent time (decode-first routing),
+	// before prefill routing begins. PrefillInstanceID is set by PrefillRoutingEvent.
 	PrefillInstanceID InstanceID
 	DecodeInstanceID  InstanceID
 }

--- a/sim/cluster/pd_events.go
+++ b/sim/cluster/pd_events.go
@@ -71,7 +71,7 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 			cs.inFlightRequests[decision.TargetInstance]++
 			// Phase 1B-2a: track tenant in-flight count for fair-share enforcement in PD mode.
 			// PD disaggregation semantics: OnStart is called once here (prefill) and once in
-			// DecodeRoutingEvent (decode), so one parent request consumes 2 capacity slots —
+			// KVTransferCompletedEvent (decode), so one parent request consumes 2 capacity slots —
 			// one on the prefill pool, one on the decode pool. IsOverBudget reflects actual
 			// resource occupancy across both pools. OnComplete fires symmetrically via
 			// OnRequestDone when each sub-request finishes.

--- a/sim/cluster/pd_events.go
+++ b/sim/cluster/pd_events.go
@@ -179,7 +179,9 @@ type KVTransferCompletedEvent struct {
 func (e *KVTransferCompletedEvent) Timestamp() int64 { return e.time }
 func (e *KVTransferCompletedEvent) Priority() int     { return 6 }
 
-// Execute creates the decode sub-request and schedules DecodeRoutingEvent.
+// Execute creates the decode sub-request and injects it directly into the pre-selected
+// decode pod (stored in parentReq.DecodeInstanceID by DisaggregationDecisionEvent).
+// This eliminates the former DecodeRoutingEvent (second routing decision), fixing P2.
 func (e *KVTransferCompletedEvent) Execute(cs *ClusterSimulator) {
 	cs.transfersCompleted++
 	e.parentReq.TransferCompleteTime = e.time
@@ -215,122 +217,78 @@ func (e *KVTransferCompletedEvent) Execute(cs *ClusterSimulator) {
 		IsDecodeSubRequest: true,
 	}
 
-	logrus.Debugf("[cluster] KV transfer completed for %s, scheduling decode routing", e.parentReq.ID)
+	// Look up the pre-selected decode instance (set at DisaggregationDecisionEvent time).
+	decodeInstID := string(e.parentReq.DecodeInstanceID)
+	logrus.Debugf("[cluster] KV transfer completed for %s, injecting to pre-selected decode pod %s", e.parentReq.ID, decodeInstID)
 
-	heap.Push(&cs.clusterEvents, clusterEventEntry{
-		event: &DecodeRoutingEvent{
-			time:         e.time,
-			parentReq:    e.parentReq,
-			decodeSubReq: decodeSubReq,
-		},
-		seqID: cs.nextSeqID(),
-	})
-}
+	var decodeInst *InstanceSimulator
+	for _, inst := range cs.instances {
+		if string(inst.ID()) == decodeInstID {
+			decodeInst = inst
+			break
+		}
+	}
 
-// DecodeRoutingEvent routes a decode sub-request to a decode pool instance.
-// Priority 7: after transfer completion.
-type DecodeRoutingEvent struct {
-	time         int64
-	parentReq    *ParentRequest
-	decodeSubReq *sim.Request
-}
-
-func (e *DecodeRoutingEvent) Timestamp() int64 { return e.time }
-func (e *DecodeRoutingEvent) Priority() int     { return 7 }
-
-// Execute routes the decode sub-request to a decode pool instance, pre-allocates KV, and injects.
-func (e *DecodeRoutingEvent) Execute(cs *ClusterSimulator) {
-	filteredSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
-	if len(filteredSnapshots) == 0 {
-		logrus.Warnf("[cluster] decode req %s: no routable instances in decode pool — request dropped", e.parentReq.ID)
+	if decodeInst == nil || !decodeInst.IsRoutable() {
+		// The pre-selected decode pod became non-routable (e.g., terminated) during KV transfer.
+		logrus.Warnf("[cluster] decode instance %s for %s is no longer routable — request dropped",
+			decodeInstID, e.parentReq.ID)
 		cs.droppedAtDecodeKV++
 		e.parentReq.CompletionTime = e.time
 		return
 	}
-	state := &sim.RouterState{Snapshots: filteredSnapshots, Clock: cs.clock}
 
-	policy := cs.decodeRoutingPolicy
-	if policy == nil {
-		policy = cs.routingPolicy
+	// Pre-allocate KV blocks for the transferred input.
+	if ok := decodeInst.AllocateTransferredKV(decodeSubReq); !ok {
+		logrus.Warnf("[cluster] decode instance %s: insufficient KV capacity for %s (%d input tokens)",
+			decodeInstID, decodeSubReq.ID, len(decodeSubReq.InputTokens))
+		// R1/INV-1: count the drop so aggregated DroppedUnservable remains accurate.
+		cs.droppedAtDecodeKV++
+		// Mark parent CompletionTime so ParentRequests() doesn't contain records in limbo.
+		e.parentReq.CompletionTime = e.time
+		return
 	}
-	decision := policy.Route(e.decodeSubReq, state)
 
-	logrus.Debugf("[cluster] decode req %s → instance %s", e.decodeSubReq.ID, decision.TargetInstance)
+	// Successful KV allocation: set state and record trace (R5: no partial state on failure path).
+	decodeSubReq.AssignedInstance = decodeInstID
+	e.parentReq.DecodeEnqueueTime = e.time
 
-	// Find target decode instance
-	for _, inst := range cs.instances {
-		if string(inst.ID()) == decision.TargetInstance {
-			// Pre-allocate KV blocks for transferred input
-			if ok := inst.AllocateTransferredKV(e.decodeSubReq); !ok {
-				logrus.Warnf("[cluster] decode instance %s: insufficient KV capacity for %s (%d input tokens)",
-					decision.TargetInstance, e.decodeSubReq.ID, len(e.decodeSubReq.InputTokens))
-				// R1/INV-1: count the drop so aggregated DroppedUnservable remains accurate.
-				cs.droppedAtDecodeKV++
-				// Mark parent CompletionTime so ParentRequests() doesn't contain records in limbo.
-				e.parentReq.CompletionTime = e.time
-				return
-			}
+	// INV-PD-1 structural guarantee: DecodeEnqueueTime >= TransferCompleteTime.
+	// Both TransferCompleteTime and DecodeEnqueueTime are set in this event at the same tick.
 
-			// Set state after successful allocation (R5: no partial state on failure path)
-			e.decodeSubReq.AssignedInstance = decision.TargetInstance
-			e.parentReq.DecodeInstanceID = InstanceID(decision.TargetInstance)
-			e.parentReq.DecodeEnqueueTime = e.time
-
-			// INV-PD-1 structural guarantee: DecodeEnqueueTime >= TransferCompleteTime.
-			// KVTransferCompletedEvent (priority 6) schedules DecodeRoutingEvent (priority 7)
-			// at the same timestamp (e.time), so both fields are equal by construction.
-
-			// Record KV transfer and decode routing after successful KV allocation (BC-PD-17, BC-PD-19).
-			// Placement after AllocateTransferredKV ensures no KVTransferRecord or DecodeRoutingRecord
-			// is written for a request that will not begin the decode phase.
-			// KVTransferRecord is recorded here so DecodeInstanceID is fully populated.
-			if cs.trace != nil {
-				// INV-PD-4: transfer_start ≤ transfer_complete by timestamp sequencing.
-				// Defensive clamp: warn and record 0 if violated.
-				transferDuration := e.parentReq.TransferCompleteTime - e.parentReq.TransferStartTime
-				if transferDuration < 0 {
-					logrus.Warnf("[cluster] INV-PD-4 violated: TransferCompleteTime (%d) < TransferStartTime (%d) for req %s; recording 0",
-						e.parentReq.TransferCompleteTime, e.parentReq.TransferStartTime, e.parentReq.ID)
-					transferDuration = 0
-				}
-				cs.trace.RecordKVTransfer(trace.KVTransferRecord{
-					ParentRequestID:   e.parentReq.ID,
-					TransferStartTime: e.parentReq.TransferStartTime,
-					TransferDuration:  transferDuration,
-					NumKVBlocks:       e.parentReq.NumKVBlocks,
-					PrefillInstanceID: string(e.parentReq.PrefillInstanceID),
-					DecodeInstanceID:  string(e.parentReq.DecodeInstanceID),
-				})
-				decodeRecord := trace.DecodeRoutingRecord{
-					ParentRequestID: e.parentReq.ID,
-					Clock:           cs.clock,
-					ChosenInstance:  decision.TargetInstance,
-					Scores:          copyScores(decision.Scores),
-				}
-				if cs.trace.Config.CounterfactualK > 0 {
-					decodeRecord.Candidates, decodeRecord.Regret = computeCounterfactual(
-						decision.TargetInstance, decision.Scores,
-						filteredSnapshots, cs.trace.Config.CounterfactualK,
-					)
-				}
-				cs.trace.RecordDecodeRouting(decodeRecord)
-			}
-
-			cs.inFlightRequests[decision.TargetInstance]++
-			// Phase 1B-2a: track decode slot for fair-share (see PrefillRoutingEvent comment
-			// for PD slot-doubling semantics). OnStart placement here (after AllocateTransferredKV)
-			// ensures balance: a failed KV allocation returns early above without calling OnStart,
-			// matching the zero OnComplete calls for the dropped decode sub-request.
-			if cs.tenantTracker != nil {
-				cs.tenantTracker.OnStart(e.decodeSubReq.TenantID)
-			}
-			// Register decode sub-request so detectDecodeCompletions can stamp ParentRequest.CompletionTime
-			// and read DecodeSubReq.State/ProgressIndex for timeout detection and context accumulation.
-			e.parentReq.DecodeSubReq = e.decodeSubReq
-			cs.pendingDecodeCompletions[e.decodeSubReq.ID] = e.parentReq.ID
-			inst.InjectDecodeOnline(e.decodeSubReq, e.time)
-			return
+	// Record KV transfer after successful allocation (BC-PD-17).
+	// Placement after AllocateTransferredKV ensures no KVTransferRecord is written for
+	// a request that will not begin the decode phase.
+	if cs.trace != nil {
+		// INV-PD-4: transfer_start ≤ transfer_complete by timestamp sequencing.
+		// Defensive clamp: warn and record 0 if violated.
+		transferDuration := e.parentReq.TransferCompleteTime - e.parentReq.TransferStartTime
+		if transferDuration < 0 {
+			logrus.Warnf("[cluster] INV-PD-4 violated: TransferCompleteTime (%d) < TransferStartTime (%d) for req %s; recording 0",
+				e.parentReq.TransferCompleteTime, e.parentReq.TransferStartTime, e.parentReq.ID)
+			transferDuration = 0
 		}
+		cs.trace.RecordKVTransfer(trace.KVTransferRecord{
+			ParentRequestID:   e.parentReq.ID,
+			TransferStartTime: e.parentReq.TransferStartTime,
+			TransferDuration:  transferDuration,
+			NumKVBlocks:       e.parentReq.NumKVBlocks,
+			PrefillInstanceID: string(e.parentReq.PrefillInstanceID),
+			DecodeInstanceID:  decodeInstID,
+		})
 	}
-	panic(fmt.Sprintf("DecodeRoutingEvent: invalid TargetInstance %q", decision.TargetInstance))
+
+	cs.inFlightRequests[decodeInstID]++
+	// Phase 1B-2a: track decode slot for fair-share (see PrefillRoutingEvent comment
+	// for PD slot-doubling semantics). OnStart placement here (after AllocateTransferredKV)
+	// ensures balance: a failed KV allocation returns early above without calling OnStart,
+	// matching the zero OnComplete calls for the dropped decode sub-request.
+	if cs.tenantTracker != nil {
+		cs.tenantTracker.OnStart(decodeSubReq.TenantID)
+	}
+	// Register decode sub-request so detectDecodeCompletions can stamp ParentRequest.CompletionTime
+	// and read DecodeSubReq.State/ProgressIndex for timeout detection and context accumulation.
+	e.parentReq.DecodeSubReq = decodeSubReq
+	cs.pendingDecodeCompletions[decodeSubReq.ID] = e.parentReq.ID
+	decodeInst.InjectDecodeOnline(decodeSubReq, e.time)
 }

--- a/sim/cluster/pd_traces_test.go
+++ b/sim/cluster/pd_traces_test.go
@@ -285,10 +285,10 @@ func TestPDTrace_DroppedAtDecodeKV_NoOrphanRecords(t *testing.T) {
 	if len(tr.KVTransfers) >= len(tr.Disaggregations) {
 		t.Errorf("KVTransfers=%d >= Disaggregations=%d under drops (drops must reduce KV record count)", len(tr.KVTransfers), len(tr.Disaggregations))
 	}
-	// For decode-side drops (cases 2/3), PrefillRoutings == Disaggregations because
+	// For decode-side drops (case 2), PrefillRoutings == Disaggregations because
 	// prefill routing succeeds before the drop. This equality does NOT hold for case 1
 	// (no routable prefill instances), where PrefillRoutings < Disaggregations.
-	// This test exercises cases 2/3 exclusively (decode KV OOM via AllocateTransferredKV).
+	// This test exercises case 2 exclusively (decode pod non-routable or KV OOM).
 	if len(tr.PrefillRoutings) != len(tr.Disaggregations) {
 		t.Errorf("PrefillRoutings=%d != Disaggregations=%d (prefill routing unaffected by decode KV drop)", len(tr.PrefillRoutings), len(tr.Disaggregations))
 	}

--- a/sim/cluster/pd_traces_test.go
+++ b/sim/cluster/pd_traces_test.go
@@ -81,8 +81,10 @@ func TestPDTrace_DisaggMode_AllRecordTypesPresent(t *testing.T) {
 	if len(tr.KVTransfers) != numRequests {
 		t.Errorf("KVTransfers: expected %d, got %d", numRequests, len(tr.KVTransfers))
 	}
-	if len(tr.DecodeRoutings) != numRequests {
-		t.Errorf("DecodeRoutings: expected %d, got %d", numRequests, len(tr.DecodeRoutings))
+	// DecodeRoutings is always empty: the decode pod is pre-selected at DisaggregationDecisionEvent
+	// time; KVTransferCompletedEvent injects directly without a second routing decision (P2 fix).
+	if len(tr.DecodeRoutings) != 0 {
+		t.Errorf("DecodeRoutings: expected 0 (no second routing decision), got %d", len(tr.DecodeRoutings))
 	}
 
 	// Verify KVTransfer records have both instance IDs and non-zero duration
@@ -113,15 +115,6 @@ func TestPDTrace_DisaggMode_AllRecordTypesPresent(t *testing.T) {
 			t.Errorf("PrefillRoutings[%d]: ParentRequestID empty", i)
 		}
 	}
-	for i, r := range tr.DecodeRoutings {
-		if r.ChosenInstance == "" {
-			t.Errorf("DecodeRoutings[%d]: ChosenInstance empty", i)
-		}
-		if r.ParentRequestID == "" {
-			t.Errorf("DecodeRoutings[%d]: ParentRequestID empty", i)
-		}
-	}
-
 	// Verify cross-record ID linkage: every downstream ParentRequestID must appear
 	// in Disaggregations[*].RequestID (the contract stated in DisaggregationRecord doc).
 	disaggIDs := make(map[string]struct{}, len(tr.Disaggregations))
@@ -136,11 +129,6 @@ func TestPDTrace_DisaggMode_AllRecordTypesPresent(t *testing.T) {
 	for i, kv := range tr.KVTransfers {
 		if _, ok := disaggIDs[kv.ParentRequestID]; !ok {
 			t.Errorf("KVTransfers[%d]: ParentRequestID %q not found in Disaggregations", i, kv.ParentRequestID)
-		}
-	}
-	for i, r := range tr.DecodeRoutings {
-		if _, ok := disaggIDs[r.ParentRequestID]; !ok {
-			t.Errorf("DecodeRoutings[%d]: ParentRequestID %q not found in Disaggregations", i, r.ParentRequestID)
 		}
 	}
 }
@@ -176,25 +164,17 @@ func TestPDTrace_DisaggMode_Counterfactual(t *testing.T) {
 			t.Errorf("PrefillRoutings[%d]: Regret=%f, want ≥0", i, r.Regret)
 		}
 	}
-
-	// THEN decode routing records have candidates (BC-PD-19)
-	for i, r := range tr.DecodeRoutings {
-		if len(r.Candidates) == 0 {
-			t.Errorf("DecodeRoutings[%d]: expected candidates with k=2, got none", i)
-		}
-		if len(r.Candidates) > 2 {
-			t.Errorf("DecodeRoutings[%d]: expected ≤2 candidates, got %d", i, len(r.Candidates))
-		}
-		if r.Regret < 0 {
-			t.Errorf("DecodeRoutings[%d]: Regret=%f, want ≥0", i, r.Regret)
-		}
+	// DecodeRoutings is empty (no second routing decision); counterfactual not applicable.
+	if len(tr.DecodeRoutings) != 0 {
+		t.Errorf("expected 0 DecodeRoutings (no second routing decision), got %d", len(tr.DecodeRoutings))
 	}
 }
 
 // TestPDTrace_DisaggMode_Cardinality verifies the PD trace cardinality conservation law (R7):
-// with AlwaysDisaggregate, DisaggregatedCount == len(PrefillRoutings) == len(KVTransfers) == len(DecodeRoutings).
+// with AlwaysDisaggregate, DisaggregatedCount == len(PrefillRoutings) == len(KVTransfers).
+// DecodeRoutings is always 0 because the decode pod is pre-selected at DisaggregationDecisionEvent
+// time; there is no second routing decision.
 // Note: len(Disaggregations) >= DisaggregatedCount (Disaggregations records ALL decisions, including disaggregate=false).
-// The general invariant is DisaggregatedCount == len(PrefillRoutings) == len(KVTransfers) == len(DecodeRoutings).
 func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	// GIVEN disaggregated simulation with trace enabled
 	const numRequests = 5
@@ -207,7 +187,7 @@ func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	mustRun(t, cs)
 
 	// THEN trace record counts satisfy the cardinality conservation law.
-	// With AlwaysDisaggregate: DisaggregatedCount == len(Disaggregations) == len(PrefillRoutings) == len(KVTransfers) == len(DecodeRoutings)
+	// With AlwaysDisaggregate: DisaggregatedCount == len(Disaggregations) == len(PrefillRoutings) == len(KVTransfers)
 	tr := cs.Trace()
 	if tr == nil {
 		t.Fatal("expected non-nil trace")
@@ -216,20 +196,20 @@ func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	disaggCount := summary.DisaggregatedCount
 	np := len(tr.PrefillRoutings)
 	nk := len(tr.KVTransfers)
-	nd2 := len(tr.DecodeRoutings)
 	// With AlwaysDisaggregate, DisaggregatedCount == len(Disaggregations)
 	if disaggCount != len(tr.Disaggregations) {
 		t.Errorf("cardinality violation: DisaggregatedCount=%d != len(Disaggregations)=%d (AlwaysDisaggregate expects all true)", disaggCount, len(tr.Disaggregations))
 	}
-	// The general PD cardinality law: DisaggregatedCount == PrefillRoutings == KVTransfers == DecodeRoutings
+	// The PD cardinality law: DisaggregatedCount == PrefillRoutings == KVTransfers
 	if np != disaggCount {
 		t.Errorf("cardinality violation: PrefillRoutings=%d != DisaggregatedCount=%d", np, disaggCount)
 	}
 	if nk != np {
 		t.Errorf("cardinality violation: KVTransfers=%d != PrefillRoutings=%d", nk, np)
 	}
-	if nd2 != nk {
-		t.Errorf("cardinality violation: DecodeRoutings=%d != KVTransfers=%d", nd2, nk)
+	// DecodeRoutings is always empty after P2 fix (no second routing decision)
+	if len(tr.DecodeRoutings) != 0 {
+		t.Errorf("cardinality violation: DecodeRoutings=%d, want 0 (no second routing decision)", len(tr.DecodeRoutings))
 	}
 }
 
@@ -297,10 +277,10 @@ func TestPDTrace_DroppedAtDecodeKV_NoOrphanRecords(t *testing.T) {
 		t.Fatal("expected non-nil trace with trace-level decisions")
 	}
 
-	// The cardinality law under drops: KVTransfers == DecodeRoutings (they are always co-recorded)
-	// and KVTransfers < DisaggregatedCount (dropped requests have no KV record).
-	if len(tr.KVTransfers) != len(tr.DecodeRoutings) {
-		t.Errorf("KVTransfers=%d != DecodeRoutings=%d (must be co-recorded)", len(tr.KVTransfers), len(tr.DecodeRoutings))
+	// The cardinality law under drops: KVTransfers < DisaggregatedCount (dropped requests have no KV record).
+	// DecodeRoutings is always 0 (no second routing decision).
+	if len(tr.DecodeRoutings) != 0 {
+		t.Errorf("DecodeRoutings=%d, want 0 (no second routing decision)", len(tr.DecodeRoutings))
 	}
 	if len(tr.KVTransfers) >= len(tr.Disaggregations) {
 		t.Errorf("KVTransfers=%d >= Disaggregations=%d under drops (drops must reduce KV record count)", len(tr.KVTransfers), len(tr.Disaggregations))

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -428,7 +428,7 @@ func (sim *Simulator) EnqueueRequest(r *Request) {
 // (blocks already allocated, guard would leak them) and does NOT increment TotalInputTokens
 // (input tokens were already counted by the prefill sub-request).
 // clusterTime is the cluster-level clock when this request is injected (from
-// DecodeRoutingEvent.Execute()). The StepEvent is scheduled at
+// KVTransferCompletedEvent.Execute()). The StepEvent is scheduled at
 // max(sim.Clock, clusterTime) to prevent the instance from processing the
 // decode sub-request at a stale internal time that precedes the request's arrival.
 // Triggers StepEvent if the instance is idle (INV-8: work-conserving).

--- a/sim/trace/record.go
+++ b/sim/trace/record.go
@@ -34,22 +34,22 @@ type RoutingRecord struct {
 
 // DisaggregationRecord captures a PD disaggregation decision.
 // When Disaggregate=true, the request follows the disaggregated path. Paired
-// PrefillRoutingRecord, KVTransferRecord, and DecodeRoutingRecord are recorded
-// for the same RequestID except in three drop scenarios:
+// PrefillRoutingRecord and KVTransferRecord are recorded for the same RequestID
+// except in two drop scenarios:
 //
 //  1. No routable prefill pool instances (routingRejections++): no downstream records.
-//  2. No routable decode pool instances (droppedAtDecodeKV++): PrefillRoutingRecord
-//     exists but KVTransferRecord and DecodeRoutingRecord are absent.
-//  3. AllocateTransferredKV fails on the decode instance (droppedAtDecodeKV++):
-//     same as case 2.
+//  2. Pre-selected decode pod became non-routable or AllocateTransferredKV fails
+//     (droppedAtDecodeKV++): PrefillRoutingRecord exists but KVTransferRecord is absent.
 //
 // To detect case 1: check for the absence of a PrefillRoutingRecord with a
-// matching ParentRequestID in the trace. To detect cases 2 and 3: check the
+// matching ParentRequestID in the trace. To detect case 2: check the
 // absence of a KVTransferRecord for a given ParentRequestID.
+// Note: DecodeRoutingRecord is never emitted; the decode pod is pre-selected at
+// DisaggregationDecisionEvent time (no second routing decision).
 type DisaggregationRecord struct {
 	RequestID    string
 	Clock        int64
-	Disaggregate bool // true = routed to prefill pool; false = standard routing
+	Disaggregate bool // true = routed to prefill pool; false = standard routing to decode pool
 }
 
 // PrefillRoutingRecord captures a prefill pool routing decision with optional counterfactual analysis.
@@ -80,7 +80,7 @@ type DecodeRoutingRecord struct {
 
 // KVTransferRecord captures a KV cache transfer event between prefill and decode instances.
 // TransferDuration is always >= 0; negative values are clamped to 0 with a warning in
-// DecodeRoutingEvent.Execute() (sim/cluster/pd_events.go) if INV-PD-4 is ever violated.
+// KVTransferCompletedEvent.Execute() (sim/cluster/pd_events.go) if INV-PD-4 is ever violated.
 type KVTransferRecord struct {
 	ParentRequestID   string
 	TransferStartTime int64 // microseconds (sim clock)

--- a/sim/trace/summary.go
+++ b/sim/trace/summary.go
@@ -8,7 +8,7 @@ type TraceSummary struct {
 	MeanRegret         float64
 	MaxRegret          float64
 	UniqueTargets      int
-	TargetDistribution map[string]int // instance ID → count of requests routed via standard routing only (not PD pool routing); use PrefillRoutings/DecodeRoutings for per-pool counts
+	TargetDistribution map[string]int // instance ID → count of requests routed via standard routing only (not PD pool routing); use PrefillRoutings for prefill-pool counts
 
 	// PD disaggregation summary (zero when disaggregation is not configured)
 	DisaggregationCount  int     // number of disaggregation decisions recorded (true and false combined)


### PR DESCRIPTION
## Summary

Fixes three behavioral bugs in the PD disaggregation routing pipeline to match llm-d's `disagg-profile-handler` semantics. Closes #1158.

- **P1 (routing order inverted)**: `DisaggregationDecisionEvent` now selects the decode pod first via `buildPoolFilteredSnapshots(PoolRoleDecode)` before the disaggregation decision is made. `ParentRequest.DecodeInstanceID` is set upfront at disaggregation time, not after KV transfer.

- **P2 (spurious second routing decision)**: `DecodeRoutingEvent` is eliminated. `KVTransferCompletedEvent` injects directly to the pre-selected decode pod — no second routing decision after KV transfer.

- **P3 (non-disaggregated requests landing on prefill pods)**: When `disaggregate=false`, requests are injected to the decode pool instance selected in step 1, not via `buildRouterState()` which included all instances (both prefill and decode pools).

## New routing flow (matches llm-d)

```
DisaggregationDecisionEvent:
  1. buildPoolFilteredSnapshots(PoolRoleDecode) → select decode pod
  2. disaggregationDecider.Decide() — with decode pod known
  3a. !disaggregate → inject directly to selected decode pod (decode pool only)
  3b. disaggregate → store DecodeInstanceID in ParentRequest, schedule PrefillRoutingEvent
        → prefill → KV transfer → KVTransferCompletedEvent injects to pre-selected decode pod
```

## Test plan

- [ ] `TestDisaggregation_NonDisaggRoutedToDecodePoolOnly` — verifies P3: non-disagg requests land on decode-pool instances only
- [ ] `TestDisaggregation_DecodeInstancePreSelected` — verifies P1: `DecodeInstanceID` is set and valid for all parent requests
- [ ] `TestDisaggregation_NoDecodeRoutingEvent` — verifies P2: `tr.DecodeRoutings` is empty (no second routing decision)
- [ ] All existing PD tests pass (disaggregation, pd_traces, transfer_contention, pool, parent_request)
- [ ] INV-1 conservation preserved
- [ ] `go test ./...` passes; `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)