### PR TITLE
hardening(cluster): fix incorrect R6 citation in PD routing panic comments

### DIFF
--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1839,7 +1839,8 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 		}
 	}
 	if decodeInst == nil {
-		// R6: routing policy must return a valid target from the provided snapshot set.
+		// The routing policy contract requires Route to return a TargetInstance from the
+		// provided snapshot set; a panic here indicates a policy implementation bug.
 		panic(fmt.Sprintf("executeDisaggregatedRouting: invalid decode TargetInstance %q returned by routing policy", decodeDecision.TargetInstance))
 	}
 

--- a/sim/cluster/pd_events.go
+++ b/sim/cluster/pd_events.go
@@ -82,7 +82,8 @@ func (e *PrefillRoutingEvent) Execute(cs *ClusterSimulator) {
 			return
 		}
 	}
-	// R6: library panic on programming error — policy must return valid target
+	// The routing policy contract requires Route to return a TargetInstance from the
+	// provided snapshot set; a panic here indicates a policy implementation bug.
 	panic(fmt.Sprintf("PrefillRoutingEvent: invalid TargetInstance %q returned by routing policy", decision.TargetInstance))
 }
 


### PR DESCRIPTION
## Summary

Two panic guards in PD disaggregation code cite **R6** for the wrong reason. Per [`docs/contributing/standards/rules.md`](https://github.com/inference-sim/inference-sim/blob/main/docs/contributing/standards/rules.md), R6 is *"No `logrus.Fatalf` in library code"* — it says nothing about routing-policy contracts. The panics themselves are correct (programming error on invariant violation); only the rule tag was wrong.

- `sim/cluster/cluster.go` — `executeDisaggregatedRouting`, decode-instance lookup fallback
- `sim/cluster/pd_events.go` — `PrefillRoutingEvent.Execute`, prefill-instance lookup fallback

Both are replaced with rule-accurate phrasing describing the actual `Route` contract: the routing policy must return a `TargetInstance` from the provided snapshot set; a panic here indicates a policy implementation bug.

Comment-only; no behavior change.

## Behavioral Contracts

None. Pure comment fix — no runtime change, no test change.

## Testing

- `go build ./...` — passes
- `go test ./sim/cluster/... -count=1` — passes (203s)
- `go vet ./sim/cluster/...` — clean

## Discovered Issues

`sim/cluster/cluster_event.go:375` carries the same mis-citation pattern. Issue #1293 stated that PR #1265 already fixed this line, but the merge commit for #1265 (`cd34024`) did not touch `cluster_event.go` — the fix lives only on a local branch that never merged. To respect the scope declared in #1293 (the two files explicitly listed), `cluster_event.go` is **deferred from this PR**. A follow-up issue should be filed (or #1293 expanded) to clean it up separately. No code change; purely a comment inconsistency.

## PR size tier

**Express Lane** — 4 lines of comment text changed across 2 files, purely mechanical comment rewording, no behavioral change, not in a source-of-truth file. Per [`docs/contributing/pr-workflow.md`](https://github.com/inference-sim/inference-sim/blob/main/docs/contributing/pr-workflow.md) Express Lane: implement → self-audit (correctness / determinism / consistency) → commit. The worktree and compact plan were added because the user's invocation explicitly required worktree isolation for parallel work.

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)