### PR TITLE
fix(replay): use send_time_us as DES injection time for observed traces

### DIFF
--- a/docs/plans/pr-1270-replay-send-time-plan.md
+++ b/docs/plans/pr-1270-replay-send-time-plan.md
@@ -1,0 +1,242 @@
+# fix(replay): Use send_time_us as DES injection time for observed traces
+
+**Goal:** Fix systematic TTFT pessimism in calibration by using `send_time_us` (when set) as the DES injection time instead of `arrival_time_us`, aligning `blis replay` timing with the reference used by `blis calibrate`.
+**Source:** https://github.com/inference-sim/inference-sim/issues/1270
+**Closes:** Fixes #1270
+
+## Behavioral Contracts
+
+BC-1: Concurrency-mode injection time alignment
+- GIVEN a trace record where `SendTimeUs > 0` (observed trace, concurrency mode)
+- WHEN `LoadTraceV2Requests` builds a `sim.Request`
+- THEN `req.ArrivalTime == rec.SendTimeUs` (not `rec.ArrivalTimeUs`)
+
+BC-2: Rate-mode and zero-send-time backward compatibility
+- GIVEN a trace record where `SendTimeUs == 0` (legacy or generated trace)
+- WHEN `LoadTraceV2Requests` builds a `sim.Request`
+- THEN `req.ArrivalTime == rec.ArrivalTimeUs` (no behavioral change)
+
+BC-3: Session round-0 injection time alignment
+- GIVEN a session trace record (round-0) where `SendTimeUs > 0`
+- WHEN `LoadTraceV2SessionBlueprints` builds the initial `sim.Request`
+- THEN `req.ArrivalTime == rec.SendTimeUs`
+
+BC-4: Non-session record injection time alignment
+- GIVEN a non-session trace record where `SendTimeUs > 0`
+- WHEN `LoadTraceV2SessionBlueprints` appends it as a standalone request
+- THEN `req.ArrivalTime == rec.SendTimeUs`
+
+BC-5: Think-time gap derivation unaffected
+- GIVEN a multi-round session trace where `SendTimeUs > ArrivalTimeUs` for round-0
+- WHEN `LoadTraceV2SessionBlueprints` derives inter-round think times
+- THEN think times are derived from `ArrivalTimeUs` differences (unchanged)
+
+## Tasks
+
+### Task 1: Add tests for concurrency-mode injection time (BC-1, BC-2, BC-3, BC-4, BC-5)
+
+**Files:** modify `sim/workload/replay_test.go`
+
+**Test:**
+
+```go
+// TestLoadTraceV2Requests_ConcurrencyModeUseSendTime verifies BC-1 and BC-2.
+func TestLoadTraceV2Requests_ConcurrencyModeUseSendTime(t *testing.T) {
+	tests := []struct {
+		name          string
+		sendTimeUs    int64
+		arrivalTimeUs int64
+		wantArrival   int64
+	}{
+		{
+			name:          "non-zero send_time overrides arrival_time",
+			sendTimeUs:    50000, // observed trace: slot wait caused send_time > arrival_time
+			arrivalTimeUs: 0,
+			wantArrival:   50000,
+		},
+		{
+			name:          "send_time equals arrival_time: returns send_time unchanged",
+			sendTimeUs:    100000,
+			arrivalTimeUs: 100000,
+			wantArrival:   100000,
+		},
+		{
+			name:          "zero send_time falls back to arrival_time",
+			sendTimeUs:    0,
+			arrivalTimeUs: 200000,
+			wantArrival:   200000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := &TraceV2{
+				Records: []TraceRecord{
+					{
+						RequestID:     0,
+						ArrivalTimeUs: tc.arrivalTimeUs,
+						SendTimeUs:    tc.sendTimeUs,
+						InputTokens:   50,
+						OutputTokens:  25,
+						Status:        "ok",
+					},
+				},
+			}
+			reqs, err := LoadTraceV2Requests(trace, 42)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(reqs) != 1 {
+				t.Fatalf("got %d requests, want 1", len(reqs))
+			}
+			if reqs[0].ArrivalTime != tc.wantArrival {
+				t.Errorf("ArrivalTime = %d, want %d", reqs[0].ArrivalTime, tc.wantArrival)
+			}
+		})
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection verifies BC-3, BC-4, BC-5.
+func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
+	// Session round-0 with send_time > arrival_time (BC-3)
+	// Non-session record with send_time > arrival_time (BC-4)
+	// Think-time gap still uses arrival_time_us deltas (BC-5)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			// Session A: round-0 delayed by concurrency slot wait (50ms)
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				ArrivalTimeUs: 0, SendTimeUs: 50000,
+				InputTokens: 100, OutputTokens: 50},
+			// Session A: round-1 delayed by concurrency slot wait (30ms)
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				ArrivalTimeUs: 200000, SendTimeUs: 230000,
+				InputTokens: 150, OutputTokens: 60},
+			// Non-session record with send_time > arrival_time (BC-4)
+			{RequestID: 3, SessionID: "",
+				ArrivalTimeUs: 10000, SendTimeUs: 40000,
+				InputTokens: 80, OutputTokens: 30},
+		},
+	}
+
+	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the session round-0 request and the non-session request by ArrivalTime
+	sessionArrival := int64(-1)
+	nonSessionArrival := int64(-1)
+	for _, r := range requests {
+		if r.SessionID == "A" {
+			sessionArrival = r.ArrivalTime
+		} else if r.SessionID == "" {
+			nonSessionArrival = r.ArrivalTime
+		}
+	}
+	if sessionArrival == -1 {
+		t.Fatal("session round-0 request not found")
+	}
+	if nonSessionArrival == -1 {
+		t.Fatal("non-session request not found")
+	}
+
+	// BC-3: session round-0 uses send_time
+	if sessionArrival != 50000 {
+		t.Errorf("BC-3: session round-0 ArrivalTime = %d, want 50000 (send_time_us)", sessionArrival)
+	}
+
+	// BC-4: non-session request uses send_time
+	if nonSessionArrival != 40000 {
+		t.Errorf("BC-4: non-session ArrivalTime = %d, want 40000 (send_time_us)", nonSessionArrival)
+	}
+
+	// BC-5: think-time gap derived from ArrivalTimeUs differences (200000 - 0 = 200000)
+	if len(blueprints) != 1 {
+		t.Fatalf("expected 1 blueprint, got %d", len(blueprints))
+	}
+	bp := blueprints[0]
+	if bp.ThinkTimeSampler == nil {
+		t.Fatal("expected ThinkTimeSampler for multi-round session")
+	}
+	gotThinkTime := bp.ThinkTimeSampler.Sample(nil)
+	if gotThinkTime != 200000 {
+		t.Errorf("BC-5: think time = %d, want 200000 (from ArrivalTimeUs gap, not SendTimeUs gap)", gotThinkTime)
+	}
+}
+```
+
+**Verify:** `go test ./sim/workload/... -run TestLoadTraceV2Requests_ConcurrencyMode -count=1`
+**Verify:** `go test ./sim/workload/... -run TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection -count=1`
+
+Expected: FAIL (tests will fail before implementation because `ArrivalTimeUs` is used for injection in all paths)
+
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `test(workload): add failing tests for concurrency-mode send_time injection (BC-1..5)`
+
+---
+
+### Task 2: Fix injection time in LoadTraceV2Requests and LoadTraceV2SessionBlueprints (BC-1..4)
+
+**Files:** modify `sim/workload/replay.go`
+
+**Impl:**
+
+Add a package-level helper (used in 3 places in this file):
+
+```go
+// injectionTime returns the DES injection time for a trace record.
+// For observed traces (concurrency mode), SendTimeUs > 0 and represents
+// when the request was actually sent to the server — the correct reference
+// for TTFT comparison against calibrate's send_time baseline.
+// Falls back to ArrivalTimeUs for generated traces (SendTimeUs == 0).
+func injectionTime(rec TraceRecord) int64 {
+	if rec.SendTimeUs > 0 {
+		return rec.SendTimeUs
+	}
+	return rec.ArrivalTimeUs
+}
+```
+
+Then apply in three spots in `replay.go`:
+
+1. In `LoadTraceV2Requests`, the `req := &sim.Request{...}` block (line ~48):
+   ```go
+   ArrivalTime: injectionTime(rec),
+   ```
+
+2. In `LoadTraceV2SessionBlueprints`, the round-0 `req := &sim.Request{...}` block (line ~203):
+   ```go
+   ArrivalTime: injectionTime(r0),
+   ```
+
+3. In `LoadTraceV2SessionBlueprints`, the non-session block `req := &sim.Request{...}` (line ~253):
+   ```go
+   ArrivalTime: injectionTime(rec),
+   ```
+
+Note: The think-time gap loop (`rounds[i].ArrivalTimeUs - rounds[i-1].ArrivalTimeUs`) is not modified — it correctly uses `ArrivalTimeUs` to preserve client pacing semantics (BC-5).
+
+**Verify:** `go test ./sim/workload/... -run TestLoadTraceV2Requests_ConcurrencyMode -count=1`
+**Verify:** `go test ./sim/workload/... -run TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection -count=1`
+
+Expected: PASS
+
+**Verify all:** `go test ./sim/workload/... -count=1`
+
+Expected: all pass (regression check)
+
+**Lint:** `golangci-lint run ./sim/workload/...`
+**Commit:** `fix(replay): use send_time_us as DES injection time for observed traces (BC-1..4)`
+
+---
+
+## Sanity Checklist
+
+- [ ] R1: No silent `continue` — not applicable (no new error paths)
+- [ ] R3: No new numeric parameters added — not applicable
+- [ ] R4: No struct literal construction sites changed (no fields added, only which value is assigned to `ArrivalTime`)
+- [ ] INV-3 Clock monotonicity: `SendTimeUs >= ArrivalTimeUs` for observed traces; sim-generated traces have `SendTimeUs == ArrivalTimeUs`. No new ordering violation.
+- [ ] INV-5 Causality: `req.ArrivalTime` will now be `SendTimeUs` (≥ `ArrivalTimeUs`) — causality still holds since `send_time ≤ first_chunk_time ≤ last_chunk_time`
+- [ ] INV-6 Determinism: helper is pure (no RNG, no map iteration) — determinism preserved
+- [ ] BC-5 think-time gap: `ArrivalTimeUs` differences in the gap loop are not touched
+- [ ] Backward compat: `SendTimeUs == 0` falls back to `ArrivalTimeUs` — old traces unaffected

--- a/docs/plans/pr-1270-replay-send-time-plan.md
+++ b/docs/plans/pr-1270-replay-send-time-plan.md
@@ -66,6 +66,15 @@ func TestLoadTraceV2Requests_ConcurrencyModeUseSendTime(t *testing.T) {
 			arrivalTimeUs: 200000,
 			wantArrival:   200000,
 		},
+		{
+			// Negative send_time (clock corruption) must NOT be used as injection
+			// time — the > 0 guard ensures we fall back to arrival_time rather
+			// than injecting a negative DES timestamp (which would violate INV-3).
+			name:          "negative send_time falls back to arrival_time",
+			sendTimeUs:    -100,
+			arrivalTimeUs: 300000,
+			wantArrival:   300000,
+		},
 	}
 
 	for _, tc := range tests {
@@ -127,9 +136,10 @@ func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
 	sessionArrival := int64(-1)
 	nonSessionArrival := int64(-1)
 	for _, r := range requests {
-		if r.SessionID == "A" {
+		switch r.SessionID {
+		case "A":
 			sessionArrival = r.ArrivalTime
-		} else if r.SessionID == "" {
+		case "":
 			nonSessionArrival = r.ArrivalTime
 		}
 	}
@@ -150,7 +160,10 @@ func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
 		t.Errorf("BC-4: non-session ArrivalTime = %d, want 40000 (send_time_us)", nonSessionArrival)
 	}
 
-	// BC-5: think-time gap derived from ArrivalTimeUs differences (200000 - 0 = 200000)
+	// BC-5: think-time gap derived from ArrivalTimeUs differences (200000 - 0 = 200000).
+	// ArrivalTimeUs gap: 200000 - 0 = 200000.
+	// SendTimeUs gap:    230000 - 50000 = 180000.
+	// Both assertions make the law explicit: think-time MUST come from ArrivalTimeUs deltas.
 	if len(blueprints) != 1 {
 		t.Fatalf("expected 1 blueprint, got %d", len(blueprints))
 	}
@@ -160,7 +173,49 @@ func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
 	}
 	gotThinkTime := bp.ThinkTimeSampler.Sample(nil)
 	if gotThinkTime != 200000 {
-		t.Errorf("BC-5: think time = %d, want 200000 (from ArrivalTimeUs gap, not SendTimeUs gap)", gotThinkTime)
+		t.Errorf("BC-5: think time = %d, want 200000 (ArrivalTimeUs gap); if 180000, SendTimeUs gap was used instead", gotThinkTime)
+	}
+	if gotThinkTime == 180000 {
+		t.Error("BC-5: think time == 180000 (SendTimeUs gap) — must use ArrivalTimeUs gap instead")
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_NegativeSendTime verifies that negative SendTimeUs
+// (clock corruption) falls back to ArrivalTimeUs for both the session round-0 and
+// non-session call sites in LoadTraceV2SessionBlueprints (INV-3 guard).
+func TestLoadTraceV2SessionBlueprints_NegativeSendTime(t *testing.T) {
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				ArrivalTimeUs: 10000, SendTimeUs: -500,
+				InputTokens: 50, OutputTokens: 25},
+			{RequestID: 2, SessionID: "",
+				ArrivalTimeUs: 20000, SendTimeUs: -100,
+				InputTokens: 30, OutputTokens: 15},
+		},
+	}
+
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sessionArrival := int64(-1)
+	nonSessionArrival := int64(-1)
+	for _, r := range requests {
+		switch r.SessionID {
+		case "A":
+			sessionArrival = r.ArrivalTime
+		case "":
+			nonSessionArrival = r.ArrivalTime
+		}
+	}
+
+	if sessionArrival != 10000 {
+		t.Errorf("session round-0: ArrivalTime = %d, want 10000 (negative send_time must fall back)", sessionArrival)
+	}
+	if nonSessionArrival != 20000 {
+		t.Errorf("non-session: ArrivalTime = %d, want 20000 (negative send_time must fall back)", nonSessionArrival)
 	}
 }
 ```
@@ -185,10 +240,21 @@ Add a package-level helper (used in 3 places in this file):
 
 ```go
 // injectionTime returns the DES injection time for a trace record.
-// For observed traces (concurrency mode), SendTimeUs > 0 and represents
-// when the request was actually sent to the server — the correct reference
-// for TTFT comparison against calibrate's send_time baseline.
-// Falls back to ArrivalTimeUs for generated traces (SendTimeUs == 0).
+// For traces where SendTimeUs > 0, uses SendTimeUs as the DES injection time.
+// For blis observe traces with --concurrency, SendTimeUs is when the HTTP
+// request was actually dispatched (after any concurrency-slot wait), which
+// matches calibrate's TTFT baseline of first_chunk_time_us - send_time_us.
+// For generated traces (blis run), SendTimeUs == ArrivalTimeUs, so both
+// branches produce the same result.
+// Falls back to ArrivalTimeUs whenever SendTimeUs <= 0:
+//   - SendTimeUs == 0: legacy traces or generated traces where no real network
+//     send occurred.
+//   - SendTimeUs < 0: defensive guard against corrupted trace timestamps;
+//     a negative DES injection time would violate INV-3 (clock monotonicity).
+//
+// Note: in closed-loop session replay, think-time gaps between rounds are
+// derived from ArrivalTimeUs deltas (not SendTimeUs) to preserve client-side
+// pacing semantics; only the initial injection point uses SendTimeUs.
 func injectionTime(rec TraceRecord) int64 {
 	if rec.SendTimeUs > 0 {
 		return rec.SendTimeUs
@@ -235,7 +301,7 @@ Expected: all pass (regression check)
 - [ ] R1: No silent `continue` — not applicable (no new error paths)
 - [ ] R3: No new numeric parameters added — not applicable
 - [ ] R4: No struct literal construction sites changed (no fields added, only which value is assigned to `ArrivalTime`)
-- [ ] INV-3 Clock monotonicity: `SendTimeUs >= ArrivalTimeUs` for observed traces; sim-generated traces have `SendTimeUs == ArrivalTimeUs`. No new ordering violation.
+- [ ] INV-3 Clock monotonicity: `SendTimeUs >= ArrivalTimeUs` for observed traces; sim-generated traces have `SendTimeUs == ArrivalTimeUs`. The `> 0` guard (not `!= 0`) additionally defends against corrupted negative timestamps — a negative injection time would violate INV-3 in the event queue.
 - [ ] INV-5 Causality: `req.ArrivalTime` will now be `SendTimeUs` (≥ `ArrivalTimeUs`) — causality still holds since `send_time ≤ first_chunk_time ≤ last_chunk_time`
 - [ ] INV-6 Determinism: helper is pure (no RNG, no map iteration) — determinism preserved
 - [ ] BC-5 think-time gap: `ArrivalTimeUs` differences in the gap loop are not touched

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -32,8 +32,11 @@ func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup st
 // matches calibrate's TTFT baseline of first_chunk_time_us - send_time_us.
 // For generated traces (blis run), SendTimeUs == ArrivalTimeUs, so both
 // branches produce the same result.
-// Falls back to ArrivalTimeUs only for legacy traces without send_time
-// (SendTimeUs == 0) and for requests with ArrivalTimeUs == 0.
+// Falls back to ArrivalTimeUs whenever SendTimeUs <= 0:
+//   - SendTimeUs == 0: legacy traces or generated traces (blis run) where no
+//     real network send occurred.
+//   - SendTimeUs < 0: defensive guard against corrupted trace timestamps;
+//     a negative DES injection time would violate INV-3 (clock monotonicity).
 //
 // Note: in closed-loop session replay, think-time gaps between rounds are
 // derived from ArrivalTimeUs deltas (not SendTimeUs) to preserve client-side

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -25,6 +25,18 @@ func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup st
 	return inputTokens
 }
 
+// injectionTime returns the DES injection time for a trace record.
+// For observed traces, SendTimeUs > 0 and represents when the request was
+// actually sent to the server — the correct reference for TTFT comparison
+// against calibrate's send_time baseline. Falls back to ArrivalTimeUs for
+// generated traces (SendTimeUs == 0) and legacy traces without send_time.
+func injectionTime(rec TraceRecord) int64 {
+	if rec.SendTimeUs > 0 {
+		return rec.SendTimeUs
+	}
+	return rec.ArrivalTimeUs
+}
+
 // LoadTraceV2Requests converts trace v2 records into sim.Request objects
 // with synthetic token IDs for simulation replay. Requests in the same
 // prefix_group share identical prefix token sequences.
@@ -61,7 +73,7 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 
 		req := &sim.Request{
 			ID:               fmt.Sprintf("request_%d", rec.RequestID),
-			ArrivalTime:      rec.ArrivalTimeUs,
+			ArrivalTime:      injectionTime(rec),
 			InputTokens:      inputTokens,
 			OutputTokens:     outputTokens,
 			MaxOutputLen:     len(outputTokens),
@@ -215,7 +227,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 
 		req := &sim.Request{
 			ID:              fmt.Sprintf("request_%d", r0.RequestID),
-			ArrivalTime:     r0.ArrivalTimeUs,
+			ArrivalTime:     injectionTime(r0),
 			InputTokens:     inputTokens,
 			OutputTokens:    outputTokens,
 			MaxOutputLen:    len(outputTokens),
@@ -267,7 +279,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		outputTokens := sim.GenerateRandomTokenIDs(rng, rec.OutputTokens)
 		req := &sim.Request{
 			ID:              fmt.Sprintf("request_%d", rec.RequestID),
-			ArrivalTime:     rec.ArrivalTimeUs,
+			ArrivalTime:     injectionTime(rec),
 			InputTokens:     inputTokens,
 			OutputTokens:    outputTokens,
 			MaxOutputLen:    len(outputTokens),

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -26,10 +26,13 @@ func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup st
 }
 
 // injectionTime returns the DES injection time for a trace record.
-// For observed traces, SendTimeUs > 0 and represents when the request was
-// actually sent to the server — the correct reference for TTFT comparison
-// against calibrate's send_time baseline. Falls back to ArrivalTimeUs for
-// generated traces (SendTimeUs == 0) and legacy traces without send_time.
+// For observed traces (blis observe), SendTimeUs > 0 and represents when the
+// HTTP request was actually sent to the server — the correct reference for
+// TTFT comparison against calibrate's send_time_us baseline. In concurrency
+// mode, SendTimeUs >= ArrivalTimeUs because requests may wait for a free
+// concurrency slot before being dispatched.
+// Falls back to ArrivalTimeUs for generated traces (SendTimeUs == 0) and
+// legacy traces without send_time.
 func injectionTime(rec TraceRecord) int64 {
 	if rec.SendTimeUs > 0 {
 		return rec.SendTimeUs

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -26,13 +26,18 @@ func effectiveInputTokenCount(inputTokens, serverInputTokens int, prefixGroup st
 }
 
 // injectionTime returns the DES injection time for a trace record.
-// For observed traces (blis observe), SendTimeUs > 0 and represents when the
-// HTTP request was actually sent to the server — the correct reference for
-// TTFT comparison against calibrate's send_time_us baseline. In concurrency
-// mode, SendTimeUs >= ArrivalTimeUs because requests may wait for a free
-// concurrency slot before being dispatched.
-// Falls back to ArrivalTimeUs for generated traces (SendTimeUs == 0) and
-// legacy traces without send_time.
+// For traces where SendTimeUs > 0, uses SendTimeUs as the DES injection time.
+// For blis observe traces with --concurrency, SendTimeUs is when the HTTP
+// request was actually dispatched (after any concurrency-slot wait), which
+// matches calibrate's TTFT baseline of first_chunk_time_us - send_time_us.
+// For generated traces (blis run), SendTimeUs == ArrivalTimeUs, so both
+// branches produce the same result.
+// Falls back to ArrivalTimeUs only for legacy traces without send_time
+// (SendTimeUs == 0) and for requests with ArrivalTimeUs == 0.
+//
+// Note: in closed-loop session replay, think-time gaps between rounds are
+// derived from ArrivalTimeUs deltas (not SendTimeUs) to preserve client-side
+// pacing semantics; only the initial injection point uses SendTimeUs.
 func injectionTime(rec TraceRecord) int64 {
 	if rec.SendTimeUs > 0 {
 		return rec.SendTimeUs

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -649,6 +649,15 @@ func TestLoadTraceV2Requests_ConcurrencyModeUseSendTime(t *testing.T) {
 			arrivalTimeUs: 200000,
 			wantArrival:   200000,
 		},
+		{
+			// Negative send_time (clock corruption) must NOT be used as injection
+			// time — the > 0 guard ensures we fall back to arrival_time rather
+			// than injecting a negative DES timestamp (which would violate INV-3).
+			name:          "negative send_time falls back to arrival_time",
+			sendTimeUs:    -100,
+			arrivalTimeUs: 300000,
+			wantArrival:   300000,
+		},
 	}
 
 	for _, tc := range tests {

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -752,7 +752,58 @@ func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
 		t.Fatal("expected ThinkTimeSampler for multi-round session")
 	}
 	gotThinkTime := bp.ThinkTimeSampler.Sample(nil)
+	// ArrivalTimeUs gap: 200000 - 0 = 200000.
+	// SendTimeUs gap:    230000 - 50000 = 180000.
+	// Asserting == 200000 AND != 180000 makes the law explicit: think-time MUST
+	// come from ArrivalTimeUs deltas, not SendTimeUs deltas.
 	if gotThinkTime != 200000 {
-		t.Errorf("BC-5: think time = %d, want 200000 (from ArrivalTimeUs gap, not SendTimeUs gap)", gotThinkTime)
+		t.Errorf("BC-5: think time = %d, want 200000 (ArrivalTimeUs gap); if 180000, SendTimeUs gap was used instead", gotThinkTime)
+	}
+	if gotThinkTime == 180000 {
+		t.Error("BC-5: think time == 180000 (SendTimeUs gap) — must use ArrivalTimeUs gap instead")
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_NegativeSendTime verifies that negative SendTimeUs
+// (clock corruption) falls back to ArrivalTimeUs for both the session round-0 and
+// non-session call sites in LoadTraceV2SessionBlueprints (INV-3 guard, mirroring the
+// negative case in TestLoadTraceV2Requests_ConcurrencyModeUseSendTime).
+func TestLoadTraceV2SessionBlueprints_NegativeSendTime(t *testing.T) {
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			// Session round-0: negative SendTimeUs must not become injection time.
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				ArrivalTimeUs: 10000, SendTimeUs: -500,
+				InputTokens: 50, OutputTokens: 25},
+			// Non-session: same guard on the independent call site.
+			{RequestID: 2, SessionID: "",
+				ArrivalTimeUs: 20000, SendTimeUs: -100,
+				InputTokens: 30, OutputTokens: 15},
+		},
+	}
+
+	requests, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sessionArrival := int64(-1)
+	nonSessionArrival := int64(-1)
+	for _, r := range requests {
+		switch r.SessionID {
+		case "A":
+			sessionArrival = r.ArrivalTime
+		case "":
+			nonSessionArrival = r.ArrivalTime
+		}
+	}
+
+	// Session round-0: must use ArrivalTimeUs (10000), not SendTimeUs (-500).
+	if sessionArrival != 10000 {
+		t.Errorf("session round-0: ArrivalTime = %d, want 10000 (negative send_time must fall back)", sessionArrival)
+	}
+	// Non-session: must use ArrivalTimeUs (20000), not SendTimeUs (-100).
+	if nonSessionArrival != 20000 {
+		t.Errorf("non-session: ArrivalTime = %d, want 20000 (negative send_time must fall back)", nonSessionArrival)
 	}
 }

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -622,3 +622,128 @@ func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 		t.Errorf("request 1 input token count = %d, want 50 (fallback)", len(requests[1].InputTokens))
 	}
 }
+
+// TestLoadTraceV2Requests_ConcurrencyModeUseSendTime verifies BC-1 and BC-2.
+func TestLoadTraceV2Requests_ConcurrencyModeUseSendTime(t *testing.T) {
+	tests := []struct {
+		name          string
+		sendTimeUs    int64
+		arrivalTimeUs int64
+		wantArrival   int64
+	}{
+		{
+			name:          "non-zero send_time overrides arrival_time",
+			sendTimeUs:    50000, // observed trace: slot wait caused send_time > arrival_time
+			arrivalTimeUs: 0,
+			wantArrival:   50000,
+		},
+		{
+			name:          "send_time equals arrival_time: returns send_time unchanged",
+			sendTimeUs:    100000,
+			arrivalTimeUs: 100000,
+			wantArrival:   100000,
+		},
+		{
+			name:          "zero send_time falls back to arrival_time",
+			sendTimeUs:    0,
+			arrivalTimeUs: 200000,
+			wantArrival:   200000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := &TraceV2{
+				Records: []TraceRecord{
+					{
+						RequestID:     0,
+						ArrivalTimeUs: tc.arrivalTimeUs,
+						SendTimeUs:    tc.sendTimeUs,
+						InputTokens:   50,
+						OutputTokens:  25,
+						Status:        "ok",
+					},
+				},
+			}
+			reqs, err := LoadTraceV2Requests(trace, 42)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(reqs) != 1 {
+				t.Fatalf("got %d requests, want 1", len(reqs))
+			}
+			if reqs[0].ArrivalTime != tc.wantArrival {
+				t.Errorf("ArrivalTime = %d, want %d", reqs[0].ArrivalTime, tc.wantArrival)
+			}
+		})
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection verifies BC-3, BC-4, BC-5.
+func TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection(t *testing.T) {
+	// Session round-0 with send_time > arrival_time (BC-3)
+	// Non-session record with send_time > arrival_time (BC-4)
+	// Think-time gap still uses arrival_time_us deltas (BC-5)
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			// Session A: round-0 delayed by concurrency slot wait (50ms)
+			{RequestID: 1, SessionID: "A", RoundIndex: 0,
+				ArrivalTimeUs: 0, SendTimeUs: 50000,
+				InputTokens: 100, OutputTokens: 50},
+			// Session A: round-1 delayed by concurrency slot wait (30ms)
+			{RequestID: 2, SessionID: "A", RoundIndex: 1,
+				ArrivalTimeUs: 200000, SendTimeUs: 230000,
+				InputTokens: 150, OutputTokens: 60},
+			// Non-session record with send_time > arrival_time (BC-4)
+			{RequestID: 3, SessionID: "",
+				ArrivalTimeUs: 10000, SendTimeUs: 40000,
+				InputTokens: 80, OutputTokens: 30},
+		},
+	}
+
+	requests, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the session round-0 request and the non-session request by ArrivalTime
+	sessionArrival := int64(-1)
+	nonSessionArrival := int64(-1)
+	for _, r := range requests {
+		switch r.SessionID {
+		case "A":
+			sessionArrival = r.ArrivalTime
+		case "":
+			nonSessionArrival = r.ArrivalTime
+		}
+	}
+	if sessionArrival == -1 {
+		t.Fatal("session round-0 request not found")
+	}
+	if nonSessionArrival == -1 {
+		t.Fatal("non-session request not found")
+	}
+
+	// BC-3: session round-0 uses send_time
+	if sessionArrival != 50000 {
+		t.Errorf("BC-3: session round-0 ArrivalTime = %d, want 50000 (send_time_us)", sessionArrival)
+	}
+
+	// BC-4: non-session request uses send_time
+	if nonSessionArrival != 40000 {
+		t.Errorf("BC-4: non-session ArrivalTime = %d, want 40000 (send_time_us)", nonSessionArrival)
+	}
+
+	// BC-5: think-time gap derived from ArrivalTimeUs differences (200000 - 0 = 200000)
+	if len(blueprints) != 1 {
+		t.Fatalf("expected 1 blueprint, got %d", len(blueprints))
+	}
+	bp := blueprints[0]
+	if bp.ThinkTimeSampler == nil {
+		t.Fatal("expected ThinkTimeSampler for multi-round session")
+	}
+	gotThinkTime := bp.ThinkTimeSampler.Sample(nil)
+	if gotThinkTime != 200000 {
+		t.Errorf("BC-5: think time = %d, want 200000 (from ArrivalTimeUs gap, not SendTimeUs gap)", gotThinkTime)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes systematic TTFT pessimism in calibration for concurrency-mode traces
- Adds `injectionTime()` helper in `sim/workload/replay.go` that returns `SendTimeUs` when `> 0`, else falls back to `ArrivalTimeUs`
- Applies at all three `sim.Request` construction sites in `LoadTraceV2Requests` and `LoadTraceV2SessionBlueprints`
- Think-time gap derivation for sessions (`ArrivalTimeUs` differences) is deliberately unchanged per issue specification

## Root cause

When `blis observe --concurrency N` runs, requests that wait for a free slot have `send_time_us > arrival_time_us`. `blis calibrate` correctly measures real TTFT as `first_chunk_time_us - send_time_us`. But `blis replay` was injecting at `arrival_time_us` — up to 50ms+ too early — causing the sim to accumulate phantom queue time that never existed on the server. This made the simulator look consistently pessimistic for all concurrency-mode traces.

For rate-mode traces and generated traces, `send_time_us == arrival_time_us` (or `send_time_us == 0`), so those are unaffected.

## Behavioral Contracts

- **BC-1**: GIVEN a trace record where `SendTimeUs > 0`, WHEN `LoadTraceV2Requests` builds a request, THEN `req.ArrivalTime == rec.SendTimeUs`
- **BC-2**: GIVEN `SendTimeUs == 0`, THEN `req.ArrivalTime == rec.ArrivalTimeUs` (backward-compatible)
- **BC-3**: Session round-0 requests also use `SendTimeUs` when set
- **BC-4**: Non-session records in `LoadTraceV2SessionBlueprints` also use `SendTimeUs`
- **BC-5**: Inter-round think-time gaps still derived from `ArrivalTimeUs` differences (unchanged)

## Test plan

- [ ] `TestLoadTraceV2Requests_ConcurrencyModeUseSendTime` — table-driven: non-zero SendTimeUs overrides, equal values, zero fallback
- [ ] `TestLoadTraceV2SessionBlueprints_ConcurrencyModeInjection` — BC-3 (session round-0), BC-4 (non-session), BC-5 (think-time gap unchanged)
- [ ] All existing tests pass (`go test ./... -count=1`)
- [ ] Lint clean (`golangci-lint run ./...`)

## Discovered Issues

- #1302: `LoadTraceV2Requests` / `LoadTraceV2SessionBlueprints` lack validation that `ArrivalTimeUs >= 0` (pre-existing, filed during code review)

Fixes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)