### PR TITLE
feat(cluster): expose LatencyStats on InstanceSimulator and wire through RoutingSnapshot

### DIFF
--- a/sim/cluster/autoscaler.go
+++ b/sim/cluster/autoscaler.go
@@ -47,7 +47,7 @@ type ReplicaMetrics struct {
 	CostPerHour           float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
 	TTFT                  float64 // μs — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
 	DispatchRate          float64 // req/s — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
-	ITL                   float64 // μs — zero until QueueingModelAnalyzer
+	ITL                   float64 // μs — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
 	AvgInTokens           float64 // average input tokens per completed request; zero until QueueingModelAnalyzer
 	AvgOutTokens          float64 // average output tokens per completed request; zero until QueueingModelAnalyzer
 	MaxBatchSize          float64 // server-configured max batch size; zero means use DefaultMaxBatchSize

--- a/sim/cluster/autoscaler.go
+++ b/sim/cluster/autoscaler.go
@@ -39,12 +39,12 @@ func NewVariantSpec(gpuType string, tpDegree int) VariantSpec {
 // Produced by Collector, consumed by Analyzer. All numeric invariants must hold:
 // KVUtilization ∈ [0.0, 1.0], QueueDepth ≥ 0, InFlightCount ≥ 0.
 type ReplicaMetrics struct {
-	InstanceID            string
-	Variant               VariantSpec
-	KVUtilization         float64 // [0.0, 1.0]
-	QueueDepth            int
-	InFlightCount         int
-	CostPerHour           float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
+	InstanceID    string
+	Variant       VariantSpec
+	KVUtilization float64 // [0.0, 1.0]
+	QueueDepth    int
+	InFlightCount int
+	CostPerHour   float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
 	// Latency fields are live observability signals populated by buildRouterState() on every
 	// admission, routing, autoscaler, and flow-control tick via LatencyStats(). They are zero
 	// until the first request on this replica completes; any consumer must guard against zero.
@@ -106,6 +106,7 @@ type ScaleDecision struct {
 //   - slots held by WarmingUp instances
 //   - slots held by Active instances
 //   - slots held by Draining instances (hold GPUs until drain completes)
+//
 // Pending (Scheduling) placements are NOT subtracted. Terminated instances are NOT subtracted.
 // Callers must use FreeSlots() and Variants() to read (R2: map iteration is non-deterministic).
 type GPUInventory struct {

--- a/sim/cluster/autoscaler.go
+++ b/sim/cluster/autoscaler.go
@@ -47,6 +47,10 @@ type ReplicaMetrics struct {
 	CostPerHour           float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
 	TTFT                  float64 // μs — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
 	DispatchRate          float64 // req/s — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
+	ITL                   float64 // μs — zero until QueueingModelAnalyzer
+	AvgInTokens           float64 // average input tokens per completed request; zero until QueueingModelAnalyzer
+	AvgOutTokens          float64 // average output tokens per completed request; zero until QueueingModelAnalyzer
+	MaxBatchSize          float64 // server-configured max batch size; zero means use DefaultMaxBatchSize
 	TotalKvCapacityTokens int64   // Total KV cache capacity in tokens; used by V2SaturationAnalyzer for k1 (memory-bound capacity)
 	KvTokensInUse         int64   // Current KV token occupancy; used by V2SaturationAnalyzer for demand computation
 }

--- a/sim/cluster/autoscaler.go
+++ b/sim/cluster/autoscaler.go
@@ -45,11 +45,11 @@ type ReplicaMetrics struct {
 	QueueDepth            int
 	InFlightCount         int
 	CostPerHour           float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
-	TTFT                  float64 // μs — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
-	DispatchRate          float64 // req/s — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
-	ITL                   float64 // μs — zero until QueueingModelAnalyzer; Analyze() must guard against zero before dividing
-	AvgInTokens           float64 // average input tokens per completed request; zero until QueueingModelAnalyzer
-	AvgOutTokens          float64 // average output tokens per completed request; zero until QueueingModelAnalyzer
+	TTFT                  float64 // μs — zero until first completion; Analyze() must guard against zero before dividing
+	DispatchRate          float64 // req/s — zero until first completion; Analyze() must guard against zero before dividing
+	ITL                   float64 // μs — zero until first completion; Analyze() must guard against zero before dividing
+	AvgInTokens           float64 // average input tokens per completed request; zero until first completion
+	AvgOutTokens          float64 // average output tokens per completed request; zero until first completion
 	MaxBatchSize          float64 // server-configured max batch size; zero means use DefaultMaxBatchSize
 	TotalKvCapacityTokens int64   // Total KV cache capacity in tokens; used by V2SaturationAnalyzer for k1 (memory-bound capacity)
 	KvTokensInUse         int64   // Current KV token occupancy; used by V2SaturationAnalyzer for demand computation
@@ -144,8 +144,8 @@ type Collector interface {
 // Analyzer assesses capacity for one model. Name() returns a human-readable identifier.
 // Analyze() is called once per model per tick. Must not access RouterState, GPUInventory,
 // or any external state — only ModelSignals. Must not panic on empty Replicas slice.
-// Must guard against zero-valued fields (TTFT, DispatchRate) — these are intentionally
-// zero until QueueingModelAnalyzer ships; dividing by them without a guard will panic.
+// Must guard against zero-valued fields (TTFT, DispatchRate) — these are zero until
+// first request completion; dividing by them without a guard will panic.
 // Invariants: sum(vc.Supply) == TotalSupply; sum(vc.Demand) == TotalDemand.
 type Analyzer interface {
 	Name() string

--- a/sim/cluster/autoscaler.go
+++ b/sim/cluster/autoscaler.go
@@ -45,6 +45,9 @@ type ReplicaMetrics struct {
 	QueueDepth            int
 	InFlightCount         int
 	CostPerHour           float64 // $/hr from NodePool; used for CostPerReplica in VariantCapacity
+	// Latency fields are live observability signals populated by buildRouterState() on every
+	// admission, routing, autoscaler, and flow-control tick via LatencyStats(). They are zero
+	// until the first request on this replica completes; any consumer must guard against zero.
 	TTFT                  float64 // μs — zero until first completion; Analyze() must guard against zero before dividing
 	DispatchRate          float64 // req/s — zero until first completion; Analyze() must guard against zero before dividing
 	ITL                   float64 // μs — zero until first completion; Analyze() must guard against zero before dividing

--- a/sim/cluster/autoscaler_test.go
+++ b/sim/cluster/autoscaler_test.go
@@ -602,10 +602,3 @@ func TestGPUInventory(t *testing.T) {
 	})
 }
 
-func TestReplicaMetricsHasLatencyFields(t *testing.T) {
-	rm := ReplicaMetrics{}
-	_ = rm.ITL
-	_ = rm.AvgInTokens
-	_ = rm.AvgOutTokens
-	_ = rm.MaxBatchSize
-}

--- a/sim/cluster/autoscaler_test.go
+++ b/sim/cluster/autoscaler_test.go
@@ -601,3 +601,11 @@ func TestGPUInventory(t *testing.T) {
 		}
 	})
 }
+
+func TestReplicaMetricsHasLatencyFields(t *testing.T) {
+	rm := ReplicaMetrics{}
+	_ = rm.ITL
+	_ = rm.AvgInTokens
+	_ = rm.AvgOutTokens
+	_ = rm.MaxBatchSize
+}

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -83,7 +83,7 @@ func buildRouterState(cs *ClusterSimulator, req *sim.Request) *sim.RouterState {
 		snap.GPUType = inst.GPU()
 		snap.TPDegree = inst.TPDegree
 		snap.CostPerHour = inst.CostPerHour
-		// Populate latency stats for QueueingModelAnalyzer.
+		// Populate latency stats from completed-request metrics (zero until first completion).
 		if inst.HasSim() {
 			ls := inst.LatencyStats()
 			snap.TTFT = ls.TTFT

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -92,7 +92,7 @@ func buildRouterState(cs *ClusterSimulator, req *sim.Request) *sim.RouterState {
 			snap.AvgInTokens = ls.AvgInTokens
 			snap.AvgOutTokens = ls.AvgOutTokens
 		}
-		snap.MaxBatchSize = float64(inst.MaxBatchSize())
+		snap.MaxBatchSize = float64(inst.MaxBatchSize()) // float64: QueueingModelAnalyzer uses it in float arithmetic
 		snapshots = append(snapshots, snap)
 	}
 	return &sim.RouterState{

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -83,6 +83,16 @@ func buildRouterState(cs *ClusterSimulator, req *sim.Request) *sim.RouterState {
 		snap.GPUType = inst.GPU()
 		snap.TPDegree = inst.TPDegree
 		snap.CostPerHour = inst.CostPerHour
+		// Populate latency stats for QueueingModelAnalyzer.
+		if inst.HasSim() {
+			ls := inst.LatencyStats()
+			snap.TTFT = ls.TTFT
+			snap.ITL = ls.ITL
+			snap.DispatchRate = ls.DispatchRate
+			snap.AvgInTokens = ls.AvgInTokens
+			snap.AvgOutTokens = ls.AvgOutTokens
+		}
+		snap.MaxBatchSize = float64(inst.MaxBatchSize())
 		snapshots = append(snapshots, snap)
 	}
 	return &sim.RouterState{

--- a/sim/cluster/default_collector.go
+++ b/sim/cluster/default_collector.go
@@ -11,7 +11,8 @@ import (
 
 // DefaultCollector maps RoutingSnapshot fields to ReplicaMetrics, grouping by model.
 // Pure function: no filtering, no thresholding, no modification of signals.
-// TTFT and DispatchRate are set to zero (future: QueueingModelAnalyzer).
+// Latency fields (TTFT, ITL, DispatchRate, AvgInTokens, AvgOutTokens, MaxBatchSize) are
+// populated from the snapshot when available (set by buildRouterState via LatencyStats).
 type DefaultCollector struct{}
 
 // Collect produces one ModelSignals per active model from the current RouterState.
@@ -39,6 +40,12 @@ func (c *DefaultCollector) Collect(state *sim.RouterState) []ModelSignals {
 			QueueDepth:            snap.QueueDepth,
 			InFlightCount:         snap.InFlightRequests,
 			CostPerHour:           snap.CostPerHour,
+			TTFT:                  snap.TTFT,
+			ITL:                   snap.ITL,
+			DispatchRate:          snap.DispatchRate,
+			AvgInTokens:           snap.AvgInTokens,
+			AvgOutTokens:          snap.AvgOutTokens,
+			MaxBatchSize:          snap.MaxBatchSize,
 			TotalKvCapacityTokens: snap.TotalKvCapacityTokens,
 			KvTokensInUse:         snap.KvTokensInUse,
 		}

--- a/sim/cluster/default_collector_test.go
+++ b/sim/cluster/default_collector_test.go
@@ -6,6 +6,51 @@ import (
 	"github.com/inference-sim/inference-sim/sim"
 )
 
+func TestDefaultCollectorMapsLatencyFields(t *testing.T) {
+	state := &sim.RouterState{
+		Snapshots: []sim.RoutingSnapshot{
+			{
+				ID:           "i1",
+				Model:        "llama",
+				GPUType:      "A100",
+				TPDegree:     1,
+				TTFT:         200_000, // 200ms in μs
+				ITL:          10_000,  // 10ms in μs
+				DispatchRate: 2.5,
+				AvgInTokens:  512,
+				AvgOutTokens: 128,
+				MaxBatchSize: 256,
+			},
+		},
+	}
+
+	collector := &DefaultCollector{}
+	signals := collector.Collect(state)
+
+	if len(signals) != 1 || len(signals[0].Replicas) != 1 {
+		t.Fatalf("expected 1 model with 1 replica, got %+v", signals)
+	}
+	rm := signals[0].Replicas[0]
+	if rm.TTFT != 200_000 {
+		t.Errorf("TTFT: want 200000 got %v", rm.TTFT)
+	}
+	if rm.ITL != 10_000 {
+		t.Errorf("ITL: want 10000 got %v", rm.ITL)
+	}
+	if rm.DispatchRate != 2.5 {
+		t.Errorf("DispatchRate: want 2.5 got %v", rm.DispatchRate)
+	}
+	if rm.AvgInTokens != 512 {
+		t.Errorf("AvgInTokens: want 512 got %v", rm.AvgInTokens)
+	}
+	if rm.AvgOutTokens != 128 {
+		t.Errorf("AvgOutTokens: want 128 got %v", rm.AvgOutTokens)
+	}
+	if rm.MaxBatchSize != 256 {
+		t.Errorf("MaxBatchSize: want 256 got %v", rm.MaxBatchSize)
+	}
+}
+
 func TestDefaultCollectorCollect(t *testing.T) {
 	collector := &DefaultCollector{}
 

--- a/sim/cluster/default_collector_test.go
+++ b/sim/cluster/default_collector_test.go
@@ -146,10 +146,10 @@ func TestDefaultCollectorCollect(t *testing.T) {
 						t.Errorf("KvTokensInUse = %d, want 14000", r.KvTokensInUse)
 					}
 					if r.TTFT != 0 {
-						t.Errorf("TTFT = %f, want 0 (future QueueingModelAnalyzer)", r.TTFT)
+						t.Errorf("TTFT = %f, want 0 (no latency data in test snapshot)", r.TTFT)
 					}
 					if r.DispatchRate != 0 {
-						t.Errorf("DispatchRate = %f, want 0 (future QueueingModelAnalyzer)", r.DispatchRate)
+						t.Errorf("DispatchRate = %f, want 0 (no latency data in test snapshot)", r.DispatchRate)
 					}
 				}
 			}

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -43,7 +43,7 @@ type InstanceSimulator struct {
 	CostPerHour float64 // $/hr from NodePool.CostPerHour; 0 = unplaced/free tier
 
 	// maxRunningReqs stores cfg.BatchConfig.MaxRunningReqs at construction time.
-	// Exposed via MaxBatchSize() for the autoscaler pipeline (Task 3).
+	// Exposed via MaxBatchSize() for the autoscaler pipeline.
 	maxRunningReqs int64
 }
 
@@ -225,9 +225,10 @@ func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
 	}
 	n := float64(m.CompletedRequests)
 
-	// DispatchRate: use the span between first and last completion time so that
-	// idle time at simulation start does not dilute the rate (rolling-window approximation).
-	// Falls back to total-elapsed-time when all completions share the same tick.
+	// DispatchRate: when simulation has ended, use SimEndedTime as the denominator
+	// (exact throughput, matches ResponsesPerSec in metrics.go:SaveResults).
+	// Mid-simulation fallback: span between first and last completion time excludes
+	// idle ramp-up time (rolling-window approximation). Final fallback: current clock.
 	// INV-6 note: min/max reduction is order-independent (unlike float sums), so this map
 	// range is exempt from the R2 sort requirement.
 	var minCT, maxCT float64
@@ -242,7 +243,9 @@ func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
 		first = false
 	}
 	var dispatchRate float64
-	if span := maxCT - minCT; span > 0 {
+	if m.SimEndedTime > 0 {
+		dispatchRate = n / (float64(m.SimEndedTime) / 1e6)
+	} else if span := maxCT - minCT; span > 0 {
 		dispatchRate = n / (span / 1e6)
 	} else if clockUs := i.Clock(); clockUs > 0 {
 		dispatchRate = n / (float64(clockUs) / 1e6)

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -6,6 +6,7 @@ package cluster
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/inference-sim/inference-sim/sim"
 	"github.com/inference-sim/inference-sim/sim/kv"
@@ -223,17 +224,43 @@ func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
 		return InstanceLatencyStats{}
 	}
 	n := float64(m.CompletedRequests)
-	clockUs := i.Clock()
+
+	// DispatchRate: use the span between first and last completion time so that
+	// idle time at simulation start does not dilute the rate (rolling-window approximation).
+	// Falls back to total-elapsed-time when all completions share the same tick.
+	// INV-6 note: min/max reduction is order-independent (unlike float sums), so this map
+	// range is exempt from the R2 sort requirement.
+	var minCT, maxCT float64
+	first := true
+	for _, ct := range m.RequestCompletionTimes {
+		if first || ct < minCT {
+			minCT = ct
+		}
+		if first || ct > maxCT {
+			maxCT = ct
+		}
+		first = false
+	}
 	var dispatchRate float64
-	if clockUs > 0 {
+	if span := maxCT - minCT; span > 0 {
+		dispatchRate = n / (span / 1e6)
+	} else if clockUs := i.Clock(); clockUs > 0 {
 		dispatchRate = n / (float64(clockUs) / 1e6)
 	}
+
 	// Compute ITL from RequestITLs (per-request average ITL in µs).
+	// Sort keys before accumulating to satisfy INV-6 determinism (R2).
 	// ITLSum is never populated by the simulator; RequestITLs is the authoritative source.
-	var itlSum float64
-	for _, v := range m.RequestITLs {
-		itlSum += v
+	reqIDs := make([]string, 0, len(m.RequestITLs))
+	for id := range m.RequestITLs {
+		reqIDs = append(reqIDs, id)
 	}
+	sort.Strings(reqIDs)
+	var itlSum float64
+	for _, id := range reqIDs {
+		itlSum += m.RequestITLs[id]
+	}
+
 	return InstanceLatencyStats{
 		TTFT:         float64(m.TTFTSum) / n,
 		ITL:          itlSum / n,

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -200,7 +200,7 @@ func (i *InstanceSimulator) PreemptionCount() int64 {
 	return i.sim.Metrics.PreemptionCount
 }
 
-// InstanceLatencyStats holds rolling-window averages of per-instance latency and throughput.
+// InstanceLatencyStats holds cumulative averages of per-instance latency and throughput from completed requests.
 // Units: TTFT and ITL are in microseconds (ticks = µs in the simulator clock).
 // DispatchRate is in req/s; AvgInTokens and AvgOutTokens are per-request averages.
 // All fields are zero when no requests have completed.
@@ -227,8 +227,8 @@ func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
 
 	// DispatchRate: when simulation has ended, use SimEndedTime as the denominator
 	// (exact throughput, matches ResponsesPerSec in metrics.go:SaveResults).
-	// Mid-simulation fallback: span between first and last completion time excludes
-	// idle ramp-up time (rolling-window approximation). Final fallback: current clock.
+	// Mid-simulation fallback: span between first and last completion time (growing window —
+	// rate decreases over time even at steady throughput). Final fallback: current clock.
 	// INV-6 note: min/max reduction is order-independent (unlike float sums), so this map
 	// range is exempt from the R2 sort requirement.
 	var minCT, maxCT float64

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -40,6 +40,10 @@ type InstanceSimulator struct {
 	// GPUType is available via inst.GPU(); TPDegree and CostPerHour are autoscaler-specific.
 	TPDegree    int     // tensor-parallel degree; 0 = unplaced/unknown
 	CostPerHour float64 // $/hr from NodePool.CostPerHour; 0 = unplaced/free tier
+
+	// maxRunningReqs stores cfg.BatchConfig.MaxRunningReqs at construction time.
+	// Exposed via MaxBatchSize() for the autoscaler pipeline (Task 3).
+	maxRunningReqs int64
 }
 
 // NewInstanceSimulator creates an InstanceSimulator from a SimConfig struct.
@@ -58,9 +62,10 @@ func NewInstanceSimulator(id InstanceID, cfg sim.SimConfig) *InstanceSimulator {
 		panic(fmt.Sprintf("NewInstanceSimulator(%s): %v", id, err))
 	}
 	return &InstanceSimulator{
-		id:  id,
-		sim: s,
-		gpu: cfg.GPU,
+		id:             id,
+		sim:            s,
+		gpu:            cfg.GPU,
+		maxRunningReqs: cfg.MaxRunningReqs,
 	}
 }
 
@@ -192,6 +197,50 @@ func (i *InstanceSimulator) KvTokensInUse() int64 {
 // PreemptionCount returns the cumulative number of preemption events on this instance.
 func (i *InstanceSimulator) PreemptionCount() int64 {
 	return i.sim.Metrics.PreemptionCount
+}
+
+// InstanceLatencyStats holds rolling-window averages of per-instance latency and throughput.
+// Units: TTFT and ITL are in microseconds (ticks = µs in the simulator clock).
+// DispatchRate is in req/s; AvgInTokens and AvgOutTokens are per-request averages.
+// All fields are zero when no requests have completed.
+type InstanceLatencyStats struct {
+	TTFT         float64 // µs
+	ITL          float64 // µs
+	DispatchRate float64 // req/s
+	AvgInTokens  float64
+	AvgOutTokens float64
+}
+
+// LatencyStats returns aggregate latency and throughput statistics from completed requests.
+// All fields are 0 when no requests have completed.
+// TTFT and ITL are in microseconds; DispatchRate is in req/s.
+func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
+	m := i.sim.Metrics
+	if m == nil || m.CompletedRequests == 0 {
+		return InstanceLatencyStats{}
+	}
+	n := float64(m.CompletedRequests)
+	clockUs := i.Clock()
+	var dispatchRate float64
+	if clockUs > 0 {
+		dispatchRate = n / (float64(clockUs) / 1e6)
+	}
+	return InstanceLatencyStats{
+		TTFT:         float64(m.TTFTSum) / n,
+		ITL:          float64(m.ITLSum) / n,
+		DispatchRate: dispatchRate,
+		AvgInTokens:  float64(m.TotalInputTokens) / n,
+		AvgOutTokens: float64(m.TotalOutputTokens) / n,
+	}
+}
+
+// MaxBatchSize returns the simulator's configured maximum number of concurrent requests
+// (BatchConfig.MaxRunningReqs). Returns 0 when the instance has no underlying simulator.
+func (i *InstanceSimulator) MaxBatchSize() int {
+	if i.sim == nil {
+		return 0
+	}
+	return int(i.maxRunningReqs)
 }
 
 // GetCachedBlockCount returns the number of consecutive cached prefix blocks

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -215,6 +215,9 @@ type InstanceLatencyStats struct {
 // All fields are 0 when no requests have completed.
 // TTFT and ITL are in microseconds; DispatchRate is in req/s.
 func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
+	if i.sim == nil {
+		return InstanceLatencyStats{}
+	}
 	m := i.sim.Metrics
 	if m == nil || m.CompletedRequests == 0 {
 		return InstanceLatencyStats{}
@@ -225,9 +228,15 @@ func (i *InstanceSimulator) LatencyStats() InstanceLatencyStats {
 	if clockUs > 0 {
 		dispatchRate = n / (float64(clockUs) / 1e6)
 	}
+	// Compute ITL from RequestITLs (per-request average ITL in µs).
+	// ITLSum is never populated by the simulator; RequestITLs is the authoritative source.
+	var itlSum float64
+	for _, v := range m.RequestITLs {
+		itlSum += v
+	}
 	return InstanceLatencyStats{
 		TTFT:         float64(m.TTFTSum) / n,
-		ITL:          float64(m.ITLSum) / n,
+		ITL:          itlSum / n,
 		DispatchRate: dispatchRate,
 		AvgInTokens:  float64(m.TotalInputTokens) / n,
 		AvgOutTokens: float64(m.TotalOutputTokens) / n,

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -509,3 +509,38 @@ func TestInstanceSimulator_PostDecodeFixedOverhead_DelegatesToSim(t *testing.T) 
 		t.Errorf("PostDecodeFixedOverhead() = %d, want 0 for roofline model", got)
 	}
 }
+
+func TestInstanceSimulatorLatencyStats_Empty(t *testing.T) {
+	inst := NewInstanceSimulator("test", newTestSimConfig())
+	stats := inst.LatencyStats()
+	if stats.TTFT != 0 || stats.ITL != 0 || stats.DispatchRate != 0 || stats.AvgInTokens != 0 || stats.AvgOutTokens != 0 {
+		t.Errorf("expected all-zero stats on fresh instance, got %+v", stats)
+	}
+}
+
+func TestInstanceSimulatorLatencyStats_AfterRun(t *testing.T) {
+	cfg := newTestDeploymentConfig(1).ToSimConfig()
+	inst := NewInstanceSimulator("test", cfg)
+
+	reqs := testGenerateRequests(42, cfg.Horizon, 0.0005,
+		3, 0, 512, 50, 100, 1024, 128, 20, 32, 256,
+	)
+	for _, r := range reqs {
+		inst.InjectRequest(r)
+	}
+	inst.Run()
+
+	if inst.Metrics().CompletedRequests == 0 {
+		t.Skip("no completed requests in test sim; check horizon/rate")
+	}
+	stats := inst.LatencyStats()
+	if stats.DispatchRate <= 0 {
+		t.Errorf("DispatchRate should be > 0 after completing requests, got %v", stats.DispatchRate)
+	}
+	if stats.AvgInTokens <= 0 {
+		t.Errorf("AvgInTokens should be > 0, got %v", stats.AvgInTokens)
+	}
+	if stats.AvgOutTokens <= 0 {
+		t.Errorf("AvgOutTokens should be > 0, got %v", stats.AvgOutTokens)
+	}
+}

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -527,16 +527,38 @@ func TestLatencyStatsITLSortedMean(t *testing.T) {
 	}
 }
 
-// TestLatencyStatsDispatchRateUsesCompletionWindow verifies that DispatchRate is computed
-// from the span between first and last completion time, not from total elapsed simulation time.
-// When completions span a 9s window, DispatchRate should reflect ~10/9 req/s, not 0 (which
-// the old implementation produces when the sim clock has not advanced).
+// TestLatencyStatsDispatchRateUsesSimEndedTime verifies that when SimEndedTime > 0
+// (simulation has ended), DispatchRate uses SimEndedTime as the denominator rather than
+// the completion-window span, matching ResponsesPerSec in metrics.go:SaveResults.
+func TestLatencyStatsDispatchRateUsesSimEndedTime(t *testing.T) {
+	inst := NewInstanceSimulator("test", newTestSimConfig())
+	m := inst.sim.Metrics
+	const n = 10
+	m.CompletedRequests = n
+	m.SimEndedTime = 10_000_000 // 10s in µs
+	// Completion window spans 9s (1s to 10s) — SimEndedTime should take precedence.
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		m.RequestCompletionTimes[id] = float64((i + 1) * 1_000_000) // µs
+	}
+
+	stats := inst.LatencyStats()
+	// SimEndedTime = 10s → rate = 10/10 = 1.0 req/s (not 10/9 window rate)
+	wantRate := float64(n) / 10.0
+	if math.Abs(stats.DispatchRate-wantRate) > 0.01 {
+		t.Errorf("DispatchRate = %.4f, want %.4f (SimEndedTime rate)", stats.DispatchRate, wantRate)
+	}
+}
+
+// TestLatencyStatsDispatchRateUsesCompletionWindow verifies that when SimEndedTime == 0
+// (mid-simulation), DispatchRate falls back to the completion-window span so that idle
+// ramp-up time does not dilute the rate.
 func TestLatencyStatsDispatchRateUsesCompletionWindow(t *testing.T) {
 	inst := NewInstanceSimulator("test", newTestSimConfig())
 	m := inst.sim.Metrics
 	const n = 10
 	m.CompletedRequests = n
-	// Completions span from 1s to 10s (1e6 µs to 10e6 µs).
+	// Completions span from 1s to 10s (1e6 µs to 10e6 µs); SimEndedTime left at 0.
 	for i := 0; i < n; i++ {
 		id := fmt.Sprintf("req-%d", i)
 		m.RequestCompletionTimes[id] = float64((i + 1) * 1_000_000) // µs

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -530,10 +530,13 @@ func TestInstanceSimulatorLatencyStats_AfterRun(t *testing.T) {
 	}
 	inst.Run()
 
+	stats := inst.LatencyStats()
 	if inst.Metrics().CompletedRequests == 0 {
 		t.Skip("no completed requests in test sim; check horizon/rate")
 	}
-	stats := inst.LatencyStats()
+	if stats.ITL <= 0 {
+		t.Errorf("ITL should be > 0 after completing requests, got %v", stats.ITL)
+	}
 	if stats.DispatchRate <= 0 {
 		t.Errorf("DispatchRate should be > 0 after completing requests, got %v", stats.DispatchRate)
 	}

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -627,3 +627,13 @@ func TestInstanceSimulatorLatencyStats_AfterRun(t *testing.T) {
 		t.Errorf("AvgOutTokens should be > 0, got %v", stats.AvgOutTokens)
 	}
 }
+
+func TestInstanceSimulator_MaxBatchSize_ReturnsConstructorValue(t *testing.T) {
+	cfg := newTestSimConfig()
+	cfg.BatchConfig = sim.NewBatchConfig(128, 2048, 0)
+	inst := NewInstanceSimulator(InstanceID("test"), cfg)
+
+	if got := inst.MaxBatchSize(); got != 128 {
+		t.Errorf("MaxBatchSize() = %d, want 128", got)
+	}
+}

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -510,6 +510,64 @@ func TestInstanceSimulator_PostDecodeFixedOverhead_DelegatesToSim(t *testing.T) 
 	}
 }
 
+// TestLatencyStatsITLSortedMean verifies that LatencyStats().ITL equals the arithmetic mean
+// of all values in RequestITLs, exercising the R2-compliant sorted-key accumulation path.
+func TestLatencyStatsITLSortedMean(t *testing.T) {
+	inst := NewInstanceSimulator("test", newTestSimConfig())
+	m := inst.sim.Metrics
+	m.CompletedRequests = 3
+	m.RequestITLs["req-a"] = 100.0
+	m.RequestITLs["req-b"] = 200.0
+	m.RequestITLs["req-c"] = 300.0
+
+	stats := inst.LatencyStats()
+	const wantITL = 200.0 // (100+200+300)/3
+	if stats.ITL != wantITL {
+		t.Errorf("ITL = %v, want %v", stats.ITL, wantITL)
+	}
+}
+
+// TestLatencyStatsDispatchRateUsesCompletionWindow verifies that DispatchRate is computed
+// from the span between first and last completion time, not from total elapsed simulation time.
+// When completions span a 9s window, DispatchRate should reflect ~10/9 req/s, not 0 (which
+// the old implementation produces when the sim clock has not advanced).
+func TestLatencyStatsDispatchRateUsesCompletionWindow(t *testing.T) {
+	inst := NewInstanceSimulator("test", newTestSimConfig())
+	m := inst.sim.Metrics
+	const n = 10
+	m.CompletedRequests = n
+	// Completions span from 1s to 10s (1e6 µs to 10e6 µs).
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		m.RequestCompletionTimes[id] = float64((i + 1) * 1_000_000) // µs
+	}
+
+	stats := inst.LatencyStats()
+	// span = 10s - 1s = 9s → rate ≈ 10/9 ≈ 1.111 req/s
+	wantRate := float64(n) / 9.0
+	if math.Abs(stats.DispatchRate-wantRate) > 0.01 {
+		t.Errorf("DispatchRate = %.4f, want %.4f (completion-window rate)", stats.DispatchRate, wantRate)
+	}
+}
+
+func TestLatencyStatsDispatchRateFallsBackToClockWhenSingleCompletion(t *testing.T) {
+	inst := NewInstanceSimulator("test", newTestSimConfig())
+	m := inst.sim.Metrics
+	m.CompletedRequests = 1
+	m.RequestCompletionTimes["req-0"] = 5_000_000 // 5s in µs
+
+	// Single completion: span = 0, so rate cannot be computed from window.
+	// DispatchRate should be 0 (clock hasn't advanced in the fresh sim).
+	stats := inst.LatencyStats()
+	if stats.DispatchRate != 0 {
+		// If the clock somehow advanced, DispatchRate will be n/clockUs which is fine.
+		// We only check it's not NaN/Inf.
+		if math.IsNaN(stats.DispatchRate) || math.IsInf(stats.DispatchRate, 0) {
+			t.Errorf("DispatchRate is NaN or Inf with single completion: %v", stats.DispatchRate)
+		}
+	}
+}
+
 func TestInstanceSimulatorLatencyStats_Empty(t *testing.T) {
 	inst := NewInstanceSimulator("test", newTestSimConfig())
 	stats := inst.LatencyStats()

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -12,17 +12,17 @@ import (
 // Timestamp is intentionally excluded: snapshot freshness is managed by
 // CachedSnapshotProvider and is not a policy concern.
 type RoutingSnapshot struct {
-	ID               string
-	QueueDepth       int
-	BatchSize        int
-	KVUtilization    float64
-	FreeKVBlocks     int64
-	CacheHitRate     float64
-	InFlightRequests int   // Requests dispatched to this instance but not yet completed
-	PreemptionCount  int64 // Cumulative preemption events since instance start (monotonically increasing; Immediate by default, Periodic when --snapshot-refresh-interval > 0)
-	Model            string // Model served by this instance; used by buildRouterState() for per-model filtering
-	GPUType          string  // GPU hardware type (e.g. "A100-80GB"); populated by buildRouterState() from instance config
-	TPDegree         int     // Tensor-parallel degree; populated by buildRouterState() from instance config
+	ID                    string
+	QueueDepth            int
+	BatchSize             int
+	KVUtilization         float64
+	FreeKVBlocks          int64
+	CacheHitRate          float64
+	InFlightRequests      int     // Requests dispatched to this instance but not yet completed
+	PreemptionCount       int64   // Cumulative preemption events since instance start (monotonically increasing; Immediate by default, Periodic when --snapshot-refresh-interval > 0)
+	Model                 string  // Model served by this instance; used by buildRouterState() for per-model filtering
+	GPUType               string  // GPU hardware type (e.g. "A100-80GB"); populated by buildRouterState() from instance config
+	TPDegree              int     // Tensor-parallel degree; populated by buildRouterState() from instance config
 	CostPerHour           float64 // Node pool cost in $/hr; populated by buildRouterState() from NodePool.CostPerHour
 	TotalKvCapacityTokens int64   // Total KV cache capacity in tokens (TotalBlocks × BlockSizeTokens); used by V2SaturationAnalyzer
 	KvTokensInUse         int64   // Current KV cache occupancy in tokens (UsedBlocks × BlockSizeTokens); used by V2SaturationAnalyzer

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -26,12 +26,12 @@ type RoutingSnapshot struct {
 	CostPerHour           float64 // Node pool cost in $/hr; populated by buildRouterState() from NodePool.CostPerHour
 	TotalKvCapacityTokens int64   // Total KV cache capacity in tokens (TotalBlocks × BlockSizeTokens); used by V2SaturationAnalyzer
 	KvTokensInUse         int64   // Current KV cache occupancy in tokens (UsedBlocks × BlockSizeTokens); used by V2SaturationAnalyzer
-	TTFT         float64 // μs; 0 if not yet available
-	ITL          float64 // μs; 0 if not yet available
-	DispatchRate float64 // req/s completed by this instance; 0 if not yet available
-	AvgInTokens  float64 // average input tokens per completed request; 0 if not yet available
-	AvgOutTokens float64 // average output tokens per completed request; 0 if not yet available
-	MaxBatchSize float64 // server-configured max batch size; 0 if not yet available
+	TTFT                  float64 // μs; 0 if not yet available
+	ITL                   float64 // μs; 0 if not yet available
+	DispatchRate          float64 // req/s completed by this instance; 0 if not yet available
+	AvgInTokens           float64 // average input tokens per completed request; 0 if not yet available
+	AvgOutTokens          float64 // average output tokens per completed request; 0 if not yet available
+	MaxBatchSize          float64 // server-configured max batch size; 0 if not yet available
 }
 
 // EffectiveLoad returns the total effective load on this instance:

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -26,6 +26,12 @@ type RoutingSnapshot struct {
 	CostPerHour           float64 // Node pool cost in $/hr; populated by buildRouterState() from NodePool.CostPerHour
 	TotalKvCapacityTokens int64   // Total KV cache capacity in tokens (TotalBlocks × BlockSizeTokens); used by V2SaturationAnalyzer
 	KvTokensInUse         int64   // Current KV cache occupancy in tokens (UsedBlocks × BlockSizeTokens); used by V2SaturationAnalyzer
+	TTFT         float64 // μs; 0 if not yet available
+	ITL          float64 // μs; 0 if not yet available
+	DispatchRate float64 // req/s completed by this instance; 0 if not yet available
+	AvgInTokens  float64 // average input tokens per completed request; 0 if not yet available
+	AvgOutTokens float64 // average output tokens per completed request; 0 if not yet available
+	MaxBatchSize float64 // server-configured max batch size; 0 if not yet available
 }
 
 // EffectiveLoad returns the total effective load on this instance:


### PR DESCRIPTION
## Summary

Foundational latency metrics plumbing required by the QueueingModelAnalyzer (#1196). Exposes per-instance latency and throughput statistics and threads them through the autoscaler pipeline.

- **`InstanceLatencyStats`** struct + **`LatencyStats()`** method on `InstanceSimulator` — computes TTFT, ITL, DispatchRate, AvgInTokens, AvgOutTokens from completed-request metrics
- **`MaxBatchSize()`** accessor on `InstanceSimulator` — exposes `BatchConfig.MaxRunningReqs` for the autoscaler
- **`ReplicaMetrics`** extended with `ITL`, `AvgInTokens`, `AvgOutTokens`, `MaxBatchSize` fields
- **`RoutingSnapshot`** extended with the same fields (populated by `buildRouterState`)
- **`DefaultCollector`** maps the new snapshot fields into `ReplicaMetrics`

Part of #1197 (split of #1151, partial #954). Closes #1194.

## Test plan

- [x] `go test ./sim/cluster/... -run TestInstanceSimulatorLatencyStats` — zero-value and after-run cases
- [x] `go test ./sim/cluster/... -run TestDefaultCollectorMapsLatencyFields` — field pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)