### PR TITLE
feat(cluster): SLO-deadline ordering + per-request SLO target pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,11 @@ go build -o blis main.go
 # Run with flow control and request TTL (expire queued requests after 5 seconds)
 ./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
   --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 --request-ttl 5000000
+
+# Run with SLO-deadline dispatch ordering (tightest SLO target dispatches first)
+./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
+  --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
+  --dispatch-order slo-deadline --slo-targets "critical=100000,standard=500000"
 ```
 
 ## Testing

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -99,6 +100,7 @@ type PendingRequest struct {
 	Unconstrained   bool
 	MinTokens       int
 	DeadlineUs      int64
+	SLOTargetUs     int64
 }
 
 // RequestRecord captures one request-response cycle.
@@ -207,6 +209,9 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 	}
 	if req.SLOClass != "" {
 		httpReq.Header.Set("x-gateway-inference-objective", req.SLOClass)
+	}
+	if req.SLOTargetUs > 0 {
+		httpReq.Header.Set("x-slo-ttft-ms", strconv.FormatInt(req.SLOTargetUs/1000, 10))
 	}
 
 	// Record send time
@@ -459,6 +464,7 @@ func (r *Recorder) RecordRequest(pending *PendingRequest, result *RequestRecord,
 		InputTokens:       inputTokens,
 		OutputTokens:      result.OutputTokens,
 		DeadlineUs:        pending.DeadlineUs,
+		SLOTargetUs:       pending.SLOTargetUs,
 		ArrivalTimeUs:     arrivalTimeUs,
 		SendTimeUs:        result.SendTimeUs,
 		FirstChunkTimeUs:  result.FirstChunkTimeUs,

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -108,8 +108,8 @@ type RequestRecord struct {
 	RequestID         int
 	OutputTokens      int
 	ServerInputTokens int
-	VLLMPriority      int     // vLLM priority value (0=highest urgency, higher=lower urgency); 0 when not set
-	Status            string  // "ok", "error", "timeout"
+	VLLMPriority      int    // vLLM priority value (0=highest urgency, higher=lower urgency); 0 when not set
+	Status            string // "ok", "error", "timeout"
 	ErrorMessage      string
 	SendTimeUs        int64
 	FirstChunkTimeUs  int64
@@ -211,7 +211,8 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 		httpReq.Header.Set("x-gateway-inference-objective", req.SLOClass)
 	}
 	if req.SLOTargetUs > 0 {
-		httpReq.Header.Set("x-slo-ttft-ms", strconv.FormatInt(req.SLOTargetUs/1000, 10))
+		ms := (req.SLOTargetUs + 999) / 1000 // ceiling division: µs→ms
+		httpReq.Header.Set("x-slo-ttft-ms", strconv.FormatInt(ms, 10))
 	}
 
 	// Record send time
@@ -520,4 +521,3 @@ func (r *Recorder) ITLRecords() []workload.ITLRecord {
 func (r *Recorder) ExportITL(path string) error {
 	return workload.ExportITL(r.ITLRecords(), path)
 }
-

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -925,6 +925,7 @@ func requestToPending(req *sim.Request, reqIndex int, noStreaming, unconstrained
 		Unconstrained:   unconstrained,
 		MinTokens:       minTokens,
 		DeadlineUs:      req.Deadline,
+		SLOTargetUs:     req.SLOTargetUs,
 	}
 }
 

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	traceHeaderPath string
-	traceDataPath   string
+	traceHeaderPath     string
+	traceDataPath       string
 	replayTraceOutput   string // File prefix for TraceV2 re-export (<prefix>.yaml + <prefix>.csv)
 	replaySessionMode   string
 	replayThinkTimeMs   int
@@ -486,6 +486,7 @@ Example:
 			FlowControlEnabled:              flowControlEnabled,
 			FlowControlDetector:             flowControlDetector,
 			FlowControlDispatchOrder:        flowControlDispatchOrder,
+			FlowControlSLOTargets:           sloTargetsMap,
 			FlowControlMaxQueueDepth:        flowControlMaxQueueDepth,
 			FlowControlQueueDepthThreshold:  flowControlQueueDepthThreshold,
 			FlowControlKVCacheUtilThreshold: flowControlKVCacheUtilThreshold,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -98,6 +99,7 @@ var (
 	tierShedMinPriority   int                // Tier-shed minimum admitted priority under overload
 	tenantBudgets         map[string]float64 // Per-tenant fraction of total capacity (nil = no enforcement)
 	sloPriorityOverrides  map[string]int     // SLO class → priority overrides (nil = GAIE defaults)
+	sloTargetsMap         map[string]int64   // SLO class → TTFT target µs for slo-deadline ordering (nil = disabled)
 	gaieQDThreshold       float64            // GAIE-legacy queue depth threshold per instance (default 5)
 	gaieKVThreshold       float64            // GAIE-legacy KV cache utilization threshold (default 0.8)
 
@@ -155,6 +157,7 @@ var (
 	flowControlEnabled              bool
 	flowControlDetector             string
 	flowControlDispatchOrder        string
+	flowControlSLOTargets           string
 	flowControlMaxQueueDepth        int
 	flowControlQueueDepthThreshold  float64
 	flowControlKVCacheUtilThreshold float64
@@ -720,7 +723,10 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 				}
 			}
 		}
-		if bundle.Admission.GAIEQDThreshold != nil {
+		if bundle.Admission.SLOTargets != nil && sloTargetsMap == nil {
+				sloTargetsMap = bundle.Admission.SLOTargets
+			}
+			if bundle.Admission.GAIEQDThreshold != nil {
 			gaieQDThreshold = *bundle.Admission.GAIEQDThreshold
 		}
 		if bundle.Admission.GAIEKVThreshold != nil {
@@ -826,8 +832,8 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 		if !sim.IsValidSaturationDetector(flowControlDetector) {
 			logrus.Fatalf("Unknown saturation detector %q. Valid: %s", flowControlDetector, strings.Join(sim.ValidSaturationDetectorNames(), ", "))
 		}
-		if flowControlDispatchOrder != "fifo" && flowControlDispatchOrder != "priority" {
-			logrus.Fatalf("--dispatch-order must be 'fifo' or 'priority', got %q", flowControlDispatchOrder)
+		if flowControlDispatchOrder != "fifo" && flowControlDispatchOrder != "priority" && flowControlDispatchOrder != "slo-deadline" {
+			logrus.Fatalf("--dispatch-order must be 'fifo', 'priority', or 'slo-deadline', got %q", flowControlDispatchOrder)
 		}
 		if flowControlMaxQueueDepth < 0 {
 			logrus.Fatalf("--max-gateway-queue-depth must be >= 0, got %d", flowControlMaxQueueDepth)
@@ -843,6 +849,21 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 		}
 		if flowControlUsageLimitThreshold < 1.0 && flowControlDispatchOrder == "fifo" {
 			logrus.Warnf("--usage-limit-threshold < 1.0 with --dispatch-order fifo: HoL blocking uses priority-order iteration, FIFO semantics will not apply to gating decisions")
+		}
+		// Parse --slo-targets into map (e.g. "critical=100000,standard=500000")
+		if flowControlSLOTargets != "" {
+			sloTargetsMap = make(map[string]int64)
+			for _, pair := range strings.Split(flowControlSLOTargets, ",") {
+				parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+				if len(parts) != 2 {
+					logrus.Fatalf("--slo-targets: invalid format %q (expected key=value)", pair)
+				}
+				v, parseErr := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				if parseErr != nil || v < 0 {
+					logrus.Fatalf("--slo-targets: invalid value for %q: %s", strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+				}
+				sloTargetsMap[strings.TrimSpace(parts[0])] = v
+			}
 		}
 		// Validate only parameters consumed by the selected detector
 		switch flowControlDetector {
@@ -989,7 +1010,8 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	// Flow control config (issue #882, GIE parity)
 	cmd.Flags().BoolVar(&flowControlEnabled, "flow-control", false, "Enable gateway queue with saturation-gated dispatch (GIE flow control)")
 	cmd.Flags().StringVar(&flowControlDetector, "saturation-detector", "never", "Saturation detector: "+strings.Join(sim.ValidSaturationDetectorNames(), ", "))
-	cmd.Flags().StringVar(&flowControlDispatchOrder, "dispatch-order", "fifo", "Gateway queue dispatch order: fifo, priority")
+	cmd.Flags().StringVar(&flowControlDispatchOrder, "dispatch-order", "fifo", "Gateway queue dispatch order: fifo, priority, slo-deadline")
+	cmd.Flags().StringVar(&flowControlSLOTargets, "slo-targets", "", "Per-SLO-class TTFT targets in µs for slo-deadline ordering (e.g., critical=100000,standard=500000)")
 	cmd.Flags().IntVar(&flowControlMaxQueueDepth, "max-gateway-queue-depth", 0, "Max gateway queue depth (0=unlimited)")
 	cmd.Flags().Float64Var(&flowControlQueueDepthThreshold, "queue-depth-threshold", 5, "Queue depth threshold for utilization detector")
 	cmd.Flags().Float64Var(&flowControlKVCacheUtilThreshold, "kv-cache-util-threshold", 0.8, "KV cache utilization threshold for utilization detector")
@@ -1593,6 +1615,7 @@ var runCmd = &cobra.Command{
 			FlowControlEnabled:              flowControlEnabled,
 			FlowControlDetector:             flowControlDetector,
 			FlowControlDispatchOrder:        flowControlDispatchOrder,
+			FlowControlSLOTargets:           sloTargetsMap,
 			FlowControlMaxQueueDepth:        flowControlMaxQueueDepth,
 			FlowControlQueueDepthThreshold:  flowControlQueueDepthThreshold,
 			FlowControlKVCacheUtilThreshold: flowControlKVCacheUtilThreshold,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,15 +181,15 @@ var (
 	requestTimeoutSecs int
 
 	// output file paths
-	metricsPath string // File to write MetricsOutput JSON for blis run (--metrics-path)
-	resultsPath string // File to write []SimResult JSON for blis replay (--results-path)
+	metricsPath      string // File to write MetricsOutput JSON for blis run (--metrics-path)
+	resultsPath      string // File to write []SimResult JSON for blis replay (--results-path)
 	saturationReport string // File to write BacklogDriftReport JSON for saturation analysis (--saturation-report)
 
 	// saturation analysis configuration
-	saturationWindowSec int // Window size in seconds for backlog-drift analysis (--saturation-window)
-	saturationMinWindows int // Minimum number of windows required for classification (--saturation-min-windows)
-	saturationPeakRatio float64 // Peak/mean ratio threshold for transient backlog detection (--saturation-peak-ratio)
-	saturationPeakBand float64 // Confidence band around peak ratio threshold (--saturation-peak-band)
+	saturationWindowSec  int     // Window size in seconds for backlog-drift analysis (--saturation-window)
+	saturationMinWindows int     // Minimum number of windows required for classification (--saturation-min-windows)
+	saturationPeakRatio  float64 // Peak/mean ratio threshold for transient backlog detection (--saturation-peak-ratio)
+	saturationPeakBand   float64 // Confidence band around peak ratio threshold (--saturation-peak-band)
 	saturationConfidence float64 // Confidence level for slope CI (--saturation-ci)
 
 	// trace export
@@ -724,9 +724,9 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 			}
 		}
 		if bundle.Admission.SLOTargets != nil && sloTargetsMap == nil {
-				sloTargetsMap = bundle.Admission.SLOTargets
-			}
-			if bundle.Admission.GAIEQDThreshold != nil {
+			sloTargetsMap = bundle.Admission.SLOTargets
+		}
+		if bundle.Admission.GAIEQDThreshold != nil {
 			gaieQDThreshold = *bundle.Admission.GAIEQDThreshold
 		}
 		if bundle.Admission.GAIEKVThreshold != nil {
@@ -858,12 +858,19 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 				if len(parts) != 2 {
 					logrus.Fatalf("--slo-targets: invalid format %q (expected key=value)", pair)
 				}
-				v, parseErr := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
-				if parseErr != nil || v < 0 {
-					logrus.Fatalf("--slo-targets: invalid value for %q: %s", strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+				key := strings.TrimSpace(parts[0])
+				if key == "" {
+					logrus.Fatalf("--slo-targets: empty key in pair %q (expected key=value)", pair)
 				}
-				sloTargetsMap[strings.TrimSpace(parts[0])] = v
+				v, parseErr := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				if parseErr != nil || v <= 0 {
+					logrus.Fatalf("--slo-targets: value for %q must be a positive integer (µs), got %s", key, strings.TrimSpace(parts[1]))
+				}
+				sloTargetsMap[key] = v
 			}
+		}
+		if sloTargetsMap != nil && flowControlDispatchOrder != "slo-deadline" {
+			logrus.Warnf("--slo-targets has no effect without --dispatch-order slo-deadline")
 		}
 		// Validate only parameters consumed by the selected detector
 		switch flowControlDetector {

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -225,6 +225,39 @@ shedding of sheddable entries.
   --per-band-capacity 100 --max-gateway-queue-depth 500
 ```
 
+### SLO-Deadline Dispatch Ordering
+
+With `--dispatch-order slo-deadline`, the gateway queue dispatches requests with the tightest SLO targets first within each flow. This matches GIE's `slo-deadline-ordering-policy`.
+
+**How it works:**
+
+1. Fairness policy picks the flow (same as priority mode)
+2. Within the picked flow, dequeue the request with the earliest SLO deadline
+3. Deadline = `GatewayEnqueueTime + SLOTargetUs`
+4. Fallback hierarchy: per-request `SLOTargetUs` → per-tier `--slo-targets` → far-future (FCFS)
+5. Equal deadlines use arrival order (seqID) as tiebreaker
+
+**Setting SLO targets:**
+
+- **Per-request** (workload spec): `slo_target_us: 200000` on a cohort (200ms TTFT target)
+- **Per-tier** (CLI flag): `--slo-targets critical=100000,standard=500000` (fallback when workload spec doesn't set per-request targets)
+- **Per-tier** (policy bundle): `admission.slo_targets` in YAML
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--dispatch-order slo-deadline` | Enable SLO-deadline ordering | `fifo` |
+| `--slo-targets` | Per-SLO-class TTFT targets in µs (e.g., `critical=100000,standard=500000`) | none |
+
+**Example:**
+
+```bash
+./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
+  --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
+  --dispatch-order slo-deadline --slo-targets "critical=100000,standard=500000"
+```
+
+**Observe integration:** When `slo_target_us > 0`, `blis observe` injects the `x-slo-ttft-ms` HTTP header on outgoing requests, matching GIE's header convention.
+
 ### In-Flight Eviction
 
 When flow control is enabled and the system is saturated, BLIS can evict sheddable requests that are already running on instances to free capacity for higher-priority waiting requests. This matches GIE's eviction architecture.
@@ -252,7 +285,7 @@ When flow control is enabled and the system is saturated, BLIS can evict sheddab
 |--------|--------------------------------------|---------------------|
 | Admission | Separate from queuing | Queue IS admission |
 | Queue structure | None (admit/reject then route directly) | Per-priority-band, per-flow |
-| Dispatch order | N/A (no queue) | `--dispatch-order` (fifo/priority) |
+| Dispatch order | N/A (no queue) | `--dispatch-order` (fifo/priority/slo-deadline) |
 | Capacity | N/A (no queue) | Per-band + global |
 
 ## Pipeline Latency

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -192,7 +192,7 @@ admission decision, matching llm-d's `FlowControlAdmissionController`.
 
 1. Incoming request is enqueued into a per-priority-band, per-flow queue
 2. Each unique (TenantID, Priority) pair gets its own FIFO queue within a priority band
-3. Dispatch order follows `--dispatch-order`: with `priority`, iterates bands highest-priority first; with `fifo` (default), picks the globally-earliest arrival across all bands
+3. Dispatch order follows `--dispatch-order`: with `priority`, iterates bands highest-priority first; with `fifo` (default), picks the globally-earliest arrival across all bands; with `slo-deadline`, dispatches the request with the earliest SLO deadline within each flow (see [SLO-Deadline Dispatch Ordering](#slo-deadline-dispatch-ordering) below)
 4. Within a band, `--fairness-policy` controls flow selection: `global-strict` (default) picks the earliest arrival (lowest sequence ID); `round-robin` cycles through tenants in sorted key order
 5. Saturation gating: dispatch only when cluster saturation < 1.0
 6. Completion-triggered dispatch: each completion frees capacity and tries to dispatch from the queue
@@ -227,7 +227,7 @@ shedding of sheddable entries.
 
 ### SLO-Deadline Dispatch Ordering
 
-With `--dispatch-order slo-deadline`, the gateway queue dispatches requests with the tightest SLO targets first within each flow. This matches GIE's `slo-deadline-ordering-policy`.
+With `--dispatch-order slo-deadline`, the gateway queue dispatches the request with the earliest SLO deadline first within each flow. This matches GIE's `slo-deadline-ordering-policy`.
 
 **How it works:**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -236,7 +236,7 @@ admission:
 |-----------|------|----------------------|
 | Tier-shed admission | `sim/admission.go` | Rejects requests with `Priority(class) < MinAdmitPriority` under overload |
 | Tenant budget enforcement | `sim/cluster/cluster_event.go` | Sheds over-budget requests where `IsSheddable(class)` is true (priority < 0) |
-| Gateway queue dispatch | `sim/cluster/gateway_queue.go` | Priority-ordered dispatch: higher priority dequeued first; capacity shedding evicts lowest priority |
+| Gateway queue dispatch | `sim/cluster/gateway_queue.go` | Priority-ordered or SLO-deadline dispatch: higher priority dequeued first (priority mode), earliest SLO deadline within flow (slo-deadline mode); capacity shedding evicts lowest priority |
 | Backward compatibility | `sim/admission.go` | `SLOTierPriority()` delegates to `DefaultSLOPriorityMap().Priority()` |
 
 **Per-tenant fair-share budgets** (`tenant_budgets`): A secondary admission layer that runs *after* the admission policy. If the admission policy rejects a request, tenant budgets are not consulted. If the admission policy admits a request, tenant budgets then apply: over-budget tenants have sheddable requests (`IsSheddable(class) = priority < 0`) preferentially shed, while non-sheddable traffic (critical, standard) is always protected. Configured via `--policy-config` YAML only (no CLI flag):

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -254,6 +254,9 @@ admission:
   tier_shed_min_priority: 3  # admit standard(3) and critical(4); shed sheddable tiers (priority < 0)
   slo_priorities:             # optional: override specific priorities
     batch: 0                  # promote batch to non-sheddable
+  slo_targets:                # optional: per-class TTFT targets in µs for slo-deadline ordering
+    critical: 100000          # 100ms TTFT target
+    standard: 500000          # 500ms TTFT target
 
 tenant_budgets:
   alice: 0.3   # alice may use at most 30% of total cluster capacity
@@ -271,7 +274,8 @@ When `--flow-control` is enabled, admission IS the queue — requests are enqueu
 | `--queue-depth-threshold` | int | 5 | Queue depth threshold for utilization-based saturation |
 | `--kv-cache-util-threshold` | float64 | 0.8 | KV cache utilization threshold for saturation |
 | `--max-concurrency` | int | 64 | Max in-flight requests for concurrency-based saturation |
-| `--dispatch-order` | string | "fifo" | Cross-band dispatch: `fifo` (globally-earliest), `priority` (highest band first) |
+| `--dispatch-order` | string | "fifo" | Cross-band dispatch: `fifo` (globally-earliest), `priority` (highest band first), `slo-deadline` (earliest SLO deadline within flow) |
+| `--slo-targets` | string | "" | Per-SLO-class TTFT targets in µs for slo-deadline ordering (e.g., `critical=100000,standard=500000`) |
 | `--fairness-policy` | string | "global-strict" | Intra-band flow selection: `global-strict` (earliest seqID), `round-robin` (tenant cycling) |
 | `--per-band-capacity` | int | 0 | Max requests per priority band (0=unlimited) |
 | `--max-gateway-queue-depth` | int | 0 | Global queue depth limit (0=unlimited) |

--- a/docs/reference/workload-spec.md
+++ b/docs/reference/workload-spec.md
@@ -40,6 +40,8 @@ Each entry in the `clients` list defines a traffic source:
 | `lifecycle` | object | No | Activity window configuration |
 | `multimodal` | object | No | Multimodal token generation |
 | `reasoning` | object | No | Reasoning multi-turn behavior |
+| `timeout` | int64 | No | Per-request timeout in µs. nil = default (300s for sessions). 0 = no timeout |
+| `slo_target_us` | int64 | No | Per-request SLO TTFT target in µs. nil/0 = no target. Used by `--dispatch-order slo-deadline` |
 
 ## Arrival Process
 
@@ -107,6 +109,8 @@ Each entry in the `cohorts` list defines a population with lifecycle dynamics. C
 | `diurnal` | object | No | Sinusoidal rate modulation (see below) |
 | `spike` | object | No | Traffic spike configuration (see below) |
 | `drain` | object | No | Linear ramp-down to zero (see below) |
+| `timeout` | int64 | No | Per-request timeout in µs (same as Client) |
+| `slo_target_us` | int64 | No | Per-request SLO TTFT target in µs (same as Client) |
 
 ### Diurnal Pattern
 

--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -38,7 +38,8 @@ type AdmissionConfig struct {
 	GAIEKVThreshold *float64 `yaml:"gaie_kv_threshold"` // nil = use default (0.8)
 	// SLOPriorities overrides default SLO class → priority mappings.
 	// nil = use GAIE defaults (critical=4, standard=3, batch=-1, sheddable=-2, background=-3).
-	SLOPriorities map[string]int `yaml:"slo_priorities,omitempty"`
+	SLOPriorities map[string]int   `yaml:"slo_priorities,omitempty"`
+	SLOTargets    map[string]int64 `yaml:"slo_targets,omitempty"` // Per-SLO-class TTFT targets in µs for slo-deadline ordering
 }
 
 // RoutingConfig holds routing policy configuration.

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -434,6 +434,9 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		}
 		cs.flowControlEnabled = true
 		gq := NewGatewayQueue(dispatchOrder, config.FlowControlMaxQueueDepth, cs.priorityMap)
+		if config.FlowControlSLOTargets != nil {
+			gq.SetSLOTargets(config.FlowControlSLOTargets)
+		}
 		if config.FlowControlPerBandCapacity > 0 {
 			gq.SetPerBandCapacity(config.FlowControlPerBandCapacity)
 		}

--- a/sim/cluster/deployment.go
+++ b/sim/cluster/deployment.go
@@ -122,8 +122,9 @@ type DeploymentConfig struct {
 	// and requests flow directly from admission to routing (BC-1 pass-through).
 	FlowControlEnabled              bool    `yaml:"flow_control_enabled,omitempty"`
 	FlowControlDetector             string  `yaml:"flow_control_detector,omitempty"`                // "never" (default), "utilization", "concurrency"
-	FlowControlDispatchOrder        string  `yaml:"flow_control_dispatch_order,omitempty"`          // "fifo" (default), "priority"
-	FlowControlMaxQueueDepth        int     `yaml:"flow_control_max_queue_depth,omitempty"`         // 0 = unlimited
+	FlowControlDispatchOrder        string           `yaml:"flow_control_dispatch_order,omitempty"`  // "fifo" (default), "priority", "slo-deadline"
+	FlowControlSLOTargets           map[string]int64 `yaml:"flow_control_slo_targets,omitempty"`     // SLO class → TTFT target µs for slo-deadline ordering
+	FlowControlMaxQueueDepth        int              `yaml:"flow_control_max_queue_depth,omitempty"` // 0 = unlimited
 	FlowControlQueueDepthThreshold  float64 `yaml:"flow_control_queue_depth_threshold,omitempty"`   // for utilization detector
 	FlowControlKVCacheUtilThreshold float64 `yaml:"flow_control_kv_cache_util_threshold,omitempty"` // for utilization detector
 	FlowControlMaxConcurrency       int     `yaml:"flow_control_max_concurrency,omitempty"`         // for concurrency detector

--- a/sim/cluster/gateway_queue.go
+++ b/sim/cluster/gateway_queue.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -144,19 +145,21 @@ type GatewayQueue struct {
 	shedCount            int
 	rejectedCount        int
 	priorityMap          *sim.SLOPriorityMap
-	priorityMode         bool    // true for "priority", false for "fifo"
-	usageLimitThreshold  float64 // per-band HoL blocking ceiling (default 1.0 = no HoL)
+	priorityMode         bool               // true for "priority" or "slo-deadline", false for "fifo"
+	sloDeadlineMode      bool               // true when dispatch-order == "slo-deadline"
+	sloTargets           map[string]int64   // SLO class → target latency µs (per-tier fallback); nil = disabled
+	usageLimitThreshold  float64            // per-band HoL blocking ceiling (default 1.0 = no HoL)
 	fairnessPolicy       FairnessPolicy
 	requestIndex         map[string]requestLocation // request ID → flow coordinates for TTL removal
 }
 
 // NewGatewayQueue creates a gateway queue with the given dispatch order and max depth.
-// dispatchOrder: "fifo" or "priority". maxDepth: 0 = unlimited.
+// dispatchOrder: "fifo", "priority", or "slo-deadline". maxDepth: 0 = unlimited.
 // If priorityMap is nil, DefaultSLOPriorityMap() is used.
 // Panics if dispatchOrder is invalid or maxDepth < 0.
 func NewGatewayQueue(dispatchOrder string, maxDepth int, priorityMap *sim.SLOPriorityMap) *GatewayQueue {
-	if dispatchOrder != "fifo" && dispatchOrder != "priority" {
-		panic(fmt.Sprintf("GatewayQueue: unknown dispatch order %q (must be fifo or priority)", dispatchOrder))
+	if dispatchOrder != "fifo" && dispatchOrder != "priority" && dispatchOrder != "slo-deadline" {
+		panic(fmt.Sprintf("GatewayQueue: unknown dispatch order %q (must be fifo, priority, or slo-deadline)", dispatchOrder))
 	}
 	if maxDepth < 0 {
 		panic(fmt.Sprintf("GatewayQueue: maxDepth must be >= 0, got %d", maxDepth))
@@ -167,11 +170,18 @@ func NewGatewayQueue(dispatchOrder string, maxDepth int, priorityMap *sim.SLOPri
 	return &GatewayQueue{
 		maxDepth:            maxDepth,
 		priorityMap:         priorityMap,
-		priorityMode:        dispatchOrder == "priority",
+		priorityMode:        dispatchOrder == "priority" || dispatchOrder == "slo-deadline",
+		sloDeadlineMode:     dispatchOrder == "slo-deadline",
 		usageLimitThreshold: 1.0,
 		fairnessPolicy:      &GlobalStrictPolicy{},
 		requestIndex:        make(map[string]requestLocation),
 	}
+}
+
+// SetSLOTargets sets per-SLO-class TTFT target latencies in microseconds.
+// Used as fallback when Request.SLOTargetUs is 0.
+func (q *GatewayQueue) SetSLOTargets(targets map[string]int64) {
+	q.sloTargets = targets
 }
 
 // SetFairnessPolicy sets the intra-band dispatch fairness policy.
@@ -367,7 +377,9 @@ func (q *GatewayQueue) Dequeue() *sim.Request {
 	}
 
 	var req *sim.Request
-	if q.priorityMode {
+	if q.sloDeadlineMode {
+		req = q.dequeueSLODeadline()
+	} else if q.priorityMode {
 		req = q.dequeuePriority()
 	} else {
 		req = q.dequeueFIFO()
@@ -418,9 +430,14 @@ func (q *GatewayQueue) DequeueGated(saturation float64) *sim.Request {
 		}
 
 		// Dispatch from this band.
-		req := q.dequeueFromBand(band)
+		var req *sim.Request
+		if q.sloDeadlineMode {
+			req = q.dequeueFromBandSLODeadline(band)
+		} else {
+			req = q.dequeueFromBand(band)
+		}
 		if req == nil {
-			panic(fmt.Sprintf("GatewayQueue.DequeueGated: band priority=%d has totalLen=%d but dequeueFromBand returned nil — counter desync", band.priority, band.totalLen))
+			panic(fmt.Sprintf("GatewayQueue.DequeueGated: band priority=%d has totalLen=%d but dequeue returned nil — counter desync", band.priority, band.totalLen))
 		}
 		return req
 	}
@@ -486,6 +503,64 @@ func (q *GatewayQueue) dequeueFromBand(band *priorityBand) *sim.Request {
 	req := flow.requests[0].request
 	delete(q.requestIndex, req.ID)
 	flow.requests = flow.requests[1:]
+	band.totalLen--
+	q.totalLen--
+	if len(flow.requests) == 0 {
+		delete(band.flows, flow.key.TenantID)
+	}
+	return req
+}
+
+// sloDeadline computes the SLO deadline for ordering: enqueue_time + target.
+// Returns math.MaxInt64 when no target is available (sorts to back).
+func (q *GatewayQueue) sloDeadline(req *sim.Request) int64 {
+	if req.SLOTargetUs > 0 {
+		return req.GatewayEnqueueTime + req.SLOTargetUs
+	}
+	if q.sloTargets != nil {
+		if target, ok := q.sloTargets[req.SLOClass]; ok {
+			return req.GatewayEnqueueTime + target
+		}
+	}
+	return math.MaxInt64
+}
+
+// dequeueSLODeadline dispatches from the highest non-empty band using deadline ordering.
+func (q *GatewayQueue) dequeueSLODeadline() *sim.Request {
+	for _, band := range q.bands {
+		if band.totalLen == 0 {
+			continue
+		}
+		return q.dequeueFromBandSLODeadline(band)
+	}
+	return nil
+}
+
+// dequeueFromBandSLODeadline picks a flow via fairness, then dequeues the
+// request with the earliest SLO deadline within that flow. Equal deadlines
+// use seqID as FCFS tiebreaker (INV-6: deterministic).
+func (q *GatewayQueue) dequeueFromBandSLODeadline(band *priorityBand) *sim.Request {
+	flow := q.fairnessPolicy.Pick(band)
+	if flow == nil {
+		return nil
+	}
+
+	bestIdx := 0
+	bestDeadline := q.sloDeadline(flow.requests[0].request)
+	bestSeqID := flow.requests[0].seqID
+	for i := 1; i < len(flow.requests); i++ {
+		d := q.sloDeadline(flow.requests[i].request)
+		if d < bestDeadline || (d == bestDeadline && flow.requests[i].seqID < bestSeqID) {
+			bestIdx = i
+			bestDeadline = d
+			bestSeqID = flow.requests[i].seqID
+		}
+	}
+
+	entry := flow.requests[bestIdx]
+	req := entry.request
+	delete(q.requestIndex, req.ID)
+	flow.requests = append(flow.requests[:bestIdx], flow.requests[bestIdx+1:]...)
 	band.totalLen--
 	q.totalLen--
 	if len(flow.requests) == 0 {

--- a/sim/cluster/gateway_queue_test.go
+++ b/sim/cluster/gateway_queue_test.go
@@ -920,3 +920,108 @@ func TestGatewayQueue_RemoveByRequestID_WithShed(t *testing.T) {
 		t.Fatalf("expected nil for shed request, got %v", got)
 	}
 }
+
+// --- SLO-deadline ordering tests (BC-1 through BC-5, BC-9) ---
+
+func TestGatewayQueue_SLODeadline_EarliestFirst(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	// R1: long SLO target → late deadline. R2: short SLO target → early deadline.
+	// Same flow (tenant), same priority (standard).
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 500000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 200, SLOTargetUs: 100000}, 2)
+
+	// R2 deadline = 200+100000 = 100200. R1 deadline = 100+500000 = 500100. R2 first.
+	r := q.Dequeue()
+	if r.ID != "r2" {
+		t.Fatalf("expected r2 (earliest deadline), got %s", r.ID)
+	}
+	r = q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1, got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_NoTarget_FarFuture(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	// R1 has SLO target. R2 has none (0 → far-future → sorts to back).
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 200000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 0}, 2)
+
+	r := q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1 (has target), got %s", r.ID)
+	}
+	r = q.Dequeue()
+	if r.ID != "r2" {
+		t.Fatalf("expected r2, got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_EqualDeadline_FCFS(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	// Same deadline, R1 enqueued first (lower seqID) → R1 dispatches first.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 200000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 200000}, 2)
+
+	r := q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1 (lower seqID), got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_WithinFlowOnly(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	// Two flows. Flow t1 head has seqID=1, flow t2 head has seqID=2.
+	// GlobalStrictPolicy picks t1 (earliest seqID head).
+	// t2's request has earlier deadline, but fairness picks t1 first.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 500000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t2", GatewayEnqueueTime: 100, SLOTargetUs: 100000}, 2)
+
+	r := q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1 (fairness picks flow t1 by seqID), got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_PerTierFallback(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	q.SetSLOTargets(map[string]int64{"critical": 100000})
+	// R1: no per-request target but SLOClass=critical → fallback to 100000.
+	// R2: no per-request target, SLOClass=standard → no fallback → far-future.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "critical", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 0}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 0}, 2)
+
+	r := q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1 (per-tier fallback), got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_PerRequestOverridesTier(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	q.SetSLOTargets(map[string]int64{"standard": 500000})
+	// R1: per-request target 100000 (overrides tier). R2: tier fallback 500000.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 100000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 0}, 2)
+
+	r := q.Dequeue()
+	if r.ID != "r1" {
+		t.Fatalf("expected r1 (per-request overrides tier), got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_NoTargets_DegeneratesToFCFS(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	// No slo-targets set, no per-request targets → all deadlines are MaxInt64 → FCFS by seqID.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 200}, 2)
+	q.Enqueue(&sim.Request{ID: "r3", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 50}, 3)
+
+	ids := []string{q.Dequeue().ID, q.Dequeue().ID, q.Dequeue().ID}
+	expected := []string{"r1", "r2", "r3"}
+	for i, id := range ids {
+		if id != expected[i] {
+			t.Fatalf("position %d: expected %s, got %s (all deadlines MaxInt64 → FCFS by seqID)", i, expected[i], id)
+		}
+	}
+}

--- a/sim/cluster/gateway_queue_test.go
+++ b/sim/cluster/gateway_queue_test.go
@@ -25,7 +25,7 @@ func TestGatewayQueue_FIFO_DequeueOrder(t *testing.T) {
 }
 
 func TestGatewayQueue_Priority_DequeueOrder(t *testing.T) {
-	q := NewGatewayQueue("priority", 0, nil) // unlimited
+	q := NewGatewayQueue("priority", 0, nil)                            // unlimited
 	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "background"}, 1) // priority -3
 	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "critical"}, 2)   // priority 4
 	_, _ = q.Enqueue(&sim.Request{ID: "r3", SLOClass: "standard"}, 3)   // priority 3
@@ -1023,5 +1023,36 @@ func TestGatewayQueue_SLODeadline_NoTargets_DegeneratesToFCFS(t *testing.T) {
 		if id != expected[i] {
 			t.Fatalf("position %d: expected %s, got %s (all deadlines MaxInt64 → FCFS by seqID)", i, expected[i], id)
 		}
+	}
+}
+
+func TestGatewayQueue_SLODeadline_DequeueGated(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	q.SetUsageLimitThreshold(0.5)
+	// Two requests in same flow, different deadlines.
+	q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 500000}, 1)
+	q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1", GatewayEnqueueTime: 100, SLOTargetUs: 100000}, 2)
+
+	// Low saturation → should dispatch, and r2 (earlier deadline) first.
+	r := q.DequeueGated(0.3)
+	if r == nil {
+		t.Fatal("expected non-nil from DequeueGated at low saturation")
+	}
+	if r.ID != "r2" {
+		t.Fatalf("expected r2 (earliest deadline via DequeueGated), got %s", r.ID)
+	}
+
+	// Saturation >= ceiling (1.0 for single band) → should block.
+	r = q.DequeueGated(1.0)
+	if r != nil {
+		t.Fatalf("expected nil from DequeueGated at saturation >= ceiling, got %s", r.ID)
+	}
+}
+
+func TestGatewayQueue_SLODeadline_EmptyQueue(t *testing.T) {
+	q := NewGatewayQueue("slo-deadline", 0, nil)
+	r := q.Dequeue()
+	if r != nil {
+		t.Fatalf("expected nil from empty slo-deadline queue, got %v", r)
 	}
 }

--- a/sim/request.go
+++ b/sim/request.go
@@ -75,6 +75,11 @@ type Request struct {
 	// Computed during workload generation as ArrivalTime + timeout.
 	Deadline int64
 
+	// Per-request SLO TTFT target in microseconds (0 = no target).
+	// Used by slo-deadline dispatch ordering: deadline = GatewayEnqueueTime + SLOTargetUs.
+	// Distinct from Deadline (hard timeout). Set from workload spec or trace.
+	SLOTargetUs int64
+
 	// Redirected marks a request that was re-injected by the REDIRECT drain policy.
 	// The source instance never completes it (the request was in WaitQ at drain time,
 	// so it never ran on the source). The destination instance is the sole completion

--- a/sim/workload/cohort.go
+++ b/sim/workload/cohort.go
@@ -42,9 +42,10 @@ func ExpandCohorts(cohorts []CohortSpec, seed int64) []ClientSpec {
 				PrefixLength: cohort.PrefixLength,
 				// Pointer fields shared across all expanded clients.
 				// Safe: GenerateRequests reads but never mutates these fields.
-				Reasoning:  cohort.Reasoning,
-				ClosedLoop: cohort.ClosedLoop,
-				Timeout:    cohort.Timeout,
+				Reasoning:   cohort.Reasoning,
+				ClosedLoop:  cohort.ClosedLoop,
+				Timeout:     cohort.Timeout,
+				SLOTargetUs: cohort.SLOTargetUs,
 				Network:    cohort.Network,
 				Multimodal: cohort.Multimodal,
 			}

--- a/sim/workload/cohort.go
+++ b/sim/workload/cohort.go
@@ -46,8 +46,8 @@ func ExpandCohorts(cohorts []CohortSpec, seed int64) []ClientSpec {
 				ClosedLoop:  cohort.ClosedLoop,
 				Timeout:     cohort.Timeout,
 				SLOTargetUs: cohort.SLOTargetUs,
-				Network:    cohort.Network,
-				Multimodal: cohort.Multimodal,
+				Network:     cohort.Network,
+				Multimodal:  cohort.Multimodal,
 			}
 
 			// Build lifecycle windows from cohort patterns

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -378,8 +378,8 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 
 // GeneratedWorkload holds the output of GenerateWorkload: requests plus session blueprints.
 type GeneratedWorkload struct {
-	Requests       []*sim.Request
-	Sessions       []SessionBlueprint // nil for non-session workloads
+	Requests []*sim.Request
+	Sessions []SessionBlueprint // nil for non-session workloads
 	// FollowUpBudget is the cap on follow-up requests for concurrency sessions.
 	// -1 = no cap (maxRequests was 0/unlimited, or only closed-loop multi-turn clients present).
 	//  0 = no follow-ups allowed (seeds consumed the entire budget, or no sessions at all).
@@ -523,6 +523,7 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 				TenantID:      client.TenantID,
 				SLOClass:      client.SLOClass,
 				Model:         client.Model,
+				SLOTargetUs:   derefInt64(client.SLOTargetUs),
 			})
 		}
 	}
@@ -646,6 +647,7 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 				TenantID:        client.TenantID,
 				SLOClass:        client.SLOClass,
 				Model:           client.Model,
+				SLOTargetUs:     derefInt64(client.SLOTargetUs),
 			})
 		}
 		totalConcurrencyUsers += client.Concurrency

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -194,9 +194,10 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 						req.PrefixLength = len(prefix)
 					}
 				}
-				// Set Deadline on all reasoning requests (not set in reasoning.go)
+				// Set Deadline and SLOTargetUs on all reasoning requests (not set in reasoning.go)
 				for _, req := range reasoningReqs {
 					req.Deadline = computeDeadline(req.ArrivalTime, client.Timeout, true)
+					req.SLOTargetUs = derefInt64(client.SLOTargetUs)
 				}
 				for _, req := range reasoningReqs {
 					if req.ArrivalTime >= horizon {
@@ -251,9 +252,10 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 						req.PrefixLength = len(prefix)
 					}
 				}
-				// Set Deadline on all reasoning requests (not set in reasoning.go)
+				// Set Deadline and SLOTargetUs on all reasoning requests (not set in reasoning.go)
 				for _, req := range reasoningReqs {
 					req.Deadline = computeDeadline(req.ArrivalTime, client.Timeout, true)
+					req.SLOTargetUs = derefInt64(client.SLOTargetUs)
 				}
 				// Count all generated rounds for perClientCap safety (R19)
 				clientReqCount += int64(len(reasoningReqs))
@@ -345,6 +347,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				AudioTokenCount:  audioCount,
 				VideoTokenCount:  videoCount,
 				Deadline:         computeDeadline(currentTime, client.Timeout, isClosedLoop(client)),
+				SLOTargetUs:      derefInt64(client.SLOTargetUs),
 				ClientID:         client.ID,
 				PrefixGroup:      client.PrefixGroup,
 				PrefixLength:     prefixLength,
@@ -613,6 +616,7 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 				MaxOutputLen: len(outputTokens),
 				State:        sim.StateQueued,
 				Deadline:     computeDeadline(arrivalTime, client.Timeout, true),
+				SLOTargetUs:  derefInt64(client.SLOTargetUs),
 				TenantID:     client.TenantID,
 				SLOClass:     client.SLOClass,
 				Model:        client.Model,
@@ -722,6 +726,13 @@ func computeDeadline(arrivalTime int64, clientTimeout *int64, isSessionClient bo
 		return 0 // explicit no timeout
 	}
 	return arrivalTime + *clientTimeout
+}
+
+func derefInt64(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 // isClosedLoop returns whether a client should use closed-loop session generation.
@@ -1030,6 +1041,7 @@ func generateRequestsForWindow(
 			ClientID:     client.ID,
 			Streaming:    client.Streaming,
 			Deadline:     0, // Set by caller if needed.
+			SLOTargetUs:  derefInt64(client.SLOTargetUs),
 		}
 		requests = append(requests, req)
 	}

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -102,6 +102,7 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 			ReasonRatio:      rec.ReasonRatio,
 			Model:            rec.Model,      // BC-3, BC-6: model identity from trace; empty = default model
 			Deadline:         rec.DeadlineUs, // BC-4, BC-5: client timeout; 0 = no timeout
+			SLOTargetUs:      rec.SLOTargetUs,
 			ClientID:         rec.ClientID,
 			PrefixGroup:      rec.PrefixGroup,
 			PrefixLength:     rec.PrefixLength,
@@ -255,6 +256,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			ReasonRatio:     r0.ReasonRatio,
 			Model:           r0.Model,
 			Deadline:        r0.DeadlineUs,
+			SLOTargetUs:     r0.SLOTargetUs,
 			ClientID:        r0.ClientID,
 			PrefixGroup:     r0.PrefixGroup,
 			PrefixLength:    r0.PrefixLength,
@@ -306,6 +308,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			ReasonRatio:     rec.ReasonRatio,
 			Model:           rec.Model,
 			Deadline:        rec.DeadlineUs,
+			SLOTargetUs:     rec.SLOTargetUs,
 			ClientID:        rec.ClientID,
 			PrefixGroup:     rec.PrefixGroup,
 			PrefixLength:    rec.PrefixLength,

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -238,12 +238,12 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		}
 
 		req := &sim.Request{
-			ID:              fmt.Sprintf("request_%d", r0.RequestID),
-			ArrivalTime:     injectionTime(r0),
-			InputTokens:     inputTokens,
-			OutputTokens:    outputTokens,
-			MaxOutputLen:    len(outputTokens),
-			State:           sim.StateQueued,
+			ID:           fmt.Sprintf("request_%d", r0.RequestID),
+			ArrivalTime:  injectionTime(r0),
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+			MaxOutputLen: len(outputTokens),
+			State:        sim.StateQueued,
 			// ScheduledStepIdx, FinishedStepIdx default to 0 (R4: consistent with LoadTraceV2Requests)
 			TenantID:        r0.TenantID,
 			SLOClass:        r0.SLOClass,
@@ -277,6 +277,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			TenantID:         r0.TenantID,
 			SLOClass:         r0.SLOClass,
 			Model:            r0.Model,
+			SLOTargetUs:      r0.SLOTargetUs,
 		}
 		blueprints = append(blueprints, bp)
 	}

--- a/sim/workload/session.go
+++ b/sim/workload/session.go
@@ -43,6 +43,7 @@ type SessionBlueprint struct {
 	TenantID         string
 	SLOClass         string
 	Model            string
+	SLOTargetUs      int64 // per-request SLO TTFT target in µs; 0 = no target
 }
 
 // activeSession tracks mutable per-session lifecycle state.
@@ -221,6 +222,7 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 		MaxOutputLen: len(outputTokens),
 		State:        sim.StateQueued,
 		Deadline:     computeDeadline(arrivalTime, bp.Timeout, true), // session follow-up always gets default timeout
+		SLOTargetUs:  bp.SLOTargetUs,
 		TenantID:     bp.TenantID,
 		SLOClass:     bp.SLOClass,
 		Model:        bp.Model,

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -76,6 +76,7 @@ type CohortSpec struct {
 	Reasoning    *ReasoningSpec  `yaml:"reasoning,omitempty"`
 	ClosedLoop   *bool           `yaml:"closed_loop,omitempty"`
 	Timeout      *int64          `yaml:"timeout,omitempty"`
+	SLOTargetUs  *int64          `yaml:"slo_target_us,omitempty"` // Per-request SLO TTFT target in µs. nil/0 = no target. (R9: pointer)
 	Network      *NetworkSpec    `yaml:"network,omitempty"`
 	Multimodal   *MultimodalSpec `yaml:"multimodal,omitempty"`
 }
@@ -121,6 +122,7 @@ type ClientSpec struct {
 	Multimodal   *MultimodalSpec `yaml:"multimodal,omitempty"`
 	Reasoning    *ReasoningSpec  `yaml:"reasoning,omitempty"`
 	Timeout      *int64          `yaml:"timeout,omitempty"`     // Per-request timeout in µs. nil = default (300s). 0 = no timeout. (R9: pointer for zero-value)
+	SLOTargetUs  *int64          `yaml:"slo_target_us,omitempty"` // Per-request SLO TTFT target in µs. nil/0 = no target. (R9: pointer)
 	ClosedLoop   *bool           `yaml:"closed_loop,omitempty"` // nil = default (true for reasoning/multi-turn). false = open-loop (all rounds pre-generated).
 	// CustomSamplerFactory allows programmatic injection of arrival sampler factories,
 	// bypassing the factory-based construction from Arrival.Process.
@@ -477,6 +479,9 @@ func validateClient(c *ClientSpec, idx int) error {
 	if c.Timeout != nil && *c.Timeout < 0 {
 		return fmt.Errorf("%s: timeout must be non-negative, got %d", prefix, *c.Timeout)
 	}
+	if c.SLOTargetUs != nil && *c.SLOTargetUs < 0 {
+		return fmt.Errorf("%s: slo_target_us must be non-negative, got %d", prefix, *c.SLOTargetUs)
+	}
 	// Validate MaxRounds for reasoning/multi-turn (prevents panic in NewSessionManager)
 	if c.Reasoning != nil && c.Reasoning.MultiTurn != nil && c.Reasoning.MultiTurn.MaxRounds < 1 {
 		return fmt.Errorf("%s: reasoning.multi_turn.max_rounds must be >= 1, got %d", prefix, c.Reasoning.MultiTurn.MaxRounds)
@@ -594,6 +599,9 @@ func validateCohort(c *CohortSpec, idx int) error {
 	}
 	if c.Timeout != nil && *c.Timeout < 0 {
 		return fmt.Errorf("%s: timeout must be non-negative, got %d", prefix, *c.Timeout)
+	}
+	if c.SLOTargetUs != nil && *c.SLOTargetUs < 0 {
+		return fmt.Errorf("%s: slo_target_us must be non-negative, got %d", prefix, *c.SLOTargetUs)
 	}
 	if c.Reasoning != nil && c.Reasoning.MultiTurn != nil && c.Reasoning.MultiTurn.MaxRounds < 1 {
 		return fmt.Errorf("%s: reasoning.multi_turn.max_rounds must be >= 1, got %d", prefix, c.Reasoning.MultiTurn.MaxRounds)

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -150,7 +150,7 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		if i == 3 && includeVLLMPriority {
 			columns = append(columns, "vllm_priority")
 		}
-		// Insert slo_target_us immediately after deadline_us (index 17 in base columns)
+		// Insert slo_target_us immediately after deadline_us (matched by name)
 		if col == "deadline_us" && includeSLOTarget {
 			columns = append(columns, "slo_target_us")
 		}
@@ -288,7 +288,7 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool) (*TraceRecord, error) {
 	// Column offset: optional columns shift subsequent indices.
 	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.
-	// slo_target_us appears after deadline_us (base index 17) → shifts everything after by +1.
+	// slo_target_us appears after deadline_us → shifts everything after by +1.
 	offset := 0
 	if hasVLLMPriority {
 		offset = 1

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -69,6 +69,7 @@ type TraceRecord struct {
 	ReasonRatio       float64
 	Model             string // model name (e.g., "meta-llama/Llama-3.1-8B-Instruct"); empty = default model
 	DeadlineUs        int64  // absolute deadline timestamp in microseconds (same time origin as ArrivalTimeUs); 0 = no timeout
+	SLOTargetUs       int64  // per-request SLO TTFT target in microseconds; 0 = no target
 	ServerInputTokens int    // server-reported prompt_tokens; 0 = not recorded (e.g., generated traces)
 	ArrivalTimeUs     int64
 	SendTimeUs        int64
@@ -132,13 +133,26 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		}
 	}
 
+	// Conditionally include slo_target_us column: present iff any record has non-zero SLO target.
+	includeSLOTarget := false
+	for _, r := range records {
+		if r.SLOTargetUs > 0 {
+			includeSLOTarget = true
+			break
+		}
+	}
+
 	// Build column header list
-	columns := make([]string, 0, len(traceV2Columns)+1)
+	columns := make([]string, 0, len(traceV2Columns)+2)
 	for i, col := range traceV2Columns {
 		columns = append(columns, col)
 		// Insert vllm_priority immediately after slo_class (index 3)
 		if i == 3 && includeVLLMPriority {
 			columns = append(columns, "vllm_priority")
+		}
+		// Insert slo_target_us immediately after deadline_us (index 17 in base columns)
+		if col == "deadline_us" && includeSLOTarget {
+			columns = append(columns, "slo_target_us")
 		}
 	}
 
@@ -175,6 +189,11 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 			strconv.FormatFloat(r.ReasonRatio, 'f', -1, 64),
 			r.Model,
 			strconv.FormatInt(r.DeadlineUs, 10),
+		)
+		if includeSLOTarget {
+			row = append(row, strconv.FormatInt(r.SLOTargetUs, 10))
+		}
+		row = append(row,
 			strconv.Itoa(r.ServerInputTokens),
 			strconv.FormatInt(r.ArrivalTimeUs, 10),   // integer format
 			strconv.FormatInt(r.SendTimeUs, 10),       // integer format
@@ -222,12 +241,15 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 		return nil, fmt.Errorf("reading CSV header: %w", err)
 	}
 
-	// Detect if vllm_priority column is present (appears after slo_class)
+	// Detect optional columns from header
 	hasVLLMPriority := false
+	hasSLOTarget := false
 	for _, col := range headerRow {
 		if col == "vllm_priority" {
 			hasVLLMPriority = true
-			break
+		}
+		if col == "slo_target_us" {
+			hasSLOTarget = true
 		}
 	}
 
@@ -242,13 +264,16 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 		}
 		minCols := len(traceV2Columns)
 		if hasVLLMPriority {
-			minCols++ // expect 28 columns when vllm_priority is present
+			minCols++
+		}
+		if hasSLOTarget {
+			minCols++
 		}
 		if len(row) < minCols {
 			return nil, fmt.Errorf("CSV row has %d columns, expected at least %d", len(row), minCols)
 		}
 
-		r, err := parseTraceRecord(row, hasVLLMPriority)
+		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget)
 		if err != nil {
 			return nil, err
 		}
@@ -258,11 +283,12 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 	return &TraceV2{Header: header, Records: records}, nil
 }
 
-// parseTraceRecord parses a CSV row. Handles both 27-column (without vllm_priority)
-// and 28-column (with vllm_priority after slo_class) schemas.
-func parseTraceRecord(row []string, hasVLLMPriority bool) (*TraceRecord, error) {
-	// Column offset: when vllm_priority is present at index 4, all columns after
-	// slo_class (index 3) shift by +1.
+// parseTraceRecord parses a CSV row. Handles optional columns vllm_priority
+// (after slo_class) and slo_target_us (after deadline_us).
+func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool) (*TraceRecord, error) {
+	// Column offset: optional columns shift subsequent indices.
+	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.
+	// slo_target_us appears after deadline_us (base index 17) → shifts everything after by +1.
 	offset := 0
 	if hasVLLMPriority {
 		offset = 1
@@ -360,6 +386,18 @@ func parseTraceRecord(row []string, hasVLLMPriority bool) (*TraceRecord, error) 
 	if deadlineUs < 0 {
 		return nil, fmt.Errorf("parsing deadline_us: negative value %d not allowed (use 0 for no timeout)", deadlineUs)
 	}
+	// Parse optional slo_target_us (appears after deadline_us when present)
+	var sloTargetUs int64
+	if hasSLOTarget {
+		sloTargetUs, err = strconv.ParseInt(row[18+offset], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parsing slo_target_us %q: %w", row[18+offset], err)
+		}
+		if sloTargetUs < 0 {
+			return nil, fmt.Errorf("parsing slo_target_us: negative value %d not allowed (use 0 for no target)", sloTargetUs)
+		}
+		offset++
+	}
 	serverInputTokens, err := strconv.Atoi(row[18+offset])
 	if err != nil {
 		return nil, fmt.Errorf("parsing server_input_tokens %q: %w", row[18+offset], err)
@@ -418,6 +456,7 @@ func parseTraceRecord(row []string, hasVLLMPriority bool) (*TraceRecord, error) 
 		ReasonRatio:       reasonRatio,
 		Model:             row[16+offset],
 		DeadlineUs:        deadlineUs,
+		SLOTargetUs:       sloTargetUs,
 		ServerInputTokens: serverInputTokens,
 		ArrivalTimeUs:     arrivalTimeUs,
 		SendTimeUs:        sendTimeUs,
@@ -497,6 +536,7 @@ func RequestsToTraceRecords(requests []*sim.Request) []TraceRecord {
 			ReasonRatio:      req.ReasonRatio,
 			Model:            req.Model,
 			DeadlineUs:       req.Deadline,
+			SLOTargetUs:      req.SLOTargetUs,
 			ArrivalTimeUs:    req.ArrivalTime,
 			SendTimeUs:       req.ArrivalTime, // no real network send in simulation
 			FirstChunkTimeUs: firstChunkUs,

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -123,8 +123,8 @@ func TestTraceV2_RoundTrip_NewFields(t *testing.T) {
 		},
 		{
 			RequestID:         1,
-			Model:             "",  // zero value: default model
-			DeadlineUs:        0,   // zero value: no timeout
+			Model:             "", // zero value: default model
+			DeadlineUs:        0,  // zero value: no timeout
 			ServerInputTokens: 0,  // zero value: not recorded
 			InputTokens:       128,
 			OutputTokens:      32,
@@ -134,7 +134,7 @@ func TestTraceV2_RoundTrip_NewFields(t *testing.T) {
 		{
 			RequestID:         2,
 			Model:             "org/model,with-comma", // CSV-special: encoding/csv quotes automatically
-			DeadlineUs:        9000, // > ArrivalTimeUs (6000) — valid per cross-field invariant
+			DeadlineUs:        9000,                   // > ArrivalTimeUs (6000) — valid per cross-field invariant
 			ServerInputTokens: 0,
 			InputTokens:       64,
 			OutputTokens:      16,
@@ -263,7 +263,7 @@ func TestLoadTraceV2_UnknownYAMLField_ReturnsError(t *testing.T) {
 func TestParseTraceRecord_InvalidInteger_ReturnsError(t *testing.T) {
 	// GIVEN a row with a non-numeric request_id
 	row := make([]string, 27) // must match current column count
-	row[0] = "abc"             // request_id should be integer
+	row[0] = "abc"            // request_id should be integer
 	for i := 1; i < len(row); i++ {
 		row[i] = "0"
 	}
@@ -490,9 +490,9 @@ func TestParseTraceRecord_InvalidReasonRatio_ReturnsError(t *testing.T) {
 func TestTraceV2_FinishReason_RoundTrip(t *testing.T) {
 	header := &TraceHeader{Version: 1, TimeUnit: "us", Mode: "real"}
 	records := []TraceRecord{{
-		RequestID:    1,
-		InputTokens:  10,
-		OutputTokens: 5,
+		RequestID:     1,
+		InputTokens:   10,
+		OutputTokens:  5,
 		ArrivalTimeUs: 1000,
 		SendTimeUs:    2000,
 		Status:        "ok",
@@ -807,7 +807,7 @@ func TestRequestsToTraceRecords_RoundTrip(t *testing.T) {
 			ClientID:       "c1",
 			Streaming:      true,
 			Model:          "test-model",
-			Deadline:        50000,
+			Deadline:       50000,
 		},
 		{
 			ID:           "request_1",
@@ -1106,7 +1106,7 @@ func TestExportTraceV2_VLLMPriority_ConditionalColumn(t *testing.T) {
 		}
 		row1 := strings.Split(lines[1], ",")
 		row2 := strings.Split(lines[2], ",")
-		
+
 		if row1[vllmIdx] != "0" {
 			t.Errorf("Row 1 vllm_priority: got %q, want \"0\"", row1[vllmIdx])
 		}
@@ -1174,7 +1174,7 @@ func TestLoadTraceV2Requests_IgnoresVLLMPriority_SimulationIsolation(t *testing.
 	// BC-5: LoadTraceV2Requests must NOT read VLLMPriority into Request.Priority
 	// This is a simulation isolation requirement — observability metadata must
 	// not affect simulation behavior.
-	
+
 	trace := &TraceV2{
 		Header: TraceHeader{Version: 2, TimeUnit: "us"},
 		Records: []TraceRecord{
@@ -1211,7 +1211,7 @@ func TestLoadTraceV2Requests_IgnoresVLLMPriority_SimulationIsolation(t *testing.
 func TestLoadTraceV2SessionBlueprints_IgnoresVLLMPriority_SimulationIsolation(t *testing.T) {
 	// BC-6: LoadTraceV2SessionBlueprints must NOT read VLLMPriority
 	// Same simulation isolation requirement as BC-5, but for session blueprints.
-	
+
 	trace := &TraceV2{
 		Header: TraceHeader{Version: 2, TimeUnit: "us"},
 		Records: []TraceRecord{
@@ -1250,5 +1250,117 @@ func TestLoadTraceV2SessionBlueprints_IgnoresVLLMPriority_SimulationIsolation(t 
 	// AND request should have SLOClass preserved
 	if requests[0].SLOClass != "critical" {
 		t.Errorf("Request 0 SLOClass=%q, want %q", requests[0].SLOClass, "critical")
+	}
+}
+
+func TestTraceV2_SLOTargetUs_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+
+	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "generated"}
+	records := []TraceRecord{
+		{RequestID: 0, SLOTargetUs: 200000, DeadlineUs: 500000, ArrivalTimeUs: 100, Status: "ok"},
+		{RequestID: 1, SLOTargetUs: 0, DeadlineUs: 300000, ArrivalTimeUs: 200, Status: "ok"},
+	}
+
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded.Records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(loaded.Records))
+	}
+	if loaded.Records[0].SLOTargetUs != 200000 {
+		t.Errorf("record 0 SLOTargetUs=%d, want 200000", loaded.Records[0].SLOTargetUs)
+	}
+	if loaded.Records[1].SLOTargetUs != 0 {
+		t.Errorf("record 1 SLOTargetUs=%d, want 0", loaded.Records[1].SLOTargetUs)
+	}
+	// Verify other fields survived the offset shift
+	if loaded.Records[0].DeadlineUs != 500000 {
+		t.Errorf("record 0 DeadlineUs=%d, want 500000", loaded.Records[0].DeadlineUs)
+	}
+	if loaded.Records[0].ArrivalTimeUs != 100 {
+		t.Errorf("record 0 ArrivalTimeUs=%d, want 100", loaded.Records[0].ArrivalTimeUs)
+	}
+}
+
+func TestTraceV2_SLOTargetUs_AllZero_ColumnOmitted(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+
+	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "generated"}
+	records := []TraceRecord{
+		{RequestID: 0, SLOTargetUs: 0, ArrivalTimeUs: 100, Status: "ok"},
+	}
+
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// Read raw CSV to verify column is absent
+	data, _ := os.ReadFile(dataPath)
+	if strings.Contains(string(data), "slo_target_us") {
+		t.Error("slo_target_us column should be omitted when all values are 0")
+	}
+
+	// Verify it still loads correctly
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Records[0].SLOTargetUs != 0 {
+		t.Errorf("SLOTargetUs=%d, want 0", loaded.Records[0].SLOTargetUs)
+	}
+}
+
+func TestTraceV2_SLOTargetUs_WithVLLMPriority_DoubleOffset(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+
+	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "real"}
+	records := []TraceRecord{
+		{
+			RequestID: 0, SLOClass: "critical", VLLMPriority: 4,
+			SLOTargetUs: 150000, DeadlineUs: 400000,
+			ArrivalTimeUs: 1000, SendTimeUs: 1100,
+			FirstChunkTimeUs: 2000, LastChunkTimeUs: 3000,
+			NumChunks: 5, Status: "ok",
+		},
+	}
+
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	r := loaded.Records[0]
+	if r.VLLMPriority != 4 {
+		t.Errorf("VLLMPriority=%d, want 4", r.VLLMPriority)
+	}
+	if r.SLOTargetUs != 150000 {
+		t.Errorf("SLOTargetUs=%d, want 150000", r.SLOTargetUs)
+	}
+	if r.DeadlineUs != 400000 {
+		t.Errorf("DeadlineUs=%d, want 400000", r.DeadlineUs)
+	}
+	if r.ArrivalTimeUs != 1000 {
+		t.Errorf("ArrivalTimeUs=%d, want 1000 (double-offset corruption)", r.ArrivalTimeUs)
+	}
+	if r.SendTimeUs != 1100 {
+		t.Errorf("SendTimeUs=%d, want 1100 (double-offset corruption)", r.SendTimeUs)
+	}
+	if r.NumChunks != 5 {
+		t.Errorf("NumChunks=%d, want 5 (double-offset corruption)", r.NumChunks)
 	}
 }

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -269,7 +269,7 @@ func TestParseTraceRecord_InvalidInteger_ReturnsError(t *testing.T) {
 	}
 
 	// WHEN parsing
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -288,7 +288,7 @@ func TestParseTraceRecord_InvalidDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "not_a_number" // deadline_us column (shifted +1 by prefix_length)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric deadline_us, got nil")
@@ -306,7 +306,7 @@ func TestParseTraceRecord_InvalidServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "not_a_number" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric server_input_tokens, got nil")
@@ -326,7 +326,7 @@ func TestParseTraceRecord_InvalidVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "not_a_number" // vllm_priority column (index 4)
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true)
+	_, err := parseTraceRecord(row, true, false)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -347,7 +347,7 @@ func TestParseTraceRecord_NegativeVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "-1" // negative vllm_priority
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true)
+	_, err := parseTraceRecord(row, true, false)
 
 	// THEN error about negative value
 	if err == nil {
@@ -369,7 +369,7 @@ func TestParseTraceRecord_NegativeDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "-1" // negative deadline_us (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for negative deadline_us, got nil")
@@ -388,7 +388,7 @@ func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[9] = "-1" // input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for negative input_tokens, got nil")
@@ -407,7 +407,7 @@ func TestParseTraceRecord_NegativeOutputTokens_ReturnsError(t *testing.T) {
 	}
 	row[10] = "-1" // output_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for negative output_tokens, got nil")
@@ -426,7 +426,7 @@ func TestParseTraceRecord_NegativeServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "-1" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for negative server_input_tokens, got nil")
@@ -446,7 +446,7 @@ func TestParseTraceRecord_DeadlineBeforeArrival_ReturnsError(t *testing.T) {
 	row[17] = "1000" // deadline_us = 1000 (shifted +1)
 	row[19] = "5000" // arrival_time_us = 5000 (shifted +1)
 
-	_, err := parseTraceRecord(row, false)
+	_, err := parseTraceRecord(row, false, false)
 
 	if err == nil {
 		t.Fatal("expected error for deadline before arrival, got nil")
@@ -475,7 +475,7 @@ func TestParseTraceRecord_InvalidReasonRatio_ReturnsError(t *testing.T) {
 		}
 		row[15] = tc.value // reason_ratio column (shifted +1)
 
-		_, err := parseTraceRecord(row, false)
+		_, err := parseTraceRecord(row, false, false)
 
 		if err == nil {
 			t.Errorf("reason_ratio=%q: expected error, got nil", tc.value)


### PR DESCRIPTION
## Summary

- Add `--dispatch-order slo-deadline` mode to gateway queue: dispatches requests with the earliest SLO deadline first within each flow (GIE `slo-deadline-ordering-policy` parity)
- Add per-request `SLOTargetUs` field flowing through workload spec → generator → Request → observe → trace → replay → gateway queue
- Add `--slo-targets` CLI flag and policy bundle YAML for per-tier TTFT target fallbacks

## Behavioral Contracts

- **BC-1**: `deadline = GatewayEnqueueTime + SLOTargetUs`, earliest dispatches first within flow
- **BC-2**: No SLO target → `math.MaxInt64` (far-future, sorts to back → FCFS)
- **BC-3**: Equal deadlines → FCFS tiebreaker by seqID
- **BC-4**: Fairness policy picks flow first, then deadline ordering within picked flow
- **BC-5**: Fallback hierarchy: per-request `SLOTargetUs` → per-tier `--slo-targets` → far-future
- **BC-6**: Workload spec `slo_target_us` wired to `Request.SLOTargetUs`
- **BC-7**: `slo_target_us` optional TraceV2 column survives observe→trace→replay round-trip
- **BC-8**: `x-slo-ttft-ms` HTTP header injected in observe (µs→ms conversion)
- **BC-9**: Existing `fifo`/`priority` dispatch orders unchanged
- **BC-10**: Negative `slo_target_us` rejected in spec validation

## Test Plan

- [x] 7 targeted SLO-deadline tests (earliest-first, far-future, FCFS tiebreak, within-flow-only, per-tier fallback, per-request override, FCFS degenerate)
- [x] All 9 packages pass (`go test ./... -count=1`)
- [x] Build passes (`go build ./...`)
- [x] 10-perspective convergence review: 0 CRITICAL, 0 IMPORTANT
- [x] Pre-commit self-audit: 10 dimensions clean

Fixes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)