### PR TITLE
docs(glossary): add 12 missing glossary entries

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -32,6 +32,10 @@ The JSON output of `blis calibrate` comparing real observed latencies against si
 
 A vLLM optimization where long prefill sequences are split into chunks that fit within the per-step token budget (`max-num-scheduled-tokens`). Controlled by `--long-prefill-token-threshold`. See [Core Engine: Batch Formation](core-engine.md#batch-formation).
 
+### Cohort
+
+A workload primitive that models a population of similar clients sharing the same arrival process, token distributions, and SLO class, with an optional time-varying lifecycle modifier. A cohort specifies a `population` count and one of three lifecycle patterns (`diurnal`, `spike`, `drain`); BLIS expands it into individual `ClientSpec` entries at workload generation time, each seeded independently for staggered arrival times. Distinct from a single `ClientSpec` in that cohorts directly model populations of concurrent users rather than a single traffic source. See [Workload Specifications: Cohort Dynamics](../guide/workloads.md#cohort-dynamics) and [Workload Spec Schema](../reference/workload-spec.md).
+
 ### Continuous Batching
 
 The serving strategy where new requests can join the running batch between decode steps, rather than waiting for the entire batch to complete. BLIS models this by re-evaluating the batch composition at every step. See [Core Engine: Batch Formation](core-engine.md#batch-formation).
@@ -64,6 +68,18 @@ A routing signal computed as `QueueDepth + BatchSize + InFlightRequests`. Becaus
 
 A single numeric value summarizing multi-objective simulation performance. Computed as a weighted combination of configurable metrics (TTFT percentiles, E2E percentiles, throughput). Latency metrics normalized via `1/(1 + value/1000)`; throughput metrics via `value/(value + reference)`. See [Configuration Reference](../reference/configuration.md#fitness-evaluation).
 
+### GAIE (Gateway API Inference Extension)
+
+The Kubernetes gateway component in the [llm-d](#llm-d) project responsible for admission control and request routing to LLM inference engines. BLIS's `gaie-legacy` admission policy replicates GAIE's production saturation-based shedding behavior: pool-average saturation is computed as `avg(max(qd/qdThreshold, kvUtil/kvThreshold))` across instances; non-sheddable requests always pass, sheddable requests (priority < 0) are rejected when saturation ≥ 1.0. Default thresholds match GAIE production: `qdThreshold=5`, `kvThreshold=0.8`. See [Admission Control: GAIE-Legacy Admission](../guide/admission.md#gaie-legacy-admission).
+
+### Gateway Queue
+
+An optional flow-control buffer between admission and routing, enabled with `--flow-control`. When active, admitted requests enter a priority-ordered queue instead of routing immediately. A saturation detector (`--saturation-detector`) evaluates cluster capacity on each step completion; when saturation falls below 1.0, the highest-priority waiting request is dequeued and routed with fresh routing snapshots (late-binding dispatch). Requests that exceed `--max-gateway-queue-depth` are shed and counted in the INV-1 conservation formula. See [Cluster Architecture](architecture.md#admission-pipeline).
+
+### HOL Blocking (Head-of-Line Blocking)
+
+A scheduling pathology where one long prefill monopolizes the GPU for an entire step, preventing shorter requests from entering decode until it completes. In BLIS, a 2,048-token prompt can occupy an entire step (~97 ms on Qwen3-14B / H100 / TP=1 in roofline mode), blocking all decode-phase requests during that step. Detected and counted as "HOL Blocking Events" in the anomaly counters. The mitigation is chunked prefill (`--long-prefill-token-threshold`), which splits long prefills so decode requests can be interleaved. See [KV Cache: Chunked Prefill](../guide/kv-cache.md#chunked-prefill) and [Chunked Prefill](#chunked-prefill).
+
 ### Horizon
 
 The simulation time limit in ticks (microseconds). The simulation stops when the clock exceeds the horizon or all requests complete, whichever comes first. See [Configuration Reference](../reference/configuration.md#simulation-control).
@@ -80,9 +96,21 @@ GPU memory organized as blocks that store key-value tensors computed during atte
 
 The component that predicts GPU execution time for a batch step. Two modes: *Roofline* (default; analytical FLOPs/bandwidth estimation) and *Trained-Physics* (physics-informed basis functions with architecture-aware MoE scaling). See [Core Engine: Latency Models](core-engine.md#latency-models), [Roofline Estimation](roofline.md), and [Latency Models Guide](../guide/latency-models.md).
 
+### llm-d
+
+An open-source LLM inference routing and serving framework that BLIS is designed to simulate and validate against. The default weighted routing profile (`precise-prefix-cache:2, queue-depth:1, kv-utilization:1`) matches llm-d's production Endpoint Picker scoring pipeline, and several BLIS components directly mirror llm-d counterparts: `gaie-legacy` admission replicates [GAIE](#gaie-gateway-api-inference-extension) behavior, `vllm-dp` routing replicates `DPLBAsyncMPClient`, and scorer names map to llm-d scorer identifiers. See [Cluster Architecture: Routing Pipeline](architecture.md#routing-pipeline).
+
 ### MaxModelLen
 
-Maximum total sequence length (input + output) for a single request, in tokens. Mirrors vLLM's `--max-model-len`. When set (> 0), requests whose input alone fills the context window (`input >= MaxModelLen`) or whose input + output budget exceeds it are dropped before entering the wait queue. A three-part proactive cap matches vLLM `scheduler.py:773-774`: FormBatch clamps token scheduling to `maxModelLen - 1 - ProgressIndex`, executeBatchStep skips decode when 0 tokens allocated, and processCompletions force-completes at the `maxModelLen - 1` boundary. Output per length-capped request: `maxModelLen - 1 - inputLen`. Set to 0 for unlimited. Auto-derived from `max_position_embeddings` in roofline and trained-physics modes, with `rope_scaling` factor application and KV-feasible capping. See [Configuration Reference](../reference/configuration.md#simulation-control).
+Maximum total sequence length (input + output) for a single request, in tokens. Mirrors vLLM's `--max-model-len`. When set (> 0), requests whose input alone fills the context window (`input >= MaxModelLen`) or whose input + output budget exceeds it are dropped before entering the wait queue. A three-part proactive cap matches vLLM `scheduler.py:773-774`: FormBatch clamps token scheduling to `maxModelLen - 1 - ProgressIndex`, executeBatchStep skips decode when 0 tokens allocated, and processCompletions force-completes at the `maxModelLen - 1` boundary. Output per length-capped request: `maxModelLen - 1 - inputLen`. Set to 0 for unlimited. Auto-derived from `max_position_embeddings` in roofline and trained-physics modes, with [`rope_scaling`](#rope_scaling) factor application and KV-feasible capping. See [Configuration Reference](../reference/configuration.md#simulation-control).
+
+### MFU (Model FLOPS Utilization)
+
+The fraction of a GPU's theoretical peak TFLOPS actually achieved during model execution, accounting for kernel efficiency, memory-access patterns, and CUDA overhead. BLIS uses separate MFU values for the prefill phase (`mfuPrefill`, typically higher because prefill is compute-bound) and the decode phase (`mfuDecode`, lower because decode is memory-bandwidth-bound). Both are configured per GPU in `hardware_config.json`. In trained-physics mode, MFU-equivalent corrections are captured by the learned β₁–β₄ coefficients rather than explicit fractions. See [Roofline Estimation](roofline.md).
+
+### MoE (Mixture of Experts)
+
+A transformer architecture variant where each layer routes each token to a subset of specialist sub-networks (experts) rather than processing all tokens through shared weights. BLIS distinguishes two MoE layouts: *uniform MoE* (every layer is a MoE layer, e.g., Mixtral-8x7B) and *interleaved MoE* (alternating MoE and dense layers, e.g., Scout). The trained-physics latency model applies a per-MoE-layer overhead term (β₈) only to interleaved architectures, auto-detected from `interleave_moe_layer_step` in the HuggingFace `config.json`. See [Latency Models Guide](../guide/latency-models.md).
 
 ### Observe / Replay / Calibrate Pipeline
 
@@ -124,6 +152,12 @@ A per-instance policy that assigns a numeric priority score to each request befo
 
 An analytical latency estimation technique that predicts step time as `max(FLOPs / peak_compute, bytes / peak_bandwidth)`. Requires only the model's HuggingFace `config.json` and GPU hardware specs. No training data needed. See [Roofline Estimation](roofline.md).
 
+### rope_scaling
+
+A field in a model's HuggingFace `config.json` that extends the effective context window beyond the base `max_position_embeddings` value by scaling the positional frequencies of RoPE (Rotary Position Embeddings). The object contains a `type` (or `rope_type`) field identifying the scaling method and a `factor` field specifying the multiplier.
+
+BLIS applies the scaling factor when auto-deriving [`MaxModelLen`](#maxmodellen) in roofline and trained-physics modes, following vLLM's blacklist approach: types `linear`, `dynamic`, `yarn`, `default`, and `mrope` apply the factor; types `su`, `longrope`, and `llama3` are excluded because they encode the full extended context length directly in `max_position_embeddings`. For `yarn`, `original_max_position_embeddings` is used as the base when present. Models whose `model_type` contains `gemma3` skip `rope_scaling` entirely — their `max_position_embeddings` is already pre-scaled. Override the auto-derived value with `--max-model-len`. See [Latency Models Guide](../guide/latency-models.md#roofline-mode-default) and [Configuration Reference](../reference/configuration.md#simulation-control).
+
 ### Routing Policy
 
 A cluster-level policy that selects which instance receives an admitted request. Simple policies (round-robin, least-loaded) use fixed rules. The weighted scoring policy composes multiple scorers with configurable weights. See [Cluster Architecture: Routing Pipeline](architecture.md#routing-pipeline).
@@ -131,6 +165,10 @@ A cluster-level policy that selects which instance receives an admitted request.
 ### Routing Snapshot
 
 A point-in-time view of instance state used for routing decisions. Contains queue depth, batch size, KV utilization, cache hit rate, and pending request count. Signals have different freshness tiers depending on how they're collected. See [Cluster Architecture: Signal Freshness](architecture.md#signal-freshness).
+
+### Scheduling Delay
+
+The elapsed time between a request's arrival and the moment it enters the running batch, reported as `scheduling_delay_ms` (per-request JSON) and `scheduling_delay_p99_ms` (aggregate). Includes the alpha queueing overhead (`alpha0 + alpha1 × inputLen`) plus wait queue residence time. Distinct from TTFT, which additionally includes prefill compute time. High scheduling delay with low preemption rate indicates queue saturation (add instances); low scheduling delay with high TTFT indicates compute saturation (reduce batch size or enable chunked prefill). See [Metrics & Results](../guide/results.md#scheduling-delay) and [Core Engine: Metrics](core-engine.md#metrics).
 
 ### Scorer
 
@@ -140,9 +178,17 @@ A component in the weighted scoring pipeline that produces a per-instance score 
 
 The random seed for deterministic simulation. Same seed produces byte-identical stdout across runs (INV-6). BLIS uses partitioned RNG to isolate randomness across subsystems. See [Configuration Reference](../reference/configuration.md#simulation-control).
 
+### SLO Class
+
+A label that categorizes each request by service-level objective sensitivity, governing admission decisions, scheduling priority, gateway queue dispatch order, and per-class metric reporting. BLIS uses five classes with GAIE-compatible integer priorities: `critical` (4), `standard` (3), `batch` (−1), `sheddable` (−2), `background` (−3). Classes with negative priority are *sheddable* — preferentially dropped under overload or when a tenant exceeds their capacity budget. Non-sheddable classes (`critical`, `standard`) are always protected. Set via `slo_class` in the workload spec YAML. See [Workload Specifications](../guide/workloads.md#slo-classes) and [Configuration Reference](../reference/configuration.md#slo-tier-priorities).
+
 ### Step
 
 A single iteration of the inference engine. Each step processes one batch: prefill tokens for new/continuing requests and decode tokens for generating output. Step time is predicted by the latency model. See [Core Engine: Step Phases](core-engine.md#step-phases).
+
+### Tensor Parallelism (TP)
+
+A parallelism strategy that shards a model's weight tensors across multiple GPUs, reducing per-GPU compute load and KV memory requirements. Configured via `--tp`. Higher TP reduces per-request latency (fewer FLOPs per GPU, less KV memory per rank) but adds All-Reduce communication overhead per transformer layer (modeled by the β₄ coefficient in trained-physics mode). Increasing the instance count (replication) instead increases throughput without reducing per-request latency. BLIS does not model data parallelism (DP) or expert parallelism (EP). See [Latency Models Guide](../guide/latency-models.md#tensor-parallelism-and-roofline) and [Roofline Estimation](roofline.md).
 
 ### Tick
 
@@ -151,6 +197,10 @@ The fundamental time unit in BLIS, representing one microsecond. All timestamps,
 ### Tiered KV Cache
 
 An extension of the KV cache with GPU and CPU tiers. When GPU utilization exceeds a threshold, blocks are offloaded to CPU memory. On cache miss, blocks can be reloaded from CPU with a transfer latency penalty. See [Core Engine: KV Cache](core-engine.md#kv-cache-management).
+
+### TPOT (Time Per Output Token)
+
+The mean inter-token latency across all decode steps for a request, computed as `mean(ITL)`. TPOT represents the steady-state token generation speed once prefill completes; lower TPOT means faster streaming throughput. Each ITL sample includes the step time plus the alpha2 output-processing overhead per token. Reported as the `itl_mean_ms` field in JSON output. See [ITL](#itl-inter-token-latency) and [Core Engine: Metrics](core-engine.md#metrics).
 
 ### TraceV2
 

--- a/docs/plans/pr604-glossary-rope-scaling-plan.md
+++ b/docs/plans/pr604-glossary-rope-scaling-plan.md
@@ -1,0 +1,82 @@
+# Plan: Add 12 Missing Glossary Entries
+
+**Goal:** Add 12 standalone glossary entries to `docs/concepts/glossary.md` identified as gaps in issue #604 comment.
+**Source:** Issue #604 and gap audit comment posted 2026-04-27.
+**Closes:** #604
+**Tier:** Small (docs-only, single file)
+
+---
+
+## Behavioral Contracts
+
+**BC-1 — Twelve new entries appear at correct alphabetical positions**
+- GIVEN the glossary is sorted alphabetically (case-insensitive)
+- WHEN a user browses the glossary
+- THEN the 12 new entries appear in these positions:
+  - Cohort: between Chunked Prefill and Continuous Batching
+  - GAIE: between Fitness Score and Gateway Queue
+  - Gateway Queue: between GAIE and HOL Blocking
+  - HOL Blocking: between Gateway Queue and Horizon
+  - llm-d: between Latency Model and MaxModelLen
+  - MFU: between MaxModelLen and MoE
+  - MoE: between MFU and Observe/Replay/Calibrate Pipeline
+  - rope_scaling: between Roofline Model and Routing Policy
+  - Scheduling Delay: between Routing Snapshot and Scorer
+  - SLO Class: between Seed and Step
+  - Tensor Parallelism (TP): between Step and Tick
+  - TPOT: between Tiered KV Cache and TraceV2
+
+**BC-2 — rope_scaling entry is accurate**
+- Types that apply the factor: `linear`, `dynamic`, `yarn`, `default`, `mrope`
+- Types that are excluded: `su`, `longrope`, `llama3`
+- `yarn` special case: uses `original_max_position_embeddings` as base when present
+- `gemma3` special case: skips `rope_scaling` entirely
+- Links to MaxModelLen, latency-models guide, configuration reference
+
+**BC-3 — SLO Class entry lists all five tiers with correct priorities**
+- critical=4, standard=3, batch=−1, sheddable=−2, background=−3
+- Explains sheddability (priority < 0 = sheddable)
+- Links to workloads guide and configuration reference
+
+**BC-4 — All 12 entries cross-link to existing authoritative sections**
+- No links to non-existent anchors
+- Anchors verified against actual section headings in target files
+
+**BC-5 — MaxModelLen entry cross-links rope_scaling**
+- GIVEN the MaxModelLen entry contains inline `rope_scaling`
+- THEN the backtick reference becomes an anchor link to `#rope_scaling`
+
+---
+
+## Tasks
+
+### Task 1 — Add all 12 entries to glossary.md and update MaxModelLen cross-reference
+
+**Verification (manual):** After write, confirm:
+1. All 12 headings present: `grep "^### " docs/concepts/glossary.md`
+2. Alphabetical order preserved (verify the 12 insertion points listed in BC-1)
+3. MaxModelLen entry contains `[#rope_scaling]` link anchor
+4. All cross-link anchors are valid (spot-check 3 anchors in target files)
+
+**Implementation:** Write the complete updated `docs/concepts/glossary.md` with all 12 entries inserted in the correct alphabetical positions.
+
+**Commit:** `docs(glossary): add 12 missing glossary entries (rope_scaling, SLO Class, TP, MoE, etc.), closes #604`
+
+---
+
+## Sanity Checklist
+
+- [ ] 12 new headings present in file
+- [ ] Alphabetical order correct for all 12 insertions
+- [ ] rope_scaling content matches cmd/root.go:186-191 and latency-models.md:87 verbatim
+- [ ] SLO class priorities match configuration.md SLO Tier Priorities table
+- [ ] MoE interleaved vs uniform distinction present
+- [ ] All cross-link anchors verified against target files
+- [ ] MaxModelLen cross-link to rope_scaling present
+- [ ] No process/workflow docs changed
+
+---
+
+## Deviation Log
+
+**Scope expansion from source:** Issue #604 requested only `rope_scaling`. Based on the gap audit posted in the same issue thread, this plan adds all 12 identified Tier 1+2 gaps in one PR to avoid 12 separate single-entry PRs for related documentation work. No deviations from the individual entry content proposed in the audit comment.


### PR DESCRIPTION
## Summary

- Adds 12 standalone glossary entries to `docs/concepts/glossary.md` for terms that were referenced throughout the docs but lacked dedicated definitions
- Updates the `MaxModelLen` entry to link its inline `rope_scaling` reference to the new entry
- All content sourced from existing documentation and source code — no new information introduced

**Tier 1 entries added** (high-frequency, core inference concepts):
`rope_scaling`, `SLO Class`, `Tensor Parallelism (TP)`, `MoE (Mixture of Experts)`, `TPOT`, `Scheduling Delay`

**Tier 2 entries added** (BLIS-specific features):
`Cohort`, `GAIE`, `Gateway Queue`, `HOL Blocking`, `llm-d`, `MFU`

Full gap analysis documented in [#604 comment](https://github.com/inference-sim/inference-sim/issues/604#issuecomment-4330680068).

## Test plan

- [x] All 54 entries present (42 existing + 12 new): `grep "^### " docs/concepts/glossary.md | wc -l`
- [x] Alphabetical order preserved across all insertions
- [x] `rope_scaling` type list matches `cmd/root.go:186-191` verbatim (apply: linear/dynamic/yarn/default/mrope; exclude: su/longrope/llama3; gemma3 skips)
- [x] SLO class priorities match `configuration.md` SLO Tier Priorities table
- [x] All internal cross-link anchors verified against target section headings
- [x] GAIE ↔ llm-d mutual cross-links present
- [x] MaxModelLen → rope_scaling anchor link present

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)