### PR TITLE
fix(cluster): restore trace-gap comment + pass through admission reason in TenantBudgetAdmission

### DIFF
--- a/sim/admission.go
+++ b/sim/admission.go
@@ -348,5 +348,5 @@ func (t *TenantBudgetAdmission) Admit(req *Request, state *RouterState) (bool, s
 	if t.tracker.IsOverBudget(req.TenantID) && t.priorityMap.IsSheddable(req.SLOClass) {
 		return false, "tenant-budget-shed"
 	}
-	return true, ""
+	return true, reason
 }

--- a/sim/admission_test.go
+++ b/sim/admission_test.go
@@ -349,3 +349,19 @@ func TestSLOPriorityMap_InvertForVLLM_PreservesUrgencyOrder(t *testing.T) {
 			critical, standard, batch, sheddable, background)
 	}
 }
+
+type stubAdmitWithReason struct{ reason string }
+
+func (s *stubAdmitWithReason) Admit(*Request, *RouterState) (bool, string) { return true, s.reason }
+
+func TestTenantBudgetAdmission_PassesThroughInnerAdmissionReason(t *testing.T) {
+	inner := &stubAdmitWithReason{reason: "inner-policy-reason"}
+	policy := NewTenantBudgetAdmission(inner, &stubTracker{overBudget: false}, DefaultSLOPriorityMap())
+	admitted, reason := policy.Admit(&Request{ID: "r1", TenantID: "t1", SLOClass: "standard"}, &RouterState{})
+	if !admitted {
+		t.Fatal("expected request to be admitted")
+	}
+	if reason != "inner-policy-reason" {
+		t.Errorf("expected reason %q from inner policy, got %q", "inner-policy-reason", reason)
+	}
+}

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -186,6 +186,9 @@ func (e *AdmissionDecisionEvent) Execute(cs *ClusterSimulator) {
 			// NOT added to cs.rejectedRequests — that tracks admission rejections only.
 			// Gateway rejections are a separate INV-1 bucket (mutual exclusivity: the
 			// !admitted path returns early before reaching this flow-control block).
+			// Trace gap: RecordAdmission above already wrote Admitted:true for this request.
+			// No correction record is emitted here. Trace consumers must not assume all
+			// Admitted:true requests have routing records when flow control is enabled.
 			return
 		case ShedVictim:
 			if victim == nil {

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -178,6 +178,10 @@ func (e *AdmissionDecisionEvent) Execute(cs *ClusterSimulator) {
 	if cs.flowControlEnabled {
 		e.request.GatewayEnqueueTime = cs.clock
 		outcome, victim := cs.gatewayQueue.Enqueue(e.request, cs.nextSeqID())
+		// Trace gap: RecordAdmission above already wrote Admitted:true for any request
+		// that reaches the gateway queue. No trace.RoutingRecord is emitted for requests
+		// subsequently rejected or shed from the queue. Trace consumers must not assume
+		// all Admitted:true requests have routing records when flow control is enabled.
 		switch outcome {
 		case Rejected:
 			logrus.Debugf("[cluster] req %s: admitted but rejected by gateway queue (full, incoming could not displace any entry)", e.request.ID)
@@ -186,9 +190,8 @@ func (e *AdmissionDecisionEvent) Execute(cs *ClusterSimulator) {
 			// NOT added to cs.rejectedRequests — that tracks admission rejections only.
 			// Gateway rejections are a separate INV-1 bucket (mutual exclusivity: the
 			// !admitted path returns early before reaching this flow-control block).
-			// Trace gap: RecordAdmission above already wrote Admitted:true for this request.
-			// No correction record is emitted here. Trace consumers must not assume all
-			// Admitted:true requests have routing records when flow control is enabled.
+			// No trace.RoutingRecord is emitted for this request. Counted in
+			// GatewayQueueRejected() (gw_rejected, INV-1), not in rejectedRequests.
 			return
 		case ShedVictim:
 			if victim == nil {


### PR DESCRIPTION
## Summary

Follow-up to #1202 addressing two findings from post-merge review:

- **`cluster_event.go`**: The `Rejected` case now carries the trace-gap warning that existed on the old `shed == true` branch. `RecordAdmission(Admitted:true)` is already written before `Enqueue` is called, so trace consumers must not assume all `Admitted:true` requests have routing records when flow control is enabled. The comment was dropped in #1202 and this reinstates the equivalent for the new `Rejected` path.

- **`admission.go`**: `TenantBudgetAdmission.Admit` returns `(true, reason)` on success instead of `(true, "")`, preserving the inner policy's admission reason and following the standard decorator pass-through contract.

## Test plan

- [x] `go test ./sim/... ./sim/cluster/...` passes — no behavioral change, comment + one-liner fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)