### PR TITLE
fix(workload): normalize ServeGen lifecycle timestamps to start from zero

### DIFF
--- a/sim/workload/convert.go
+++ b/sim/workload/convert.go
@@ -22,7 +22,6 @@ func ConvertServeGen(path string, timeWindow string) (*WorkloadSpec, error) {
 	if err := loadServeGenData(spec); err != nil {
 		return nil, fmt.Errorf("loading ServeGen data from %s: %w", path, err)
 	}
-
 	spec.ServeGenData = nil // clear after loading; clients are now populated
 	return spec, nil
 }

--- a/sim/workload/convert.go
+++ b/sim/workload/convert.go
@@ -22,6 +22,7 @@ func ConvertServeGen(path string, timeWindow string) (*WorkloadSpec, error) {
 	if err := loadServeGenData(spec); err != nil {
 		return nil, fmt.Errorf("loading ServeGen data from %s: %w", path, err)
 	}
+
 	spec.ServeGenData = nil // clear after loading; clients are now populated
 	return spec, nil
 }

--- a/sim/workload/servegen.go
+++ b/sim/workload/servegen.go
@@ -710,3 +710,44 @@ func loadServeGenDataset(path string, sgConfig *ServeGenDataSpec) (map[int]float
 
 	return inputPDF, outputPDF, nil
 }
+
+// normalizeLifecycleTimestamps shifts all lifecycle window timestamps to start
+// from zero while preserving relative timing. Finds the minimum StartUs across
+// all clients' lifecycle windows and subtracts it from every StartUs and EndUs.
+// No-op if clients list is empty or no clients have lifecycle windows.
+func normalizeLifecycleTimestamps(clients *[]ClientSpec) {
+	if len(*clients) == 0 {
+		return
+	}
+
+	// Pass 1: Find global minimum StartUs across all clients and windows.
+	minStartUs := int64(math.MaxInt64)
+	for i := range *clients {
+		client := &(*clients)[i]
+		if client.Lifecycle == nil || len(client.Lifecycle.Windows) == 0 {
+			continue
+		}
+		for _, window := range client.Lifecycle.Windows {
+			if window.StartUs < minStartUs {
+				minStartUs = window.StartUs
+			}
+		}
+	}
+
+	// If no windows found, nothing to normalize.
+	if minStartUs == math.MaxInt64 {
+		return
+	}
+
+	// Pass 2: Shift all timestamps by subtracting the minimum.
+	for i := range *clients {
+		client := &(*clients)[i]
+		if client.Lifecycle == nil {
+			continue
+		}
+		for j := range client.Lifecycle.Windows {
+			client.Lifecycle.Windows[j].StartUs -= minStartUs
+			client.Lifecycle.Windows[j].EndUs -= minStartUs
+		}
+	}
+}

--- a/sim/workload/servegen.go
+++ b/sim/workload/servegen.go
@@ -164,6 +164,12 @@ func loadServeGenData(spec *WorkloadSpec) error {
 		logrus.Infof("loadServeGenData: using absolute rate mode (aggregate_rate=0); peak rate was %.2f within %s window", peakAggregate, spec.ServeGenData.TimeWindow)
 	}
 
+	// Normalize lifecycle window timestamps to start from zero.
+	// ServeGen traces contain absolute clock times (e.g., 8:00 AM = 28800s).
+	// Without normalization, the generator waits for simulated time to reach
+	// those absolute timestamps before dispatching requests.
+	normalizeLifecycleTimestamps(&spec.Clients)
+
 	return nil
 }
 

--- a/sim/workload/servegen_temporal_test.go
+++ b/sim/workload/servegen_temporal_test.go
@@ -452,19 +452,21 @@ func TestServeGenConversion_E2E(t *testing.T) {
 				i, requests[i-1].ArrivalTime, requests[i].ArrivalTime)
 		}
 
-		// Check requests span multiple windows (from both 600s and 1200s windows)
+		// Check requests span multiple windows.
+		// After normalization (loadServeGenData normalizes to zero-origin),
+		// the original 600s and 1200s windows become 0s and 600s respectively.
 		hasWindow1 := false
 		hasWindow2 := false
 		for _, req := range requests {
-			if req.ArrivalTime >= 600*1e6 && req.ArrivalTime < 1200*1e6 {
+			if req.ArrivalTime >= 0 && req.ArrivalTime < 600*1e6 {
 				hasWindow1 = true
 			}
-			if req.ArrivalTime >= 1200*1e6 && req.ArrivalTime < 1800*1e6 {
+			if req.ArrivalTime >= 600*1e6 && req.ArrivalTime < 1200*1e6 {
 				hasWindow2 = true
 			}
 		}
-		assert.True(t, hasWindow1, "should have requests in window 1 (600-1200s)")
-		assert.True(t, hasWindow2, "should have requests in window 2 (1200-1800s)")
+		assert.True(t, hasWindow1, "should have requests in window 1 (0-600s, normalized from 600-1200s)")
+		assert.True(t, hasWindow2, "should have requests in window 2 (600-1200s, normalized from 1200-1800s)")
 
 		// Check both chunks contributed (interleaved requests)
 		clientIDs := make(map[string]bool)

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -870,3 +870,35 @@ func TestServeGenDataLoading_SyntheticDataset_ProducesClients(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertServeGen_NormalizesTimestamps(t *testing.T) {
+	// This test verifies that ConvertServeGen calls normalizeLifecycleTimestamps
+	// so that the production path produces zero-based timestamps.
+
+	// GIVEN a WorkloadSpec with clients at non-zero start times
+	// (simulating what loadServeGenData would produce)
+	clients := []ClientSpec{
+		{
+			ID: "servegen-chunk-0",
+			Lifecycle: &LifecycleSpec{
+				Windows: []ActiveWindow{
+					{StartUs: 28800000000, EndUs: 29400000000}, // 8:00 AM start
+				},
+			},
+		},
+	}
+
+	// WHEN normalization is applied (as ConvertServeGen does)
+	normalizeLifecycleTimestamps(&clients)
+
+	// THEN timestamps start at zero
+	if clients[0].Lifecycle.Windows[0].StartUs != 0 {
+		t.Errorf("expected normalized StartUs=0, got %d", clients[0].Lifecycle.Windows[0].StartUs)
+	}
+
+	expectedDuration := int64(600000000) // 10 minutes in microseconds
+	actualDuration := clients[0].Lifecycle.Windows[0].EndUs - clients[0].Lifecycle.Windows[0].StartUs
+	if actualDuration != expectedDuration {
+		t.Errorf("expected duration %d, got %d", expectedDuration, actualDuration)
+	}
+}

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -741,6 +741,99 @@ func TestNormalizeLifecycleTimestamps_Scenarios(t *testing.T) {
 			},
 			checkFn: nil, // structural check via want comparison is sufficient
 		},
+		{
+			name: "idempotency: normalizing twice equals normalizing once",
+			clients: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 28800000000, EndUs: 29400000000}, // 8:00-8:10 AM
+							{StartUs: 29400000000, EndUs: 30000000000}, // 8:10-8:20 AM
+						},
+					},
+				},
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 30000000000, EndUs: 30600000000}, // 8:20-8:30 AM
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 600000000},
+							{StartUs: 600000000, EndUs: 1200000000},
+						},
+					},
+				},
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 1200000000, EndUs: 1800000000},
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, _, normalized []ClientSpec) {
+				// Snapshot the state after the first normalization
+				snapshotWindows := make([][]ActiveWindow, len(normalized))
+				for i, c := range normalized {
+					if c.Lifecycle != nil {
+						ws := make([]ActiveWindow, len(c.Lifecycle.Windows))
+						copy(ws, c.Lifecycle.Windows)
+						snapshotWindows[i] = ws
+					}
+				}
+
+				// Apply normalization a second time
+				normalizeLifecycleTimestamps(&normalized)
+
+				// Verify all timestamps are identical after the second call
+				for i, c := range normalized {
+					if c.Lifecycle == nil {
+						continue
+					}
+					for j, w := range c.Lifecycle.Windows {
+						if w.StartUs != snapshotWindows[i][j].StartUs || w.EndUs != snapshotWindows[i][j].EndUs {
+							t.Errorf("idempotency violation: client[%d] window[%d] changed on second normalize: "+
+								"StartUs %d->%d, EndUs %d->%d",
+								i, j,
+								snapshotWindows[i][j].StartUs, w.StartUs,
+								snapshotWindows[i][j].EndUs, w.EndUs)
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "all clients with nil lifecycle: no-op (exercises MaxInt64 guard)",
+			clients: []ClientSpec{
+				{ID: "client1", Lifecycle: nil},
+				{ID: "client2", Lifecycle: nil},
+				{ID: "client3", Lifecycle: nil},
+			},
+			want: []ClientSpec{
+				{ID: "client1", Lifecycle: nil},
+				{ID: "client2", Lifecycle: nil},
+				{ID: "client3", Lifecycle: nil},
+			},
+			checkFn: func(t *testing.T, _, normalized []ClientSpec) {
+				// All lifecycles must remain nil — the MaxInt64 guard
+				// at line 744 must prevent any modification.
+				for i, c := range normalized {
+					if c.Lifecycle != nil {
+						t.Errorf("client[%d] Lifecycle was unexpectedly modified from nil", i)
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -872,33 +965,46 @@ func TestServeGenDataLoading_SyntheticDataset_ProducesClients(t *testing.T) {
 }
 
 func TestConvertServeGen_NormalizesTimestamps(t *testing.T) {
-	// This test verifies that ConvertServeGen calls normalizeLifecycleTimestamps
-	// so that the production path produces zero-based timestamps.
+	// This test verifies end-to-end that ConvertServeGen produces zero-based
+	// timestamps. It creates real ServeGen files with non-zero absolute clock
+	// times and calls ConvertServeGen, ensuring a future developer cannot remove
+	// the normalization call from loadServeGenData without breaking this test.
 
-	// GIVEN a WorkloadSpec with clients at non-zero start times
-	// (simulating what loadServeGenData would produce)
-	clients := []ClientSpec{
-		{
-			ID: "servegen-chunk-0",
-			Lifecycle: &LifecycleSpec{
-				Windows: []ActiveWindow{
-					{StartUs: 28800000000, EndUs: 29400000000}, // 8:00 AM start
-				},
-			},
-		},
-	}
+	dir := t.TempDir()
 
-	// WHEN normalization is applied (as ConvertServeGen does)
-	normalizeLifecycleTimestamps(&clients)
+	// GIVEN a ServeGen chunk with absolute clock timestamps starting at 8:00 AM (28800s).
+	// Two consecutive 10-minute windows: 28800-29400, 29400-30000.
+	traceCSV := "28800,5.0,2.5,Gamma,0.16,6.25\n29400,3.0,1.5,Gamma,0.16,6.25\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "chunk-0-trace.csv"), []byte(traceCSV), 0644))
 
-	// THEN timestamps start at zero
-	if clients[0].Lifecycle.Windows[0].StartUs != 0 {
-		t.Errorf("expected normalized StartUs=0, got %d", clients[0].Lifecycle.Windows[0].StartUs)
-	}
+	// Dataset entry at timestamp 21600 (Hour 6) — nearest-preceding for Hour 8 windows.
+	datasetJSON := `{"21600": {"input_tokens": "{256: 1.0}", "output_tokens": "{100: 1.0}"}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "chunk-0-dataset.json"), []byte(datasetJSON), 0644))
 
-	expectedDuration := int64(600000000) // 10 minutes in microseconds
-	actualDuration := clients[0].Lifecycle.Windows[0].EndUs - clients[0].Lifecycle.Windows[0].StartUs
-	if actualDuration != expectedDuration {
-		t.Errorf("expected duration %d, got %d", expectedDuration, actualDuration)
+	// WHEN ConvertServeGen processes these files
+	spec, err := ConvertServeGen(dir, "")
+
+	// THEN conversion succeeds
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+	require.Len(t, spec.Clients, 1, "expected 1 client from chunk-0")
+
+	client := spec.Clients[0]
+	require.NotNil(t, client.Lifecycle)
+	require.Len(t, client.Lifecycle.Windows, 2, "expected 2 windows from trace rows")
+
+	// AND the earliest window starts at zero (normalization applied)
+	assert.Equal(t, int64(0), client.Lifecycle.Windows[0].StartUs,
+		"first window StartUs should be normalized to 0")
+
+	// AND the second window is offset by 600s (preserving relative timing)
+	assert.Equal(t, int64(600000000), client.Lifecycle.Windows[1].StartUs,
+		"second window StartUs should be 600s after first")
+
+	// AND window durations are preserved (10 minutes = 600,000,000 us each)
+	for i, w := range client.Lifecycle.Windows {
+		duration := w.EndUs - w.StartUs
+		assert.Equal(t, int64(600000000), duration,
+			"window[%d] duration should be 600s (10 min)", i)
 	}
 }

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -534,6 +534,19 @@ func TestServeGenConversion_HighCVTrace(t *testing.T) {
 	}
 }
 
+func TestNormalizeLifecycleTimestamps_EmptyClientList(t *testing.T) {
+	// GIVEN an empty client list
+	clients := []ClientSpec{}
+
+	// WHEN normalization is called
+	normalizeLifecycleTimestamps(&clients)
+
+	// THEN it completes without panic and leaves list unchanged
+	if len(clients) != 0 {
+		t.Errorf("expected empty list to remain empty, got %d clients", len(clients))
+	}
+}
+
 func TestServeGenDataLoading_SyntheticDataset_ProducesClients(t *testing.T) {
 	dir := t.TempDir()
 	// Create chunk-0-trace.csv

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -905,6 +905,9 @@ func TestNormalizeLifecycleTimestamps_Scenarios(t *testing.T) {
 	}
 }
 
+// This test uses trace data starting at t=0, so normalization is a no-op.
+// The test validates per-window shape/scale parameter population from trace columns 5-6,
+// not normalization behavior (which is thoroughly covered by other tests).
 func TestServeGenDataLoading_SyntheticDataset_ProducesClients(t *testing.T) {
 	dir := t.TempDir()
 	// Create chunk-0-trace.csv

--- a/sim/workload/servegen_test.go
+++ b/sim/workload/servegen_test.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -544,6 +545,270 @@ func TestNormalizeLifecycleTimestamps_EmptyClientList(t *testing.T) {
 	// THEN it completes without panic and leaves list unchanged
 	if len(clients) != 0 {
 		t.Errorf("expected empty list to remain empty, got %d clients", len(clients))
+	}
+}
+
+func TestNormalizeLifecycleTimestamps_Scenarios(t *testing.T) {
+	tests := []struct {
+		name    string
+		clients []ClientSpec
+		want    []ClientSpec
+		checkFn func(t *testing.T, original, normalized []ClientSpec)
+	}{
+		{
+			name: "single client with single window at non-zero time",
+			clients: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 28800000000, EndUs: 29400000000}, // 8:00-8:10 AM
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 600000000}, // 0:00-0:10 (10 min duration preserved)
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, original, normalized []ClientSpec) {
+				// BC-1: earliest window starts at 0
+				if normalized[0].Lifecycle.Windows[0].StartUs != 0 {
+					t.Errorf("BC-1 violation: expected StartUs=0, got %d", normalized[0].Lifecycle.Windows[0].StartUs)
+				}
+				// BC-6: duration preserved
+				origDuration := original[0].Lifecycle.Windows[0].EndUs - original[0].Lifecycle.Windows[0].StartUs
+				normDuration := normalized[0].Lifecycle.Windows[0].EndUs - normalized[0].Lifecycle.Windows[0].StartUs
+				if origDuration != normDuration {
+					t.Errorf("BC-6 violation: duration changed from %d to %d", origDuration, normDuration)
+				}
+			},
+		},
+		{
+			name: "multiple clients with different start times",
+			clients: []ClientSpec{
+				{
+					ID: "clientA",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 100000000, EndUs: 200000000}, // starts at 100s
+						},
+					},
+				},
+				{
+					ID: "clientB",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 50000000, EndUs: 150000000}, // starts at 50s (earlier)
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{
+					ID: "clientA",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 50000000, EndUs: 150000000}, // shifted by -50s
+						},
+					},
+				},
+				{
+					ID: "clientB",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 100000000}, // shifted by -50s
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, original, normalized []ClientSpec) {
+				// BC-5: global minimum across all clients
+				minStart := int64(math.MaxInt64)
+				for _, c := range normalized {
+					if c.Lifecycle != nil {
+						for _, w := range c.Lifecycle.Windows {
+							if w.StartUs < minStart {
+								minStart = w.StartUs
+							}
+						}
+					}
+				}
+				if minStart != 0 {
+					t.Errorf("BC-5 violation: global minimum is %d, expected 0", minStart)
+				}
+			},
+		},
+		{
+			name: "consecutive windows preserve relative timing",
+			clients: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 1000, EndUs: 2000}, // window 1
+							{StartUs: 3000, EndUs: 4000}, // window 2 (2000us gap)
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{
+					ID: "client1",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 1000},
+							{StartUs: 2000, EndUs: 3000}, // 2000us gap preserved
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, original, normalized []ClientSpec) {
+				// BC-2: relative timing preserved
+				origGap := original[0].Lifecycle.Windows[1].StartUs - original[0].Lifecycle.Windows[0].EndUs
+				normGap := normalized[0].Lifecycle.Windows[1].StartUs - normalized[0].Lifecycle.Windows[0].EndUs
+				if origGap != normGap {
+					t.Errorf("BC-2 violation: gap changed from %d to %d", origGap, normGap)
+				}
+			},
+		},
+		{
+			name: "client with nil lifecycle is skipped safely",
+			clients: []ClientSpec{
+				{ID: "client1", Lifecycle: nil},
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 1000, EndUs: 2000},
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{ID: "client1", Lifecycle: nil}, // unchanged
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 1000}, // normalized
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, original, normalized []ClientSpec) {
+				// Verify nil lifecycle wasn't touched
+				if normalized[0].Lifecycle != nil {
+					t.Error("nil Lifecycle was unexpectedly modified")
+				}
+			},
+		},
+		{
+			name: "client with empty windows slice is skipped safely",
+			clients: []ClientSpec{
+				{
+					ID:        "client1",
+					Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{}},
+				},
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 5000, EndUs: 6000},
+						},
+					},
+				},
+			},
+			want: []ClientSpec{
+				{
+					ID:        "client1",
+					Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{}}, // unchanged
+				},
+				{
+					ID: "client2",
+					Lifecycle: &LifecycleSpec{
+						Windows: []ActiveWindow{
+							{StartUs: 0, EndUs: 1000},
+						},
+					},
+				},
+			},
+			checkFn: nil, // structural check via want comparison is sufficient
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a deep copy of original for checkFn comparison
+			// (shallow copy is insufficient: ClientSpec.Lifecycle is a pointer,
+			// so mutations via normalizeLifecycleTimestamps would be visible
+			// through both originalCopy and tt.clients, making BC-2/BC-6 checks vacuous)
+			originalCopy := make([]ClientSpec, len(tt.clients))
+			for i, c := range tt.clients {
+				originalCopy[i] = c
+				if c.Lifecycle != nil {
+					lc := *c.Lifecycle
+					lc.Windows = make([]ActiveWindow, len(c.Lifecycle.Windows))
+					copy(lc.Windows, c.Lifecycle.Windows)
+					originalCopy[i].Lifecycle = &lc
+				}
+			}
+
+			// WHEN normalization is called
+			normalizeLifecycleTimestamps(&tt.clients)
+
+			// THEN structural expectations match
+			if len(tt.clients) != len(tt.want) {
+				t.Fatalf("client count mismatch: got %d, want %d", len(tt.clients), len(tt.want))
+			}
+
+			for i := range tt.clients {
+				gotClient := tt.clients[i]
+				wantClient := tt.want[i]
+
+				if gotClient.ID != wantClient.ID {
+					t.Errorf("client[%d] ID mismatch: got %q, want %q", i, gotClient.ID, wantClient.ID)
+				}
+
+				if (gotClient.Lifecycle == nil) != (wantClient.Lifecycle == nil) {
+					t.Errorf("client[%d] Lifecycle nil mismatch", i)
+					continue
+				}
+
+				if gotClient.Lifecycle != nil {
+					if len(gotClient.Lifecycle.Windows) != len(wantClient.Lifecycle.Windows) {
+						t.Errorf("client[%d] window count mismatch: got %d, want %d",
+							i, len(gotClient.Lifecycle.Windows), len(wantClient.Lifecycle.Windows))
+						continue
+					}
+
+					for j := range gotClient.Lifecycle.Windows {
+						gotWindow := gotClient.Lifecycle.Windows[j]
+						wantWindow := wantClient.Lifecycle.Windows[j]
+
+						if gotWindow.StartUs != wantWindow.StartUs {
+							t.Errorf("client[%d] window[%d] StartUs: got %d, want %d",
+								i, j, gotWindow.StartUs, wantWindow.StartUs)
+						}
+						if gotWindow.EndUs != wantWindow.EndUs {
+							t.Errorf("client[%d] window[%d] EndUs: got %d, want %d",
+								i, j, gotWindow.EndUs, wantWindow.EndUs)
+						}
+					}
+				}
+			}
+
+			// THEN behavioral contracts verified by custom check function
+			if tt.checkFn != nil {
+				tt.checkFn(t, originalCopy, tt.clients)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1176

## Summary

Adds automatic timestamp normalization to ServeGen conversion, ensuring converted workloads start at t=0 instead of absolute clock times (e.g., 28800s for 8:00 AM). Without this fix, `blis observe` would wait indefinitely for simulated clock time to reach those absolute timestamps before dispatching requests.

## Changes

- **Added `normalizeLifecycleTimestamps()` function** in `sim/workload/servegen.go` with two-pass algorithm:
  - Pass 1: Find global minimum `StartUs` across all clients' lifecycle windows
  - Pass 2: Subtract minimum from all `StartUs` and `EndUs` to shift to zero-origin
  - Defensive guards for empty clients, nil lifecycles, empty windows
- **Comprehensive test coverage**: 10 test cases covering all behavioral contracts (BC-1 through BC-6)
- **Wired into `loadServeGenData()`** to fix both CLI (`blis convert servegen`) and programmatic (`blis run`/`observe`) paths

## Behavioral Contracts Verified

- ✅ BC-1: Earliest window starts at 0
- ✅ BC-2: Relative timing preserved between windows  
- ✅ BC-3: Empty client list safety (no-op)
- ✅ BC-4: Single client normalization
- ✅ BC-5: Multi-client global minimum detection
- ✅ BC-6: Window duration preservation

## Testing

- All existing tests pass (92+ workload package tests, full test suite)
- New table-driven tests with structural verification + behavioral `checkFn` closures
- Edge cases: empty clients, nil lifecycle, empty windows, consecutive windows
- Integration test verifying end-to-end normalization

## Manual Verification

For users with ServeGen data:

```bash
# After this fix:
./blis convert servegen --path /path/to/data --time morning > workload.yaml
grep "start_us:" workload.yaml
# Shows: start_us: 0 (normalized, not 28800000000)

# Verify usability:
./blis observe --server-url http://localhost:8000 --workload-spec workload.yaml \
  --model qwen/qwen3-14b --trace-header t.yaml --trace-data t.csv
# Starts immediately without waiting for absolute clock time
```

🤖 Generated with Claude Code