### PR TITLE
refactor(sim): move InstanceState type from sim/cluster to sim package

### DIFF
--- a/docs/plans/pr1204-move-instance-state-plan.md
+++ b/docs/plans/pr1204-move-instance-state-plan.md
@@ -1,0 +1,111 @@
+# Move InstanceState to sim Package — Implementation Plan
+
+**Goal:** Move `InstanceState` type and constants from `sim/cluster/` to `sim/` so that `InstanceSnapshot.State` can be typed as `InstanceState` instead of `string`, enabling compile-time safety for ProgressHook consumers.
+**Source:** [Issue #1204](https://github.com/inference-sim/inference-sim/issues/1204)
+**Closes:** `Fixes #1204`
+
+**Tier:** Medium by file count (7 production files), but purely mechanical renames — no design decisions, no behavioral changes. Using compact format.
+
+## Behavioral Contracts
+
+BC-1: Type availability at sim package level
+- GIVEN a consumer imports `github.com/inference-sim/inference-sim/sim`
+- WHEN they reference `sim.InstanceState`, `sim.InstanceStateActive`, etc.
+- THEN the compiler resolves the type and all 6 constants without importing `sim/cluster`
+
+BC-2: InstanceSnapshot.State typed as InstanceState
+- GIVEN a ProgressHook implementation receives an InstanceSnapshot
+- WHEN it reads the State field
+- THEN the field type is `sim.InstanceState` (not `string`), enabling typed switch/comparison
+
+BC-3: Zero behavioral regression
+- GIVEN identical simulation inputs
+- WHEN running before and after this refactor
+- THEN simulation output is byte-identical (INV-6 preserved)
+
+BC-4: No circular imports
+- GIVEN the package dependency graph
+- WHEN `sim/cluster/` uses `sim.InstanceState` constants
+- THEN compilation succeeds (sim/cluster already imports sim/)
+
+## Tasks
+
+### Task 1: Create sim/instance_state.go (BC-1, BC-4)
+
+**Files:** create `sim/instance_state.go`, test `sim/instance_state_test.go`
+
+**Test:**
+```go
+// sim/instance_state_test.go
+package sim
+
+import "testing"
+
+func TestInstanceState_Constants(t *testing.T) {
+	states := []InstanceState{
+		InstanceStateScheduling,
+		InstanceStateLoading,
+		InstanceStateWarmingUp,
+		InstanceStateActive,
+		InstanceStateDraining,
+		InstanceStateTerminated,
+	}
+	for _, s := range states {
+		if s == "" {
+			t.Errorf("InstanceState constant is empty")
+		}
+		if !IsValidInstanceState(string(s)) {
+			t.Errorf("IsValidInstanceState(%q) = false, want true", s)
+		}
+	}
+	if IsValidInstanceState("bogus") {
+		t.Error("IsValidInstanceState(bogus) = true, want false")
+	}
+}
+```
+
+**Impl:**
+Move type declaration, 6 constants, `validInstanceStates` map, and `IsValidInstanceState` function from `sim/cluster/infra_node.go` to new `sim/instance_state.go`.
+
+**Verify:** `go test ./sim/... -run TestInstanceState_Constants`
+**Lint:** `golangci-lint run ./sim/...`
+**Commit:** `refactor(sim): move InstanceState type to sim package (BC-1)`
+
+### Task 2: Update sim/cluster references (BC-3, BC-4)
+
+**Files:** modify `sim/cluster/infra_node.go`, `sim/cluster/instance.go`, `sim/cluster/cluster.go`, `sim/cluster/direct_actuator.go`, `sim/cluster/infra_lifecycle_event.go`
+
+**Impl:**
+- Remove `InstanceState` type, constants, validation map, and `IsValidInstanceState` from `infra_node.go`
+- Replace all bare `InstanceState*` references in cluster package with `sim.InstanceState*`
+- Replace `InstanceState` type references with `sim.InstanceState`
+- Update `validInstanceTransitions` map type annotations
+- Update `TransitionTo` parameter type
+
+**Verify:** `go build ./... && go test ./sim/cluster/... -count=1`
+**Lint:** `golangci-lint run ./sim/cluster/...`
+**Commit:** `refactor(sim/cluster): use sim.InstanceState from parent package (BC-3, BC-4)`
+
+### Task 3: Update InstanceSnapshot.State type (BC-2)
+
+**Files:** modify `sim/progress_hook.go`, modify `sim/cluster/cluster.go` (cluster construction site), modify `sim/simulator.go` (single-instance construction site)
+
+**Impl:**
+- Change `InstanceSnapshot.State` from `string` to `InstanceState`
+- In `sim/simulator.go:326`: change `State: "Active"` to `State: InstanceStateActive`
+- In `sim/cluster/cluster.go:812`: change `State: string(inst.State)` to `State: inst.State` (no cast needed — type is now `sim.InstanceState`)
+- Update comment on State field (remove "matches string constants" wording)
+
+**Verify:** `go build ./... && go test ./... -count=1`
+**Lint:** `golangci-lint run ./...`
+**Commit:** `refactor(sim): type InstanceSnapshot.State as InstanceState (BC-2)`
+
+## Sanity Checklist
+
+- [ ] No circular imports (sim/cluster → sim is existing direction)
+- [ ] All 6 constants preserve exact string values (byte-identical output)
+- [ ] `validInstanceTransitions` map types updated
+- [ ] `TransitionTo` method signature updated
+- [ ] `IsValidInstanceState` moved (not duplicated)
+- [ ] Test files in sim/cluster still compile (they use unqualified names within package)
+- [ ] No stale references remain (grep confirms zero hits for old location)

--- a/docs/plans/pr1204-move-instance-state-plan.md
+++ b/docs/plans/pr1204-move-instance-state-plan.md
@@ -102,10 +102,10 @@ Move type declaration, 6 constants, `validInstanceStates` map, and `IsValidInsta
 
 ## Sanity Checklist
 
-- [ ] No circular imports (sim/cluster → sim is existing direction)
-- [ ] All 6 constants preserve exact string values (byte-identical output)
-- [ ] `validInstanceTransitions` map types updated
-- [ ] `TransitionTo` method signature updated
-- [ ] `IsValidInstanceState` moved (not duplicated)
-- [ ] Test files in sim/cluster still compile (they use unqualified names within package)
-- [ ] No stale references remain (grep confirms zero hits for old location)
+- [x] No circular imports (sim/cluster → sim is existing direction)
+- [x] All 6 constants preserve exact string values (byte-identical output)
+- [x] `validInstanceTransitions` map types updated
+- [x] `TransitionTo` method signature updated
+- [x] `IsValidInstanceState` moved (not duplicated)
+- [x] Test files in sim/cluster still compile (they use unqualified names within package)
+- [x] No stale references remain (grep confirms zero hits for old location)

--- a/sim/cluster/actuator_test.go
+++ b/sim/cluster/actuator_test.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"fmt"
 	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
 )
 
 // TestDirectActuatorApply verifies DirectActuator behavior for scale-up and scale-down.
@@ -15,7 +17,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		inst := NewInstanceSimulator(InstanceID(id), simCfg)
 		inst.Model = model
 		inst.TPDegree = tp
-		inst.State = InstanceStateActive
+		inst.State = sim.InstanceStateActive
 		return inst
 	}
 
@@ -36,10 +38,10 @@ func TestDirectActuatorApply(t *testing.T) {
 		}
 
 		// inst-a sorts before inst-b — inst-a should be drained
-		if inst2.State != InstanceStateDraining {
+		if inst2.State != sim.InstanceStateDraining {
 			t.Errorf("inst-a State = %q, want Draining (oldest by ID)", inst2.State)
 		}
-		if inst1.State != InstanceStateActive {
+		if inst1.State != sim.InstanceStateActive {
 			t.Errorf("inst-b State = %q, want Active (not selected)", inst1.State)
 		}
 	})
@@ -63,7 +65,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		// One Draining instance, one Active — should only drain the Active one.
 		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
 		draining := newActiveInst("inst-a", "m1", "A100", 1)
-		draining.State = InstanceStateDraining
+		draining.State = sim.InstanceStateDraining
 		active := newActiveInst("inst-b", "m1", "A100", 1)
 		cs.instances = []*InstanceSimulator{draining, active}
 
@@ -74,7 +76,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Apply returned error: %v", err)
 		}
-		if active.State != InstanceStateDraining {
+		if active.State != sim.InstanceStateDraining {
 			t.Errorf("active inst State = %q, want Draining", active.State)
 		}
 	})
@@ -108,7 +110,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		if err == nil {
 			t.Error("Apply should return error for partial scale-down failure")
 		}
-		if inst.State != InstanceStateDraining {
+		if inst.State != sim.InstanceStateDraining {
 			t.Errorf("inst State = %q, want Draining (first iteration should succeed)", inst.State)
 		}
 	})
@@ -165,7 +167,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		inst := cs.instances[0]
 
 		// THEN: instance is past Scheduling (Loading if delay>0, WarmingUp/Active if delay==0).
-		if inst.State == InstanceStateScheduling {
+		if inst.State == sim.InstanceStateScheduling {
 			t.Errorf("instance State = %q: must be past Scheduling after scaleUp (Loading/WarmingUp/Active expected)", inst.State)
 		}
 

--- a/sim/cluster/autoscaler_test.go
+++ b/sim/cluster/autoscaler_test.go
@@ -518,7 +518,7 @@ func TestGPUInventory(t *testing.T) {
 		return cfg
 	}
 	// newA100Inst builds an InstanceSimulator with GPU="A100" and the given state/TPDegree.
-	newA100Inst := func(id string, tp int, state InstanceState) *InstanceSimulator {
+	newA100Inst := func(id string, tp int, state sim.InstanceState) *InstanceSimulator {
 		simCfg := newTestDeploymentConfig(1).ToSimConfig()
 		simCfg.GPU = "A100"
 		inst := NewInstanceSimulator(InstanceID(id), simCfg)
@@ -549,7 +549,7 @@ func TestGPUInventory(t *testing.T) {
 	t.Run("active_instances_subtract_gpus", func(t *testing.T) {
 		// 1 Active instance with TPDegree=2 uses 2 of 8 GPUs → 6 free.
 		cs := NewClusterSimulator(newPoolCfg(2), nil, nil)
-		cs.instances = []*InstanceSimulator{newA100Inst("inst-a", 2, InstanceStateActive)}
+		cs.instances = []*InstanceSimulator{newA100Inst("inst-a", 2, sim.InstanceStateActive)}
 		v := NewVariantSpec("A100", 2)
 		if got := cs.gpuInventory().FreeSlots(v); got != 6 {
 			t.Errorf("active instance: FreeSlots = %d, want 6 (8 - 2)", got)
@@ -562,12 +562,12 @@ func TestGPUInventory(t *testing.T) {
 		// Pool: 8 GPUs → 8 - 4 = 4 free.
 		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
 		cs.instances = []*InstanceSimulator{
-			newA100Inst("loading", 1, InstanceStateLoading),
-			newA100Inst("warmup", 1, InstanceStateWarmingUp),
-			newA100Inst("active", 1, InstanceStateActive),
-			newA100Inst("draining", 1, InstanceStateDraining),
-			newA100Inst("scheduling", 1, InstanceStateScheduling),   // must NOT subtract
-			newA100Inst("terminated", 1, InstanceStateTerminated),   // must NOT subtract
+			newA100Inst("loading", 1, sim.InstanceStateLoading),
+			newA100Inst("warmup", 1, sim.InstanceStateWarmingUp),
+			newA100Inst("active", 1, sim.InstanceStateActive),
+			newA100Inst("draining", 1, sim.InstanceStateDraining),
+			newA100Inst("scheduling", 1, sim.InstanceStateScheduling),   // must NOT subtract
+			newA100Inst("terminated", 1, sim.InstanceStateTerminated),   // must NOT subtract
 		}
 		v := NewVariantSpec("A100", 1)
 		if got := cs.gpuInventory().FreeSlots(v); got != 4 {
@@ -593,7 +593,7 @@ func TestGPUInventory(t *testing.T) {
 		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
 		cs.instances = nil
 		for i := 0; i < 10; i++ {
-			cs.instances = append(cs.instances, newA100Inst("over-"+string(rune('a'+i)), 1, InstanceStateActive))
+			cs.instances = append(cs.instances, newA100Inst("over-"+string(rune('a'+i)), 1, sim.InstanceStateActive))
 		}
 		v := NewVariantSpec("A100", 1)
 		if got := cs.gpuInventory().FreeSlots(v); got != 0 {

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -303,7 +303,7 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 			inst.TPDegree = tpDegree
 			inst.CostPerHour = poolCostPerHour
 			inst.warmUpRemaining = config.InstanceLifecycle.WarmUpRequestCount
-			inst.TransitionTo(InstanceStateLoading)
+			inst.TransitionTo(sim.InstanceStateLoading)
 			cs.scheduleInstanceLoadedEvent(inst)
 			cs.instances = append(cs.instances, inst)
 			instanceMap[id] = inst
@@ -317,9 +317,9 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 			inst.Model = config.Model
 			inst.warmUpRemaining = config.InstanceLifecycle.WarmUpRequestCount
 			if inst.warmUpRemaining > 0 {
-				inst.TransitionTo(InstanceStateWarmingUp)
+				inst.TransitionTo(sim.InstanceStateWarmingUp)
 			} else {
-				inst.TransitionTo(InstanceStateActive)
+				inst.TransitionTo(sim.InstanceStateActive)
 			}
 			cs.instances = append(cs.instances, inst)
 			instanceMap[id] = inst
@@ -632,8 +632,8 @@ func (c *ClusterSimulator) Run() error {
 			// T042: drain completion accounting (Phase 1A).
 			// When a Draining instance has no more queued or running requests,
 			// transition it to Terminated and release its GPU allocations.
-			if inst.State == InstanceStateDraining && inst.QueueDepth() == 0 && inst.BatchSize() == 0 {
-				inst.TransitionTo(InstanceStateTerminated)
+			if inst.State == sim.InstanceStateDraining && inst.QueueDepth() == 0 && inst.BatchSize() == 0 {
+				inst.TransitionTo(sim.InstanceStateTerminated)
 				c.releaseInstanceGPUs(inst)
 				c.snapshotProvider.RemoveCacheInstance(inst.ID())
 				delete(c.cacheQueryFn, string(inst.ID()))
@@ -791,10 +791,10 @@ func (c *ClusterSimulator) maybeDeliverProgressSnapshot(isFinal bool) {
 	activeCount := 0
 	instanceSnaps := make([]sim.InstanceSnapshot, 0, len(c.instances))
 	for _, inst := range c.instances {
-		if inst.State == InstanceStateTerminated {
+		if inst.State == sim.InstanceStateTerminated {
 			continue
 		}
-		if inst.State == InstanceStateActive || inst.State == InstanceStateWarmingUp {
+		if inst.State == sim.InstanceStateActive || inst.State == sim.InstanceStateWarmingUp {
 			activeCount++
 		}
 		instanceSnaps = append(instanceSnaps, sim.InstanceSnapshot{
@@ -809,7 +809,7 @@ func (c *ClusterSimulator) maybeDeliverProgressSnapshot(isFinal bool) {
 			CompletedRequests: inst.Metrics().CompletedRequests,
 			InFlightRequests:  c.inFlightRequests[string(inst.ID())],
 			TimedOutRequests:  inst.Metrics().TimedOutRequests,
-			State:             string(inst.State),
+			State:             inst.State,
 			Model:             inst.Model,
 		})
 	}
@@ -925,7 +925,7 @@ func (cs *ClusterSimulator) addLiveInstance(
 	inst.TPDegree = tpDegree
 	inst.CostPerHour = costPerHour
 	inst.warmUpRemaining = cs.config.InstanceLifecycle.WarmUpRequestCount
-	inst.TransitionTo(InstanceStateLoading)
+	inst.TransitionTo(sim.InstanceStateLoading)
 
 	if cs.snapshotProvider == nil {
 		// snapshotProvider is nil — can only happen in unit tests that bypass
@@ -1227,7 +1227,7 @@ func (c *ClusterSimulator) gpuInventory() GPUInventory {
 	}
 	for _, inst := range c.instances {
 		switch inst.State {
-		case InstanceStateLoading, InstanceStateWarmingUp, InstanceStateActive, InstanceStateDraining:
+		case sim.InstanceStateLoading, sim.InstanceStateWarmingUp, sim.InstanceStateActive, sim.InstanceStateDraining:
 			if inst.GPU() != "" {
 				usedByGPUType[inst.GPU()] += inst.TPDegree
 				if inst.TPDegree > 0 {

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -2236,8 +2236,8 @@ func TestNodeReadyEvent_DeferredConstruction_UsesPoolGPUType(t *testing.T) {
 		}
 		// Verify scheduleInstanceLoadedEvent fired and instance reached Active state
 		// (WarmUpRequestCount=0 and loading delay=0, so Loading → Active immediately).
-		if got := inst.State; got != InstanceStateActive {
-			t.Errorf("instance %s: State = %v, want InstanceStateActive (scheduleInstanceLoadedEvent must fire)", inst.ID(), got)
+		if got := inst.State; got != sim.InstanceStateActive {
+			t.Errorf("instance %s: State = %v, want sim.InstanceStateActive (scheduleInstanceLoadedEvent must fire)", inst.ID(), got)
 		}
 	}
 

--- a/sim/cluster/direct_actuator.go
+++ b/sim/cluster/direct_actuator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/inference-sim/inference-sim/sim"
 	"github.com/sirupsen/logrus"
 )
 
@@ -122,7 +123,7 @@ func (a *DirectActuator) scaleDown(d ScaleDecision) error {
 			lastErr = err
 			continue // keep trying remaining iterations (next iteration may find different variant match)
 		}
-		inst.TransitionTo(InstanceStateDraining)
+		inst.TransitionTo(sim.InstanceStateDraining)
 		logrus.Infof("[actuator] scale-down: draining instance %s for model %q", inst.ID(), d.ModelID)
 	}
 	return lastErr
@@ -136,7 +137,7 @@ func (a *DirectActuator) findOldestActive(model string, variant VariantSpec) *In
 		if inst.Model != model {
 			continue
 		}
-		if inst.State != InstanceStateActive {
+		if inst.State != sim.InstanceStateActive {
 			continue
 		}
 		gpuType := inst.GPU()

--- a/sim/cluster/infra_lifecycle_event.go
+++ b/sim/cluster/infra_lifecycle_event.go
@@ -6,6 +6,7 @@ import (
 	"container/heap"
 	"fmt"
 
+	"github.com/inference-sim/inference-sim/sim"
 	"github.com/sirupsen/logrus"
 )
 
@@ -110,9 +111,9 @@ func (e *InstanceLoadedEvent) Execute(cs *ClusterSimulator) {
 			warmUpCount := cs.config.InstanceLifecycle.WarmUpRequestCount
 			if warmUpCount <= 0 {
 				// Skip WarmingUp phase entirely — go directly to Active
-				inst.TransitionTo(InstanceStateActive)
+				inst.TransitionTo(sim.InstanceStateActive)
 			} else {
-				inst.TransitionTo(InstanceStateWarmingUp)
+				inst.TransitionTo(sim.InstanceStateWarmingUp)
 			}
 			return
 		}
@@ -135,9 +136,9 @@ func (cs *ClusterSimulator) scheduleInstanceLoadedEvent(inst *InstanceSimulator)
 		// an event at the same timestamp. Avoids unnecessary heap push/pop overhead.
 		warmUpCount := cs.config.InstanceLifecycle.WarmUpRequestCount
 		if warmUpCount <= 0 {
-			inst.TransitionTo(InstanceStateActive)
+			inst.TransitionTo(sim.InstanceStateActive)
 		} else {
-			inst.TransitionTo(InstanceStateWarmingUp)
+			inst.TransitionTo(sim.InstanceStateWarmingUp)
 		}
 		return
 	}
@@ -191,7 +192,7 @@ func NewDrainPolicy(name DrainPolicyName) DrainPolicy {
 type drainImmediate struct{}
 
 func (d *drainImmediate) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
-	inst.TransitionTo(InstanceStateDraining)
+	inst.TransitionTo(sim.InstanceStateDraining)
 
 	// C1/I2: Decrement inFlightRequests for all requests that will never complete —
 	// both queued (WaitQ) and in-flight (running batch). Drain the WaitQ so those
@@ -208,7 +209,7 @@ func (d *drainImmediate) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
 		}
 	}
 
-	inst.TransitionTo(InstanceStateTerminated)
+	inst.TransitionTo(sim.InstanceStateTerminated)
 	if cs != nil {
 		cs.releaseInstanceGPUs(inst)
 		if cs.snapshotProvider != nil {
@@ -223,7 +224,7 @@ func (d *drainImmediate) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
 type drainWait struct{}
 
 func (d *drainWait) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
-	inst.TransitionTo(InstanceStateDraining)
+	inst.TransitionTo(sim.InstanceStateDraining)
 	// Routing exclusion handled by buildRouterState() via inst.IsRoutable().
 
 	// I3: If the instance is already idle (no queued or running requests), transition
@@ -231,7 +232,7 @@ func (d *drainWait) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
 	// in the main event loop (cluster.go:264, T042 marker) handles the transition when
 	// work finishes. This ensures GPUs are always released (INV-4 conservation).
 	if cs != nil && inst.HasSim() && inst.QueueDepth() == 0 && inst.BatchSize() == 0 {
-		inst.TransitionTo(InstanceStateTerminated)
+		inst.TransitionTo(sim.InstanceStateTerminated)
 		cs.releaseInstanceGPUs(inst)
 		if cs.snapshotProvider != nil {
 			cs.snapshotProvider.RemoveCacheInstance(inst.ID())
@@ -245,7 +246,7 @@ func (d *drainWait) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
 type drainRedirect struct{}
 
 func (d *drainRedirect) Drain(inst *InstanceSimulator, cs *ClusterSimulator) {
-	inst.TransitionTo(InstanceStateDraining)
+	inst.TransitionTo(sim.InstanceStateDraining)
 	// Note: RemoveInstance and delete(cs.cacheQueryFn, ...) are intentionally absent here.
 	// The instance remains alive while processing in-flight and late-arriving requests.
 	// Cleanup happens via the T042 drain-completion check (QueueDepth==0 && BatchSize==0)

--- a/sim/cluster/infra_node.go
+++ b/sim/cluster/infra_node.go
@@ -1,5 +1,5 @@
 // infra_node.go defines the node/GPU infrastructure types for Phase 1A.
-// NodeState and InstanceState enums, Node and GPU runtime entities.
+// NodeState enum, Node and GPU runtime entities.
 package cluster
 
 import "fmt"
@@ -28,33 +28,6 @@ func IsValidNodeState(s string) bool {
 	return ok
 }
 
-// InstanceState represents the lifecycle state of an instance (model server).
-type InstanceState string
-
-const (
-	InstanceStateScheduling InstanceState = "Scheduling"
-	InstanceStateLoading    InstanceState = "Loading"
-	InstanceStateWarmingUp  InstanceState = "WarmingUp"
-	InstanceStateActive     InstanceState = "Active"
-	InstanceStateDraining   InstanceState = "Draining"
-	InstanceStateTerminated InstanceState = "Terminated"
-)
-
-// validInstanceStates is the unexported validation map (R8).
-var validInstanceStates = map[InstanceState]struct{}{
-	InstanceStateScheduling: {},
-	InstanceStateLoading:    {},
-	InstanceStateWarmingUp:  {},
-	InstanceStateActive:     {},
-	InstanceStateDraining:   {},
-	InstanceStateTerminated: {},
-}
-
-// IsValidInstanceState returns true if s is a known InstanceState value.
-func IsValidInstanceState(s string) bool {
-	_, ok := validInstanceStates[InstanceState(s)]
-	return ok
-}
 
 // Node represents a single machine in a node pool.
 // Carries a fixed inventory of GPUs tracked as allocated or free.

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -28,7 +28,7 @@ type InstanceSimulator struct {
 	// Phase 1A: lifecycle and placement fields.
 	// All zero-value safe (backward-compatible with no-node-pool mode).
 	Model            string        // target model identifier (empty = default/single-model)
-	State            InstanceState // lifecycle state; empty = untracked (backward-compat)
+	State            sim.InstanceState // lifecycle state; empty = untracked (backward-compat)
 	warmUpRemaining  int           // requests remaining in warm-up phase; 0 = no warm-up
 	warmUpRequestIDs []string      // IDs of requests served during warm-up (for TTFT factor)
 	nodeID           string        // node this instance is placed on (empty = unplaced)
@@ -250,7 +250,7 @@ func (i *InstanceSimulator) InjectRequestOnline(req *sim.Request, eventTime int6
 // for backward compatibility with pre-Phase-1A cluster tests.
 func (i *InstanceSimulator) IsRoutable() bool {
 	switch i.State {
-	case InstanceStateActive, InstanceStateWarmingUp:
+	case sim.InstanceStateActive, sim.InstanceStateWarmingUp:
 		return true
 	case "": // untracked — backward-compat
 		return true
@@ -266,7 +266,7 @@ func (i *InstanceSimulator) HasSim() bool {
 
 // IsWarmingUp returns true if the warm-up TTFT penalty should be applied.
 func (i *InstanceSimulator) IsWarmingUp() bool {
-	return i.State == InstanceStateWarmingUp && i.warmUpRemaining > 0
+	return i.State == sim.InstanceStateWarmingUp && i.warmUpRemaining > 0
 }
 
 // RecordWarmUpRequest marks a request ID as having been served during warm-up.
@@ -294,25 +294,25 @@ func (i *InstanceSimulator) ConsumeWarmUpRequest() {
 		return
 	}
 	i.warmUpRemaining--
-	if i.warmUpRemaining == 0 && i.State == InstanceStateWarmingUp {
-		i.TransitionTo(InstanceStateActive)
+	if i.warmUpRemaining == 0 && i.State == sim.InstanceStateWarmingUp {
+		i.TransitionTo(sim.InstanceStateActive)
 	}
 }
 
 // validInstanceTransitions maps valid source → target pairs for instance lifecycle.
-var validInstanceTransitions = map[InstanceState]map[InstanceState]struct{}{
-	InstanceStateScheduling: {InstanceStateLoading: {}, InstanceStateTerminated: {}},
-	InstanceStateLoading:    {InstanceStateWarmingUp: {}, InstanceStateActive: {}, InstanceStateTerminated: {}},
-	InstanceStateWarmingUp:  {InstanceStateActive: {}, InstanceStateDraining: {}, InstanceStateTerminated: {}},
-	InstanceStateActive:     {InstanceStateDraining: {}, InstanceStateTerminated: {}},
-	InstanceStateDraining:   {InstanceStateTerminated: {}},
-	InstanceStateTerminated: {},
+var validInstanceTransitions = map[sim.InstanceState]map[sim.InstanceState]struct{}{
+	sim.InstanceStateScheduling: {sim.InstanceStateLoading: {}, sim.InstanceStateTerminated: {}},
+	sim.InstanceStateLoading:    {sim.InstanceStateWarmingUp: {}, sim.InstanceStateActive: {}, sim.InstanceStateTerminated: {}},
+	sim.InstanceStateWarmingUp:  {sim.InstanceStateActive: {}, sim.InstanceStateDraining: {}, sim.InstanceStateTerminated: {}},
+	sim.InstanceStateActive:     {sim.InstanceStateDraining: {}, sim.InstanceStateTerminated: {}},
+	sim.InstanceStateDraining:   {sim.InstanceStateTerminated: {}},
+	sim.InstanceStateTerminated: {},
 }
 
 // TransitionTo validates and applies an instance state transition.
 // Panics on invalid transition (invariant violation per Principle V).
 // No-op when State is empty (backward-compat: lifecycle not tracked).
-func (i *InstanceSimulator) TransitionTo(state InstanceState) {
+func (i *InstanceSimulator) TransitionTo(state sim.InstanceState) {
 	if i.State == "" {
 		// Lifecycle tracking not enabled — silently accept transition to initialize state.
 		i.State = state

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -311,7 +311,7 @@ var validInstanceTransitions = map[sim.InstanceState]map[sim.InstanceState]struc
 
 // TransitionTo validates and applies an instance state transition.
 // Panics on invalid transition (invariant violation per Principle V).
-// No-op when State is empty (backward-compat: lifecycle not tracked).
+// Initializes State on first call when State is empty (backward-compat: lifecycle not tracked).
 func (i *InstanceSimulator) TransitionTo(state sim.InstanceState) {
 	if i.State == "" {
 		// Lifecycle tracking not enabled — silently accept transition to initialize state.

--- a/sim/cluster/instance_lifecycle_test.go
+++ b/sim/cluster/instance_lifecycle_test.go
@@ -86,7 +86,7 @@ func TestInstanceLifecycle_WarmUpTTFTPenalty(t *testing.T) {
 func TestInstanceLifecycle_WaitDrainExcludesRouting(t *testing.T) {
 	// GIVEN an instance in Draining state with WAIT policy
 	inst := &InstanceSimulator{id: "wait-inst"}
-	inst.TransitionTo(InstanceStateActive)
+	inst.TransitionTo(sim.InstanceStateActive)
 
 	policy := &drainWait{}
 	policy.Drain(inst, nil)
@@ -97,7 +97,7 @@ func TestInstanceLifecycle_WaitDrainExcludesRouting(t *testing.T) {
 	}
 
 	// AND instance is in Draining state
-	if inst.State != InstanceStateDraining {
+	if inst.State != sim.InstanceStateDraining {
 		t.Errorf("instance state = %q, want Draining", inst.State)
 	}
 }
@@ -105,7 +105,7 @@ func TestInstanceLifecycle_WaitDrainExcludesRouting(t *testing.T) {
 func TestInstanceLifecycle_ImmediateDrain(t *testing.T) {
 	// GIVEN an Active instance
 	inst := &InstanceSimulator{id: "imm-inst"}
-	inst.TransitionTo(InstanceStateActive)
+	inst.TransitionTo(sim.InstanceStateActive)
 
 	// drainImmediate needs releaseInstanceGPUs which needs a cluster — use a mock cs
 	// that has nil placement (no-op release)
@@ -114,7 +114,7 @@ func TestInstanceLifecycle_ImmediateDrain(t *testing.T) {
 	policy.Drain(inst, cs)
 
 	t.Run("instance terminates immediately", func(t *testing.T) {
-		if inst.State != InstanceStateTerminated {
+		if inst.State != sim.InstanceStateTerminated {
 			t.Errorf("instance state = %q, want Terminated after IMMEDIATE drain", inst.State)
 		}
 	})
@@ -203,18 +203,18 @@ func TestInstanceLifecycle_RedirectDrainPreservesConservation(t *testing.T) {
 func TestInstanceStateMachine_ValidTransitions(t *testing.T) {
 	cases := []struct {
 		name   string
-		from   InstanceState
-		to     InstanceState
+		from   sim.InstanceState
+		to     sim.InstanceState
 		wantOK bool
 	}{
-		{"Scheduling→Loading", InstanceStateScheduling, InstanceStateLoading, true},
-		{"Loading→WarmingUp", InstanceStateLoading, InstanceStateWarmingUp, true},
-		{"Loading→Active", InstanceStateLoading, InstanceStateActive, true},
-		{"WarmingUp→Active", InstanceStateWarmingUp, InstanceStateActive, true},
-		{"Active→Draining", InstanceStateActive, InstanceStateDraining, true},
-		{"Draining→Terminated", InstanceStateDraining, InstanceStateTerminated, true},
-		{"Active→Loading (invalid)", InstanceStateActive, InstanceStateLoading, false},
-		{"Terminated→Active (invalid)", InstanceStateTerminated, InstanceStateActive, false},
+		{"Scheduling→Loading", sim.InstanceStateScheduling, sim.InstanceStateLoading, true},
+		{"Loading→WarmingUp", sim.InstanceStateLoading, sim.InstanceStateWarmingUp, true},
+		{"Loading→Active", sim.InstanceStateLoading, sim.InstanceStateActive, true},
+		{"WarmingUp→Active", sim.InstanceStateWarmingUp, sim.InstanceStateActive, true},
+		{"Active→Draining", sim.InstanceStateActive, sim.InstanceStateDraining, true},
+		{"Draining→Terminated", sim.InstanceStateDraining, sim.InstanceStateTerminated, true},
+		{"Active→Loading (invalid)", sim.InstanceStateActive, sim.InstanceStateLoading, false},
+		{"Terminated→Active (invalid)", sim.InstanceStateTerminated, sim.InstanceStateActive, false},
 	}
 
 	for _, tc := range cases {
@@ -236,17 +236,17 @@ func TestInstanceStateMachine_ValidTransitions(t *testing.T) {
 	}
 }
 
-// ─── InstanceState enums ─────────────────────────────────────────────────────
+// ─── sim.InstanceState enums ─────────────────────────────────────────────────────
 
 func TestInstanceState_IsValidInstanceState(t *testing.T) {
 	valid := []string{"Scheduling", "Loading", "WarmingUp", "Active", "Draining", "Terminated"}
 	for _, s := range valid {
-		if !IsValidInstanceState(s) {
-			t.Errorf("IsValidInstanceState(%q) = false, want true", s)
+		if !sim.IsValidInstanceState(s) {
+			t.Errorf("sim.IsValidInstanceState(%q) = false, want true", s)
 		}
 	}
-	if IsValidInstanceState("unknown") {
-		t.Error("IsValidInstanceState(unknown) = true, want false")
+	if sim.IsValidInstanceState("unknown") {
+		t.Error("sim.IsValidInstanceState(unknown) = true, want false")
 	}
 }
 
@@ -269,15 +269,15 @@ func TestNodeState_IsValidNodeState(t *testing.T) {
 // This is a system-law test (R7 companion to all lifecycle golden tests).
 func TestInstanceStateMachine_NoBackwardTransitions(t *testing.T) {
 	// Define the forward order — each state can only transition to a higher-index state.
-	forwardOrder := []InstanceState{
-		InstanceStateScheduling,
-		InstanceStateLoading,
-		InstanceStateWarmingUp,
-		InstanceStateActive,
-		InstanceStateDraining,
-		InstanceStateTerminated,
+	forwardOrder := []sim.InstanceState{
+		sim.InstanceStateScheduling,
+		sim.InstanceStateLoading,
+		sim.InstanceStateWarmingUp,
+		sim.InstanceStateActive,
+		sim.InstanceStateDraining,
+		sim.InstanceStateTerminated,
 	}
-	indexOf := make(map[InstanceState]int, len(forwardOrder))
+	indexOf := make(map[sim.InstanceState]int, len(forwardOrder))
 	for i, s := range forwardOrder {
 		indexOf[s] = i
 	}

--- a/sim/cluster/multi_model_test.go
+++ b/sim/cluster/multi_model_test.go
@@ -83,7 +83,7 @@ func TestMultiModel_BuildRouterState_EmptyWhenNonActive(t *testing.T) {
 	// Mark all instances as Draining (not routable)
 	for _, inst := range cs.instances {
 		inst.Model = "model-m"
-		inst.TransitionTo(InstanceStateDraining)
+		inst.TransitionTo(sim.InstanceStateDraining)
 	}
 
 	req := newModelRequest("req-1", "model-m", 0)
@@ -203,7 +203,7 @@ func TestWarmUpTTFTFactor_AppliedInAggregateMetrics(t *testing.T) {
 
 	// Manually set instance to WarmingUp and record two warm-up requests
 	inst := cs.instances[0]
-	inst.State = InstanceStateWarmingUp
+	inst.State = sim.InstanceStateWarmingUp
 	inst.warmUpRemaining = 2
 	inst.RecordWarmUpRequest(requests[0].ID)
 	inst.RecordWarmUpRequest(requests[1].ID)

--- a/sim/instance_state.go
+++ b/sim/instance_state.go
@@ -1,0 +1,29 @@
+package sim
+
+// InstanceState represents the lifecycle state of an instance (model server).
+type InstanceState string
+
+const (
+	InstanceStateScheduling InstanceState = "Scheduling"
+	InstanceStateLoading    InstanceState = "Loading"
+	InstanceStateWarmingUp  InstanceState = "WarmingUp"
+	InstanceStateActive     InstanceState = "Active"
+	InstanceStateDraining   InstanceState = "Draining"
+	InstanceStateTerminated InstanceState = "Terminated"
+)
+
+// validInstanceStates is the unexported validation map (R8).
+var validInstanceStates = map[InstanceState]struct{}{
+	InstanceStateScheduling: {},
+	InstanceStateLoading:    {},
+	InstanceStateWarmingUp:  {},
+	InstanceStateActive:     {},
+	InstanceStateDraining:   {},
+	InstanceStateTerminated: {},
+}
+
+// IsValidInstanceState returns true if s is a known InstanceState value.
+func IsValidInstanceState(s string) bool {
+	_, ok := validInstanceStates[InstanceState(s)]
+	return ok
+}

--- a/sim/instance_state_test.go
+++ b/sim/instance_state_test.go
@@ -12,14 +12,30 @@ func TestInstanceState_Constants(t *testing.T) {
 		InstanceStateTerminated,
 	}
 	for _, s := range states {
-		if s == "" {
-			t.Errorf("InstanceState constant is empty")
-		}
 		if !IsValidInstanceState(string(s)) {
 			t.Errorf("IsValidInstanceState(%q) = false, want true", s)
 		}
 	}
 	if IsValidInstanceState("bogus") {
 		t.Error("IsValidInstanceState(bogus) = true, want false")
+	}
+}
+
+func TestInstanceState_StringValues(t *testing.T) {
+	cases := []struct {
+		constant InstanceState
+		want     string
+	}{
+		{InstanceStateScheduling, "Scheduling"},
+		{InstanceStateLoading, "Loading"},
+		{InstanceStateWarmingUp, "WarmingUp"},
+		{InstanceStateActive, "Active"},
+		{InstanceStateDraining, "Draining"},
+		{InstanceStateTerminated, "Terminated"},
+	}
+	for _, tc := range cases {
+		if got := string(tc.constant); got != tc.want {
+			t.Errorf("InstanceState constant: got %q, want %q", got, tc.want)
+		}
 	}
 }

--- a/sim/instance_state_test.go
+++ b/sim/instance_state_test.go
@@ -1,0 +1,25 @@
+package sim
+
+import "testing"
+
+func TestInstanceState_Constants(t *testing.T) {
+	states := []InstanceState{
+		InstanceStateScheduling,
+		InstanceStateLoading,
+		InstanceStateWarmingUp,
+		InstanceStateActive,
+		InstanceStateDraining,
+		InstanceStateTerminated,
+	}
+	for _, s := range states {
+		if s == "" {
+			t.Errorf("InstanceState constant is empty")
+		}
+		if !IsValidInstanceState(string(s)) {
+			t.Errorf("IsValidInstanceState(%q) = false, want true", s)
+		}
+	}
+	if IsValidInstanceState("bogus") {
+		t.Error("IsValidInstanceState(bogus) = true, want false")
+	}
+}

--- a/sim/progress_hook.go
+++ b/sim/progress_hook.go
@@ -76,9 +76,8 @@ type InstanceSnapshot struct {
 
 	TimedOutRequests int
 
-	// State matches InstanceState string constants defined in sim/cluster
-	// (e.g. "Active", "Loading", "Draining"). Always "Active" in single-instance mode.
-	State string
+	// State is the instance lifecycle state. Always InstanceStateActive in single-instance mode.
+	State InstanceState
 
 	Model string
 }

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -329,7 +329,7 @@ func (sim *Simulator) buildInstanceSnapshot() InstanceSnapshot {
 	return InstanceSnapshot{
 		ID:                "instance-0",
 		Model:             sim.model,
-		State:             "Active",
+		State:             InstanceStateActive,
 		QueueDepth:        sim.QueueDepth(),
 		BatchSize:         sim.BatchSize(),
 		KVUtilization:     float64(sim.KVCache.UsedBlocks()) / float64(max(sim.KVCache.TotalCapacity(), 1)),


### PR DESCRIPTION
## Summary

- Moves `InstanceState` type declaration, 6 constants, and `IsValidInstanceState()` from `sim/cluster/infra_node.go` to `sim/instance_state.go`
- Changes `InstanceSnapshot.State` field type from `string` to `sim.InstanceState`, enabling typed constant matching for ProgressHook consumers
- Updates all ~100 references in `sim/cluster/` (12 files) to use qualified `sim.InstanceState*` names

## Behavioral Contracts

**BC-1:** Consumers can reference `sim.InstanceState` and all 6 constants without importing `sim/cluster`  
**BC-2:** `InstanceSnapshot.State` is typed as `InstanceState` — switch statements get compiler checks  
**BC-3:** Zero behavioral regression — all constants preserve exact string values (INV-6 determinism)  
**BC-4:** No circular imports — `sim/cluster` already imports `sim/`

## Test plan

- [x] New `TestInstanceState_Constants` validates all 6 constants + `IsValidInstanceState`
- [x] Full test suite passes (`go test ./... -count=1`) — 0 failures
- [x] Lint passes (`golangci-lint run ./...`) — 0 issues
- [x] Build passes (`go build ./...`)

Fixes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)