### PR TITLE
refactor(sim): PrefixThresholdDecider queries per-pod KV cache (GAP-3)

### DIFF
--- a/docs/plans/pr1263-prefix-threshold-per-pod-plan.md
+++ b/docs/plans/pr1263-prefix-threshold-per-pod-plan.md
@@ -1,0 +1,293 @@
+# Rewrite PrefixThresholdDecider to Use Per-Pod KV Cache State (GAP-3) — Implementation Plan
+
+**Goal:** Replace `PrefixThresholdDecider`'s cluster-wide LRU approximation with a per-pod KV cache query against the *pre-selected decode pod*, matching llm-d's `PrefixBasedPDDecider.disaggregate` (queries `endpoint.Get(PrefixCacheMatchInfoKey)`). Thread `cacheQueryFn` (already wired for the `precise-prefix-cache` scorer since PR #883) through the decider constructor, and add `RouterState.SelectedInstance` so the decider can identify which snapshot was pre-selected. Delete the now-redundant `DisaggregationObserver` / `ObserveRouting` machinery.
+
+**Source:** https://github.com/inference-sim/inference-sim/issues/1263 (parent tracker: #1260; prereq: #1262 merged as PR #1265). Addresses @mtoslalibu's GAP-3 note on PR #1265 — chose "option (a) receive the selected pod ID alongside state" over "option (b) scan all snapshots" for direct llm-d parity; joint-D+P policies remain viable via `DisaggregationDecision.DecodePodOverride` (added in GAP-2) against the widened `state.Snapshots`.
+
+**Closes:** Fixes #1263
+
+## Scope & Non-Goals
+
+**In scope:**
+- `sim/disaggregation.go`: `PrefixThresholdDecider` body rewrite + constructor signature + deletion of observer interface/scratchpad.
+- `sim/router_state.go`: additive `SelectedInstance` field.
+- `sim/cluster/cluster.go`: pass `cs.cacheQueryFn` into `NewPrefixThresholdDecider`; populate `state.SelectedInstance` before `Decide`; remove `notifyDisaggregationObserver` helper.
+- `sim/cluster/pd_events.go`, `sim/cluster/disaggregation_test.go`: remove observer call sites; rewrite one behavioral test that asserted observer wiring.
+- `sim/disaggregation_test.go`: replace LRU-warming tests with per-pod cache-query tests using a stub `cacheQueryFn`.
+
+**Out of scope:**
+- Joint D+P policies that exploit `DecodePodOverride` based on cache affinity (option B from the review comment) — future work.
+- Threshold-zero short-circuit (llm-d behavior #1250 fix 3) — `threshold=0` already means "disaggregate any non-empty request," which is the more natural semantics for the BLIS flag; not re-semanticing here.
+- `RequestView` type for structural INV-9 enforcement (#1250 fix 5) — separate track.
+
+## Behavioral Contracts
+
+**BC-1: Decider queries the pre-selected pod's cache**
+- GIVEN a `PrefixThresholdDecider` constructed with `cacheQuery` map
+- WHEN the cluster calls `Decide(req, state)` with `state.SelectedInstance = "decode_X"`
+- THEN the decider invokes `cacheQuery["decode_X"](req.InputTokens)` (and no other closure in the map) to obtain the cached block count used in the formula `nonCachedTokens = len(InputTokens) − cachedBlocks × blockSize`.
+
+**BC-2: Decision formula preserved**
+- GIVEN `cachedBlocks` returned by the per-pod query
+- WHEN `Decide` computes `nonCachedTokens = len(InputTokens) − cachedBlocks × blockSize`
+- THEN `Disaggregate = (nonCachedTokens > threshold)` — identical threshold semantics to pre-GAP-3 behavior (strict `>`, not `>=`).
+
+**BC-3: Empty-input and missing-selection short-circuits**
+- GIVEN `len(req.InputTokens) == 0`, OR `state == nil`, OR `state.SelectedInstance == ""`, OR `state.SelectedInstance` is not a key in the `cacheQuery` map
+- WHEN `Decide` runs
+- THEN the decision is `DisaggregationDecision{Disaggregate: false}` (conservative: if we can't locate the selected pod's cache, assume we don't need to disaggregate — matches llm-d's nil-endpoint guard at `prefix_based_pd_decider.go:108-111`).
+
+**BC-4: Per-pod isolation — cache hits on pod A do not influence a decision targeting pod B**
+- GIVEN two decode pods A and B where A's KV store contains the request's prefix blocks and B's does not
+- WHEN `Decide` is called with `state.SelectedInstance = "B"`
+- THEN `Disaggregate` reflects B's cold cache (i.e. `nonCachedTokens = len(InputTokens)`) and returns `true` when `len(InputTokens) > threshold`.
+
+**BC-5: Cluster populates `state.SelectedInstance` with the decode routing policy's pick**
+- GIVEN `executeDisaggregatedRouting` in `cluster.go`
+- WHEN it calls `cs.disaggregationDecider.Decide(req, state)`
+- THEN `state.SelectedInstance == decodeDecision.TargetInstance` at the moment of the call. (This is the observable wiring contract; `DecodePodOverride` may retarget AFTER the decider returns, but the decider itself sees the routing policy's pick.)
+
+**BC-6: Observer machinery fully removed, no call sites remain**
+- GIVEN the post-PR tree
+- WHEN grep searches for `DisaggregationObserver`, `ObserveRouting`, or `notifyDisaggregationObserver`
+- THEN no matches remain in production source (`sim/**/*.go` excluding `_test.go`).
+
+**BC-7: INV-9 oracle boundary preserved**
+- No implementation reads `req.OutputTokens`. The decider consumes only `req.InputTokens`, `state.SelectedInstance`, and the cache query map.
+
+## Cross-path parity (run / replay / observe)
+
+All changes live in `sim/` and `sim/cluster/` (the DES kernel and cluster layer). Applies uniformly to `blis run` and `blis replay`. `blis observe` dispatches to a real server and never invokes a `DisaggregationDecider` — out of scope.
+
+## Tasks
+
+### Task 1: Add `RouterState.SelectedInstance` field (BC-5 precondition)
+
+**Files:** modify `sim/router_state.go`.
+
+**Impl:**
+
+```go
+type RouterState struct {
+    Snapshots        []RoutingSnapshot
+    LoadingSnapshots []RoutingSnapshot
+    Clock            int64
+    // SelectedInstance is the instance ID pre-selected by the caller (typically
+    // the decode-routing policy) before invoking a DisaggregationDecider.
+    // Empty for contexts where no prior selection has been made (e.g., when
+    // RoutingPolicy.Route itself builds the state). DisaggregationDecider
+    // implementations may read this to identify which snapshot in Snapshots
+    // was chosen upstream; a zero value must be tolerated (treat as "unknown").
+    SelectedInstance string
+}
+```
+
+**Test — `sim/disaggregation_test.go`:**
+- Update existing `TestDisaggregationDecider_StateAgnostic` — the state-agnostic contract applies to `NeverDisaggregate` and `AlwaysDisaggregate` only after GAP-3. `PrefixThresholdDecider` is no longer state-agnostic. Split into two sub-tests: one for the two ignorant deciders (unchanged behavior), one for `PrefixThresholdDecider` with an explicit stub `cacheQuery` returning `0` (zero blocks → cold → decision depends on threshold).
+
+**Verify:** `go build ./...` (compiles).
+
+**Lint:** `golangci-lint run ./sim/...`.
+
+### Task 2: Rewrite `PrefixThresholdDecider` (BC-1..BC-4, BC-7)
+
+**Files:** modify `sim/disaggregation.go`, `sim/disaggregation_test.go`.
+
+**Impl — struct and constructor:**
+
+```go
+type PrefixThresholdDecider struct {
+    threshold  int
+    blockSize  int
+    cacheQuery map[string]func([]int) int // per-pod cache lookup (same map as precise-prefix-cache scorer)
+}
+
+// NewPrefixThresholdDecider creates a PrefixThresholdDecider.
+// threshold must be >= 0, blockSize must be > 0.
+// cacheQuery may be nil (all requests treated as cold); in production callers
+// pass the cluster's cacheQueryFn map built from CachedSnapshotProvider.
+func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]func([]int) int) *PrefixThresholdDecider {
+    if threshold < 0 {
+        panic(fmt.Sprintf("NewPrefixThresholdDecider: threshold must be >= 0, got %d", threshold))
+    }
+    if blockSize <= 0 {
+        panic(fmt.Sprintf("NewPrefixThresholdDecider: blockSize must be > 0, got %d", blockSize))
+    }
+    return &PrefixThresholdDecider{threshold: threshold, blockSize: blockSize, cacheQuery: cacheQuery}
+}
+```
+
+**Impl — `Decide` body:**
+
+```go
+func (p *PrefixThresholdDecider) Decide(req *Request, state *RouterState) DisaggregationDecision {
+    if len(req.InputTokens) == 0 {
+        return DisaggregationDecision{Disaggregate: false}
+    }
+    if state == nil || state.SelectedInstance == "" || p.cacheQuery == nil {
+        return DisaggregationDecision{Disaggregate: false}
+    }
+    fn, ok := p.cacheQuery[state.SelectedInstance]
+    if !ok || fn == nil {
+        return DisaggregationDecision{Disaggregate: false}
+    }
+    cachedBlocks := fn(req.InputTokens)
+    nonCachedTokens := len(req.InputTokens) - cachedBlocks*p.blockSize
+    return DisaggregationDecision{Disaggregate: nonCachedTokens > p.threshold}
+}
+```
+
+**Impl — deletions (in `sim/disaggregation.go`):**
+- `globalVirtualInstance` constant (L92).
+- `defaultDisaggLRUCapacity` constant (L96).
+- `DisaggregationObserver` interface (L98-113) including its doc comment.
+- Fields `idx`, `cachedHashes`, `cachedReqID` on `PrefixThresholdDecider`.
+- `ObserveRouting` method (L174-194).
+- Compile-time assertion `var _ DisaggregationObserver = (*PrefixThresholdDecider)(nil)` (L201).
+- Doc comment line referencing the observer in the `DisaggregationDecider` interface docs (L39-40): "Stateful implementations may additionally implement DisaggregationObserver…".
+- Doc comment line in `PrefixThresholdDecider` struct doc about the scratchpad and observer.
+
+**Impl — `sim/disaggregation_test.go` test updates:**
+- Delete `noopDisaggregationObserver` (L239-244).
+- Delete `TestPrefixThresholdDecider_Interface` as currently written (L246-252) — rewrite to assert `DisaggregationDecider` only (R13 no longer applies because we're removing the observer interface entirely).
+- Delete `TestPrefixThresholdDecider_CacheAware` and `TestPrefixThresholdDecider_CacheAware_SubRequestIDMismatch` (L329-413) — these tested the LRU-warming-via-ObserveRouting path which no longer exists.
+- Update `TestNewPrefixThresholdDecider_PanicsOnNegativeThreshold` / `_PanicsOnZeroBlockSize` to pass `nil` as the third constructor argument.
+- Update `TestDisaggregationDecider_INV9_OracleBoundary` to construct the decider with `nil` cacheQuery.
+- Add `TestPrefixThresholdDecider_PerPodCacheQuery` (BC-1, BC-4): stub `cacheQuery := map[string]func([]int) int{"decode_A": func(t []int) int { return 40 }, "decode_B": func(t []int) int { return 0 }}` (A: 40×16=640 cached tokens; B: cold). Construct `NewPrefixThresholdDecider(512, 16, cacheQuery)`. Call `Decide(req-840-tokens, &RouterState{SelectedInstance: "decode_A"})` → expect `Disaggregate=false` (840−640=200 ≤ 512). Call with `SelectedInstance="decode_B"` → expect `Disaggregate=true` (840−0=840 > 512).
+- Add `TestPrefixThresholdDecider_MissingSelection_ReturnsFalse` (BC-3): nil state, empty `SelectedInstance`, unknown `SelectedInstance`, and nil closure in the map → all return `Disaggregate=false`.
+- Update `TestPrefixThresholdDecider_EmptyTokens`, `_AboveThreshold`, `_BelowOrAtThreshold`, `_ZeroThreshold` to pass a stub `cacheQuery` (or `nil`) — with nil or missing-selection they hit the BC-3 short-circuit. Rework these tests to use a stub returning `0` for the selected pod so the decision path actually exercises the formula with cachedBlocks=0.
+- Keep `TestDisaggregationDecider_StateAgnostic` only for the two always-constant deciders (`NeverDisaggregate`, `AlwaysDisaggregate`). Remove `PrefixThresholdDecider` from that test (no longer state-agnostic — that's the whole point of this PR).
+
+**Verify:** `go test ./sim/ -run TestPrefix -v && go test ./sim/ -run TestDisagg -v`.
+
+**Lint:** `golangci-lint run ./sim/...`.
+
+### Task 3: Wire cluster construction + populate `SelectedInstance` + remove observer helper (BC-5, BC-6)
+
+**Files:** modify `sim/cluster/cluster.go`, `sim/cluster/pd_events.go`.
+
+**Impl in `cluster.go` — reorder decider construction:**
+
+The current switch (L236-241) constructs the decider at L238 *before* `cs.cacheQueryFn` is built at L351. Move the `case "prefix-threshold":` branch to after L351 while keeping the `default:` branch in place — or cleanest: move the whole switch. I'll move the whole switch block from L236-241 to a new location right after L351 (where `cs.cacheQueryFn` is guaranteed populated), and leave the pool-membership + parent-map setup at L233-245.
+
+**Sketch:**
+
+```go
+// near L234 — keep pool membership + parent maps; drop decider wiring
+if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
+    cs.poolMembership = prePoolMembership
+    cs.parentRequests = make(map[string]*ParentRequest)
+    cs.pendingPrefillCompletions = make(map[string]string)
+    cs.pendingDecodeCompletions = make(map[string]string)
+    logrus.Infof("[cluster] PD disaggregation enabled: …")
+    if config.SharedInstances > 0 && !reflect.DeepEqual(config.PrefillOverrides, config.DecodeOverrides) {
+        logrus.Infof("[cluster] shared-role pods use DecodeOverrides …")
+    }
+}
+
+// … line 351 populates cs.cacheQueryFn …
+cs.cacheQueryFn = cs.snapshotProvider.BuildCacheQueryFn()
+
+// NEW: decider construction moved here (needs cacheQueryFn)
+if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
+    switch config.PDDecider {
+    case "prefix-threshold":
+        cs.disaggregationDecider = sim.NewPrefixThresholdDecider(config.PDPrefixThreshold, int(config.BlockSizeTokens), cs.cacheQueryFn)
+    default:
+        cs.disaggregationDecider = sim.NewDisaggregationDecider(config.PDDecider)
+    }
+}
+```
+
+**Impl in `cluster.go` — populate `SelectedInstance` and remove notifier:**
+
+```go
+// executeDisaggregatedRouting — unchanged up to decodeDecision. Then:
+state.SelectedInstance = decodeDecision.TargetInstance
+disaggDecision := cs.disaggregationDecider.Decide(req, state)
+```
+
+Delete:
+- `notifyDisaggregationObserver` helper (L1399-1410).
+- Call sites at L1705 (standard routing path, post-GAP-1 unified path) and L1808 (executeDisaggregatedRouting non-disagg path).
+
+**Impl in `pd_events.go`:**
+- Delete L84 `cs.notifyDisaggregationObserver(e.request, decision.TargetInstance)` and any surrounding comment referencing it.
+
+**Verify:** `go build ./... && go test ./sim/cluster/ -run TestDisagg -v`.
+
+**Lint:** `golangci-lint run ./sim/cluster/...`.
+
+### Task 4: Rewrite cluster-level behavioral test for per-pod cache (BC-1 e2e)
+
+**Files:** modify `sim/cluster/disaggregation_test.go`.
+
+**Impl:**
+
+Rename `TestPrefixThreshold_ObserverWarmsCache` (L656-721) → `TestPrefixThreshold_PerPodCacheQuery`. The scenario shifts:
+
+- Before: req1's prefill warmed a global LRU via `ObserveRouting`; req2 with overlapping prefix consulted the global LRU → not disaggregated.
+- After: req1's prefill runs on decode pod X (via PD disaggregated path), X's actual KV cache stores the blocks; req2 arrives later, its decode routing policy picks pod X (sticky prefix-affinity from `precise-prefix-cache` scorer OR by configuration), the decider queries X's per-pod cache → finds the blocks → not disaggregated.
+
+The test needs the test config to:
+- Use 1 decode instance (so there's no routing ambiguity — req1 and req2 both land on the same pod), OR
+- Use `precise-prefix-cache` scorer and `--cache-signal-delay=0` (oracle mode) to guarantee routing affinity.
+
+Option "1 decode instance" is simpler. Update `newTestPrefixThresholdConfig` caller here to use `newTestDisaggDeploymentConfig(2, 1, 1)` — 1 prefill + 1 decode. (Other tests in the file use 2+2; leave them untouched.)
+
+Also delete the error message references to `notifyDisaggregationObserver` wiring (L718).
+
+**Keep other `TestPrefixThreshold_*` tests** (BelowThreshold, AboveThreshold) as-is — they don't depend on observer warming; they just exercise threshold bifurcation with unique tokens (no cache hits expected).
+
+**Verify:** `go test ./sim/cluster/ -run TestPrefixThreshold -v`.
+
+### Task 5: Full test + lint gate
+
+**Commands:**
+
+```
+go build ./...
+go test ./... -count=1
+golangci-lint run ./...
+```
+
+**Pass criterion:** build clean; all packages pass; lint reports 0 issues.
+
+### Task 6: Commit and push
+
+**Commit message:**
+
+```
+refactor(sim): PrefixThresholdDecider queries per-pod KV cache (GAP-3)
+
+- Replace cluster-wide LRU approximation with per-pod cacheQueryFn lookup
+  against state.SelectedInstance, matching llm-d PrefixBasedPDDecider.
+- Add RouterState.SelectedInstance; cluster populates it before Decide.
+- Thread cs.cacheQueryFn through NewPrefixThresholdDecider; reorder
+  construction to run after cacheQueryFn is built.
+- Delete DisaggregationObserver interface, ObserveRouting, scratchpad
+  fields, globalVirtualInstance constant, notifyDisaggregationObserver
+  helper and its three call sites (BC-6).
+- Rewrite observer-wiring tests to assert per-pod cache consultation.
+
+Implements BC-1..BC-7. INV-9 preserved. Applies to blis run + blis replay.
+
+Fixes #1263
+Part of #1260
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Sanity Checklist
+
+- [x] **R1 (no silent continue):** no new error paths; deletions remove observer calls cleanly.
+- [x] **R3 (defensive validation):** constructor still validates threshold ≥ 0 and blockSize > 0; new third arg (cacheQuery) allowed to be nil (test mode).
+- [x] **R4 (canonical construction):** struct fields shrink (`idx`, `cachedHashes`, `cachedReqID` removed, `cacheQuery` added); only one construction site in `sim/cluster/cluster.go`.
+- [x] **R6 (no `logrus.Fatalf` in sim/):** no new error handling in library path.
+- [x] **R13 (interface ≥2 backends):** `DisaggregationObserver` removed entirely, so R13 no longer applies; `DisaggregationDecider` keeps ≥3 backends.
+- [x] **R17/R23 (signal freshness):** per-pod cache query inherits `CachedSnapshotProvider` staleness (controlled by `--cache-signal-delay`) — same tier as `precise-prefix-cache` scorer (documented in code comment on the new `cacheQuery` field).
+- [x] **INV-1/3/4/5/6/7/8/10/11/12:** no event ordering, conservation, or causality changes. Same `Decide` return type; same event pipeline; same aggregation.
+- [x] **INV-9:** `Decide` reads `req.InputTokens` and `state.SelectedInstance` only; no `req.OutputTokens` access.
+- [x] **INV-6 determinism:** `cacheQuery` map iteration is not used for ordered output; per-pod query is a single keyed lookup (`map[key]` access). No new sort order introduced.
+- [x] **Cross-path parity:** `blis run` + `blis replay` (DES). `blis observe` unaffected (no decider in HTTP path).
+- [x] **CLAUDE.md / docs:** no canonical-source edits required. Change-history entry skipped (the Recent Changes log was removed in #1259).

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -232,7 +232,7 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 
 	// PD disaggregation: set pool membership (topology already validated above).
 	// Decider construction is deferred until after cs.cacheQueryFn is built
-	// (PrefixThresholdDecider consumes the map; see GAP-3 / issue #1263).
+	// (PrefixThresholdDecider consumes the map).
 	if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
 		cs.poolMembership = prePoolMembership
 		cs.parentRequests = make(map[string]*ParentRequest)
@@ -356,8 +356,8 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 	}
 
 	// PD disaggregation: construct the decider now that cacheQueryFn is available.
-	// PrefixThresholdDecider consumes the per-pod cache-query map (GAP-3 / issue #1263);
-	// other deciders ignore state but share the same construction point.
+	// PrefixThresholdDecider consumes the per-pod cache-query map; other deciders
+	// ignore state but share the same construction point.
 	if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
 		switch config.PDDecider {
 		case "prefix-threshold":
@@ -1731,9 +1731,10 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 	// Step 2: disaggregation decision with decode pod known. Pass the full decode-pool
 	// RouterState so the decider can query per-pod state (cache presence, load) and
 	// optionally reconsider the decode pod via DisaggregationDecision.DecodePodOverride.
-	// state.SelectedInstance tells the decider which snapshot was pre-selected by the
-	// decode routing policy (GAP-3 / issue #1263) — PrefixThresholdDecider queries
-	// the selected pod's cacheQueryFn closure for per-pod prefix cache state.
+	// state.SelectedInstance tells the decider which snapshot was pre-selected by
+	// the decode routing policy — PrefixThresholdDecider queries the selected
+	// pod's cacheQueryFn closure for per-pod prefix cache state (matches llm-d's
+	// PrefixBasedPDDecider reading endpoint.Get(PrefixCacheMatchInfoKey)).
 	state.SelectedInstance = decodeDecision.TargetInstance
 	disaggDecision := cs.disaggregationDecider.Decide(req, state)
 	logrus.Debugf("[cluster] req %s: disaggregate=%v", req.ID, disaggDecision.Disaggregate)

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -230,21 +230,17 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		shedByTier:           make(map[string]int),
 	}
 
-	// PD disaggregation: set pool membership (topology already validated above)
+	// PD disaggregation: set pool membership (topology already validated above).
+	// Decider construction is deferred until after cs.cacheQueryFn is built
+	// (PrefixThresholdDecider consumes the map; see GAP-3 / issue #1263).
 	if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
 		cs.poolMembership = prePoolMembership
-		switch config.PDDecider {
-		case "prefix-threshold":
-			cs.disaggregationDecider = sim.NewPrefixThresholdDecider(config.PDPrefixThreshold, int(config.BlockSizeTokens))
-		default:
-			cs.disaggregationDecider = sim.NewDisaggregationDecider(config.PDDecider)
-		}
 		cs.parentRequests = make(map[string]*ParentRequest)
 		cs.pendingPrefillCompletions = make(map[string]string)
 		cs.pendingDecodeCompletions = make(map[string]string)
 
-		// Per-pool routing policies are created after the construction loop
-		// (need cacheQueryFn from instances).
+		// Per-pool routing policies and the disaggregation decider are created after
+		// the construction loop (both need cacheQueryFn from instances).
 
 		logrus.Infof("[cluster] PD disaggregation enabled: %d prefill, %d decode, %d shared (prefill-decode) instances, decider=%q",
 			config.PrefillInstances, config.DecodeInstances, config.SharedInstances, config.PDDecider)
@@ -357,6 +353,18 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 	}
 	if len(config.DecodeScorerConfigs) > 0 {
 		cs.decodeRoutingPolicy = sim.NewRoutingPolicyWithCache("weighted", config.DecodeScorerConfigs, config.BlockSizeTokens, rng.ForSubsystem("decode-router"), cs.cacheQueryFn)
+	}
+
+	// PD disaggregation: construct the decider now that cacheQueryFn is available.
+	// PrefixThresholdDecider consumes the per-pod cache-query map (GAP-3 / issue #1263);
+	// other deciders ignore state but share the same construction point.
+	if config.PrefillInstances > 0 || config.DecodeInstances > 0 || config.SharedInstances > 0 {
+		switch config.PDDecider {
+		case "prefix-threshold":
+			cs.disaggregationDecider = sim.NewPrefixThresholdDecider(config.PDPrefixThreshold, int(config.BlockSizeTokens), cs.cacheQueryFn)
+		default:
+			cs.disaggregationDecider = sim.NewDisaggregationDecider(config.PDDecider)
+		}
 	}
 
 	// Phase 1C: initialize autoscaler pipeline when ModelAutoscalerIntervalUs > 0 (issue #692).
@@ -1396,18 +1404,6 @@ func (c *ClusterSimulator) PerInstanceMetricsByID() map[string]*sim.Metrics {
 	return result
 }
 
-// notifyDisaggregationObserver calls ObserveRouting on the disaggregationDecider if it
-// implements sim.DisaggregationObserver. Called synchronously within the event loop,
-// so the prefix cache is always current at the next Decide() call.
-func (c *ClusterSimulator) notifyDisaggregationObserver(req *sim.Request, instanceID string) {
-	if c.disaggregationDecider == nil {
-		return
-	}
-	if obs, ok := c.disaggregationDecider.(sim.DisaggregationObserver); ok {
-		obs.ObserveRouting(req, instanceID)
-	}
-}
-
 // PeakConcurrentTransfers returns the maximum number of KV transfers in flight simultaneously.
 // Returns 0 when --pd-transfer-contention is disabled (backward-compat).
 func (c *ClusterSimulator) PeakConcurrentTransfers() int {
@@ -1700,9 +1696,6 @@ func (cs *ClusterSimulator) executeStandardRouting(req *sim.Request, time int64)
 			}
 
 			inst.InjectRequestOnline(req, time)
-			// Notify observer so stateful deciders (e.g., PrefixThresholdDecider) can learn
-			// from this routing decision (synchronous call — cache is always current).
-			cs.notifyDisaggregationObserver(req, decision.TargetInstance)
 			return
 		}
 	}
@@ -1738,6 +1731,10 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 	// Step 2: disaggregation decision with decode pod known. Pass the full decode-pool
 	// RouterState so the decider can query per-pod state (cache presence, load) and
 	// optionally reconsider the decode pod via DisaggregationDecision.DecodePodOverride.
+	// state.SelectedInstance tells the decider which snapshot was pre-selected by the
+	// decode routing policy (GAP-3 / issue #1263) — PrefixThresholdDecider queries
+	// the selected pod's cacheQueryFn closure for per-pod prefix cache state.
+	state.SelectedInstance = decodeDecision.TargetInstance
 	disaggDecision := cs.disaggregationDecider.Decide(req, state)
 	logrus.Debugf("[cluster] req %s: disaggregate=%v", req.ID, disaggDecision.Disaggregate)
 
@@ -1805,7 +1802,6 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 			decodeInst.RecordWarmUpRequest(req.ID)
 		}
 		decodeInst.InjectRequestOnline(req, time)
-		cs.notifyDisaggregationObserver(req, decodeDecision.TargetInstance)
 		return
 	}
 

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -654,18 +654,34 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 }
 
 // TestPrefixThreshold_PerPodCacheQuery verifies BC-1 at the cluster level
-// (issue #1263 / GAP-3): req1 (disaggregated) populates the decode pod's real
-// KV cache as part of the disaggregated pipeline (prefill → KV transfer → decode
-// lands on the selected pod); req2 (non-disaggregated) verifies that
+// for GAP-3: req1 (disaggregated) populates the decode pod's real KV cache as
+// part of the disaggregated pipeline (prefill → KV transfer → decode lands on
+// the selected pod); req2 (non-disaggregated) verifies that
 // PrefixThresholdDecider consults the pre-selected decode pod's per-pod
 // cacheQueryFn in executeDisaggregatedRouting, reducing the non-cached token
-// count below the threshold. The default weighted routing profile includes
-// `precise-prefix-cache:2` which routes req2 to the warm pod, so the query
-// sees the blocks req1 left behind. Tests the full end-to-end wiring path.
+// count below the threshold.
+//
+// Routing setup: the shared test config defaults to round-robin, which would
+// make req2's landing pod a function of routing-call count parity — fragile
+// and not representative. This test overrides RoutingPolicy to "weighted"
+// with precise-prefix-cache:2 + queue-depth:1 so req2 is routed to the warm
+// pod by the same prefix-affinity mechanism BLIS uses in production
+// (precise-prefix-cache scorer queries cacheQueryFn and prefers warm pods).
+// That is the exact mechanism PrefixThresholdDecider then re-queries via
+// state.SelectedInstance — making the per-pod cache hit the real cause of
+// the decision, not a round-robin coincidence.
 func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	const threshold = 300
 	const blockSize = 16
 	config := newTestPrefixThresholdConfig(threshold)
+	// Use prefix-affinity-dominant routing so req2 is routed to req1's decode pod
+	// by design (not round-robin coincidence). Mirrors the pattern in
+	// prefix_routing_test.go.
+	config.RoutingPolicy = "weighted"
+	config.RoutingScorerConfigs = []sim.ScorerConfig{
+		{Name: "precise-prefix-cache", Weight: 2.0},
+		{Name: "queue-depth", Weight: 1.0},
+	}
 
 	// req1: 400 tokens (25 complete blocks), no prior cache.
 	// nonCached = 400 > 300 → disaggregated; as req1 flows through the PD
@@ -685,8 +701,8 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	// req2: same 400-token prefix + 50 new tokens = 450 total.
 	// After req1 populates the decode-pod cache: nonCached = 450 - 25*16 = 450 - 400 = 50 <= 300 → NOT disaggregated.
 	// req2 arrives 2s after req1, well after req1's prefill + KV transfer + decode have populated
-	// the decode pod's KV cache. The `precise-prefix-cache` scorer in the default routing profile
-	// then routes req2 to the warm pod, so the PrefixThresholdDecider's cacheQueryFn lookup hits.
+	// the decode pod's KV cache. The `precise-prefix-cache` scorer configured above then routes
+	// req2 to the warm pod, so the PrefixThresholdDecider's cacheQueryFn lookup hits.
 	extended := make([]int, len(prefix)+50)
 	copy(extended, prefix)
 	for i := len(prefix); i < len(extended); i++ {
@@ -719,7 +735,7 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 
 	// req2 must NOT be disaggregated: the prefix is cached on the decode pod after
 	// req1's disaggregated pipeline completed — the `precise-prefix-cache` scorer
-	// in the default weighted routing profile routes req2 to the warm pod, and
+	// configured in this test routes req2 to the warm pod, and
 	// PrefixThresholdDecider's cacheQueryFn lookup sees the 25 cached blocks.
 	// Non-cached count: 450 - 400 = 50 <= 300 threshold → not disaggregated.
 	for _, pr := range cs.parentRequests {

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -653,18 +653,23 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 	}
 }
 
-// TestPrefixThreshold_ObserverWarmsCache verifies BC-PD-24 at the cluster level:
-// req1 (disaggregated) warms the prefix cache via notifyDisaggregationObserver in
-// PrefillRoutingEvent.Execute (pd_events.go); req2 (non-disaggregated) verifies that
-// the warmed cache is consulted in executeDisaggregatedRouting, reducing non-cached
-// token count below the threshold. Tests the full end-to-end wiring path.
-func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
+// TestPrefixThreshold_PerPodCacheQuery verifies BC-1 at the cluster level
+// (issue #1263 / GAP-3): req1 (disaggregated) populates the decode pod's real
+// KV cache as part of the disaggregated pipeline (prefill → KV transfer → decode
+// lands on the selected pod); req2 (non-disaggregated) verifies that
+// PrefixThresholdDecider consults the pre-selected decode pod's per-pod
+// cacheQueryFn in executeDisaggregatedRouting, reducing the non-cached token
+// count below the threshold. The default weighted routing profile includes
+// `precise-prefix-cache:2` which routes req2 to the warm pod, so the query
+// sees the blocks req1 left behind. Tests the full end-to-end wiring path.
+func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	const threshold = 300
 	const blockSize = 16
 	config := newTestPrefixThresholdConfig(threshold)
 
 	// req1: 400 tokens (25 complete blocks), no prior cache.
-	// nonCached = 400 > 300 → disaggregated; ObserveRouting warms 25 blocks in cache.
+	// nonCached = 400 > 300 → disaggregated; as req1 flows through the PD
+	// pipeline its KV cache blocks land on the selected decode pod.
 	prefix := make([]int, 400)
 	for i := range prefix {
 		prefix[i] = i + 1
@@ -678,8 +683,10 @@ func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
 	}
 
 	// req2: same 400-token prefix + 50 new tokens = 450 total.
-	// After req1 warms the cache: nonCached = 450 - 25*16 = 450 - 400 = 50 <= 300 → NOT disaggregated.
-	// req2 arrives 2s after req1, well after req1's PrefillRoutingEvent fires and warms the cache.
+	// After req1 populates the decode-pod cache: nonCached = 450 - 25*16 = 450 - 400 = 50 <= 300 → NOT disaggregated.
+	// req2 arrives 2s after req1, well after req1's prefill + KV transfer + decode have populated
+	// the decode pod's KV cache. The `precise-prefix-cache` scorer in the default routing profile
+	// then routes req2 to the warm pod, so the PrefixThresholdDecider's cacheQueryFn lookup hits.
 	extended := make([]int, len(prefix)+50)
 	copy(extended, prefix)
 	for i := len(prefix); i < len(extended); i++ {
@@ -710,12 +717,15 @@ func TestPrefixThreshold_ObserverWarmsCache(t *testing.T) {
 			"check PrefixThresholdDecider constructor wiring in NewClusterSimulator")
 	}
 
-	// req2 must NOT be disaggregated: prefix is cached after req1's PrefillRoutingEvent
-	// fires ObserveRouting, so only 50 tokens are non-cached (50 <= 300 threshold).
+	// req2 must NOT be disaggregated: the prefix is cached on the decode pod after
+	// req1's disaggregated pipeline completed — the `precise-prefix-cache` scorer
+	// in the default weighted routing profile routes req2 to the warm pod, and
+	// PrefixThresholdDecider's cacheQueryFn lookup sees the 25 cached blocks.
+	// Non-cached count: 450 - 400 = 50 <= 300 threshold → not disaggregated.
 	for _, pr := range cs.parentRequests {
 		if pr.ID == "req-follow" {
 			t.Error("req-follow (50 non-cached tokens <= 300 threshold after cache warming) must NOT be disaggregated; " +
-				"check notifyDisaggregationObserver wiring in PrefillRoutingEvent.Execute (pd_events.go)")
+				"check per-pod cacheQueryFn wiring via state.SelectedInstance (sim/cluster/cluster.go)")
 		}
 	}
 }

--- a/sim/cluster/pd_events.go
+++ b/sim/cluster/pd_events.go
@@ -79,9 +79,6 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 				cs.tenantTracker.OnStart(e.request.TenantID)
 			}
 			inst.InjectRequestOnline(e.request, e.time)
-			// Notify observer so stateful deciders (e.g., PrefixThresholdDecider) can learn
-			// from this prefill routing decision (synchronous call -- cache is always current).
-			cs.notifyDisaggregationObserver(e.request, decision.TargetInstance)
 			return
 		}
 	}

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -29,10 +29,12 @@ type DisaggregationDecision struct {
 // state carries the decode-pool RouterState — the same snapshots used to
 // pre-select the decode pod. state.SelectedInstance holds the ID of the pod
 // chosen by the decode routing policy. Implementations may read any field of
-// state except Request.OutputTokens. state may be nil in unit tests and for
-// state-agnostic deciders; implementations must tolerate a nil pointer.
-// Passing the full RouterState (rather than a single snapshot) lets joint D+P
-// policies reconsider the decode pod via DisaggregationDecision.DecodePodOverride.
+// state except Request.OutputTokens. state is guaranteed non-nil at runtime
+// (executeDisaggregatedRouting returns at the empty-decode-pool guard before
+// calling Decide), but implementations must still tolerate a nil pointer for
+// unit-test convenience. Passing the full RouterState (rather than a single
+// snapshot) lets joint D+P policies reconsider the decode pod via
+// DisaggregationDecision.DecodePodOverride.
 type DisaggregationDecider interface {
 	Decide(req *Request, state *RouterState) DisaggregationDecision
 }

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -2,8 +2,6 @@ package sim
 
 import (
 	"fmt"
-
-	"github.com/sirupsen/logrus"
 )
 
 // DisaggregationDecision encapsulates the prefill-decode disaggregation decision for a request.
@@ -28,16 +26,13 @@ type DisaggregationDecision struct {
 // use len(req.InputTokens) and req.MaxOutputLen only.
 //
 // req is guaranteed non-nil; implementations may assume a non-nil pointer.
-// state is the RouterState built from the decode pool — the same snapshots used
-// to pre-select the decode pod. Implementations may read any field of state
-// except Request.OutputTokens. state is guaranteed non-nil in practice: the
-// empty-pool case is rejected before Decide is called. Passing the full
-// RouterState (rather than a single snapshot) lets joint D+P policies reconsider
-// the decode pod via DisaggregationDecision.DecodePodOverride and keeps future
-// design open (GAP-3 will use state.Snapshots for per-pod cache queries).
-//
-// Stateful implementations may additionally implement DisaggregationObserver to
-// learn from routing outcomes (e.g., PrefixThresholdDecider).
+// state carries the decode-pool RouterState — the same snapshots used to
+// pre-select the decode pod. state.SelectedInstance holds the ID of the pod
+// chosen by the decode routing policy. Implementations may read any field of
+// state except Request.OutputTokens. state may be nil in unit tests and for
+// state-agnostic deciders; implementations must tolerate a nil pointer.
+// Passing the full RouterState (rather than a single snapshot) lets joint D+P
+// policies reconsider the decode pod via DisaggregationDecision.DecodePodOverride.
 type DisaggregationDecider interface {
 	Decide(req *Request, state *RouterState) DisaggregationDecision
 }
@@ -62,7 +57,7 @@ func (a *AlwaysDisaggregate) Decide(_ *Request, _ *RouterState) DisaggregationDe
 // Valid names are defined in validDisaggregationDeciders (bundle.go).
 // An empty string defaults to NeverDisaggregate.
 // Panics on unrecognized names or on "prefix-threshold" (use NewPrefixThresholdDecider
-// directly, as it requires a caller-supplied threshold).
+// directly, as it requires a caller-supplied threshold and cache-query map).
 func NewDisaggregationDecider(name string) DisaggregationDecider {
 	if !IsValidDisaggregationDecider(name) {
 		panic(fmt.Sprintf("unknown disaggregation decider %q", name))
@@ -73,7 +68,7 @@ func NewDisaggregationDecider(name string) DisaggregationDecider {
 	case "always":
 		return &AlwaysDisaggregate{}
 	case "prefix-threshold":
-		panic("use NewPrefixThresholdDecider(threshold, blockSize) to construct prefix-threshold decider")
+		panic("use NewPrefixThresholdDecider(threshold, blockSize, cacheQuery) to construct prefix-threshold decider")
 	default:
 		panic(fmt.Sprintf(
 			"disaggregation decider %q is registered in validDisaggregationDeciders (bundle.go) "+
@@ -82,65 +77,36 @@ func NewDisaggregationDecider(name string) DisaggregationDecider {
 	}
 }
 
-// globalVirtualInstance is the single key used in PrefixThresholdDecider's PrefixCacheIndex
-// to represent cluster-wide prefix knowledge. All requests update the same virtual instance
-// so the decider tracks the global set of recently-seen prefixes.
-// Using a single virtual key repurposes the per-instance PrefixCacheIndex structure to
-// maintain one aggregate view of cluster-wide prefix state without modifying its interface.
-// Collision with real instance IDs is not a risk: instance IDs use a numeric index (e.g.,
-// "instance_0"), whereas this sentinel uses the "__" prefix convention.
-const globalVirtualInstance = "__global__"
-
-// defaultDisaggLRUCapacity is the number of block hash slots tracked in PrefixThresholdDecider's
-// router-side prefix cache (LRU capacity). Independent of block size.
-const defaultDisaggLRUCapacity = 10000
-
-// DisaggregationObserver is an optional interface for stateful DisaggregationDeciders that need
-// to learn from routing decisions. ClusterSimulator calls ObserveRouting after each routing
-// decision that assigns a request to an instance: after standard routing (RoutingDecisionEvent
-// in cluster_event.go) and after prefill routing (PrefillRoutingEvent in pd_events.go).
-// It is not called for decode routing, because the decider's prefix knowledge is based on
-// input tokens, which are identical between prefill and decode sub-requests.
+// PrefixThresholdDecider disaggregates a request when the tokens not already
+// cached on the pre-selected decode pod exceed a configured threshold.
+// Matches llm-d's PrefixBasedPDDecider.disaggregate, which reads per-endpoint
+// PrefixCacheMatchInfo from the selected decode endpoint.
 //
-// ObserveRouting is called synchronously within the event loop immediately after each
-// routing decision, so the prefix cache is always current at the next Decide() call.
+// Formula:
 //
-// req is guaranteed non-nil. Implementations must treat req as read-only.
-// instanceID is the routing target; implementations maintaining per-instance state should
-// record it; implementations with global state (like PrefixThresholdDecider) may ignore it.
-type DisaggregationObserver interface {
-	ObserveRouting(req *Request, instanceID string)
-}
-
-// PrefixThresholdDecider disaggregates a request when its non-cached token count exceeds
-// the configured threshold. Maintains a router-side prefix cache (globalVirtualInstance)
-// to estimate how many input tokens are already cached cluster-wide.
+//	nonCachedTokens = len(req.InputTokens) − cachedBlocks × blockSize
+//	Disaggregate    = (nonCachedTokens > threshold)
 //
-// Non-cached token count: len(req.InputTokens) - cachedBlocks * blockSize (always >= 0,
-// because ComputeBlockHashes only produces complete-block hashes so cachedBlocks*blockSize
-// never exceeds len(InputTokens)). threshold and blockSize are in token counts, not bytes.
-// Decision: Disaggregate = (nonCachedTokens > threshold).
+// where cachedBlocks is obtained by calling cacheQuery[state.SelectedInstance]
+// on req.InputTokens. threshold and blockSize are in token counts, not bytes.
 //
-// The prefix cache is always current at decision time: ObserveRouting is called
-// synchronously within the event loop immediately after each routing decision.
-//
-// Threading: cachedHashes and cachedReqID are a single-use scratchpad — Decide() writes
-// them and ObserveRouting() consumes and clears them. This is safe only because the DES
-// event loop is single-threaded: no Decide() can interleave between a Decide() call and
-// its paired ObserveRouting() call. If routing is rejected after Decide() (no routable
-// instances), ObserveRouting() is not called; the stale scratchpad is harmlessly
-// overwritten by the next Decide() call.
+// cacheQuery shares the same map used by the precise-prefix-cache scorer
+// (wired in sim/cluster/cluster.go from CachedSnapshotProvider.BuildCacheQueryFn).
+// Staleness is inherited from that provider — see --cache-signal-delay (INV-7).
 type PrefixThresholdDecider struct {
-	threshold    int
-	blockSize    int
-	idx          *PrefixCacheIndex
-	cachedHashes []string
-	cachedReqID  string
+	threshold  int
+	blockSize  int
+	cacheQuery map[string]func([]int) int
 }
 
-// NewPrefixThresholdDecider creates a PrefixThresholdDecider with the given threshold and block size.
+// NewPrefixThresholdDecider creates a PrefixThresholdDecider with the given
+// threshold, block size, and per-pod cache-query map.
 // threshold must be >= 0; blockSize must be > 0. Panics otherwise (R3).
-func NewPrefixThresholdDecider(threshold, blockSize int) *PrefixThresholdDecider {
+// cacheQuery may be nil (e.g. unit tests without cluster state); when nil or
+// when state.SelectedInstance is missing from the map, Decide returns
+// Disaggregate=false (conservative fallback, consistent with llm-d's
+// nil-endpoint guard at prefix_based_pd_decider.go:108-111).
+func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]func([]int) int) *PrefixThresholdDecider {
 	if threshold < 0 {
 		panic(fmt.Sprintf("NewPrefixThresholdDecider: threshold must be >= 0, got %d", threshold))
 	}
@@ -148,55 +114,40 @@ func NewPrefixThresholdDecider(threshold, blockSize int) *PrefixThresholdDecider
 		panic(fmt.Sprintf("NewPrefixThresholdDecider: blockSize must be > 0, got %d", blockSize))
 	}
 	return &PrefixThresholdDecider{
-		threshold: threshold,
-		blockSize: blockSize,
-		idx:       NewPrefixCacheIndex(blockSize, defaultDisaggLRUCapacity),
+		threshold:  threshold,
+		blockSize:  blockSize,
+		cacheQuery: cacheQuery,
 	}
 }
 
-// Decide returns Disaggregate=true when non-cached token count exceeds the threshold.
-// Empty requests (len(InputTokens) == 0) always return Disaggregate=false.
-// Caches block hashes for reuse by ObserveRouting when the same request is routed next.
-// The state argument is accepted for interface conformance and is currently ignored;
-// issue #1263 (GAP-3) will replace the cluster-wide cache estimate with per-pod
-// cache state queried from state.Snapshots.
-func (p *PrefixThresholdDecider) Decide(req *Request, _ *RouterState) DisaggregationDecision {
+// Decide returns Disaggregate=true when the number of input tokens not cached
+// on the pre-selected decode pod exceeds the threshold.
+//
+// Early returns (all yielding Disaggregate=false):
+//   - len(req.InputTokens) == 0
+//   - state == nil
+//   - state.SelectedInstance == "" (no upstream selection)
+//   - cacheQuery is nil, or the selected instance is missing from the map,
+//     or its closure is nil (pod not yet registered / just removed)
+func (p *PrefixThresholdDecider) Decide(req *Request, state *RouterState) DisaggregationDecision {
 	if len(req.InputTokens) == 0 {
 		return DisaggregationDecision{Disaggregate: false}
 	}
-	p.cachedHashes = p.idx.ComputeBlockHashes(req.InputTokens)
-	p.cachedReqID = req.ID
-	cachedBlocks := p.idx.MatchLength(p.cachedHashes, globalVirtualInstance)
+	if state == nil || state.SelectedInstance == "" || p.cacheQuery == nil {
+		return DisaggregationDecision{Disaggregate: false}
+	}
+	fn, ok := p.cacheQuery[state.SelectedInstance]
+	if !ok || fn == nil {
+		return DisaggregationDecision{Disaggregate: false}
+	}
+	cachedBlocks := fn(req.InputTokens)
 	nonCachedTokens := len(req.InputTokens) - cachedBlocks*p.blockSize
 	return DisaggregationDecision{Disaggregate: nonCachedTokens > p.threshold}
 }
 
-// ObserveRouting updates the prefix cache after a routing decision, recording the request's
-// block hashes under globalVirtualInstance. Reuses hashes from Decide when the request ID
-// matches; otherwise recomputes. The ID mismatch case is expected in the disaggregated path:
-// notifyDisaggregationObserver is called with the prefill sub-request (ID "<parent>_prefill"),
-// which differs from the parent request evaluated by Decide.
-func (p *PrefixThresholdDecider) ObserveRouting(req *Request, _ string) {
-	if req == nil {
-		logrus.Errorf("PrefixThresholdDecider.ObserveRouting: req is nil (contract violation); skipping cache update")
-		return
-	}
-	if len(req.InputTokens) == 0 {
-		return // no complete blocks to record; consistent with Decide's early-return for empty tokens
-	}
-	hashes := p.cachedHashes
-	if req.ID != p.cachedReqID || p.cachedHashes == nil {
-		hashes = p.idx.ComputeBlockHashes(req.InputTokens)
-	}
-	p.idx.RecordBlocks(hashes, globalVirtualInstance)
-	p.cachedHashes = nil
-	p.cachedReqID = ""
-}
-
 // Compile-time interface compliance checks.
 var (
-	_ DisaggregationDecider  = (*NeverDisaggregate)(nil)
-	_ DisaggregationDecider  = (*AlwaysDisaggregate)(nil)
-	_ DisaggregationDecider  = (*PrefixThresholdDecider)(nil)
-	_ DisaggregationObserver = (*PrefixThresholdDecider)(nil)
+	_ DisaggregationDecider = (*NeverDisaggregate)(nil)
+	_ DisaggregationDecider = (*AlwaysDisaggregate)(nil)
+	_ DisaggregationDecider = (*PrefixThresholdDecider)(nil)
 )

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -35,6 +35,7 @@ func TestAlwaysDisaggregate_AlwaysReturnsTrue(t *testing.T) {
 func TestDisaggregationDecider_Interface(t *testing.T) {
 	var _ DisaggregationDecider = &NeverDisaggregate{}
 	var _ DisaggregationDecider = &AlwaysDisaggregate{}
+	var _ DisaggregationDecider = &PrefixThresholdDecider{}
 }
 
 // TestNewDisaggregationDecider_Factory verifies factory dispatches correctly
@@ -141,14 +142,24 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 	req1 := &Request{ID: "req-1", InputTokens: make([]int, 100), OutputTokens: nil}
 	req2 := &Request{ID: "req-2", InputTokens: make([]int, 100), OutputTokens: make([]int, 9999)}
 
+	// Stub cacheQuery returning 0 blocks for any instance — exercises Decide's
+	// formula path without depending on real cluster state.
+	stubCache := map[string]func([]int) int{
+		"decode_0": func([]int) int { return 0 },
+	}
+	state := &RouterState{
+		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
+		SelectedInstance: "decode_0",
+	}
+
 	deciders := []DisaggregationDecider{
 		&NeverDisaggregate{},
 		&AlwaysDisaggregate{},
-		NewPrefixThresholdDecider(512, 16),
+		NewPrefixThresholdDecider(512, 16, stubCache),
 	}
 	for _, d := range deciders {
-		d1 := d.Decide(req1, (*RouterState)(nil))
-		d2 := d.Decide(req2, (*RouterState)(nil))
+		d1 := d.Decide(req1, state)
+		d2 := d.Decide(req2, state)
 		if d1 != d2 {
 			t.Errorf("%T: decision differs with different OutputTokens (d1=%v, d2=%v); INV-9 violation",
 				d, d1, d2)
@@ -156,12 +167,11 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 	}
 }
 
-// TestDisaggregationDecider_StateAgnostic verifies BC-1/BC-2: all built-in
-// deciders accept a *RouterState argument and produce identical decisions
-// regardless of state content (nil vs populated). NeverDisaggregate and
-// AlwaysDisaggregate are constant; PrefixThresholdDecider does not yet consume
-// state (issue #1263 / GAP-3 will wire it in) and must therefore also be
-// invariant under this change.
+// TestDisaggregationDecider_StateAgnostic verifies BC-2 (from PR #1265 / GAP-2):
+// NeverDisaggregate and AlwaysDisaggregate ignore state entirely — nil vs populated
+// state yields identical decisions. PrefixThresholdDecider is intentionally NOT in
+// this list anymore: after GAP-3, its decision depends on state.SelectedInstance
+// and the cache query map; it has its own dedicated tests below.
 func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
 	nilState := (*RouterState)(nil)
@@ -170,13 +180,13 @@ func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 			{ID: "decode_0", QueueDepth: 7, KVUtilization: 0.4},
 			{ID: "decode_1", QueueDepth: 2, KVUtilization: 0.9},
 		},
-		Clock: 12345,
+		Clock:            12345,
+		SelectedInstance: "decode_1",
 	}
 
 	deciders := []DisaggregationDecider{
 		&NeverDisaggregate{},
 		&AlwaysDisaggregate{},
-		NewPrefixThresholdDecider(512, 16),
 	}
 	for _, d := range deciders {
 		gotNil := d.Decide(req, nilState)
@@ -196,12 +206,18 @@ func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 // and any regression that accidentally populates one will fail this test.
 func TestDisaggregationDecider_BuiltinsReturnNoOverrides(t *testing.T) {
 	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
-	state := &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}}
+	stubCache := map[string]func([]int) int{
+		"decode_0": func([]int) int { return 0 },
+	}
+	state := &RouterState{
+		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
+		SelectedInstance: "decode_0",
+	}
 
 	deciders := []DisaggregationDecider{
 		&NeverDisaggregate{},
 		&AlwaysDisaggregate{},
-		NewPrefixThresholdDecider(512, 16),
+		NewPrefixThresholdDecider(512, 16, stubCache),
 	}
 	for _, d := range deciders {
 		got := d.Decide(req, state)
@@ -223,7 +239,7 @@ func TestNewPrefixThresholdDecider_PanicsOnNegativeThreshold(t *testing.T) {
 			t.Error("expected panic for negative threshold")
 		}
 	}()
-	NewPrefixThresholdDecider(-1, 16)
+	NewPrefixThresholdDecider(-1, 16, nil)
 }
 
 // TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize verifies constructor validates blockSize.
@@ -233,42 +249,44 @@ func TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize(t *testing.T) {
 			t.Error("expected panic for zero blockSize")
 		}
 	}()
-	NewPrefixThresholdDecider(512, 0)
+	NewPrefixThresholdDecider(512, 0, nil)
 }
 
-// noopDisaggregationObserver is a no-op DisaggregationObserver used in tests to satisfy R13:
-// DisaggregationObserver must work for >=2 backends (not tightly coupled to PrefixThresholdDecider).
-// Any future stateful decider (e.g., adaptive-rate, popularity-based) should also implement it.
-type noopDisaggregationObserver struct{}
-
-func (*noopDisaggregationObserver) ObserveRouting(_ *Request, _ string) {}
-
-// TestPrefixThresholdDecider_Interface verifies PrefixThresholdDecider satisfies both interfaces.
-// Also verifies DisaggregationObserver is a general extension point (R13: works for >=2 backends).
-func TestPrefixThresholdDecider_Interface(t *testing.T) {
-	var _ DisaggregationDecider = &PrefixThresholdDecider{}
-	var _ DisaggregationObserver = &PrefixThresholdDecider{}
-	var _ DisaggregationObserver = &noopDisaggregationObserver{} // R13: second backend
-}
-
-// TestPrefixThresholdDecider_EmptyTokens verifies BC-PD-20: empty input returns Disaggregate=false.
-func TestPrefixThresholdDecider_EmptyTokens(t *testing.T) {
-	decider := NewPrefixThresholdDecider(512, 16)
-	req := &Request{ID: "req-empty", InputTokens: []int{}}
-
-	decision := decider.Decide(req, (*RouterState)(nil))
-
-	if decision.Disaggregate {
-		t.Error("BC-PD-20: empty InputTokens must return Disaggregate=false")
+// coldState builds a RouterState whose selected instance maps to a 0-blocks
+// cache query — the decider's formula is exercised with cachedBlocks=0, so
+// nonCachedTokens == len(InputTokens).
+func coldState(selectedID string) *RouterState {
+	return &RouterState{
+		Snapshots:        []RoutingSnapshot{{ID: selectedID}},
+		SelectedInstance: selectedID,
 	}
 }
 
-// TestPrefixThresholdDecider_AboveThreshold verifies BC-PD-21: non-cached tokens > threshold -> true.
+func coldCache(selectedID string) map[string]func([]int) int {
+	return map[string]func([]int) int{
+		selectedID: func([]int) int { return 0 },
+	}
+}
+
+// TestPrefixThresholdDecider_EmptyTokens verifies BC-3: empty input returns Disaggregate=false.
+func TestPrefixThresholdDecider_EmptyTokens(t *testing.T) {
+	decider := NewPrefixThresholdDecider(512, 16, coldCache("decode_0"))
+	req := &Request{ID: "req-empty", InputTokens: []int{}}
+
+	decision := decider.Decide(req, coldState("decode_0"))
+
+	if decision.Disaggregate {
+		t.Error("BC-3: empty InputTokens must return Disaggregate=false")
+	}
+}
+
+// TestPrefixThresholdDecider_AboveThreshold verifies BC-2: non-cached tokens > threshold -> true.
 // Uses threshold+1 as the boundary case to pin the strict > semantics (not >=).
 func TestPrefixThresholdDecider_AboveThreshold(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
+	decider := NewPrefixThresholdDecider(threshold, blockSize, coldCache("decode_0"))
+	state := coldState("decode_0")
 
 	tests := []struct {
 		name   string
@@ -281,25 +299,26 @@ func TestPrefixThresholdDecider_AboveThreshold(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tokens := make([]int, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1 // unique tokens, no cache hit
+				tokens[i] = i + 1 // unique tokens
 			}
 			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
 
-			decision := decider.Decide(req, (*RouterState)(nil))
+			decision := decider.Decide(req, state)
 
 			if !decision.Disaggregate {
-				t.Errorf("BC-PD-21: %d uncached tokens with threshold=%d should return Disaggregate=true",
+				t.Errorf("BC-2: %d uncached tokens with threshold=%d should return Disaggregate=true",
 					tc.tokens, threshold)
 			}
 		})
 	}
 }
 
-// TestPrefixThresholdDecider_BelowOrAtThreshold verifies BC-PD-22: non-cached <= threshold -> false.
+// TestPrefixThresholdDecider_BelowOrAtThreshold verifies BC-2: non-cached <= threshold -> false.
 func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
+	decider := NewPrefixThresholdDecider(threshold, blockSize, coldCache("decode_0"))
+	state := coldState("decode_0")
 
 	tests := []struct {
 		name   string
@@ -312,122 +331,205 @@ func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tokens := make([]int, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1000 // unique tokens, no cache hit
+				tokens[i] = i + 1000 // unique tokens
 			}
 			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
 
-			decision := decider.Decide(req, (*RouterState)(nil))
+			decision := decider.Decide(req, state)
 
 			if decision.Disaggregate {
-				t.Errorf("BC-PD-22: %d non-cached tokens with threshold=%d should return Disaggregate=false",
+				t.Errorf("BC-2: %d non-cached tokens with threshold=%d should return Disaggregate=false",
 					tc.tokens, threshold)
 			}
 		})
 	}
 }
 
-// TestPrefixThresholdDecider_CacheAware verifies BC-PD-24: cached prefix reduces non-cached count.
-// Scenario: warm cache has N blocks cached. New request with same prefix + additional tokens.
-// Non-cached tokens = total_tokens - cached_blocks * blockSize.
-func TestPrefixThresholdDecider_CacheAware(t *testing.T) {
+// TestPrefixThresholdDecider_PerPodCacheQuery verifies BC-1: the decider reads
+// cached block count from the SELECTED pod's closure, and BC-4: a cache hit on
+// one pod does not influence a decision targeting a different pod.
+//
+// Scenario:
+//   - decode_A has 40 cached blocks (640 tokens) for the input.
+//   - decode_B has 0 cached blocks (cold).
+//   - threshold=512, blockSize=16.
+//   - Request has 840 input tokens.
+//
+// Expected:
+//   - SelectedInstance="decode_A": nonCached = 840 - 40*16 = 200 ≤ 512 → false.
+//   - SelectedInstance="decode_B": nonCached = 840 - 0*16  = 840 > 512 → true.
+func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
-
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
-
-	// Warm cache: record 40 blocks (640 tokens) for a known prefix.
-	// Use consecutive tokens 1..640 as the shared prefix.
-	prefix := make([]int, 640) // 40 blocks
-	for i := range prefix {
-		prefix[i] = i + 1
+	cacheQuery := map[string]func([]int) int{
+		"decode_A": func([]int) int { return 40 },
+		"decode_B": func([]int) int { return 0 },
 	}
-	prefixReq := &Request{ID: "req-warm", InputTokens: prefix}
-	// Calling Decide records cachedHashes, then ObserveRouting warms the cache.
-	decider.Decide(prefixReq, (*RouterState)(nil))
-	decider.ObserveRouting(prefixReq, "instance_0")
+	decider := NewPrefixThresholdDecider(threshold, blockSize, cacheQuery)
 
-	// New request: same 640-token prefix + 200 new tokens = 840 tokens total.
-	// Cached: 40 blocks * 16 = 640 tokens. Non-cached: 840 - 640 = 200 tokens.
-	// 200 <= 512 threshold -> should NOT disaggregate.
-	extended := make([]int, len(prefix)+200)
-	copy(extended, prefix)
-	for i := len(prefix); i < len(extended); i++ {
-		extended[i] = 10000 + i // unique suffix tokens
+	tokens := make([]int, 840)
+	for i := range tokens {
+		tokens[i] = i + 1
 	}
-	req := &Request{ID: "req-cached", InputTokens: extended}
+	req := &Request{ID: "req-multi-pod", InputTokens: tokens}
 
-	decision := decider.Decide(req, (*RouterState)(nil))
-
-	if decision.Disaggregate {
-		t.Errorf("BC-PD-24: with 640 tokens cached (40 blocks), 200 non-cached tokens should not disaggregate (threshold=%d)", threshold)
+	tests := []struct {
+		selectedInstance string
+		wantDisagg       bool
+		reason           string
+	}{
+		{"decode_A", false, "warm pod: 840-640=200 ≤ 512"},
+		{"decode_B", true, "cold pod: 840-0=840 > 512"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.selectedInstance, func(t *testing.T) {
+			state := &RouterState{
+				Snapshots: []RoutingSnapshot{
+					{ID: "decode_A"},
+					{ID: "decode_B"},
+				},
+				SelectedInstance: tc.selectedInstance,
+			}
+			got := decider.Decide(req, state).Disaggregate
+			if got != tc.wantDisagg {
+				t.Errorf("SelectedInstance=%s: Disaggregate=%v, want %v (%s)",
+					tc.selectedInstance, got, tc.wantDisagg, tc.reason)
+			}
+		})
 	}
 }
 
-// TestPrefixThresholdDecider_CacheAware_SubRequestIDMismatch verifies BC-PD-24 via the
-// disaggregated pipeline path: ObserveRouting is called with a sub-request whose ID
-// differs from the parent request passed to Decide (e.g., "<parent>_prefill" vs "<parent>").
-// ObserveRouting must recompute hashes and still correctly populate the cache.
-func TestPrefixThresholdDecider_CacheAware_SubRequestIDMismatch(t *testing.T) {
+// TestPrefixThresholdDecider_MissingSelection_ReturnsFalse verifies BC-3 — the
+// conservative-cold fallback paths. In any of these four scenarios the decider
+// cannot locate a valid per-pod cache closure, so it returns Disaggregate=false:
+//  1. state == nil
+//  2. state.SelectedInstance == "" (upstream made no selection)
+//  3. state.SelectedInstance is not a key in cacheQuery
+//  4. cacheQuery[SelectedInstance] is nil
+//
+// (A separate path — cacheQuery itself is nil — is covered at the end.)
+func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
+	const threshold = 100
 	const blockSize = 16
-	const threshold = 512
-	decider := NewPrefixThresholdDecider(threshold, blockSize)
-
-	// Shared prefix: 40 blocks (640 tokens), unique token values.
-	prefix := make([]int, 640)
-	for i := range prefix {
-		prefix[i] = i + 1
+	// Request is large enough that if the selected-pod path were taken with a
+	// 0-blocks closure, the decision would be Disaggregate=true. So any test
+	// that observes Disaggregate=false proves the early-return fired.
+	tokens := make([]int, 400) // 400 > 100 threshold
+	for i := range tokens {
+		tokens[i] = i + 1
 	}
+	req := &Request{ID: "req-missing", InputTokens: tokens}
 
-	// Step 1: Decide is called with the parent request.
-	parentReq := &Request{ID: "req-parent", InputTokens: prefix}
-	decider.Decide(parentReq, (*RouterState)(nil))
-
-	// Step 2: Overwrite cachedHashes with a stale unrelated request so that ObserveRouting
-	// MUST recompute when it sees the mismatched sub-request ID. Without this step, the
-	// original test cannot detect an inversion of the != check: parentReq and subReq share
-	// the same token content, so stale hashes from parentReq would produce the same result.
-	staleReq := &Request{ID: "req-stale", InputTokens: []int{99999, 99998}} // < blockSize, 0 hashes
-	decider.Decide(staleReq, (*RouterState)(nil)) // overwrites cachedHashes (empty) and cachedReqID = "req-stale"
-
-	// Step 3: ObserveRouting is called with a sub-request (different ID from stale, same
-	// InputTokens as prefix). ID mismatch must trigger recompute — without it the empty stale
-	// hashes would be recorded and the follow-up request would incorrectly disaggregate.
-	subReq := &Request{ID: "req-parent_prefill", InputTokens: prefix}
-	decider.ObserveRouting(subReq, "prefill_0") // ID mismatch → must recompute + record
-
-	// Step 4: New request with same prefix + 200 unique tokens = 840 total.
-	// Cached: 40 blocks * 16 = 640 tokens. Non-cached: 200 <= 512 → should NOT disaggregate.
-	extended := make([]int, len(prefix)+200)
-	copy(extended, prefix)
-	for i := len(prefix); i < len(extended); i++ {
-		extended[i] = 10000 + i
+	tests := []struct {
+		name       string
+		cacheQuery map[string]func([]int) int
+		state      *RouterState
+	}{
+		{
+			name:       "nil_state",
+			cacheQuery: coldCache("decode_0"),
+			state:      nil,
+		},
+		{
+			name:       "empty_selected_instance",
+			cacheQuery: coldCache("decode_0"),
+			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedInstance: ""},
+		},
+		{
+			name:       "unknown_selected_instance",
+			cacheQuery: coldCache("decode_0"),
+			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedInstance: "decode_X"},
+		},
+		{
+			name: "nil_closure_in_map",
+			cacheQuery: map[string]func([]int) int{
+				"decode_0": nil,
+			},
+			state: coldState("decode_0"),
+		},
+		{
+			name:       "nil_cacheQuery_map",
+			cacheQuery: nil,
+			state:      coldState("decode_0"),
+		},
 	}
-	req := &Request{ID: "req-follow", InputTokens: extended}
-
-	decision := decider.Decide(req, (*RouterState)(nil))
-
-	if decision.Disaggregate {
-		t.Errorf("CacheAware/SubRequestIDMismatch: ObserveRouting with mismatched ID should still "+
-			"populate the cache; 200 non-cached tokens should not disaggregate (threshold=%d)", threshold)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decider := NewPrefixThresholdDecider(threshold, blockSize, tc.cacheQuery)
+			got := decider.Decide(req, tc.state).Disaggregate
+			if got {
+				t.Errorf("BC-3 %s: expected Disaggregate=false (conservative fallback), got true", tc.name)
+			}
+		})
 	}
 }
 
-// TestPrefixThresholdDecider_ZeroThreshold verifies threshold=0 means always disaggregate
-// when tokens are non-empty (any non-cached token > 0).
+// TestPrefixThresholdDecider_ZeroThreshold verifies threshold=0 means any
+// non-empty request with non-zero non-cached tokens disaggregates. A fully-
+// cached request (0 non-cached tokens) does NOT disaggregate (strict >).
 func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
 	const blockSize = 16
-	decider := NewPrefixThresholdDecider(0, blockSize)
 
-	// 100 uncached tokens -> 100 > 0 -> disaggregate
+	// Case 1: cold pod, any non-empty input → disaggregate.
+	decider := NewPrefixThresholdDecider(0, blockSize, coldCache("decode_0"))
 	tokens := make([]int, 100)
 	for i := range tokens {
 		tokens[i] = i + 1
 	}
-	req := &Request{ID: "req-zero-thresh", InputTokens: tokens}
-
-	decision := decider.Decide(req, (*RouterState)(nil))
-
-	if !decision.Disaggregate {
+	req := &Request{ID: "req-zero-thresh-cold", InputTokens: tokens}
+	if !decider.Decide(req, coldState("decode_0")).Disaggregate {
 		t.Error("threshold=0 with non-empty uncached tokens should return Disaggregate=true")
+	}
+
+	// Case 2: fully-cached prefix (cachedBlocks * blockSize == len(tokens))
+	// → nonCached = 0, 0 > 0 is false → NOT disaggregate.
+	//
+	// This pins the strict > semantics at the boundary, guarding against an
+	// accidental >= flip in the formula.
+	fullCache := map[string]func([]int) int{
+		"decode_0": func(t []int) int { return len(t) / blockSize },
+	}
+	fullyCachedDecider := NewPrefixThresholdDecider(0, blockSize, fullCache)
+	exactBlocks := make([]int, 64) // 64 tokens = 4 full blocks
+	for i := range exactBlocks {
+		exactBlocks[i] = i + 1
+	}
+	reqFull := &Request{ID: "req-fully-cached", InputTokens: exactBlocks}
+	if fullyCachedDecider.Decide(reqFull, coldState("decode_0")).Disaggregate {
+		t.Error("threshold=0 with fully-cached tokens (nonCached=0) should return Disaggregate=false (strict >)")
+	}
+}
+
+// TestPrefixThresholdDecider_QueriesOnlySelectedPod verifies BC-1 (isolation): when
+// Decide runs, it invokes the closure for SelectedInstance exactly once and does not
+// invoke closures for any other instance in the map. This guards against an accidental
+// "scan all pods" regression (option (b) in the #1265 review comment was explicitly
+// rejected; we implement option (a) — query only the selected pod).
+func TestPrefixThresholdDecider_QueriesOnlySelectedPod(t *testing.T) {
+	var aCalls, bCalls int
+	cacheQuery := map[string]func([]int) int{
+		"decode_A": func([]int) int { aCalls++; return 0 },
+		"decode_B": func([]int) int { bCalls++; return 0 },
+	}
+	decider := NewPrefixThresholdDecider(512, 16, cacheQuery)
+
+	req := &Request{ID: "req-isolation", InputTokens: make([]int, 100)}
+	for i := range req.InputTokens {
+		req.InputTokens[i] = i + 1
+	}
+	state := &RouterState{
+		Snapshots: []RoutingSnapshot{
+			{ID: "decode_A"},
+			{ID: "decode_B"},
+		},
+		SelectedInstance: "decode_A",
+	}
+	decider.Decide(req, state)
+
+	if aCalls != 1 {
+		t.Errorf("decode_A closure called %d times, want 1", aCalls)
+	}
+	if bCalls != 0 {
+		t.Errorf("decode_B closure called %d times, want 0 (must not query non-selected pods)", bCalls)
 	}
 }

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -252,9 +252,11 @@ func TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize(t *testing.T) {
 	NewPrefixThresholdDecider(512, 0, nil)
 }
 
-// coldState builds a RouterState whose selected instance maps to a 0-blocks
-// cache query — the decider's formula is exercised with cachedBlocks=0, so
-// nonCachedTokens == len(InputTokens).
+// coldState builds a RouterState with SelectedInstance set to selectedID.
+// Pair with a coldCache(selectedID)-constructed decider to exercise the
+// formula with cachedBlocks=0 (so nonCachedTokens == len(InputTokens)).
+// RouterState itself carries no cache query; the cache query lives on the
+// decider via cacheQuery.
 func coldState(selectedID string) *RouterState {
 	return &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: selectedID}},
@@ -400,14 +402,13 @@ func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 }
 
 // TestPrefixThresholdDecider_MissingSelection_ReturnsFalse verifies BC-3 — the
-// conservative-cold fallback paths. In any of these four scenarios the decider
+// conservative-cold fallback paths. In any of these five scenarios the decider
 // cannot locate a valid per-pod cache closure, so it returns Disaggregate=false:
 //  1. state == nil
 //  2. state.SelectedInstance == "" (upstream made no selection)
 //  3. state.SelectedInstance is not a key in cacheQuery
-//  4. cacheQuery[SelectedInstance] is nil
-//
-// (A separate path — cacheQuery itself is nil — is covered at the end.)
+//  4. cacheQuery[SelectedInstance] is nil (closure missing at the key)
+//  5. cacheQuery itself is nil (unit tests without cluster state)
 func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
 	const threshold = 100
 	const blockSize = 16

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -264,6 +264,10 @@ func coldState(selectedID string) *RouterState {
 	}
 }
 
+// coldCache builds a cacheQuery map with a single entry for selectedID whose
+// closure always returns 0 cached blocks. Pair with coldState(selectedID) to
+// exercise the decider's formula with cachedBlocks=0 — i.e. the selected pod
+// is known but has none of the input cached.
 func coldCache(selectedID string) map[string]func([]int) int {
 	return map[string]func([]int) int{
 		selectedID: func([]int) int { return 0 },

--- a/sim/router_state.go
+++ b/sim/router_state.go
@@ -21,8 +21,11 @@ type RouterState struct {
 	// (typically the decode-routing policy) before invoking a
 	// DisaggregationDecider. Empty for contexts where no prior selection has
 	// been made (e.g., RoutingPolicy.Route itself receives RouterState with
-	// SelectedInstance == ""). DisaggregationDecider implementations may read
-	// this to identify which of Snapshots was chosen upstream; a zero value
-	// must be tolerated (treat as "no selection known").
+	// SelectedInstance == ""). DisaggregationDecider implementations may use
+	// this ID to locate the selected pod's state (e.g., in a per-pod cache-
+	// query map). Membership in Snapshots is not structurally guaranteed —
+	// implementations must tolerate both a zero value ("no selection known")
+	// and an ID that has no corresponding entry in Snapshots (e.g., the pod
+	// was removed after routing) and guard accordingly.
 	SelectedInstance string
 }

--- a/sim/router_state.go
+++ b/sim/router_state.go
@@ -16,5 +16,13 @@ type RouterState struct {
 	// TotalKvCapacityTokens. QueueDepth, BatchSize, KVUtilization, FreeKVBlocks, CacheHitRate,
 	// InFlightRequests, KvTokensInUse remain zero.
 	LoadingSnapshots []RoutingSnapshot
-	Clock            int64             // Current simulation clock in microseconds
+	Clock            int64 // Current simulation clock in microseconds
+	// SelectedInstance is the instance ID pre-selected by an upstream caller
+	// (typically the decode-routing policy) before invoking a
+	// DisaggregationDecider. Empty for contexts where no prior selection has
+	// been made (e.g., RoutingPolicy.Route itself receives RouterState with
+	// SelectedInstance == ""). DisaggregationDecider implementations may read
+	// this to identify which of Snapshots was chosen upstream; a zero value
+	// must be tolerated (treat as "no selection known").
+	SelectedInstance string
 }


### PR DESCRIPTION
## Summary

Replaces `PrefixThresholdDecider`'s cluster-wide LRU approximation with a per-pod KV cache query against the *pre-selected decode pod*, matching llm-d's `PrefixBasedPDDecider.disaggregate` (reads `endpoint.Get(PrefixCacheMatchInfoKey)` on the selected endpoint).

This is GAP-3 of the #1260 tracker. Unblocked by #1265 (GAP-2, merged). Addresses @mtoslalibu's note on PR #1265 — picks **option (a)**: decider receives the selected pod ID alongside state (via a new `RouterState.SelectedInstance` field). Option (b) remains viable for future joint-D+P policies through the `DecodePodOverride` field added in GAP-2.

**Target parity version:** llm-d-inference-scheduler @ `71e39f2a721cf8bb1e613bfab633c1941301e358`

## Behavioral Contracts

- **BC-1 (per-pod query):** Decider invokes `cacheQuery[state.SelectedInstance](req.InputTokens)` for the selected pod and no other closure.
- **BC-2 (formula preserved):** `nonCachedTokens = len(InputTokens) − cachedBlocks × blockSize`; `Disaggregate = nonCachedTokens > threshold` (strict `>`; threshold+1 and exact_threshold boundary tests pin it).
- **BC-3 (conservative fallback):** 5 paths return `Disaggregate=false` — empty input, nil state, empty `SelectedInstance`, unknown instance, nil closure. Mirrors llm-d's nil-endpoint guard (`prefix_based_pd_decider.go:108-111`).
- **BC-4 (per-pod isolation):** A warm pod A does not influence a decision targeting cold pod B — both outcomes asserted in the same test.
- **BC-5 (cluster populates `SelectedInstance`):** `executeDisaggregatedRouting` sets `state.SelectedInstance = decodeDecision.TargetInstance` before calling `Decide`.
- **BC-6 (observer machinery removed):** `DisaggregationObserver` interface, `ObserveRouting`, scratchpad fields (`idx`, `cachedHashes`, `cachedReqID`), `globalVirtualInstance`/`defaultDisaggLRUCapacity` constants, `notifyDisaggregationObserver` helper, and its 3 call sites all deleted. Grep confirms no production refs remain.
- **BC-7 (INV-9):** Decider reads only `req.InputTokens` and `state.*` — no `Request.OutputTokens` access.

## Files

- `sim/disaggregation.go` — struct/constructor/Decide rewrite + observer/LRU deletions (+28/−72).
- `sim/disaggregation_test.go` — new per-pod tests, 5-case missing-selection fallback table, strict-`>` boundary tests; observer-based tests removed (+246/−164 net).
- `sim/router_state.go` — additive `SelectedInstance` field (+8).
- `sim/cluster/cluster.go` — reorder decider construction to after `cs.cacheQueryFn` build; populate `state.SelectedInstance` before `Decide`; remove `notifyDisaggregationObserver` helper + 2 call sites (+16/−30 net).
- `sim/cluster/pd_events.go` — remove 3rd observer call site (−3).
- `sim/cluster/disaggregation_test.go` — rename observer-wiring test → per-pod-cache test; update comments to describe the new mechanism (+19/−15).
- `docs/plans/pr1263-prefix-threshold-per-pod-plan.md` — micro-plan.

## Cross-path parity

All changes are in `sim/` and `sim/cluster/` (DES kernel + cluster layer). Applies uniformly to `blis run` and `blis replay`. `blis observe` dispatches to a real server and never invokes a `DisaggregationDecider` — out of scope.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all packages pass (sim, sim/cluster, cmd, sim/workload, sim/latency, sim/kv, sim/trace, …)
- [x] `go test ./sim/ -run "TestPrefixThreshold|TestDisagg|TestNever|TestAlways"` — 19 subtests pass; notable new tests:
  - `TestPrefixThresholdDecider_PerPodCacheQuery` (BC-1, BC-4): 840-token request on warm pod A (40 cached blocks → 200 nonCached ≤ 512 → false) vs cold pod B (840 nonCached → true) using the same decider and same request — proves per-pod isolation via the closure.
  - `TestPrefixThresholdDecider_MissingSelection_ReturnsFalse` (BC-3): table-driven over all 5 fallback scenarios.
  - `TestPrefixThresholdDecider_QueriesOnlySelectedPod` (BC-1 isolation): closure call-counter stub asserts exactly 1 call on selected pod, 0 on others — guards against the option-(b) "scan all pods" regression.
  - `TestPrefixThresholdDecider_ZeroThreshold` case 2: fully-cached request (nonCached=0) returns false even at threshold=0 — pins strict `>` at the boundary.
- [x] `go test ./sim/cluster/ -run TestPrefixThreshold` — 3 tests pass, including end-to-end `TestPrefixThreshold_PerPodCacheQuery` (req1 disaggregated → KV cache warmed on selected decode pod → req2's `precise-prefix-cache` scorer routes to warm pod → decider queries per-pod cache → not disaggregated).
- [x] `go vet ./...` — no issues
- [x] Pre-commit self-audit across 10 dimensions — 0 issues
- [ ] `golangci-lint run ./...` — not installed locally; CI will run

## Scope / Non-goals

- Joint D+P policies using `DecodePodOverride` for cache-affinity retargeting (option (b) in #1265 review) — viable with today's interface; future work.
- `NonCachedTokens == 0 → return false` short-circuit (llm-d-specific "disabled" semantics from #1250 Fix 3) — BLIS `threshold=0` currently means "disaggregate when any non-cached token exists," which is the naturally-useful semantics for the BLIS flag. Not re-semanticed here.
- `RequestView` structural INV-9 enforcement (#1250 Fix 5) — separate track (#1250).
- GAP-1 (routing path unification, #1266) and GAP-4 (encode pool, #1264) — independent, out of scope.

## Closes

Fixes #1263
Part of #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)