### PR TITLE
feat(cluster): GreedyEngine and exact-N autoscaler scaling

### DIFF
--- a/docs/contributing/extension-recipes.md
+++ b/docs/contributing/extension-recipes.md
@@ -161,7 +161,7 @@ To add a new autoscaler `Engine` implementation (e.g., a cost-minimizing MIP sol
    - `sortedByAscCost`, `sortedByDescCost` — deterministic variant sort (R2: copy-and-sort to avoid mutating caller data).
    - Pass only the selected variant to `scaleUpN` (`vcs[0:1]`, not the full slice) so `perReplicaCapacityForScaleUp` uses the chosen variant's own capacity — not a different active variant's.
 
-3. **Wire the engine** in `sim/cluster/cluster.go:381` — replace `&UnlimitedEngine{}` with your engine (or add a config field + factory once multi-engine selection is implemented in the follow-up wiring PR).
+3. **Wire the engine** in `sim/cluster/cluster.go` — search for `&UnlimitedEngine{}` in the autoscaler pipeline construction and replace it with your engine (or add a config field + factory once multi-engine selection is implemented in the follow-up wiring PR).
 
 4. **Add behavioral tests** in `sim/cluster/engine_test.go`:
    - Scale-up: correct `Delta`, correct `Variant`, inventory check pass/fail.
@@ -169,7 +169,7 @@ To add a new autoscaler `Engine` implementation (e.g., a cost-minimizing MIP sol
    - Edge cases: zero `RequiredCapacity`, zero `SpareCapacity`, all variants inactive, `TPDegree > 1`.
    - Cross-model: multiple `AnalyzerResult` entries — verify decisions for each model independently.
 
-5. Extension friction: **2 touch points** (implementation + wiring in `cluster.go:381`). For research variants behind a config field, 4 touch points: implementation + `AutoscalerConfig` field + factory function + CLI flag.
+5. Extension friction: **2 touch points** (implementation + wiring via `&UnlimitedEngine{}` in `cluster.go`). For research variants behind a config field, 4 touch points: implementation + `AutoscalerConfig` field + factory function + CLI flag.
 
 Examples:
 - See `UnlimitedEngine` in `sim/cluster/engine.go` for a simple inventory-ignoring engine

--- a/docs/contributing/extension-recipes.md
+++ b/docs/contributing/extension-recipes.md
@@ -145,6 +145,36 @@ Examples:
 - See the `compressed-tensors` branch (~line 240) for formats with nested config structures
 - See `InferWeightBytesFromModelName()` for regex-based name pattern detection
 
+## Adding a New Engine
+
+To add a new autoscaler `Engine` implementation (e.g., a cost-minimizing MIP solver or an OpenEvolve-evolved policy):
+
+1. **Implement the `Engine` interface** in `sim/cluster/engine.go` (or a new file for complex engines) — 1 method:
+   - `Optimize(results []AnalyzerResult, inventory GPUInventory) []ScaleDecision`
+   - Inputs: one `AnalyzerResult` per model (supply/demand signals + per-variant breakdown) and a `GPUInventory` snapshot (free GPU slots per variant, pre-subtracted for Loading/Active/Draining instances).
+   - Output: at most one `ScaleDecision` per model per call. `Delta > 0` = add replicas; `Delta < 0` = remove replicas.
+   - **Must not** read `RouterState` or `ModelSignals` directly — only `AnalyzerResult`.
+
+2. **Reuse the shared helpers** when appropriate:
+   - `scaleUpN(requiredCapacity float64, vcs []VariantCapacity) int` — exact replica count via `ceil(requiredCapacity / prc)`; fallback to 1 when `prc == 0`.
+   - `scaleDownN(spareCapacity float64, vc VariantCapacity) int` — exact replica count via `floor(spareCapacity / prc)`, clamped to `[1, ReplicaCount]`; fallback to 1.
+   - `sortedByAscCost`, `sortedByDescCost` — deterministic variant sort (R2: copy-and-sort to avoid mutating caller data).
+   - Pass only the selected variant to `scaleUpN` (`vcs[0:1]`, not the full slice) so `perReplicaCapacityForScaleUp` uses the chosen variant's own capacity — not a different active variant's.
+
+3. **Wire the engine** in `sim/cluster/cluster.go:381` — replace `&UnlimitedEngine{}` with your engine (or add a config field + factory once multi-engine selection is implemented in the follow-up wiring PR).
+
+4. **Add behavioral tests** in `sim/cluster/engine_test.go`:
+   - Scale-up: correct `Delta`, correct `Variant`, inventory check pass/fail.
+   - Scale-down: correct `Delta` from spare capacity, `ReplicaCount` clamp.
+   - Edge cases: zero `RequiredCapacity`, zero `SpareCapacity`, all variants inactive, `TPDegree > 1`.
+   - Cross-model: multiple `AnalyzerResult` entries — verify decisions for each model independently.
+
+5. Extension friction: **2 touch points** (implementation + wiring in `cluster.go:381`). For research variants behind a config field, 4 touch points: implementation + `AutoscalerConfig` field + factory function + CLI flag.
+
+Examples:
+- See `UnlimitedEngine` in `sim/cluster/engine.go` for a simple inventory-ignoring engine
+- See `GreedyEngine` in `sim/cluster/engine.go` for an inventory-respecting greedy engine with exact-N sizing
+
 ## Adding New Per-Request Metric Fields
 
 To add a new field to per-request JSON output (appears in `--metrics-path` output):

--- a/docs/plans/2026-04-01-phase1c-autoscaling-design.md
+++ b/docs/plans/2026-04-01-phase1c-autoscaling-design.md
@@ -183,9 +183,9 @@ type Engine interface {
 ```
 **Observes:** `[]AnalyzerResult` (one per model) + `GPUInventory` (free slots per variant).  
 **Produces:** `[]ScaleDecision` — at most one per model per call (conservative, reassess next tick).  
-**Scale-up rule:** target cheapest available variant (`CostPerReplica` ascending).  
-**Scale-down rule:** target most expensive active variant (`CostPerReplica` descending).  
-**Cross-model priority:** when GPU inventory is insufficient to satisfy all scale-up requests, models are served in descending `RequiredCapacity` order (highest need first). This is the `GreedyEngine` default; other `Engine` implementations may use different priority rules (e.g. SLO tier).  
+**Scale-up rule:** target cheapest available variant (`CostPerReplica` ascending). Replica count is exact-N: `ceil(RequiredCapacity / perReplicaCapacity)`, where `perReplicaCapacity = Supply / ReplicaCount` for the chosen variant. Falls back to `Delta=+1` when `perReplicaCapacity == 0` (no active replicas yet for that variant).  
+**Scale-down rule:** target most expensive active variant (`CostPerReplica` descending). Replica count is exact-N: `floor(SpareCapacity / perReplicaCapacity)`, clamped to `[1, ReplicaCount]`. Falls back to `Delta=-1` when `perReplicaCapacity == 0`.  
+**Cross-model priority (not yet implemented):** the current `GreedyEngine` processes `results []AnalyzerResult` in input slice order — there is no sort by `RequiredCapacity`. Serving models in descending `RequiredCapacity` order when GPU inventory is insufficient is a planned research direction (Phase 2 OpenEvolve); other `Engine` implementations may use different priority rules (e.g. SLO tier). `UnlimitedEngine` also processes in input order (no inventory constraint, so cross-model priority is moot).  
 **Must not:** read `RouterState` or `ModelSignals` directly — only `AnalyzerResult`.
 
 ### `Actuator`

--- a/docs/plans/2026-04-23-queueing-model-analyzer-design.md
+++ b/docs/plans/2026-04-23-queueing-model-analyzer-design.md
@@ -1,0 +1,314 @@
+# Queueing Model Autoscaler Engine for inference-sim
+
+**Date:** 2026-04-22  
+**Updated:** 2026-04-23  
+**Status:** In Review  
+**Repos:** [inference-sim](https://github.com/inference-sim/inference-sim) (target), [llm-inferno/control-loop](https://github.com/llm-inferno/control-loop) (source of components)  
+**Reference:** [llm-d WVA queueingmodel analyzer](https://github.com/llm-d/llm-d-workload-variant-autoscaler/tree/main/internal/engines/analyzers/queueingmodel)
+
+---
+
+## Context
+
+inference-sim has a pluggable autoscaler pipeline: `Collector → Analyzer → Engine → Actuator`. The current threshold-based `V2SaturationAnalyzer` + `GreedyEngine` scales based on KV-cache utilization. The goal is to add an SLO-driven, model-based, self-tuning alternative by porting the tuner (EKF-based parameter learning) and queue analyzer (capacity prediction at target latency) from llm-inferno.
+
+inference-sim is designed to mirror the [llm-d Workload Variant Autoscaler (WVA)](https://github.com/llm-d/llm-d-workload-variant-autoscaler) and act as a DES-based testing environment for it. The new `QueueingModelAnalyzer` directly mirrors WVA's `internal/engines/analyzers/queueingmodel` package — same algorithm, same naming, same feature set — importing the same llm-inferno libraries as Go modules rather than vendoring older versions.
+
+The result is a new `QueueingModelAnalyzer` and a modified `GreedyEngine` that together replace the threshold-based pipeline. `QueueingModelAnalyzer` is a drop-in for the `Analyzer` interface. `GreedyEngine` is extended — not replaced — to support exact-N replica scaling in addition to its existing ±1 behavior.
+
+---
+
+## Terminology Mapping
+
+The repos use different vocabulary for the same concepts:
+
+| llm-inferno | inference-sim / WVA | Notes |
+|---|---|---|
+| **model** | **model** (`ModelID`) | The LLM being served (e.g. `llama_13b`) |
+| **accelerator** | **variant** (`VariantSpec.GPUType`) | GPU hardware type. inference-sim adds `TPDegree` as a second dimension of variant. |
+| **server** | **(model, variant) pair** | In llm-inferno a server is (model + accelerator + service class). In inference-sim the autoscaler groups replicas by model, with hardware heterogeneity as variants within a model's `VariantCapacity` list. No service-class dimension in inference-sim yet. |
+| **replica** (pod) | **replica** (`InstanceID`) | One running instance. |
+| **service class** | *(not modeled)* | Deferred extension point. |
+
+**EKF keying:** The model-tuner in llm-inferno keys EKF state by **(model, accelerator)** pair, since Alpha/Beta/Gamma differ by GPU type. `QueueingModelAnalyzer` follows the same approach: one estimation pipeline per **(ModelID, VariantSpec)** pair.
+
+---
+
+## Architecture
+
+One new struct implements the `Analyzer` interface; one existing struct is extended:
+
+```
+Collector → QueueingModelAnalyzer → GreedyEngine (extended) → Actuator
+             (new, Analyzer)          (modified, Engine)
+```
+
+`V2SaturationAnalyzer` continues to work with `GreedyEngine` unchanged — the extension is backward-compatible. All other existing components (`UnlimitedEngine`, `DefaultCollector`, `DirectActuator`) are untouched.
+
+---
+
+## Components
+
+### QueueingModelAnalyzer (implements `Analyzer`)
+
+**Purpose:** Learns per-(model, variant) performance parameters (Alpha/Beta/Gamma) from observed latency metrics using the same three-phase pipeline as `TunerService` in llm-inferno (NM bootstrap → sliding-window NM as primary → EKF as fallback), resolves SLO targets (from config, inferred from learned parameters, or estimated from observed latencies), and uses queue-analysis to compute max sustainable RPS per replica at target SLO.
+
+**State:**
+```go
+type QueueingModelAnalyzer struct {
+    config       QMConfig
+    variantState map[modelVariantKey]*perVariantState  // keyed by (ModelID, VariantSpec)
+}
+
+type modelVariantKey struct {
+    ModelID string
+    Variant VariantSpec
+}
+
+type perVariantState struct {
+    ie          *estimator.InitEstimator             // Phase 1: NM bootstrap (always active)
+    swe         *estimator.SlidingWindowEstimator    // Phase 2a: sliding-window NM (nil until ie.IsReady())
+    tuner       *core.Tuner                          // Phase 2b: EKF fallback (nil unless UseSliding=false or ekfFallback=true)
+    ekfFallback bool                                 // true if SW init fit quality was too poor
+    ekfUpdates  int                                  // accepted EKF updates (for NIS gate; Phase 2b only)
+    alpha, beta, gamma float64                       // current best estimates; 0 until first successful fit
+}
+
+type QMConfig struct {
+    SLOTargets        map[string]SLOTarget  // explicit per-model SLO targets; optional (guessed if absent)
+    SLOMultiplier     float64               // queueing delay multiplier k for theory-based SLO guessing (default: 3.0; ρ = 1−1/k ≈ 0.67)
+    TuningEnabled     bool                  // enable online parameter learning (default: true)
+    InitObs           int                   // observations for IE bootstrap (default: 5)
+    UseSliding        bool                  // use SlidingWindowEstimator as primary estimator (default: true)
+    WindowSize        int                   // SWE window capacity (default: 20)
+    ResidualThreshold float64               // SWE outlier rejection threshold (default: 0.3; 0 = disabled)
+    InitFitThreshold  float64               // max NM func value for SW quality gate; 0 = no gate (default: 0)
+    WarmUpCycles      int                   // EKF NIS gate disable count (default: 5; EKF path only)
+}
+
+type SLOTarget struct {
+    TargetTTFT float32  // target time-to-first-token, milliseconds
+    TargetITL  float32  // target inter-token latency, milliseconds
+}
+```
+
+**Defaults:** `DefaultMaxBatchSize = 256`, `DefaultMaxQueueSize = 100`, `DefaultSLOMultiplier = 3.0`, `DefaultFallbackHeadroom = 1.5`.
+
+SLO targets are optional in config — if absent they are inferred automatically (see SLO Resolution below). Token averages (`AvgInTokens`, `AvgOutTokens`) and `MaxBatchSize` are collected per replica at runtime — see Collector Extension. Each (model, variant) pair maintains its own estimation pipeline initialized lazily on first observation, converging independently to the variant's hardware-specific Alpha/Beta/Gamma.
+
+**`Analyze(ModelSignals) AnalyzerResult` flow:**
+1. If `ModelSignals.Replicas` is empty: return neutral result
+2. Group replicas by variant; compute per-variant `workloadMetrics` (arrival-rate-weighted averages of AvgInTokens, AvgOutTokens, AvgTTFT, AvgITL across replicas with valid observations)
+3. If `TuningEnabled`: for each variant group, for each replica with valid observations (ITL > 0, DispatchRate > 0, AvgInTokens > 0, AvgOutTokens > 0): build env (`Lambda = DispatchRate × 60`, AvgInputTokens, AvgOutputTokens, AvgTTFT, AvgITL, `MaxBatchSize = Variant.MaxBatchSize`), call `updateVariantParameters(state, env)` which implements the three-phase pipeline:
+   - **Phase 1** (`InitEstimator`): `ie.AddObservation(env)`; if not `ie.IsReady()`: return (alpha/beta/gamma remain 0)
+   - **Phase 2a** (SlidingWindowEstimator, when `UseSliding=true` and `!ekfFallback`):
+     - On first call after IE ready: create SWE seeded from IE observations; run `ie.Fit()` for NM warm start; if `InitFitThreshold > 0` and fit quality poor: set `ekfFallback=true`, fall through to Phase 2b
+     - On subsequent calls: `swe.AddObservation(env)`
+     - If not `swe.IsReady()`: return; otherwise `swe.Fit()` → update alpha/beta/gamma
+   - **Phase 2b** (EKF, when `UseSliding=false` or `ekfFallback=true`):
+     - On first call: create tuner seeded with `ie.Fit()` result (or `GuessInitState` if fit failed)
+     - `tuner.RunWithValidation(env, skipNIS)` where `skipNIS = (ekfUpdates < WarmUpCycles)`; update alpha/beta/gamma on accepted result
+4. Resolve SLO target via `getSLOTarget(modelID, workloadMetrics)` — see SLO Resolution below; if no SLO can be determined: return neutral result
+5. For each variant:
+   a. If `alpha == 0` (no successful fit yet): **exclude this variant** from supply and demand
+   b. Otherwise: call queue-analysis with (alpha, beta, gamma, TargetTTFT, TargetITL, workloadMetrics.AvgInTokens, workloadMetrics.AvgOutTokens, MaxBatchSize) → `maxRPS_per_replica`
+6. For each variant with alpha > 0:
+   - `variantSupply = maxRPS_per_replica × replicaCount` (all replicas of the variant, including those with zero observations)
+   - `variantDemand = Σ DispatchRate` across replicas of this variant
+   - Add to `VariantCapacities`
+7. Compute model-level totals, `RequiredCapacity`, and `SpareCapacity` with N-1 safety check (same logic as V2SaturationAnalyzer)
+8. Return `AnalyzerResult`
+
+New (model, variant) pairs are initialized on first `Analyze()` call — no pre-registration required.
+
+---
+
+### SLO Resolution (`getSLOTarget`)
+
+SLO targets are resolved in three priority levels, matching WVA's `guessSLOFromMetrics()`:
+
+**Priority 1 — Explicit config:** Check `QMConfig.SLOTargets[modelID]`. If present, use directly.
+
+**Priority 2 — Theory-based (from learned parameters):** For each variant with alpha > 0, apply the queueing model formulas using `SLOMultiplier` k:
+```
+TargetTTFT = k×α + (β+γ)×AvgInTokens
+TargetITL  = k×α + β + γ×(AvgInTokens + (AvgOutTokens+1)/2)
+```
+Take the maximum across all variants with learned parameters. This produces SLO targets consistent with utilization ρ = 1−1/k (at k=3.0, ρ≈0.67).
+
+**Priority 3 — Observation-based fallback:** Use `workloadMetrics.AvgTTFT` and `workloadMetrics.AvgITL` × `DefaultFallbackHeadroom` (1.5), capped at TTFT≤10000ms and ITL≤500ms.
+
+If none of the three priorities yields a result (no config, no learned params, no observations yet), return neutral — no scaling decision is emitted until SLO can be resolved.
+
+---
+
+### GreedyEngine and UnlimitedEngine (extended)
+
+**Purpose:** Both engines currently scale by ±1 per tick. The extension makes them compute the exact replica delta N from the supply/demand gap when `VariantCapacities` carry per-replica capacity information — which `QueueingModelAnalyzer` provides. The logic is not SLO-specific; it is generic and works with any analyzer that populates `VariantCapacities`. `GreedyEngine` respects `GPUInventory`; `UnlimitedEngine` does not — this distinction is unchanged.
+
+This mirrors WVA's `CostAwareOptimizer`, which applies the same exact-N formula to any `AnalyzerResult` regardless of which analyzer produced it.
+
+**Modified `Optimize([]AnalyzerResult, GPUInventory) []ScaleDecision` flow:**
+```
+for each model:
+    perReplicaCapacity = vc.Supply / vc.ReplicaCount  (from VariantCapacities; 0 if no active replicas)
+    if RequiredCapacity > 0:
+        N = ceil(RequiredCapacity / perReplicaCapacity)  if perReplicaCapacity > 0, else 1
+        → ScaleDecision{ModelID, cheapest variant with N free GPU slots, Delta: +N}
+    if SpareCapacity > 0:
+        N = floor(SpareCapacity / perReplicaCapacity), clamped to [1, replicaCount]  if perReplicaCapacity > 0, else 1
+        → ScaleDecision{ModelID, most expensive active variant, Delta: -N}
+```
+
+**Backward compatibility:** when `perReplicaCapacity == 0` (no active replicas or `VariantCapacities` unpopulated), N falls back to 1, preserving the existing ±1 behavior for `V2SaturationAnalyzer` and any other analyzer that does not populate per-replica supply.
+
+Scale-up: exact N replicas (fast convergence under step load changes).  
+Scale-down: exact N replicas (avoids prolonged resource waste when spare capacity is large).  
+GPU inventory constraint enforcement is unchanged.
+
+---
+
+## Collector Extension
+
+TTFT, ITL, DispatchRate, and average token counts are **per-instance simulator metrics**, not observable from the routing layer. `DefaultCollector` reads from `RoutingSnapshot` which is populated by `CachedSnapshotProvider` — a router-side view that does not have access to server-internal latency statistics. Four changes are needed to surface these metrics into the autoscaler pipeline.
+
+**`sim/cluster/autoscaler.go`** — extend `VariantSpec` with `MaxBatchSize`:
+```go
+type VariantSpec struct {
+    GPUType      string
+    TPDegree     int
+    MaxBatchSize int  // server-configured max batch size; static per variant
+}
+```
+
+Add `ITL`, `AvgInTokens`, `AvgOutTokens` to `ReplicaMetrics` (alongside the existing zero-filled `TTFT` and `DispatchRate`):
+```go
+ITL          float64  // μs; 0 if not yet available
+AvgInTokens  float64  // average input tokens per request; 0 if not yet available
+AvgOutTokens float64  // average output tokens per request; 0 if not yet available
+```
+
+**`sim/instance_simulator.go`** (or equivalent) — add a `LatencyStats()` method that computes rolling window averages of TTFT, ITL, DispatchRate, AvgInTokens, and AvgOutTokens from the completed-request data already tracked in `sim.Simulator.Metrics` (`RequestTTFTs`, `RequestITLs`, `AllITLs`). This is the supplier that bridges the simulator's per-request records into the per-instance aggregate view the autoscaler needs. For the initial implementation a simple sliding window over the most recent N completed requests is sufficient.
+
+**`sim/routing.go`** — add to `RoutingSnapshot`:
+```go
+TTFT         float64  // μs; 0 if not yet available
+ITL          float64  // μs; 0 if not yet available
+DispatchRate float64  // req/s completed by this instance; 0 if not yet available
+AvgInTokens  float64  // average input tokens per completed request; 0 if not yet available
+AvgOutTokens float64  // average output tokens per completed request; 0 if not yet available
+```
+`buildRouterState()` populates these by calling `LatencyStats()` on the corresponding `InstanceSimulator`.
+
+**`sim/cluster/default_collector.go`** — map the new `RoutingSnapshot` fields into `ReplicaMetrics`. The existing zero-fill behavior is preserved for any field the simulator has not yet populated (backward-compatible).
+
+---
+
+## Configuration
+
+Add a single `QMConfig` field to `DeploymentConfig` in `sim/cluster/deployment.go`:
+```go
+QMConfig QMConfig  // queueing model analyzer config; zero value uses all defaults
+```
+
+`MaxBatchSize` per variant is set on `VariantSpec` at instance placement time, not via `QMConfig`. Token averages are collected at runtime from each instance.
+
+The user selects `QueueingModelAnalyzer` at startup by constructing `autoscalerPipeline` with it in place of `V2SaturationAnalyzer`. `GreedyEngine` is used as-is — no change to pipeline wiring needed. No structural changes to autoscaler setup code.
+
+---
+
+## Error Handling & Edge Cases
+
+| Condition | Behavior |
+|---|---|
+| `ModelSignals.Replicas` is empty | Skip all estimation updates, return neutral result |
+| Zero ITL, DispatchRate, AvgInTokens, or AvgOutTokens for a replica | Exclude that replica from estimation (metrics not yet available); still count it in replicaCount for supply once that variant has alpha > 0 |
+| `TuningEnabled = false` | Skip estimation entirely; alpha/beta/gamma remain 0 unless seeded externally |
+| IE still accumulating (`ie.ObsCount() < InitObs`) | Exclude variant from both supply and demand; alpha/beta/gamma remain 0 |
+| SWE not yet ready (window not full) | Exclude variant from both supply and demand |
+| SW init fit quality poor (`InitFitThreshold > 0` and NM func value exceeds threshold) | Set `ekfFallback=true`; activate EKF path for this variant |
+| No accepted fit/EKF update yet (alpha == 0) | Exclude variant from both supply and demand; other variants in the same model are unaffected |
+| alpha/beta/gamma zero or negative after fit | Clamp to configurable minimum (e.g., 1 RPS) to prevent division-by-zero in engine |
+| No SLO target determinable (no config, no learned params, no observations) | Return neutral result; no scaling decision emitted until SLO resolves |
+| GPUInventory exhausted on scale-up | Skip decision for that model; existing `GreedyEngine` behavior unchanged |
+| `perReplicaCapacity == 0` in `GreedyEngine` (no active replicas) | Falls back to N=1, preserving original ±1 behavior |
+| New variant added to existing model | Its pipeline initializes independently; existing variants with alpha > 0 are unaffected |
+
+---
+
+## Files
+
+### New files (inference-sim)
+
+| File | Contents |
+|---|---|
+| `sim/cluster/queueing_model_analyzer.go` | `QueueingModelAnalyzer`, `modelVariantKey`, `perVariantState`, `QMConfig`, `SLOTarget`, `updateVariantParameters()`, `getSLOTarget()` |
+
+### Modified files (inference-sim)
+
+| File | Change |
+|---|---|
+| `sim/cluster/engine.go` | Extend `GreedyEngine.Optimize()` and `UnlimitedEngine.Optimize()` to compute exact N from `VariantCapacities`; falls back to N=1 when `perReplicaCapacity == 0` |
+| `sim/cluster/autoscaler.go` | Add `MaxBatchSize` to `VariantSpec`; add `ITL`, `AvgInTokens`, `AvgOutTokens` to `ReplicaMetrics` |
+| `sim/routing.go` | Add `TTFT`, `ITL`, `DispatchRate`, `AvgInTokens`, `AvgOutTokens` to `RoutingSnapshot` |
+| `sim/instance_simulator.go` | Add `LatencyStats()` method returning rolling-window averages of TTFT, ITL, DispatchRate, AvgInTokens, AvgOutTokens from completed-request metrics |
+| `sim/cluster/cluster_event.go` | Populate new `RoutingSnapshot` fields by calling `LatencyStats()` in `buildRouterState()` |
+| `sim/cluster/default_collector.go` | Map new `RoutingSnapshot` fields into `ReplicaMetrics` |
+| `sim/cluster/deployment.go` | Add `QMConfig QMConfig` to `DeploymentConfig` |
+| `go.mod` | Add `github.com/llm-inferno/model-tuner` (direct), promote `github.com/llm-inferno/queue-analysis` (direct) |
+
+### Unchanged (inference-sim)
+
+`Analyzer` interface, `Engine` interface, `DirectActuator`, `V2SaturationAnalyzer` — untouched.
+
+---
+
+## Verification
+
+**Unit tests:**
+- `QueueingModelAnalyzer`: synthetic `ModelSignals` with known TTFT/ITL/DispatchRate → assert `AnalyzerResult` supply/demand values once IE bootstrap completes
+- Bootstrap exclusion: assert variant excluded from supply/demand for first `InitObs - 1` calls; assert variant included from call `InitObs` (SWE seeded and fit succeeds); assert other variants in the same model are unaffected during exclusion
+- EKF fallback: configure `InitFitThreshold` low enough to trigger fallback; assert `ekfFallback=true` is set and EKF path activates
+- SLO guessing: assert theory-based target is computed once alpha > 0; assert observation-based fallback applies headroom multiplier; assert explicit `SLOTargets` config overrides both
+- `GreedyEngine` and `UnlimitedEngine` exact-N: various RequiredCapacity/SpareCapacity/VariantCapacity inputs → assert correct Delta; assert fallback to N=1 when perReplicaCapacity=0; assert existing `V2SaturationAnalyzer` tests still pass
+
+**Integration tests:**
+- Step load increase with `QueueingModelAnalyzer` + `GreedyEngine` → assert scale-out within expected cycles with Delta > 1
+- Compare convergence speed vs. `V2SaturationAnalyzer` + `GreedyEngine`
+- Assert no `ScaleDecision` emitted during bootstrap period (`alpha == 0`)
+
+**Regression:**
+- All existing sim tests with `V2SaturationAnalyzer` + `GreedyEngine` must pass unchanged
+
+---
+
+## Open Questions
+
+- **Multi-service-class support:** Single SLO per model for now. Extension point: `SLOTargets` can be extended to a list of `SLOTarget` entries (one per service class), with the analyzer tracking capacity per class and the engine distributing replicas across classes. Deferred.
+
+---
+
+## WVA Alignment Reference
+
+[llm-d Workload Variant Autoscaler (WVA)](https://github.com/llm-d/llm-d-workload-variant-autoscaler) is the reference implementation that `QueueingModelAnalyzer` mirrors. inference-sim serves as a DES-based testing environment for WVA. The table below maps WVA names and concepts to this implementation.
+
+| WVA | inference-sim (this spec) | Notes |
+|---|---|---|
+| `QueueingModelAnalyzer` | `QueueingModelAnalyzer` | Identical name |
+| `QMConfig` | `QMConfig` | Identical name; embedded as `DeploymentConfig.QMConfig` |
+| `SLOTarget` | `SLOTarget` | Identical name; `TargetTTFT`, `TargetITL` in float32 ms |
+| `SLOTargets map[string]*SLOTarget` | `SLOTargets map[string]SLOTarget` | WVA keys by "namespace/modelID"; inference-sim keys by `ModelID` only |
+| `SLOMultiplier` | `SLOMultiplier` | Default 3.0; ρ = 1−1/k ≈ 0.67 |
+| `TuningEnabled` | `TuningEnabled` | Guards online parameter learning |
+| `LearnedParameters` (Alpha, Beta, Gamma, NIS, Covariance) | `perVariantState.alpha/beta/gamma` + EKF covariance | WVA stores in `ParameterStore`; inference-sim embeds in `perVariantState` alongside the full estimation pipeline |
+| `updateVariantParameters()` | `updateVariantParameters()` | Identical name; inference-sim uses three-phase pipeline (NM bootstrap → SWE → EKF) vs. WVA's direct EKF |
+| `computeAllVariantCapacities()` | inline in `Analyze()` steps 5–6 | WVA separates into a named helper; same logic |
+| `guessSLOFromMetrics()` | `getSLOTarget()` | Same three-priority resolution: explicit config → theory-based → observation-based fallback |
+| `aggregateWorkloadMetrics()` | `workloadMetrics` per variant in step 2 | Arrival-rate-weighted averaging across replicas |
+| `DefaultMaxBatchSize = 256` | `DefaultMaxBatchSize = 256` | Identical |
+| `DefaultMaxQueueSize = 100` | `DefaultMaxQueueSize = 100` | Identical |
+| `DefaultFallbackHeadroom = 1.5` | `DefaultFallbackHeadroom = 1.5` | TTFT/ITL multiplier for observation-based fallback |
+| Direct EKF via `llm-inferno/kalman-filter` | Three-phase pipeline via `llm-inferno/model-tuner` | inference-sim uses richer estimation; model-tuner bundles NM bootstrap + sliding-window NM + EKF internally |
+| Vendors llm-inferno source (older versions) | Imports `llm-inferno/model-tuner`, `llm-inferno/queue-analysis` as Go modules | inference-sim uses current module versions |
+| `CostAwareOptimizer` — exact-N scale-up/down (`ceil`/`floor`) | `GreedyEngine` extended with exact-N logic | WVA has a separate optimizer layer; inference-sim extends the existing `Engine` directly. Same arithmetic: `ceil(RequiredCapacity / perReplicaCapacity)` / `floor(SpareCapacity / perReplicaCapacity)` |
+| `GreedyByScoreOptimizer` — fair-share GPU across models | *(not in scope)* | WVA's limited-GPU fair-share optimizer; inference-sim defers this |

--- a/docs/plans/2026-04-23-windowed-collector-design.md
+++ b/docs/plans/2026-04-23-windowed-collector-design.md
@@ -1,0 +1,186 @@
+# Windowed Statistical Collector for Autoscaler Pipeline
+
+**Status:** Draft  
+**Date:** 2026-04-23  
+**Feature area:** `sim/cluster` — autoscaler pipeline  
+**Related design:** `docs/plans/2026-04-01-phase1c-autoscaling-design.md`
+
+---
+
+## 1. Problem
+
+The autoscaler's `DefaultCollector` produces point-in-time snapshots of replica state at each tick. Two gaps result:
+
+1. **No temporal smoothing.** A single momentary spike in `QueueDepth` or `KVUtilization` can trigger a scale-up decision; a momentary dip can trigger scale-down. The only damping mechanism today is the cooldown window — a coarse gate, not a signal smoother.
+
+2. **No statistical richness.** The `Analyzer` receives only flat scalars. It cannot distinguish steady-state high utilization from highly variable load. Future evolved analyzers need distributions (mean, stddev, P90/P95) to reason about variability, not just level.
+
+Additionally, `ReplicaMetrics.TTFT` and `DispatchRate` are permanently zero — no mechanism computes them. `ITL` is absent entirely.
+
+---
+
+## 2. Goals
+
+1. Add a `WindowedCollector` that maintains a per-replica circular buffer of the last N tick snapshots, exposing the full history in `ModelSignals.Window` for distribution-aware Analyzers.
+2. Populate `ReplicaMetrics.TTFT`, `DispatchRate`, and a new `ITL` field via per-tick deltas of per-instance cumulative completion metrics.
+3. Keep `DefaultCollector` and all existing `Analyzer` implementations unchanged — `Window` is ignored when nil.
+4. Keep `CollectorWindowSize=0` (default) as a zero-behavioral-change config value.
+
+---
+
+## 3. Design
+
+### 3.1 Data model changes
+
+**`ReplicaMetrics`** (`autoscaler.go`) — two fields populated, one added:
+
+```go
+type ReplicaMetrics struct {
+    // ... existing fields unchanged ...
+    TTFT         float64 // μs — mean TTFT of requests completing this tick; 0 if none
+    DispatchRate float64 // req/s — completions this tick / tick interval; 0 if none
+    ITL          float64 // μs — mean ITL of requests completing this tick; 0 if none (NEW)
+}
+```
+
+`TTFT` and `DispatchRate` were declared but permanently zero. `WindowedCollector` populates them from per-tick deltas. `ITL` is new. The comment *"zero until QueueingModelAnalyzer"* is removed from both existing fields — they are now populated by the collector when `WindowedCollector` is used.
+
+**`ModelSignals`** (`autoscaler.go`) — one field added:
+
+```go
+type ModelSignals struct {
+    ModelID  string
+    Replicas []ReplicaMetrics   // current-tick snapshot (unchanged)
+    Window   [][]ReplicaMetrics // [tick][replica]; nil when DefaultCollector is used; oldest tick first
+}
+```
+
+`Window[0]` is the oldest retained tick; `Window[len-1]` is the current tick (same data as `Replicas`). Analyzers that want distributions iterate `Window`. Analyzers that don't (including `V2SaturationAnalyzer`) ignore it entirely.
+
+**`DeploymentConfig`** (`deployment.go`) — one field added:
+
+```go
+CollectorWindowSize int `yaml:"collector_window_size,omitempty"`
+// ticks to retain; 0 or 1 = DefaultCollector (point-in-time, no behavioral change)
+```
+
+### 3.2 WindowedCollector
+
+`WindowedCollector` implements `Collector` as a stateful decorator over `DefaultCollector`.
+
+```go
+type WindowedCollector struct {
+    inner          Collector
+    windowSize     int
+    tickIntervalUs float64
+    metricsQueryFn map[string]func() instanceMetricSnapshot
+
+    // circular buffer per model
+    buffer  map[string][][]ReplicaMetrics
+    head    map[string]int
+    filled  map[string]bool
+
+    // TTFT/ITL delta baselines per instance
+    prevCompleted map[string]int64
+    prevTTFTSum   map[string]float64
+    prevITLSum    map[string]float64
+}
+```
+
+`instanceMetricSnapshot` is an unexported value type: `{completedCount int64, ttftSumUs float64, itlSumUs float64}`.
+
+**`Collect(state)` per tick:**
+
+1. Call `inner.Collect(state)` to get current-tick `[]ModelSignals` with scalar `Replicas`.
+2. For each replica: call `metricsQueryFn[instanceID]()`, compute deltas vs `prev*` maps, populate `TTFT`, `DispatchRate`, `ITL`. Update `prev*` maps.
+3. Append enriched `Replicas` to the circular buffer for that model at index `head[modelID] % windowSize`. Advance `head`.
+4. Set `ModelSignals.Window` to buffer contents in oldest-first order (reordered into a fresh `[][]ReplicaMetrics`).
+5. Return enriched `[]ModelSignals`.
+
+**`AddInstance(id, inst)`** mirrors `CachedSnapshotProvider.AddInstance`: adds a new closure to `metricsQueryFn` when a deferred instance comes online mid-run.
+
+### 3.3 Pipeline wiring
+
+In `cluster.go`, where the default pipeline is constructed:
+
+```go
+var collector Collector
+if config.CollectorWindowSize >= 2 {
+    collector = NewWindowedCollector(
+        &DefaultCollector{},
+        config.CollectorWindowSize,
+        config.ModelAutoscalerIntervalUs,
+        buildMetricsQueryFn(cs),
+    )
+} else {
+    collector = &DefaultCollector{}
+}
+```
+
+`buildMetricsQueryFn` is a private helper on `ClusterSimulator` that iterates `cs.instances` and captures each `InstanceSimulator` in a closure returning `instanceMetricSnapshot` from `inst.Metrics()`. It follows the same pattern as the `cacheQueryFn` builder (`cluster.go:458`).
+
+When `NodeReadyEvent` fires for a deferred instance, `cs.autoscaler.collector` is type-asserted to `*WindowedCollector` (when non-nil) and `AddInstance` is called alongside `CachedSnapshotProvider.AddInstance`.
+
+### 3.4 Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| New instance (not yet in `prev*`) | Delta = 0 for TTFT/ITL/DispatchRate on first tick. Baseline set. No false spike. |
+| Instance disappearing (draining) | `metricsQueryFn` returns last-known values; delta is 0. Old buffer entries remain as historical data. |
+| Zero completions this tick | `TTFT`, `ITL`, `DispatchRate` all 0.0. Analyzer guards against zero before dividing (existing contract). |
+| Partial window (first N-1 ticks) | `Window` has fewer than `WindowSize` rows. `filled[modelID]` distinguishes partial from full window. |
+| `CollectorWindowSize=1` | `Window` has exactly 1 row matching `Replicas`. Equivalent to point-in-time. |
+| `CollectorWindowSize=0` (default) | `DefaultCollector` used; `Window` is nil; no behavioral change. |
+
+---
+
+## 4. Configuration
+
+All autoscaler config lives flat in `DeploymentConfig`. The new field follows the same pattern:
+
+```yaml
+model_autoscaler_interval_us: 10000000   # 10s tick
+collector_window_size: 5                  # last 5 ticks = 50s effective window
+scale_up_cooldown_us: 60000000
+scale_down_cooldown_us: 120000000
+```
+
+Effective window duration = `collector_window_size × model_autoscaler_interval_us`.
+
+---
+
+## 5. Testing
+
+### Unit: `windowed_collector_test.go`
+
+Table-driven tests covering:
+
+- Buffer growth: `Window` has 1 row after tick 1, N rows after tick N, N rows after tick N+1 (oldest evicted).
+- TTFT/ITL/DispatchRate delta: fake `metricsQueryFn` returns controlled cumulative values; assert per-tick deltas across multiple ticks including zero-completion ticks.
+- New instance mid-run: first tick produces zero deltas; subsequent ticks produce correct deltas.
+- `WindowSize=1`: `Window` has exactly 1 row matching `Replicas`.
+- Determinism (INV-6): same call sequence with same fake state produces identical output.
+
+### Unit: `default_collector_test.go`
+
+No changes. `DefaultCollector` is unchanged.
+
+### Integration: `autoscaler_test.go`
+
+- End-to-end tick sequence with `CollectorWindowSize=3`: `ModelSignals.Window` depth grows correctly; `V2SaturationAnalyzer` still produces correct decisions (backward-compat verification).
+- `CollectorWindowSize=0` (default): `Window` is nil; existing tests unaffected.
+
+### Invariant tests
+
+- `Window[len-1]` always equals `Replicas` (current tick consistency).
+- `ReplicaMetrics.TTFT >= 0`, `DispatchRate >= 0`, `ITL >= 0` always.
+- `len(Window) <= CollectorWindowSize` always.
+
+---
+
+## 6. Out of scope
+
+- Changes to `Analyzer`, `Engine`, or `Actuator` interfaces.
+- A distribution-aware Analyzer implementation (separate feature; this PR provides the data).
+- CLI flags — `collector_window_size` is bundle YAML only.
+- `QueueingModelAnalyzer` — deferred; this PR unblocks it by populating `TTFT` and `DispatchRate`.

--- a/sim/cluster/engine.go
+++ b/sim/cluster/engine.go
@@ -68,10 +68,12 @@ func (e *GreedyEngine) Optimize(results []AnalyzerResult, inventory GPUInventory
 
 	for _, r := range results {
 		if r.RequiredCapacity > 0 {
-			// Scale up: pick cheapest variant that has enough free GPU slots
+			// Scale up: pick cheapest variant that has enough free GPU slots.
+			// n is computed per-variant using that variant's own per-replica capacity
+			// so that a more capable fallback variant does not get overscaled.
 			vcs := sortedByAscCost(r.VariantCapacities)
-			n := scaleUpN(r.RequiredCapacity, vcs)
 			for _, vc := range vcs {
+				n := scaleUpN(r.RequiredCapacity, []VariantCapacity{vc})
 				needed := n * vc.Variant.TPDegree
 				if needed < 1 {
 					needed = 1

--- a/sim/cluster/engine.go
+++ b/sim/cluster/engine.go
@@ -3,7 +3,10 @@
 // GreedyEngine (1C-1d): respects GPU inventory, for production-like allocation.
 package cluster
 
-import "sort"
+import (
+	"math"
+	"sort"
+)
 
 // UnlimitedEngine converts analyzer signals into scale decisions without checking
 // GPU inventory. Scale-up targets cheapest variant; scale-down targets most expensive.
@@ -16,26 +19,83 @@ func (e *UnlimitedEngine) Optimize(results []AnalyzerResult, _ GPUInventory) []S
 
 	for _, r := range results {
 		if r.RequiredCapacity > 0 {
-			// Scale up: pick cheapest variant
+			// Scale up: pick cheapest variant, exact-N replicas
 			vcs := sortedByAscCost(r.VariantCapacities)
 			if len(vcs) > 0 {
 				decisions = append(decisions, ScaleDecision{
 					ModelID: r.ModelID,
 					Variant: vcs[0].Variant,
-					Delta:   1,
+					Delta:   scaleUpN(r.RequiredCapacity, vcs),
 				})
 			}
 			continue
 		}
 		if r.SpareCapacity > 0 {
-			// Scale down: pick most expensive variant with active replicas
+			// Scale down: pick most expensive variant with active replicas, exact-N replicas.
+			// Falls back to first desc-cost variant (Delta=-1) when no active replicas exist.
+			vcs := sortedByDescCost(r.VariantCapacities)
+			chosen := -1
+			for i, vc := range vcs {
+				if vc.ReplicaCount > 0 {
+					chosen = i
+					break
+				}
+			}
+			if chosen < 0 && len(vcs) > 0 {
+				chosen = 0 // fallback: first (most expensive) variant
+			}
+			if chosen >= 0 {
+				vc := vcs[chosen]
+				decisions = append(decisions, ScaleDecision{
+					ModelID: r.ModelID,
+					Variant: vc.Variant,
+					Delta:   -scaleDownN(r.SpareCapacity, vc),
+				})
+			}
+		}
+	}
+	return decisions
+}
+
+// GreedyEngine converts analyzer signals into scale decisions while respecting GPU inventory.
+// Scale-up targets cheapest variant with sufficient free slots; scale-down targets most expensive.
+// At most one decision per model per call.
+type GreedyEngine struct{}
+
+// Optimize produces scale decisions for all models, respecting GPU inventory for scale-up.
+func (e *GreedyEngine) Optimize(results []AnalyzerResult, inventory GPUInventory) []ScaleDecision {
+	var decisions []ScaleDecision
+
+	for _, r := range results {
+		if r.RequiredCapacity > 0 {
+			// Scale up: pick cheapest variant that has enough free GPU slots
+			vcs := sortedByAscCost(r.VariantCapacities)
+			n := scaleUpN(r.RequiredCapacity, vcs)
+			for _, vc := range vcs {
+				needed := n * vc.Variant.TPDegree
+				if needed < 1 {
+					needed = 1
+				}
+				if inventory.FreeSlots(vc.Variant) >= needed {
+					decisions = append(decisions, ScaleDecision{
+						ModelID: r.ModelID,
+						Variant: vc.Variant,
+						Delta:   n,
+					})
+					break
+				}
+			}
+			continue
+		}
+		if r.SpareCapacity > 0 {
+			// Scale down: pick most expensive variant with active replicas, exact-N replicas
 			vcs := sortedByDescCost(r.VariantCapacities)
 			for _, vc := range vcs {
 				if vc.ReplicaCount > 0 {
 					decisions = append(decisions, ScaleDecision{
 						ModelID: r.ModelID,
 						Variant: vc.Variant,
-						Delta:   -1,
+						Delta:   -scaleDownN(r.SpareCapacity, vc),
 					})
 					break
 				}
@@ -43,6 +103,53 @@ func (e *UnlimitedEngine) Optimize(results []AnalyzerResult, _ GPUInventory) []S
 		}
 	}
 	return decisions
+}
+
+// scaleUpN returns exact replicas to add.
+// Uses cheapest active variant's Supply/ReplicaCount as perReplicaCapacity.
+// Falls back to 1 when no active variant (perReplicaCapacity == 0).
+func scaleUpN(requiredCapacity float64, vcs []VariantCapacity) int {
+	prc := perReplicaCapacityForScaleUp(vcs)
+	if prc <= 0 {
+		return 1
+	}
+	n := int(math.Ceil(requiredCapacity / prc))
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// scaleDownN returns exact replicas to remove from vc.
+// Uses vc.Supply/vc.ReplicaCount as perReplicaCapacity.
+// Falls back to 1 when perReplicaCapacity == 0; clamps to [1, replicaCount].
+func scaleDownN(spareCapacity float64, vc VariantCapacity) int {
+	if vc.ReplicaCount <= 0 || vc.Supply <= 0 {
+		return 1
+	}
+	prc := vc.Supply / float64(vc.ReplicaCount)
+	if prc <= 0 {
+		return 1
+	}
+	n := int(math.Floor(spareCapacity / prc))
+	if n < 1 {
+		n = 1
+	}
+	if n > vc.ReplicaCount {
+		n = vc.ReplicaCount
+	}
+	return n
+}
+
+// perReplicaCapacityForScaleUp returns Supply/ReplicaCount from the cheapest active variant.
+// vcs must be sorted ascending by cost. Returns 0 when no active variant exists.
+func perReplicaCapacityForScaleUp(vcs []VariantCapacity) float64 {
+	for _, vc := range vcs {
+		if vc.ReplicaCount > 0 && vc.Supply > 0 {
+			return vc.Supply / float64(vc.ReplicaCount)
+		}
+	}
+	return 0
 }
 
 // sortedByAscCost returns a copy sorted by CostPerReplica ascending, then GPUType, then TPDegree (R2).

--- a/sim/cluster/engine.go
+++ b/sim/cluster/engine.go
@@ -25,7 +25,7 @@ func (e *UnlimitedEngine) Optimize(results []AnalyzerResult, _ GPUInventory) []S
 				decisions = append(decisions, ScaleDecision{
 					ModelID: r.ModelID,
 					Variant: vcs[0].Variant,
-					Delta:   scaleUpN(r.RequiredCapacity, vcs),
+					Delta:   scaleUpN(r.RequiredCapacity, vcs[0:1]),
 				})
 			}
 			continue

--- a/sim/cluster/engine.go
+++ b/sim/cluster/engine.go
@@ -32,25 +32,16 @@ func (e *UnlimitedEngine) Optimize(results []AnalyzerResult, _ GPUInventory) []S
 		}
 		if r.SpareCapacity > 0 {
 			// Scale down: pick most expensive variant with active replicas, exact-N replicas.
-			// Falls back to first desc-cost variant (Delta=-1) when no active replicas exist.
 			vcs := sortedByDescCost(r.VariantCapacities)
-			chosen := -1
-			for i, vc := range vcs {
+			for _, vc := range vcs {
 				if vc.ReplicaCount > 0 {
-					chosen = i
+					decisions = append(decisions, ScaleDecision{
+						ModelID: r.ModelID,
+						Variant: vc.Variant,
+						Delta:   -scaleDownN(r.SpareCapacity, vc),
+					})
 					break
 				}
-			}
-			if chosen < 0 && len(vcs) > 0 {
-				chosen = 0 // fallback: first (most expensive) variant
-			}
-			if chosen >= 0 {
-				vc := vcs[chosen]
-				decisions = append(decisions, ScaleDecision{
-					ModelID: r.ModelID,
-					Variant: vc.Variant,
-					Delta:   -scaleDownN(r.SpareCapacity, vc),
-				})
 			}
 		}
 	}
@@ -107,9 +98,9 @@ func (e *GreedyEngine) Optimize(results []AnalyzerResult, inventory GPUInventory
 	return decisions
 }
 
-// scaleUpN returns exact replicas to add.
-// Uses cheapest active variant's Supply/ReplicaCount as perReplicaCapacity.
-// Falls back to 1 when no active variant (perReplicaCapacity == 0).
+// scaleUpN returns exact replicas to add for the selected variant (vcs[0]).
+// Uses Supply/ReplicaCount from the first active variant in vcs as perReplicaCapacity.
+// Falls back to 1 when no active variant exists (perReplicaCapacity == 0).
 func scaleUpN(requiredCapacity float64, vcs []VariantCapacity) int {
 	prc := perReplicaCapacityForScaleUp(vcs)
 	if prc <= 0 {
@@ -123,10 +114,13 @@ func scaleUpN(requiredCapacity float64, vcs []VariantCapacity) int {
 }
 
 // scaleDownN returns exact replicas to remove from vc.
-// Uses vc.Supply/vc.ReplicaCount as perReplicaCapacity.
+// Returns 0 when vc has no active replicas (safe no-op regardless of caller).
 // Falls back to 1 when perReplicaCapacity == 0; clamps to [1, replicaCount].
 func scaleDownN(spareCapacity float64, vc VariantCapacity) int {
-	if vc.ReplicaCount <= 0 || vc.Supply <= 0 {
+	if vc.ReplicaCount <= 0 {
+		return 0
+	}
+	if vc.Supply <= 0 {
 		return 1
 	}
 	prc := vc.Supply / float64(vc.ReplicaCount)
@@ -143,8 +137,8 @@ func scaleDownN(spareCapacity float64, vc VariantCapacity) int {
 	return n
 }
 
-// perReplicaCapacityForScaleUp returns Supply/ReplicaCount from the cheapest active variant.
-// vcs must be sorted ascending by cost. Returns 0 when no active variant exists.
+// perReplicaCapacityForScaleUp returns Supply/ReplicaCount from the first active variant in vcs.
+// Returns 0 when no active variant exists.
 func perReplicaCapacityForScaleUp(vcs []VariantCapacity) float64 {
 	for _, vc := range vcs {
 		if vc.ReplicaCount > 0 && vc.Supply > 0 {

--- a/sim/cluster/engine_test.go
+++ b/sim/cluster/engine_test.go
@@ -127,6 +127,7 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 	tests := []struct {
 		name      string
 		results   []AnalyzerResult
+		wantLen   int
 		wantDelta int
 	}{
 		{
@@ -138,6 +139,7 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
 				},
 			}},
+			wantLen:   1,
 			wantDelta: 3,
 		},
 		{
@@ -149,6 +151,7 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 30, ReplicaCount: 3},
 				},
 			}},
+			wantLen:   1,
 			wantDelta: -2,
 		},
 		{
@@ -160,6 +163,7 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 30, ReplicaCount: 3},
 				},
 			}},
+			wantLen:   1,
 			wantDelta: -3,
 		},
 		{
@@ -171,10 +175,11 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 0, ReplicaCount: 0},
 				},
 			}},
+			wantLen:   1,
 			wantDelta: 1,
 		},
 		{
-			name: "scale-down falls back to Delta=-1 when perReplicaCapacity=0",
+			name: "scale-down with no active replicas → no decision",
 			results: []AnalyzerResult{{
 				ModelID:       "m1",
 				SpareCapacity: 50,
@@ -182,7 +187,7 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 0, ReplicaCount: 0},
 				},
 			}},
-			wantDelta: -1,
+			wantLen: 0, // no active replicas; emitting Delta=-1 would trigger a no-op actuator warn
 		},
 		{
 			name: "scale-up falls back to Delta=1 when cheapest variant is inactive but a more-expensive one is active",
@@ -194,14 +199,18 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 30, ReplicaCount: 3}, // active
 				},
 			}},
+			wantLen:   1,
 			wantDelta: 1, // A100 selected; its prc=0 → fallback to 1; does not borrow H100's prc
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			decisions := engine.Optimize(tt.results, GPUInventory{})
-			if len(decisions) != 1 {
-				t.Fatalf("want 1 decision, got %d", len(decisions))
+			if len(decisions) != tt.wantLen {
+				t.Fatalf("want %d decisions, got %d", tt.wantLen, len(decisions))
+			}
+			if tt.wantLen == 0 {
+				return
 			}
 			if decisions[0].Delta != tt.wantDelta {
 				t.Errorf("Delta: want %d got %d", tt.wantDelta, decisions[0].Delta)
@@ -372,5 +381,21 @@ func TestGreedyEngineScaleUpUsesChosenVariantCapacity(t *testing.T) {
 	}
 	if d.Delta != 2 {
 		t.Errorf("Delta: want 2 (ceil(20/10)), got %d — engine used cheapest variant's prc instead of chosen variant's", d.Delta)
+	}
+}
+
+// TestScaleDownNFloorToZero verifies that when floor(spareCapacity/prc) == 0, scaleDownN
+// clamps to 1 rather than emitting a Delta=0 no-op. Without the clamp a future refactor
+// could silently produce a zero-replica removal decision.
+func TestScaleDownNFloorToZero(t *testing.T) {
+	// spareCapacity=1, Supply=100, ReplicaCount=10 → prc=10 → floor(1/10)=0 → clamped to 1
+	vc := VariantCapacity{
+		Variant:      NewVariantSpec("A100", 1),
+		Supply:       100,
+		ReplicaCount: 10,
+	}
+	n := scaleDownN(1, vc)
+	if n != 1 {
+		t.Errorf("scaleDownN: want 1 (clamped from floor=0), got %d", n)
 	}
 }

--- a/sim/cluster/engine_test.go
+++ b/sim/cluster/engine_test.go
@@ -295,3 +295,41 @@ func TestGreedyEngineOptimize(t *testing.T) {
 		})
 	}
 }
+
+// TestGreedyEngineScaleUpUsesChosenVariantCapacity verifies that when the cheapest
+// variant has no free GPU slots and the engine falls back to a more expensive variant,
+// it computes n using the chosen variant's own per-replica capacity — not the cheapest
+// variant's capacity. Failing to do so overestimates n (scales too many replicas).
+func TestGreedyEngineScaleUpUsesChosenVariantCapacity(t *testing.T) {
+	engine := &GreedyEngine{}
+
+	// Cheap (A100): 2 active replicas, 10 total supply → 5 RPS/replica.
+	// Expensive (H100): 2 active replicas, 20 total supply → 10 RPS/replica.
+	// Required = 20 RPS.
+	// A100 has 0 free GPU slots → engine falls back to H100.
+	// Correct n for H100 = ceil(20/10) = 2 (not ceil(20/5) = 4).
+	results := []AnalyzerResult{{
+		ModelID:          "m1",
+		RequiredCapacity: 20,
+		VariantCapacities: []VariantCapacity{
+			{Variant: NewVariantSpec("A100", 1), CostPerReplica: 5, Supply: 10, ReplicaCount: 2},
+			{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 20, ReplicaCount: 2},
+		},
+	}}
+	inventory := newTestGPUInventory(map[VariantSpec]int{
+		NewVariantSpec("A100", 1): 0,  // full
+		NewVariantSpec("H100", 1): 10, // plenty of room
+	})
+
+	decisions := engine.Optimize(results, inventory)
+	if len(decisions) != 1 {
+		t.Fatalf("want 1 decision, got %d: %+v", len(decisions), decisions)
+	}
+	d := decisions[0]
+	if d.Variant.GPUType != "H100" {
+		t.Errorf("GPUType: want H100, got %q", d.Variant.GPUType)
+	}
+	if d.Delta != 2 {
+		t.Errorf("Delta: want 2 (ceil(20/10)), got %d — engine used cheapest variant's prc instead of chosen variant's", d.Delta)
+	}
+}

--- a/sim/cluster/engine_test.go
+++ b/sim/cluster/engine_test.go
@@ -2,6 +2,12 @@ package cluster
 
 import "testing"
 
+// newTestGPUInventory constructs a GPUInventory with the given free-slot counts.
+// Used only in engine tests within the same package.
+func newTestGPUInventory(slots map[VariantSpec]int) GPUInventory {
+	return GPUInventory{byVariant: slots}
+}
+
 func TestUnlimitedEngineOptimize(t *testing.T) {
 	engine := &UnlimitedEngine{}
 
@@ -111,6 +117,180 @@ func TestUnlimitedEngineOptimize(t *testing.T) {
 			}
 			if tc.wantGPU != "" && d.Variant.GPUType != tc.wantGPU {
 				t.Errorf("Variant.GPUType = %q, want %q", d.Variant.GPUType, tc.wantGPU)
+			}
+		})
+	}
+}
+
+func TestUnlimitedEngineExactN(t *testing.T) {
+	engine := &UnlimitedEngine{}
+	tests := []struct {
+		name      string
+		results   []AnalyzerResult
+		wantDelta int
+	}{
+		{
+			name: "scale-up exact N=3 when perReplicaCapacity=10",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 25, // ceil(25/10) = 3
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
+				},
+			}},
+			wantDelta: 3,
+		},
+		{
+			name: "scale-down exact N=2",
+			results: []AnalyzerResult{{
+				ModelID:       "m1",
+				SpareCapacity: 25, // floor(25/10) = 2
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 30, ReplicaCount: 3},
+				},
+			}},
+			wantDelta: -2,
+		},
+		{
+			name: "scale-down clamped to replicaCount when floor would exceed it",
+			results: []AnalyzerResult{{
+				ModelID:       "m1",
+				SpareCapacity: 100, // floor(100/10)=10, clamped to replicaCount=3
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 30, ReplicaCount: 3},
+				},
+			}},
+			wantDelta: -3,
+		},
+		{
+			name: "scale-up falls back to Delta=1 when no active replicas",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 50,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 0, ReplicaCount: 0},
+				},
+			}},
+			wantDelta: 1,
+		},
+		{
+			name: "scale-down falls back to Delta=-1 when perReplicaCapacity=0",
+			results: []AnalyzerResult{{
+				ModelID:       "m1",
+				SpareCapacity: 50,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 0, ReplicaCount: 0},
+				},
+			}},
+			wantDelta: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decisions := engine.Optimize(tt.results, GPUInventory{})
+			if len(decisions) != 1 {
+				t.Fatalf("want 1 decision, got %d", len(decisions))
+			}
+			if decisions[0].Delta != tt.wantDelta {
+				t.Errorf("Delta: want %d got %d", tt.wantDelta, decisions[0].Delta)
+			}
+		})
+	}
+}
+
+func TestGreedyEngineOptimize(t *testing.T) {
+	tests := []struct {
+		name      string
+		results   []AnalyzerResult
+		inventory GPUInventory
+		wantLen   int
+		wantDelta int
+		wantGPU   string
+	}{
+		{
+			name: "scale up: cheapest variant with free slots",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 10,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
+					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 10, ReplicaCount: 1},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{
+				NewVariantSpec("A100", 1): 4,
+				NewVariantSpec("H100", 1): 4,
+			}),
+			wantLen:   1,
+			wantDelta: 1,
+			wantGPU:   "A100",
+		},
+		{
+			name: "scale up: skip variant with insufficient free slots, use next cheapest",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 40,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
+					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 10, ReplicaCount: 1},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{
+				NewVariantSpec("A100", 1): 2, // need 4 — skip
+				NewVariantSpec("H100", 1): 5, // enough
+			}),
+			wantLen:   1,
+			wantDelta: 4,
+			wantGPU:   "H100",
+		},
+		{
+			name: "scale up: no free slots anywhere → no decision",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 10,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{
+				NewVariantSpec("A100", 1): 0,
+			}),
+			wantLen: 0,
+		},
+		{
+			name: "scale down: exact N from most expensive active variant",
+			results: []AnalyzerResult{{
+				ModelID:       "m1",
+				SpareCapacity: 20,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 30, ReplicaCount: 3},
+					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 30, ReplicaCount: 3},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{
+				NewVariantSpec("A100", 1): 0,
+				NewVariantSpec("H100", 1): 0,
+			}),
+			wantLen:   1,
+			wantDelta: -2, // floor(20/10)=2, using H100 perReplicaCapacity=30/3=10
+			wantGPU:   "H100",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := &GreedyEngine{}
+			decisions := engine.Optimize(tt.results, tt.inventory)
+			if len(decisions) != tt.wantLen {
+				t.Fatalf("want %d decisions, got %d: %+v", tt.wantLen, len(decisions), decisions)
+			}
+			if tt.wantLen == 0 {
+				return
+			}
+			if decisions[0].Delta != tt.wantDelta {
+				t.Errorf("Delta: want %d got %d", tt.wantDelta, decisions[0].Delta)
+			}
+			if decisions[0].Variant.GPUType != tt.wantGPU {
+				t.Errorf("GPUType: want %q got %q", tt.wantGPU, decisions[0].Variant.GPUType)
 			}
 		})
 	}

--- a/sim/cluster/engine_test.go
+++ b/sim/cluster/engine_test.go
@@ -184,6 +184,18 @@ func TestUnlimitedEngineExactN(t *testing.T) {
 			}},
 			wantDelta: -1,
 		},
+		{
+			name: "scale-up falls back to Delta=1 when cheapest variant is inactive but a more-expensive one is active",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 50,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 5, Supply: 0, ReplicaCount: 0},    // cheapest, inactive
+					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 30, ReplicaCount: 3}, // active
+				},
+			}},
+			wantDelta: 1, // A100 selected; its prc=0 → fallback to 1; does not borrow H100's prc
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -274,6 +286,35 @@ func TestGreedyEngineOptimize(t *testing.T) {
 			wantLen:   1,
 			wantDelta: -2, // floor(20/10)=2, using H100 perReplicaCapacity=30/3=10
 			wantGPU:   "H100",
+		},
+		{
+			name: "scale down: no active replicas anywhere → no decision",
+			results: []AnalyzerResult{{
+				ModelID:       "m1",
+				SpareCapacity: 20,
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 1), CostPerReplica: 10, Supply: 0, ReplicaCount: 0},
+					{Variant: NewVariantSpec("H100", 1), CostPerReplica: 20, Supply: 0, ReplicaCount: 0},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{}),
+			wantLen:   0,
+		},
+		{
+			name: "scale up: TPDegree=2 requires n*TPDegree free GPU slots",
+			results: []AnalyzerResult{{
+				ModelID:          "m1",
+				RequiredCapacity: 20, // ceil(20/10)=2 replicas; needed = 2*2 = 4 slots
+				VariantCapacities: []VariantCapacity{
+					{Variant: NewVariantSpec("A100", 2), CostPerReplica: 10, Supply: 10, ReplicaCount: 1},
+				},
+			}},
+			inventory: newTestGPUInventory(map[VariantSpec]int{
+				NewVariantSpec("A100", 2): 4, // exactly 2 replicas * 2 GPUs each
+			}),
+			wantLen:   1,
+			wantDelta: 2,
+			wantGPU:   "A100",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Inventory-aware `GreedyEngine` and exact-N replica sizing for both engines. Self-contained — no new external dependencies, independent of #1198.

- **`GreedyEngine`** — new `Engine` implementation that checks GPU free slots before committing a scale-up decision; picks cheapest affordable variant on scale-up and most expensive active variant on scale-down
- **Exact-N scaling** for both `GreedyEngine` and `UnlimitedEngine` — `ceil(RequiredCapacity / perReplicaCapacity)` replicas on scale-up, `floor(SpareCapacity / perReplicaCapacity)` on scale-down; falls back to ±1 when `perReplicaCapacity == 0` (backward-compatible with `V2SaturationAnalyzer`)

Part of #1197 (split of #1151, partial #954). Closes #1195.

## Test plan

- [x] `go test ./sim/cluster/... -run TestGreedyEngineOptimize` — 4 cases: cheap variant, skip insufficient slots, no slots anywhere, scale-down exact-N
- [x] `go test ./sim/cluster/... -run TestGreedyEngineScaleUpUsesChosenVariantCapacity` — chosen variant capacity used for N calculation
- [x] `go test ./sim/cluster/... -run TestUnlimitedEngineExactN` — 5 cases covering exact-N scale-up/down and fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)