### PR TITLE
fix(replay): use server_input_tokens for token generation to eliminate TTFT bias

### DIFF
--- a/docs/plans/replay-server-tokens-plan.md
+++ b/docs/plans/replay-server-tokens-plan.md
@@ -1,0 +1,368 @@
+# Plan: Use server_input_tokens for replay token generation
+
+**Goal:** Eliminate the systematic TTFT under-prediction that occurs when replaying chat-API traces. `blis observe --api-format chat` records both a client-side `input_tokens` count and the server-reported `server_input_tokens` (which includes hidden chat-template formatting tokens). Replay currently uses the smaller client-side count, causing the simulator to model a faster prefill than the server actually performed.
+
+**Source:** [inference-sim/inference-sim#1269](https://github.com/inference-sim/inference-sim/issues/1269)
+
+**Closes:** #1269
+
+---
+
+## Behavioral Contracts
+
+**BC-1 (ServerInputTokens priority — no prefix group):** GIVEN a `TraceRecord` with `ServerInputTokens > 0` and `PrefixGroup == ""`, WHEN `LoadTraceV2Requests` constructs the `sim.Request`, THEN `len(req.InputTokens) == rec.ServerInputTokens`.
+
+**BC-2 (Fallback to InputTokens):** GIVEN a `TraceRecord` with `ServerInputTokens == 0` OR `PrefixGroup != ""`, WHEN `LoadTraceV2Requests` constructs the `sim.Request`, THEN `len(req.InputTokens)` uses `rec.InputTokens` (plus prefix length if applicable). Zero `ServerInputTokens` means "not recorded" (generated traces). Non-empty `PrefixGroup` means `ServerInputTokens` already contains the prefix length — using it as a suffix count would double-count the prefix, so we fall back to `InputTokens`.
+
+**BC-3 (Session round-0 priority — no prefix group):** GIVEN a session trace where round-0 has `ServerInputTokens > 0` and `PrefixGroup == ""`, WHEN `LoadTraceV2SessionBlueprints` builds the initial request, THEN `len(req.InputTokens) == round0.ServerInputTokens`.
+
+**BC-4 (Session sampler priority — no prefix group):** GIVEN a session trace where round N>0 has `ServerInputTokens > 0` and `PrefixGroup == ""`, WHEN the blueprint's `InputSampler` is queried for that round, THEN it returns `ServerInputTokens` for that round (not `InputTokens`). Rounds with `PrefixGroup != ""` use `InputTokens` unchanged.
+
+**BC-5 (Non-session path parity, R23):** GIVEN a non-session record in a session-mode trace with `ServerInputTokens > 0` and `PrefixGroup == ""`, WHEN `LoadTraceV2SessionBlueprints` processes it, THEN `len(req.InputTokens) == rec.ServerInputTokens`.
+
+**BC-6 (sim.Request has no ServerInputTokens field):** `sim.Request` does not gain a `ServerInputTokens` field. The server-reported count is used only to size the synthetic token ID slice; it is not stored as a separate field on the request struct. This is unchanged from the original design — `server_input_tokens` is a trace-layer artifact, not a simulation primitive.
+
+---
+
+## Tasks
+
+### Task 1: Add failing tests for BC-1, BC-2, BC-3, BC-4, BC-5
+
+**File:** `sim/workload/replay_test.go`
+
+Write tests before implementing the fix to confirm they fail.
+
+**Test A — BC-1: `LoadTraceV2Requests` uses `ServerInputTokens` when present**
+
+```go
+func TestLoadTraceV2Requests_ServerInputTokens_UsedWhenPresent(t *testing.T) {
+    // GIVEN a trace record where ServerInputTokens > InputTokens (chat template overhead)
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 0, InputTokens: 512, ServerInputTokens: 530,
+                OutputTokens: 64, ArrivalTimeUs: 0, Status: "ok"},
+        },
+    }
+    requests, err := LoadTraceV2Requests(trace, 42)
+    if err != nil {
+        t.Fatal(err)
+    }
+    // BC-1: len(InputTokens) reflects server-reported count, not client-side count
+    if len(requests[0].InputTokens) != 530 {
+        t.Errorf("input token count = %d, want 530 (server-reported)", len(requests[0].InputTokens))
+    }
+}
+```
+
+**Test B — BC-2: `LoadTraceV2Requests` falls back to `InputTokens` when `ServerInputTokens == 0`**
+
+```go
+func TestLoadTraceV2Requests_ServerInputTokens_Zero_FallsBackToInputTokens(t *testing.T) {
+    // GIVEN a trace record with ServerInputTokens == 0 (generated trace, not observed)
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 0, InputTokens: 256, ServerInputTokens: 0,
+                OutputTokens: 32, ArrivalTimeUs: 0, Status: "ok"},
+        },
+    }
+    requests, err := LoadTraceV2Requests(trace, 42)
+    if err != nil {
+        t.Fatal(err)
+    }
+    // BC-2: fallback to InputTokens when ServerInputTokens not recorded
+    if len(requests[0].InputTokens) != 256 {
+        t.Errorf("input token count = %d, want 256 (fallback)", len(requests[0].InputTokens))
+    }
+}
+```
+
+**Test C — BC-3: session round-0 uses `ServerInputTokens`**
+
+```go
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Round0(t *testing.T) {
+    // GIVEN a 2-round session where round-0 has server overhead tokens
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 1, SessionID: "A", RoundIndex: 0,
+                InputTokens: 512, ServerInputTokens: 530,
+                OutputTokens: 64, ArrivalTimeUs: 0},
+            {RequestID: 2, SessionID: "A", RoundIndex: 1,
+                InputTokens: 256, ServerInputTokens: 274,
+                OutputTokens: 32, ArrivalTimeUs: 5000},
+        },
+    }
+    requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(requests) != 1 {
+        t.Fatalf("expected 1 round-0 request, got %d", len(requests))
+    }
+    // BC-3: round-0 token count uses ServerInputTokens
+    if len(requests[0].InputTokens) != 530 {
+        t.Errorf("round-0 input token count = %d, want 530 (server-reported)", len(requests[0].InputTokens))
+    }
+}
+```
+
+**Test D — BC-4: blueprint sampler uses `ServerInputTokens` for subsequent rounds**
+
+```go
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler(t *testing.T) {
+    // GIVEN a 3-round session with ServerInputTokens on rounds 1 and 2
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 1, SessionID: "A", RoundIndex: 0,
+                InputTokens: 512, ServerInputTokens: 530, OutputTokens: 64, ArrivalTimeUs: 0},
+            {RequestID: 2, SessionID: "A", RoundIndex: 1,
+                InputTokens: 256, ServerInputTokens: 274, OutputTokens: 32, ArrivalTimeUs: 5000},
+            {RequestID: 3, SessionID: "A", RoundIndex: 2,
+                InputTokens: 128, ServerInputTokens: 0, OutputTokens: 16, ArrivalTimeUs: 10000},
+        },
+    }
+    _, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    bp := blueprints[0]
+    // BC-4: round-1 sampler returns ServerInputTokens (274 > 256)
+    got1 := bp.InputSampler.Sample(nil)
+    if got1 != 274 {
+        t.Errorf("round-1 sampler value = %d, want 274 (server-reported)", got1)
+    }
+    // BC-2: round-2 sampler falls back to InputTokens (ServerInputTokens == 0)
+    got2 := bp.InputSampler.Sample(nil)
+    if got2 != 128 {
+        t.Errorf("round-2 sampler value = %d, want 128 (fallback)", got2)
+    }
+}
+```
+
+**Test E — BC-5: non-session path in `LoadTraceV2SessionBlueprints`**
+
+```go
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSessionRecord(t *testing.T) {
+    // GIVEN a non-session record with ServerInputTokens > InputTokens
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 1, SessionID: "", InputTokens: 512, ServerInputTokens: 530,
+                OutputTokens: 64, ArrivalTimeUs: 0},
+        },
+    }
+    requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(requests) != 1 {
+        t.Fatalf("expected 1 request, got %d", len(requests))
+    }
+    // BC-5: non-session path uses ServerInputTokens
+    if len(requests[0].InputTokens) != 530 {
+        t.Errorf("non-session input token count = %d, want 530", len(requests[0].InputTokens))
+    }
+}
+```
+
+**Test F — BC-2 (PrefixGroup fallback): `LoadTraceV2Requests` ignores `ServerInputTokens` when `PrefixGroup` is set**
+
+```go
+func TestLoadTraceV2Requests_ServerInputTokens_PrefixGroup_FallsBackToInputTokens(t *testing.T) {
+    // GIVEN a prefix-group record with ServerInputTokens > InputTokens
+    // ServerInputTokens includes the prefix length — applying it as suffix count would double-count.
+    // WHEN LoadTraceV2Requests constructs the request
+    // THEN the suffix uses InputTokens, not ServerInputTokens (prefix prepended separately)
+    trace := &TraceV2{
+        Records: []TraceRecord{
+            {RequestID: 0, InputTokens: 100, PrefixGroup: "shared", PrefixLength: 128,
+                ServerInputTokens: 246, // = PrefixLength(128) + InputTokens(100) + overhead(18)
+                OutputTokens: 32, ArrivalTimeUs: 0, Status: "ok"},
+        },
+    }
+    requests, err := LoadTraceV2Requests(trace, 42)
+    if err != nil {
+        t.Fatal(err)
+    }
+    // BC-2: total = PrefixLength(128) + InputTokens(100) = 228, not 128+246=374
+    if len(requests[0].InputTokens) != 228 {
+        t.Errorf("input token count = %d, want 228 (prefix 128 + suffix 100, not ServerInputTokens 246)",
+            len(requests[0].InputTokens))
+    }
+}
+```
+
+Run to confirm they fail:
+```bash
+cd /Users/sri/Documents/Projects/inference-sim/.worktrees/pr-replay-server-tokens
+go test ./sim/workload/... -run "TestLoadTraceV2Requests_ServerInputTokens|TestLoadTraceV2SessionBlueprints_ServerInputTokens" -v 2>&1 | head -60
+```
+Expected: FAIL (BC-1, BC-3, BC-4, BC-5 fail; BC-2 tests may coincidentally pass; Test F may fail if guard is missing).
+
+---
+
+### Task 2: Implement fix in `LoadTraceV2Requests`
+
+**File:** `sim/workload/replay.go`
+
+Replace line 35:
+```go
+inputTokens := sim.GenerateRandomTokenIDs(rng, rec.InputTokens)
+```
+With:
+```go
+nInput := rec.InputTokens
+if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+    nInput = rec.ServerInputTokens
+}
+inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
+```
+
+The `PrefixGroup == ""` guard is required because `ServerInputTokens` is the server's full prompt token count, which for prefix-group records already includes the `PrefixLength` prefix tokens. Using it as the *suffix* count and then prepending prefix tokens would double-count. For non-prefix records (the `--api-format chat` case this fix targets), no prefix is prepended so the full `ServerInputTokens` is the correct total length.
+
+Remove the now-stale comment on line 70:
+```go
+// ServerInputTokens: not propagated to sim.Request (calibration-only field, BC-7)
+```
+Replace with nothing (the field doesn't exist on sim.Request; that's structurally enforced — no comment needed).
+
+Run the BC-1 and BC-2 tests to confirm they pass:
+```bash
+go test ./sim/workload/... -run "TestLoadTraceV2Requests_ServerInputTokens" -v
+```
+Expected: PASS.
+
+Lint:
+```bash
+golangci-lint run ./sim/workload/...
+```
+Expected: no issues.
+
+---
+
+### Task 3: Implement fix in `LoadTraceV2SessionBlueprints`
+
+**File:** `sim/workload/replay.go`
+
+**3a. Fix `inputSeq` build loop** (around line 159):
+```go
+for i, rec := range rounds {
+    nInput := rec.InputTokens
+    if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+        nInput = rec.ServerInputTokens
+    }
+    inputSeq[i] = nInput
+    outputSeq[i] = rec.OutputTokens
+}
+```
+
+**3b. Fix round-0 request construction** (around line 188):
+```go
+nInput := r0.InputTokens
+if r0.ServerInputTokens > 0 && r0.PrefixGroup == "" {
+    nInput = r0.ServerInputTokens
+}
+inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, nInput)
+```
+
+**3c. Fix non-session records loop** (around line 246):
+```go
+nInput := rec.InputTokens
+if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+    nInput = rec.ServerInputTokens
+}
+inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
+```
+
+Run all new tests:
+```bash
+go test ./sim/workload/... -run "TestLoadTraceV2SessionBlueprints_ServerInputTokens" -v
+```
+Expected: PASS.
+
+Run full package:
+```bash
+go test ./sim/workload/... -v 2>&1 | tail -20
+```
+Expected: all pass.
+
+Lint:
+```bash
+golangci-lint run ./sim/workload/...
+```
+
+---
+
+### Task 4: Update stale comments in `replay_test.go`
+
+**File:** `sim/workload/replay_test.go`
+
+In `TestLoadTraceV2Requests_ModelAndDeadline`, the record at index 0 has `ServerInputTokens: 300, InputTokens: 100`. After Task 2's fix, `LoadTraceV2Requests` will generate 300 tokens (not 100) for that record. The existing comment is misleading:
+
+Old:
+```go
+ServerInputTokens: 300, // must NOT appear on sim.Request
+```
+New:
+```go
+ServerInputTokens: 300, // used as token count for InputTokens generation (> InputTokens: 100)
+```
+
+Also update the function docstring from "BC-3, BC-4, BC-5, BC-6, BC-7" to "BC-3, BC-4, BC-5, BC-6" (BC-7 is now replaced by BC-1/BC-2 from this plan).
+
+Add an assertion to `TestLoadTraceV2Requests_ModelAndDeadline` to make the behavior explicit (so it becomes a canary if someone reverts the fix):
+```go
+// BC-1: ServerInputTokens (300) used as token count, not InputTokens (100)
+if len(requests[0].InputTokens) != 300 {
+    t.Errorf("request 0 input token count = %d, want 300 (server-reported)", len(requests[0].InputTokens))
+}
+```
+
+Run to confirm:
+```bash
+go test ./sim/workload/... -run TestLoadTraceV2Requests_ModelAndDeadline -v
+```
+Expected: PASS.
+
+Final full test run and build:
+```bash
+go test ./... 2>&1 | tail -20
+go build ./...
+```
+
+Commit:
+```bash
+git add sim/workload/replay.go sim/workload/replay_test.go docs/plans/replay-server-tokens-plan.md
+git commit -m "fix(replay): use server_input_tokens for token generation to eliminate TTFT bias
+
+- BC-1: when TraceRecord.ServerInputTokens > 0, use it as token count for
+  sim.Request.InputTokens generation instead of InputTokens (chat template overhead)
+- BC-2: ServerInputTokens == 0 falls back to InputTokens (generated traces)
+- Applies to LoadTraceV2Requests, LoadTraceV2SessionBlueprints (round-0,
+  inputSeq sampler, and non-session path) for full code-path parity (R23)
+- Removes stale 'calibration-only' comment; sim.Request still has no
+  ServerInputTokens field (BC-6: structurally enforced, not comment-enforced)
+
+Closes #1269
+
+Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Sanity Checklist
+
+- [ ] BC-2 (zero fallback) is guarded by `> 0`, not `!= 0` — negative values treated as "not recorded" (consistent with R3 validation in `ParseTraceRecord` which already rejects negatives)
+- [ ] BC-2 (PrefixGroup guard): condition is `rec.ServerInputTokens > 0 && rec.PrefixGroup == ""` — the `PrefixGroup == ""` guard prevents double-counting prefix tokens (`ServerInputTokens` on prefix-group records already includes `PrefixLength`)
+- [ ] INV-6 (determinism): `ServerInputTokens` is a deterministic field from the trace CSV — using it doesn't introduce non-determinism
+- [ ] R23 (code path parity): all three call sites in `LoadTraceV2SessionBlueprints` (inputSeq, round-0, non-session) get the same `PrefixGroup == ""` guard as `LoadTraceV2Requests`
+- [ ] R4 (construction sites): no new struct fields added; `nInput` is a local variable
+- [ ] `sim.Request` still has no `ServerInputTokens` field (BC-6); verified by grep: `grep -n "ServerInputTokens" sim/request.go` returns nothing
+
+---
+
+## Deviation Log
+
+**CLARIFICATION-1:** Issue says "use it instead of `rec.InputTokens` as the token count for the sim.Request." This could mean either (a) store it as a new sim.Request field, or (b) use it only as the count for GenerateRandomTokenIDs. Interpretation: (b). `sim.Request` has no `ServerInputTokens` field — this was explicitly designed in the original observe-replay plan (BC-7 there). We preserve that design: server-reported count is a trace artifact used only to determine synthetic token ID slice length. BC-6 above documents this explicitly.
+
+**CLARIFICATION-3:** Issue does not mention prefix-group traces. For records with `PrefixGroup != ""`, `ServerInputTokens` reflects the server's full prompt token count including the shared prefix tokens. The replay code prepends prefix tokens separately on top of the suffix generated by `GenerateRandomTokenIDs`. Applying `ServerInputTokens` as the suffix count would double-count the prefix. Decision: guard with `PrefixGroup == ""` and fall back to `InputTokens` for prefix-group records. This is conservative and safe; the issue's stated use case (`--api-format chat` traces) does not combine prefix groups with chat template overhead.
+
+**CLARIFICATION-2:** The existing `TestLoadTraceV2Requests_ModelAndDeadline` test uses `ServerInputTokens: 300, InputTokens: 100`. After the fix, `len(req.InputTokens)` becomes 300 instead of 100. The test doesn't currently assert on this length, so it wouldn't catch a regression if the fix were reverted. Added an explicit assertion (Task 4) to make the test a genuine canary.

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -9,6 +9,18 @@ import (
 	"github.com/inference-sim/inference-sim/sim"
 )
 
+// effectiveInputTokenCount returns the token count to use for generating synthetic
+// input token IDs. It prefers ServerInputTokens (server-reported prompt_tokens from
+// blis observe) when > 0 and no PrefixGroup is set. The PrefixGroup guard prevents
+// double-counting: for prefix-group records, ServerInputTokens includes the prefix
+// length, but replay.go prepends prefix tokens separately.
+func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup string) int {
+	if serverInputTokens > 0 && prefixGroup == "" {
+		return serverInputTokens
+	}
+	return inputTokens
+}
+
 // LoadTraceV2Requests converts trace v2 records into sim.Request objects
 // with synthetic token IDs for simulation replay. Requests in the same
 // prefix_group share identical prefix token sequences.
@@ -31,17 +43,8 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 
 	requests := make([]*sim.Request, 0, len(trace.Records))
 	for _, rec := range trace.Records {
-		// Generate synthetic token IDs. Use server-reported token count when available
-		// (eliminates chat-template overhead bias for --api-format chat traces).
-		// Guard PrefixGroup == "": for prefix-group records, ServerInputTokens reflects
-		// the server's total prompt_tokens (prefix + suffix + template tokens, consistent
-		// with vLLM's usage reporting in blis observe). Using it as the suffix count would
-		// double-count the prefix that is prepended separately below.
-		nInput := rec.InputTokens
-		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
-			nInput = rec.ServerInputTokens
-		}
-		inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
+		// Generate synthetic token IDs, preferring server-reported count when available.
+		inputTokens := sim.GenerateRandomTokenIDs(rng, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
 
 		// Prepend prefix if in a group
 		if rec.PrefixGroup != "" {
@@ -161,17 +164,11 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			continue
 		}
 
-		// Build per-round token sequences. Use ServerInputTokens when available and no
-		// PrefixGroup (same rule as LoadTraceV2Requests — prefix-group records must fall
-		// back to InputTokens to avoid double-counting the prepended prefix).
+		// Build per-round token sequences, preferring server-reported count when available.
 		inputSeq := make([]int, len(rounds))
 		outputSeq := make([]int, len(rounds))
 		for i, rec := range rounds {
-			nInput := rec.InputTokens
-			if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
-				nInput = rec.ServerInputTokens
-			}
-			inputSeq[i] = nInput
+			inputSeq[i] = effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup)
 			outputSeq[i] = rec.OutputTokens
 		}
 
@@ -197,14 +194,9 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		// Per-session RNG for deterministic token ID generation (INV-6)
 		sessionRNG := rand.New(rand.NewSource(rng.Int63()))
 
-		// Build round-0 request. Same ServerInputTokens selection rule as LoadTraceV2Requests:
-		// skip for prefix-group records (ServerInputTokens includes prefix; avoid double-count).
+		// Build round-0 request, preferring server-reported count when available.
 		r0 := rounds[0]
-		nInputR0 := r0.InputTokens
-		if r0.ServerInputTokens > 0 && r0.PrefixGroup == "" {
-			nInputR0 = r0.ServerInputTokens
-		}
-		inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, nInputR0)
+		inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(r0.InputTokens, r0.ServerInputTokens, r0.PrefixGroup))
 		if r0.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[r0.PrefixGroup]; ok {
 				inputTokens = append(append([]int{}, prefix...), inputTokens...)
@@ -261,13 +253,8 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	}
 
 	// Append non-session requests (same construction as LoadTraceV2Requests).
-	// Same ServerInputTokens selection rule: skip for prefix-group records (avoid double-count).
 	for _, rec := range nonSessionRecords {
-		nInput := rec.InputTokens
-		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
-			nInput = rec.ServerInputTokens
-		}
-		inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
+		inputTokens := sim.GenerateRandomTokenIDs(rng, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
 		if rec.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[rec.PrefixGroup]; ok {
 				inputTokens = append(append([]int{}, prefix...), inputTokens...)

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -31,8 +31,15 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 
 	requests := make([]*sim.Request, 0, len(trace.Records))
 	for _, rec := range trace.Records {
-		// Generate synthetic token IDs
-		inputTokens := sim.GenerateRandomTokenIDs(rng, rec.InputTokens)
+		// Generate synthetic token IDs. Use server-reported token count when available
+		// (eliminates chat-template overhead bias for --api-format chat traces).
+		// Guard PrefixGroup == "": for prefix-group records, ServerInputTokens already
+		// includes the prefix length; using it as suffix count would double-count.
+		nInput := rec.InputTokens
+		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+			nInput = rec.ServerInputTokens
+		}
+		inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
 
 		// Prepend prefix if in a group
 		if rec.PrefixGroup != "" {
@@ -67,7 +74,6 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 			PrefixGroup:      rec.PrefixGroup,
 			PrefixLength:     rec.PrefixLength,
 			Streaming:        rec.Streaming,
-			// ServerInputTokens: not propagated to sim.Request (calibration-only field, BC-7)
 		}
 		requests = append(requests, req)
 	}
@@ -153,11 +159,17 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			continue
 		}
 
-		// Build per-round token sequences
+		// Build per-round token sequences. Use ServerInputTokens when available and no
+		// PrefixGroup (same rule as LoadTraceV2Requests — prefix-group records must fall
+		// back to InputTokens to avoid double-counting the prepended prefix).
 		inputSeq := make([]int, len(rounds))
 		outputSeq := make([]int, len(rounds))
 		for i, rec := range rounds {
-			inputSeq[i] = rec.InputTokens
+			nInput := rec.InputTokens
+			if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+				nInput = rec.ServerInputTokens
+			}
+			inputSeq[i] = nInput
 			outputSeq[i] = rec.OutputTokens
 		}
 
@@ -185,7 +197,11 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 
 		// Build round-0 request
 		r0 := rounds[0]
-		inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, r0.InputTokens)
+		nInputR0 := r0.InputTokens
+		if r0.ServerInputTokens > 0 && r0.PrefixGroup == "" {
+			nInputR0 = r0.ServerInputTokens
+		}
+		inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, nInputR0)
 		if r0.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[r0.PrefixGroup]; ok {
 				inputTokens = append(append([]int{}, prefix...), inputTokens...)
@@ -243,7 +259,11 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 
 	// Append non-session requests (same construction as LoadTraceV2Requests)
 	for _, rec := range nonSessionRecords {
-		inputTokens := sim.GenerateRandomTokenIDs(rng, rec.InputTokens)
+		nInput := rec.InputTokens
+		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
+			nInput = rec.ServerInputTokens
+		}
+		inputTokens := sim.GenerateRandomTokenIDs(rng, nInput)
 		if rec.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[rec.PrefixGroup]; ok {
 				inputTokens = append(append([]int{}, prefix...), inputTokens...)

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -10,10 +10,14 @@ import (
 )
 
 // effectiveInputTokenCount returns the token count to use for generating synthetic
-// input token IDs. It prefers ServerInputTokens (server-reported prompt_tokens from
-// blis observe) when > 0 and no PrefixGroup is set. The PrefixGroup guard prevents
-// double-counting: for prefix-group records, ServerInputTokens includes the prefix
-// length, but replay.go prepends prefix tokens separately.
+// input token IDs. Priority rules:
+//  1. serverInputTokens > 0 && prefixGroup == "": return serverInputTokens (server
+//     is authoritative; covers chat-template overhead in blis-observe traces).
+//  2. prefixGroup != "": return inputTokens regardless of serverInputTokens (server
+//     count includes the prefix; using it as suffix would double-count the prefix
+//     that replay.go prepends separately).
+//  3. serverInputTokens == 0: return inputTokens (field absent in
+//     generated/synthetic traces; not a real measurement).
 func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup string) int {
 	if serverInputTokens > 0 && prefixGroup == "" {
 		return serverInputTokens

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -33,8 +33,10 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 	for _, rec := range trace.Records {
 		// Generate synthetic token IDs. Use server-reported token count when available
 		// (eliminates chat-template overhead bias for --api-format chat traces).
-		// Guard PrefixGroup == "": for prefix-group records, ServerInputTokens already
-		// includes the prefix length; using it as suffix count would double-count.
+		// Guard PrefixGroup == "": for prefix-group records, ServerInputTokens reflects
+		// the server's total prompt_tokens (prefix + suffix + template tokens, consistent
+		// with vLLM's usage reporting in blis observe). Using it as the suffix count would
+		// double-count the prefix that is prepended separately below.
 		nInput := rec.InputTokens
 		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {
 			nInput = rec.ServerInputTokens
@@ -195,7 +197,8 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		// Per-session RNG for deterministic token ID generation (INV-6)
 		sessionRNG := rand.New(rand.NewSource(rng.Int63()))
 
-		// Build round-0 request
+		// Build round-0 request. Same ServerInputTokens selection rule as LoadTraceV2Requests:
+		// skip for prefix-group records (ServerInputTokens includes prefix; avoid double-count).
 		r0 := rounds[0]
 		nInputR0 := r0.InputTokens
 		if r0.ServerInputTokens > 0 && r0.PrefixGroup == "" {
@@ -257,7 +260,8 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		blueprints = append(blueprints, bp)
 	}
 
-	// Append non-session requests (same construction as LoadTraceV2Requests)
+	// Append non-session requests (same construction as LoadTraceV2Requests).
+	// Same ServerInputTokens selection rule: skip for prefix-group records (avoid double-count).
 	for _, rec := range nonSessionRecords {
 		nInput := rec.InputTokens
 		if rec.ServerInputTokens > 0 && rec.PrefixGroup == "" {

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -296,7 +296,148 @@ func TestLoadTraceV2SessionBlueprints_NonConsecutiveRoundIndex_Error(t *testing.
 	}
 }
 
-// TestLoadTraceV2Requests_ModelAndDeadline verifies BC-3, BC-4, BC-5, BC-6, BC-7.
+// --- ServerInputTokens tests (BC-1, BC-2) ---
+
+func TestLoadTraceV2Requests_ServerInputTokens_UsedWhenPresent(t *testing.T) {
+	// GIVEN a trace record where ServerInputTokens > InputTokens (chat template overhead)
+	// and no PrefixGroup (the --api-format chat use case)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 0, InputTokens: 512, ServerInputTokens: 530,
+				OutputTokens: 64, ArrivalTimeUs: 0, Status: "ok"},
+		},
+	}
+	requests, err := LoadTraceV2Requests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// BC-1: len(InputTokens) reflects server-reported count, not client-side count
+	if len(requests[0].InputTokens) != 530 {
+		t.Errorf("input token count = %d, want 530 (server-reported)", len(requests[0].InputTokens))
+	}
+}
+
+func TestLoadTraceV2Requests_ServerInputTokens_Zero_FallsBackToInputTokens(t *testing.T) {
+	// GIVEN a trace record with ServerInputTokens == 0 (generated trace, not observed)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 0, InputTokens: 256, ServerInputTokens: 0,
+				OutputTokens: 32, ArrivalTimeUs: 0, Status: "ok"},
+		},
+	}
+	requests, err := LoadTraceV2Requests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// BC-2: fallback to InputTokens when ServerInputTokens not recorded
+	if len(requests[0].InputTokens) != 256 {
+		t.Errorf("input token count = %d, want 256 (fallback)", len(requests[0].InputTokens))
+	}
+}
+
+func TestLoadTraceV2Requests_ServerInputTokens_PrefixGroup_FallsBackToInputTokens(t *testing.T) {
+	// GIVEN a prefix-group record with ServerInputTokens > InputTokens.
+	// ServerInputTokens includes the prefix length — applying it as suffix count would double-count.
+	// WHEN LoadTraceV2Requests constructs the request
+	// THEN the suffix uses InputTokens, not ServerInputTokens (prefix prepended separately)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 0, InputTokens: 100, PrefixGroup: "shared", PrefixLength: 128,
+				ServerInputTokens: 246, // = PrefixLength(128) + InputTokens(100) + overhead(18)
+				OutputTokens: 32, ArrivalTimeUs: 0, Status: "ok"},
+		},
+	}
+	requests, err := LoadTraceV2Requests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// BC-2: total = PrefixLength(128) + InputTokens(100) = 228, not 128+246=374
+	if len(requests[0].InputTokens) != 228 {
+		t.Errorf("input token count = %d, want 228 (prefix 128 + suffix 100, not ServerInputTokens 246)",
+			len(requests[0].InputTokens))
+	}
+}
+
+// --- ServerInputTokens session tests (BC-3, BC-4, BC-5) ---
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Round0(t *testing.T) {
+	// GIVEN a 2-round session where round-0 has server overhead tokens
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				InputTokens: 512, ServerInputTokens: 530,
+				OutputTokens: 64, ArrivalTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				InputTokens: 256, ServerInputTokens: 274,
+				OutputTokens: 32, ArrivalTimeUs: 5000},
+		},
+	}
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 round-0 request, got %d", len(requests))
+	}
+	// BC-3: round-0 token count uses ServerInputTokens
+	if len(requests[0].InputTokens) != 530 {
+		t.Errorf("round-0 input token count = %d, want 530 (server-reported)", len(requests[0].InputTokens))
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler(t *testing.T) {
+	// GIVEN a 3-round session with ServerInputTokens on rounds 1 and 2
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				InputTokens: 512, ServerInputTokens: 530, OutputTokens: 64, ArrivalTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				InputTokens: 256, ServerInputTokens: 274, OutputTokens: 32, ArrivalTimeUs: 5000},
+			{RequestID: 3, SessionID: "A", RoundIndex: 2,
+				InputTokens: 128, ServerInputTokens: 0, OutputTokens: 16, ArrivalTimeUs: 10000},
+		},
+	}
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bp := blueprints[0]
+	// BC-4: round-1 sampler returns ServerInputTokens (274 > 256)
+	got1 := bp.InputSampler.Sample(nil)
+	if got1 != 274 {
+		t.Errorf("round-1 sampler value = %d, want 274 (server-reported)", got1)
+	}
+	// BC-2: round-2 sampler falls back to InputTokens (ServerInputTokens == 0)
+	got2 := bp.InputSampler.Sample(nil)
+	if got2 != 128 {
+		t.Errorf("round-2 sampler value = %d, want 128 (fallback)", got2)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSessionRecord(t *testing.T) {
+	// GIVEN a non-session record with ServerInputTokens > InputTokens
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "", InputTokens: 512, ServerInputTokens: 530,
+				OutputTokens: 64, ArrivalTimeUs: 0},
+		},
+	}
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	// BC-5: non-session path uses ServerInputTokens
+	if len(requests[0].InputTokens) != 530 {
+		t.Errorf("non-session input token count = %d, want 530", len(requests[0].InputTokens))
+	}
+}
+
+// TestLoadTraceV2Requests_ModelAndDeadline verifies BC-3, BC-4, BC-5, BC-6 from the
+// original observe-replay plan, and BC-1 from this plan (ServerInputTokens used for
+// token count generation when > 0 and PrefixGroup is empty).
 func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "real"}
 	records := []TraceRecord{
@@ -304,7 +445,7 @@ func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 			RequestID:         0,
 			Model:             "meta-llama/Llama-3.1-8B-Instruct",
 			DeadlineUs:        7500000,
-			ServerInputTokens: 300, // must NOT appear on sim.Request
+			ServerInputTokens: 300, // used as token count for InputTokens generation (> InputTokens: 100)
 			InputTokens:       100,
 			OutputTokens:      50,
 			ArrivalTimeUs:     0,
@@ -356,9 +497,13 @@ func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 	if requests[1].Deadline != 0 {
 		t.Errorf("request 1 Deadline = %d, want 0", requests[1].Deadline)
 	}
-	// BC-7: ServerInputTokens is NOT on sim.Request (calibration-only field).
-	// The compiler enforces this: sim.Request has no ServerInputTokens field.
-	// No runtime assertion needed — if someone adds the field and wires it up,
-	// the compilation of this package would not catch it, but the architectural
-	// review (BC-7 in the plan) documents the non-propagation intent explicitly.
+	// BC-1: ServerInputTokens (300) used as token count for InputTokens generation, not InputTokens (100).
+	// sim.Request has no ServerInputTokens field; the value is used only to size the synthetic token slice.
+	if len(requests[0].InputTokens) != 300 {
+		t.Errorf("request 0 input token count = %d, want 300 (server-reported)", len(requests[0].InputTokens))
+	}
+	// BC-2: ServerInputTokens == 0 → fallback to InputTokens (50)
+	if len(requests[1].InputTokens) != 50 {
+		t.Errorf("request 1 input token count = %d, want 50 (fallback)", len(requests[1].InputTokens))
+	}
 }

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -518,7 +518,7 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler_PrefixGroup_Fall
 	if err != nil {
 		t.Fatal(err)
 	}
-	// round-0 sampler value is inputSeq[1]: prefix-group round → falls back to InputTokens(50)
+	// first Sample() call returns inputSeq[1] (round-1 token count): prefix-group round → falls back to InputTokens(50)
 	got := blueprints[0].InputSampler.Sample(nil)
 	if got != 50 {
 		t.Errorf("round-1 sampler value = %d, want 50 (fallback: PrefixGroup set, ServerInputTokens ignored)",
@@ -550,9 +550,9 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSession_PrefixGroup_F
 }
 
 // TestLoadTraceV2Requests_ModelAndDeadline verifies that Model, Deadline, empty Model,
-// and zero Deadline are propagated from TraceRecord to sim.Request (from the original
-// observe-replay plan), and that ServerInputTokens is used as the token count when > 0
-// and PrefixGroup is empty (replay-server-tokens-plan.md BC-1).
+// and zero Deadline are propagated from TraceRecord to sim.Request
+// (2026-03-14-pr653-tracev2-schema-plan.md BC-3–6), and that ServerInputTokens is used
+// as the token count when > 0 and PrefixGroup is empty (replay-server-tokens-plan.md BC-1).
 func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "real"}
 	records := []TraceRecord{

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -435,6 +435,85 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSessionRecord(t *test
 	}
 }
 
+// BC-2 session guard: PrefixGroup records must fall back to InputTokens even when
+// ServerInputTokens > 0, to avoid double-counting the prefix prepended by the session
+// manager. These tests guard all three application sites in LoadTraceV2SessionBlueprints.
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Round0_PrefixGroup_FallsBack(t *testing.T) {
+	// GIVEN a session with PrefixGroup on round-0 and ServerInputTokens set
+	// ServerInputTokens(246) = PrefixLength(128) + InputTokens(100) + overhead(18, illustrative)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				InputTokens: 100, PrefixGroup: "shared", PrefixLength: 128,
+				ServerInputTokens: 246, OutputTokens: 32, ArrivalTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				InputTokens: 50, PrefixGroup: "shared", PrefixLength: 128,
+				ServerInputTokens: 196, OutputTokens: 16, ArrivalTimeUs: 5000},
+		},
+	}
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 round-0 request, got %d", len(requests))
+	}
+	// BC-2: total = PrefixLength(128) + InputTokens(100) = 228, not 128+246=374
+	if len(requests[0].InputTokens) != 228 {
+		t.Errorf("round-0 input token count = %d, want 228 (prefix 128 + suffix 100, not ServerInputTokens 246)",
+			len(requests[0].InputTokens))
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler_PrefixGroup_FallsBack(t *testing.T) {
+	// GIVEN a session where round-1 has PrefixGroup set and ServerInputTokens populated
+	// THEN the InputSampler returns InputTokens (fallback), not ServerInputTokens
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				InputTokens: 512, ServerInputTokens: 530, OutputTokens: 64, ArrivalTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				InputTokens: 50, PrefixGroup: "shared", PrefixLength: 64,
+				ServerInputTokens: 132, // = PrefixLength(64) + InputTokens(50) + overhead(18)
+				OutputTokens: 16, ArrivalTimeUs: 5000},
+		},
+	}
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// round-0 sampler value is inputSeq[1]: prefix-group round → falls back to InputTokens(50)
+	got := blueprints[0].InputSampler.Sample(nil)
+	if got != 50 {
+		t.Errorf("round-1 sampler value = %d, want 50 (fallback: PrefixGroup set, ServerInputTokens ignored)",
+			got)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSession_PrefixGroup_FallsBack(t *testing.T) {
+	// GIVEN a non-session record in LoadTraceV2SessionBlueprints with PrefixGroup set
+	// and ServerInputTokens > InputTokens
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "", InputTokens: 100, PrefixGroup: "shared", PrefixLength: 128,
+				ServerInputTokens: 246, OutputTokens: 32, ArrivalTimeUs: 0},
+		},
+	}
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	// BC-2/BC-5: total = PrefixLength(128) + InputTokens(100) = 228, not 128+246=374
+	if len(requests[0].InputTokens) != 228 {
+		t.Errorf("non-session input token count = %d, want 228 (prefix 128 + suffix 100, not ServerInputTokens 246)",
+			len(requests[0].InputTokens))
+	}
+}
+
 // TestLoadTraceV2Requests_ModelAndDeadline verifies BC-3, BC-4, BC-5, BC-6 from the
 // original observe-replay plan, and BC-1 from this plan (ServerInputTokens used for
 // token count generation when > 0 and PrefixGroup is empty).

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -402,6 +402,7 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler(t *testing.T) {
 		t.Fatal(err)
 	}
 	bp := blueprints[0]
+	// SequenceSampler is stateful: each Sample() call advances to the next value.
 	// BC-4: round-1 sampler returns ServerInputTokens (274 > 256)
 	got1 := bp.InputSampler.Sample(nil)
 	if got1 != 274 {

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -110,7 +110,7 @@ func TestLoadTraceV2Requests_PrefixGroup_SharedTokens(t *testing.T) {
 	}
 }
 
-// --- LoadTraceV2SessionBlueprints tests (BC-5, BC-6, BC-7) ---
+// --- LoadTraceV2SessionBlueprints tests (BC-5, BC-6) ---
 
 func TestLoadTraceV2SessionBlueprints_GroupsBySession(t *testing.T) {
 	trace := &TraceV2{
@@ -169,12 +169,12 @@ func TestLoadTraceV2SessionBlueprints_NonSessionPassThrough(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// BC-7: 1 non-session + 1 round-0 session = 2 requests total
+	// 1 non-session + 1 round-0 session request = 2 requests total
 	if len(requests) != 2 {
-		t.Fatalf("BC-7: got %d requests, want 2", len(requests))
+		t.Fatalf("got %d requests, want 2 (1 non-session + 1 round-0 session)", len(requests))
 	}
 	if len(blueprints) != 1 {
-		t.Errorf("BC-7: got %d blueprints, want 1", len(blueprints))
+		t.Errorf("got %d blueprints, want 1", len(blueprints))
 	}
 }
 
@@ -296,6 +296,40 @@ func TestLoadTraceV2SessionBlueprints_NonConsecutiveRoundIndex_Error(t *testing.
 	}
 }
 
+// --- effectiveInputTokenCount unit tests ---
+
+func TestEffectiveInputTokenCount(t *testing.T) {
+	cases := []struct {
+		name             string
+		inputTokens      int
+		serverTokens     int
+		prefixGroup      string
+		want             int
+	}{
+		// Server > client, no prefix: use server (chat-template overhead case)
+		{"server_overrides_client", 512, 530, "", 530},
+		// Server < client, no prefix: use server (unusual but valid — server is authoritative)
+		{"server_smaller_than_client", 512, 480, "", 480},
+		// Server == client, no prefix: use server (no-op, same result)
+		{"server_equals_client", 256, 256, "", 256},
+		// Server > 0 but prefix group set: fall back to client (avoid double-counting)
+		{"prefix_group_falls_back", 100, 246, "shared", 100},
+		// Server == 0, no prefix: fall back to client (not recorded, e.g. generated trace)
+		{"zero_server_falls_back", 256, 0, "", 256},
+		// Server == 0 and prefix group: fall back to client
+		{"zero_server_prefix_group", 100, 0, "shared", 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveInputTokenCount(tc.inputTokens, tc.serverTokens, tc.prefixGroup)
+			if got != tc.want {
+				t.Errorf("effectiveInputTokenCount(%d, %d, %q) = %d, want %d",
+					tc.inputTokens, tc.serverTokens, tc.prefixGroup, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- ServerInputTokens tests (BC-1, BC-2) ---
 
 func TestLoadTraceV2Requests_ServerInputTokens_UsedWhenPresent(t *testing.T) {
@@ -402,7 +436,7 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler(t *testing.T) {
 		t.Fatal(err)
 	}
 	bp := blueprints[0]
-	// SequenceSampler is stateful: each Sample() call advances to the next value.
+	// Each successive Sample() call returns the next round's token count.
 	// BC-4: round-1 sampler returns ServerInputTokens (274 > 256)
 	got1 := bp.InputSampler.Sample(nil)
 	if got1 != 274 {
@@ -515,9 +549,10 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSession_PrefixGroup_F
 	}
 }
 
-// TestLoadTraceV2Requests_ModelAndDeadline verifies BC-3, BC-4, BC-5, BC-6 from the
-// original observe-replay plan, and BC-1 from this plan (ServerInputTokens used for
-// token count generation when > 0 and PrefixGroup is empty).
+// TestLoadTraceV2Requests_ModelAndDeadline verifies that Model, Deadline, empty Model,
+// and zero Deadline are propagated from TraceRecord to sim.Request (from the original
+// observe-replay plan), and that ServerInputTokens is used as the token count when > 0
+// and PrefixGroup is empty (replay-server-tokens-plan.md BC-1).
 func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "real"}
 	records := []TraceRecord{


### PR DESCRIPTION
## Summary

- **Root cause:** `blis replay` was using the client-side `InputTokens` count for synthetic token generation. For `--api-format chat` traces, the server applies a Jinja2 chat template (role markers, BOS token, formatting) that adds 10–30 tokens per request not visible to the client. This caused systematic TTFT under-prediction on every chat-API trace.
- **Fix:** Prefer `ServerInputTokens` over `InputTokens` as the count for `GenerateRandomTokenIDs` when `ServerInputTokens > 0 && PrefixGroup == ""`. The `PrefixGroup` guard prevents double-counting: for prefix-group records, `ServerInputTokens` already includes the prefix length, and the prefix is prepended separately.
- **Scope:** `LoadTraceV2Requests` and all three construction paths in `LoadTraceV2SessionBlueprints` (R23 code-path parity). `sim.Request` gains no new field — the server-reported count is used only to size the synthetic token ID slice.

## Behavioral Contracts

**BC-1:** GIVEN `ServerInputTokens > 0 && PrefixGroup == ""`, WHEN `LoadTraceV2Requests` or `LoadTraceV2SessionBlueprints` constructs a request, THEN `len(req.InputTokens) == rec.ServerInputTokens`.

**BC-2:** GIVEN `ServerInputTokens == 0` OR `PrefixGroup != ""`, THEN falls back to `InputTokens` (existing behavior preserved).

**BC-3/BC-4/BC-5:** Session round-0, blueprint sampler, and non-session records in `LoadTraceV2SessionBlueprints` apply the same guard (R23).

**BC-6:** `sim.Request` has no `ServerInputTokens` field. Structurally enforced.

## Test Plan

- [ ] `TestLoadTraceV2Requests_ServerInputTokens_UsedWhenPresent` — BC-1
- [ ] `TestLoadTraceV2Requests_ServerInputTokens_Zero_FallsBackToInputTokens` — BC-2 (zero)
- [ ] `TestLoadTraceV2Requests_ServerInputTokens_PrefixGroup_FallsBackToInputTokens` — BC-2 (prefix group)
- [ ] `TestLoadTraceV2SessionBlueprints_ServerInputTokens_Round0` — BC-3
- [ ] `TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler` — BC-4, BC-2 mixed
- [ ] `TestLoadTraceV2SessionBlueprints_ServerInputTokens_NonSessionRecord` — BC-5
- [ ] Existing `TestLoadTraceV2Requests_ModelAndDeadline` updated with canary assertion (`len == 300` not 100) to prevent silent regression

All tests pass (`go test ./...`), lint clean (`golangci-lint run ./sim/workload/...`).

Fixes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)