### PR TITLE
feat(cluster): surface active KV-transfer count via RouterState.ActiveTransfers (#1342) T4

### DIFF
--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1823,6 +1823,12 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 	// pod's cacheQueryFn closure for per-pod prefix cache state (matches llm-d's
 	// PrefixBasedPDDecider reading endpoint.Get(PrefixCacheMatchInfoKey)).
 	state.SelectedInstance = decodeDecision.TargetInstance
+	// Snapshot the cluster-wide in-flight KV-transfer count for the decider.
+	// Guarded by PDTransferContention so that disabling contention produces
+	// byte-identical decider inputs to the pre-change baseline. See #1342.
+	if cs.config.PDTransferContention {
+		state.ActiveTransfers = cs.activeTransfers
+	}
 	disaggDecision := cs.disaggregationDecider.Decide(req, state)
 	logrus.Debugf("[cluster] req %s: disaggregate=%v", req.ID, disaggDecision.Disaggregate)
 

--- a/sim/cluster/transfer_contention_test.go
+++ b/sim/cluster/transfer_contention_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -920,16 +921,6 @@ func runWithActiveTransfersRecorder(t *testing.T, config DeploymentConfig, numRe
 	return rec.seen
 }
 
-func maxInt(xs []int) int {
-	m := xs[0]
-	for _, x := range xs[1:] {
-		if x > m {
-			m = x
-		}
-	}
-	return m
-}
-
 // TestRouterState_ActiveTransfers_PopulatedWhenContentionEnabled verifies BC-1:
 // when --pd-transfer-contention is enabled, executeDisaggregatedRouting snapshots
 // the current cluster-wide activeTransfers count into RouterState.ActiveTransfers
@@ -1024,7 +1015,7 @@ func TestRouterState_ActiveTransfers_EndToEnd_PopulatedUnderContention(t *testin
 	if len(seen) == 0 {
 		t.Fatal("decider was never invoked — test setup did not exercise executeDisaggregatedRouting")
 	}
-	if m := maxInt(seen); m == 0 {
+	if m := slices.Max(seen); m == 0 {
 		t.Errorf("max observed RouterState.ActiveTransfers = 0 across %d Decide calls, want > 0 (contention enabled with overlapping transfers)", len(seen))
 	}
 }
@@ -1032,33 +1023,53 @@ func TestRouterState_ActiveTransfers_EndToEnd_PopulatedUnderContention(t *testin
 // TestRouterState_ActiveTransfers_BuiltinDeciderParity verifies BC-3:
 // the built-in deciders (never, always, prefix-threshold) never read
 // RouterState.ActiveTransfers, so their externally-observable decision
-// output is unchanged by toggling --pd-transfer-contention. We assert
-// this behaviorally: activeTransfersRecorder delegates to an inner built-in,
-// and the returned Disaggregate values do not depend on the observed
-// ActiveTransfers value. Issue #1342.
+// output is unchanged by toggling --pd-transfer-contention. Issue #1342.
 //
 // This is a law test, not a golden test: we assert the property that for
 // each built-in, the disaggregation decision is a pure function of inputs
 // the built-in already reads — regardless of what ActiveTransfers is set to.
+//
+// prefix-threshold is covered by two cases that exercise distinct paths
+// through PrefixThresholdDecider.Decide:
+//
+//   - "prefix-threshold-nil-cache": nil cacheQuery triggers the conservative
+//     fallback (Disaggregate=false), invariant of ActiveTransfers.
+//   - "prefix-threshold-over": non-nil cacheQuery reporting zero cached blocks
+//     plus threshold=0 drives the positive arm of the decider (Disaggregate=true
+//     because nonCachedTokens > threshold), also invariant of ActiveTransfers.
 func TestRouterState_ActiveTransfers_BuiltinDeciderParity(t *testing.T) {
 	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3}, MaxOutputLen: 4}
 
+	// For prefix-threshold-over, a cacheQuery keyed by the SelectedInstance used
+	// in the per-case state below, always reporting zero cached blocks so the
+	// decider's positive arm fires (nonCachedTokens=3 > threshold=0).
+	const selectedInst = "inst-0"
+	cacheQueryZero := map[string]func([]int) int{
+		selectedInst: func(_ []int) int { return 0 },
+	}
+
 	cases := []struct {
-		name       string
-		decider    sim.DisaggregationDecider
-		wantDisagg bool
+		name         string
+		decider      sim.DisaggregationDecider
+		selectedInst string
+		wantDisagg   bool
 	}{
-		{"never", &sim.NeverDisaggregate{}, false},
-		{"always", &sim.AlwaysDisaggregate{}, true},
+		{"never", &sim.NeverDisaggregate{}, "", false},
+		{"always", &sim.AlwaysDisaggregate{}, "", true},
+		{"prefix-threshold-nil-cache", sim.NewPrefixThresholdDecider(0, 16, nil), selectedInst, false},
+		{"prefix-threshold-over", sim.NewPrefixThresholdDecider(0, 16, cacheQueryZero), selectedInst, true},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, at := range []int{0, 1, 5, 100} {
-				state := &sim.RouterState{ActiveTransfers: at}
+				state := &sim.RouterState{
+					ActiveTransfers:  at,
+					SelectedInstance: tc.selectedInst,
+				}
 				got := tc.decider.Decide(req, state)
 				if got.Disaggregate != tc.wantDisagg {
-					t.Errorf("%s decider with ActiveTransfers=%d: Disaggregate = %v, want %v",
+					t.Errorf("%s decider with ActiveTransfers=%d: Disaggregate = %v, want %v (built-in must not depend on ActiveTransfers)",
 						tc.name, at, got.Disaggregate, tc.wantDisagg)
 				}
 			}

--- a/sim/cluster/transfer_contention_test.go
+++ b/sim/cluster/transfer_contention_test.go
@@ -882,3 +882,186 @@ func TestTransferContention_INV6_Determinism(t *testing.T) {
 			init1, init2, done1, done2)
 	}
 }
+
+// activeTransfersRecorder wraps a DisaggregationDecider and records the
+// RouterState.ActiveTransfers value observed at each Decide call. Used by the
+// tests below to verify executeDisaggregatedRouting populates the field only
+// when --pd-transfer-contention is enabled (issue #1342).
+type activeTransfersRecorder struct {
+	inner sim.DisaggregationDecider
+	seen  []int
+}
+
+func (r *activeTransfersRecorder) Decide(req *sim.Request, state *sim.RouterState) sim.DisaggregationDecision {
+	r.seen = append(r.seen, state.ActiveTransfers)
+	return r.inner.Decide(req, state)
+}
+
+// runWithActiveTransfersRecorder installs an activeTransfersRecorder wrapping
+// the supplied inner decider on a fresh ClusterSimulator, runs it, and returns
+// the sequence of ActiveTransfers values observed at each Decide call. Arrival
+// times may be overridden by the caller via arrivalTimes (one entry per request);
+// pass nil to use the arrival times produced by newTestRequests.
+func runWithActiveTransfersRecorder(t *testing.T, config DeploymentConfig, numRequests int, inner sim.DisaggregationDecider, arrivalTimes []int64) []int {
+	t.Helper()
+	requests := newTestRequests(numRequests)
+	if arrivalTimes != nil {
+		if len(arrivalTimes) != len(requests) {
+			t.Fatalf("arrivalTimes length %d != numRequests %d", len(arrivalTimes), len(requests))
+		}
+		for i, r := range requests {
+			r.ArrivalTime = arrivalTimes[i]
+		}
+	}
+	cs := NewClusterSimulator(config, requests, nil)
+	rec := &activeTransfersRecorder{inner: inner}
+	cs.disaggregationDecider = rec
+	mustRun(t, cs)
+	return rec.seen
+}
+
+func maxInt(xs []int) int {
+	m := xs[0]
+	for _, x := range xs[1:] {
+		if x > m {
+			m = x
+		}
+	}
+	return m
+}
+
+// TestRouterState_ActiveTransfers_PopulatedWhenContentionEnabled verifies BC-1:
+// when --pd-transfer-contention is enabled, executeDisaggregatedRouting snapshots
+// the current cluster-wide activeTransfers count into RouterState.ActiveTransfers
+// at the moment Decide is called. Issue #1342.
+//
+// We use direct invocation of executeDisaggregatedRouting rather than a full Run()
+// because the snapshot occurs at Decide call time — which, under a natural workload,
+// is always before that request's own transfer starts. Setting activeTransfers
+// directly simulates the presence of prior in-flight transfers from other requests
+// and makes the snapshot behavior observable independent of scheduling latency.
+func TestRouterState_ActiveTransfers_PopulatedWhenContentionEnabled(t *testing.T) {
+	config := newContentionConfig(4, 2, 2, 25.0)
+	cs := NewClusterSimulator(config, []*sim.Request{}, nil)
+	rec := &activeTransfersRecorder{inner: &sim.AlwaysDisaggregate{}}
+	cs.disaggregationDecider = rec
+
+	// Simulate the presence of three prior in-flight transfers (started by earlier
+	// requests not modeled in this test). Also advance bookkeeping counters so the
+	// end-of-run conservation check (initiated == completed) is not violated; this
+	// test does not run the simulation to completion.
+	cs.activeTransfers = 3
+	cs.transfersInitiated = 3
+
+	req := &sim.Request{
+		ID:           "unit-req-1",
+		InputTokens:  []int{1, 2, 3, 4},
+		MaxOutputLen: 8,
+		ArrivalTime:  0,
+	}
+	cs.executeDisaggregatedRouting(req, 0)
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("expected 1 Decide call, got %d", len(rec.seen))
+	}
+	if rec.seen[0] != 3 {
+		t.Errorf("RouterState.ActiveTransfers at Decide = %d, want 3 (mirrors cs.activeTransfers)", rec.seen[0])
+	}
+}
+
+// TestRouterState_ActiveTransfers_ZeroWhenContentionDisabled verifies BC-2:
+// when --pd-transfer-contention is disabled, executeDisaggregatedRouting does
+// NOT populate RouterState.ActiveTransfers even when cs.activeTransfers would
+// otherwise be non-zero. The field remains at its Go zero value. Issue #1342.
+func TestRouterState_ActiveTransfers_ZeroWhenContentionDisabled(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	// PDTransferContention defaults to false — leave it that way.
+	cs := NewClusterSimulator(config, []*sim.Request{}, nil)
+	rec := &activeTransfersRecorder{inner: &sim.AlwaysDisaggregate{}}
+	cs.disaggregationDecider = rec
+
+	// Even if cs.activeTransfers somehow were non-zero (it cannot be when
+	// contention is disabled, but we set it to make the assertion unambiguous),
+	// the field must not leak into RouterState.
+	cs.activeTransfers = 7
+
+	req := &sim.Request{
+		ID:           "unit-req-1",
+		InputTokens:  []int{1, 2, 3, 4},
+		MaxOutputLen: 8,
+		ArrivalTime:  0,
+	}
+	cs.executeDisaggregatedRouting(req, 0)
+
+	if len(rec.seen) != 1 {
+		t.Fatalf("expected 1 Decide call, got %d", len(rec.seen))
+	}
+	if rec.seen[0] != 0 {
+		t.Errorf("RouterState.ActiveTransfers at Decide = %d, want 0 (contention disabled)", rec.seen[0])
+	}
+}
+
+// TestRouterState_ActiveTransfers_EndToEnd_PopulatedUnderContention is an
+// end-to-end companion to the unit tests above. It runs a full simulation with
+// --pd-transfer-contention enabled and a sparse arrival pattern chosen so that
+// at least one Decide call occurs while a prior request's transfer is in flight.
+// If the assertion here ever regresses it will point to a change in the pipeline
+// ordering (arrival → routing → prefill → transfer start) that breaks the
+// ability of deciders to observe concurrent transfers through RouterState.
+func TestRouterState_ActiveTransfers_EndToEnd_PopulatedUnderContention(t *testing.T) {
+	// Low bandwidth + low-overhead base latency keeps transfers in flight for
+	// milliseconds. Spread arrivals over ~200ms so later arrivals' Decide calls
+	// overlap with earlier requests' transfers.
+	config := newContentionConfig(4, 2, 2, 0.001)
+
+	const n = 8
+	arrivals := make([]int64, n)
+	for i := range arrivals {
+		arrivals[i] = int64(i) * 30_000 // 30 ms apart, in microseconds
+	}
+	seen := runWithActiveTransfersRecorder(t, config, n, &sim.AlwaysDisaggregate{}, arrivals)
+
+	if len(seen) == 0 {
+		t.Fatal("decider was never invoked — test setup did not exercise executeDisaggregatedRouting")
+	}
+	if m := maxInt(seen); m == 0 {
+		t.Errorf("max observed RouterState.ActiveTransfers = 0 across %d Decide calls, want > 0 (contention enabled with overlapping transfers)", len(seen))
+	}
+}
+
+// TestRouterState_ActiveTransfers_BuiltinDeciderParity verifies BC-3:
+// the built-in deciders (never, always, prefix-threshold) never read
+// RouterState.ActiveTransfers, so their externally-observable decision
+// output is unchanged by toggling --pd-transfer-contention. We assert
+// this behaviorally: activeTransfersRecorder delegates to an inner built-in,
+// and the returned Disaggregate values do not depend on the observed
+// ActiveTransfers value. Issue #1342.
+//
+// This is a law test, not a golden test: we assert the property that for
+// each built-in, the disaggregation decision is a pure function of inputs
+// the built-in already reads — regardless of what ActiveTransfers is set to.
+func TestRouterState_ActiveTransfers_BuiltinDeciderParity(t *testing.T) {
+	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3}, MaxOutputLen: 4}
+
+	cases := []struct {
+		name       string
+		decider    sim.DisaggregationDecider
+		wantDisagg bool
+	}{
+		{"never", &sim.NeverDisaggregate{}, false},
+		{"always", &sim.AlwaysDisaggregate{}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for _, at := range []int{0, 1, 5, 100} {
+				state := &sim.RouterState{ActiveTransfers: at}
+				got := tc.decider.Decide(req, state)
+				if got.Disaggregate != tc.wantDisagg {
+					t.Errorf("%s decider with ActiveTransfers=%d: Disaggregate = %v, want %v",
+						tc.name, at, got.Disaggregate, tc.wantDisagg)
+				}
+			}
+		})
+	}
+}

--- a/sim/router_state.go
+++ b/sim/router_state.go
@@ -28,4 +28,12 @@ type RouterState struct {
 	// and an ID that has no corresponding entry in Snapshots (e.g., the pod
 	// was removed after routing) and guard accordingly.
 	SelectedInstance string
+	// ActiveTransfers is the live count of in-flight KV transfers at the
+	// moment RouterState is built, as observed by ClusterSimulator. It is
+	// populated only when --pd-transfer-contention is enabled; otherwise
+	// it is zero. DisaggregationDecider implementations may read it for
+	// backpressure-aware decisions (G2). No built-in decider currently
+	// reads it — adoption by an external policy in llm-d would require a
+	// cross-repo metric-emission PR; see issue #1342.
+	ActiveTransfers int
 }


### PR DESCRIPTION
## Summary

Surfaces the cluster-wide in-flight KV-transfer counter (`ClusterSimulator.activeTransfers`) into `sim.RouterState` as a new `ActiveTransfers` field, so backpressure-aware `DisaggregationDecider` implementations can throttle disaggregation when the transfer fabric is saturated (Tranche 4 / signal G2 of #1336).

The field is populated only inside `executeDisaggregatedRouting`, gated behind the existing `--pd-transfer-contention` flag. When contention is disabled (the default) the field stays at its Go zero value, preserving byte-identical decider inputs for every existing configuration. No built-in decider currently reads it — this is forward-looking surface for policy search; adoption by llm-d would require a cross-repo metric-emission PR stack on the NIXL / sidecar connector.

## Behavioral Contracts

**BC-1 — Snapshot at Decide call time (on-path)**
- GIVEN `--pd-transfer-contention` is enabled AND a workload produces concurrent KV transfers
- WHEN `DisaggregationDecider.Decide` is invoked by `executeDisaggregatedRouting`
- THEN `RouterState.ActiveTransfers` equals the cluster's in-flight transfer count at that call — and across a run with overlapping transfers, at least one `Decide` call observes a non-zero value.

**BC-2 — Zero when contention disabled (off-path)**
- GIVEN `--pd-transfer-contention` is disabled (Go zero value / default)
- WHEN `Decide` is invoked under any workload, including one that would have produced non-zero concurrency with contention on
- THEN every observed `RouterState.ActiveTransfers` is zero.

**BC-3 — Built-in decider parity**
- GIVEN any built-in decider (`never`, `always`, `prefix-threshold`)
- WHEN toggled with `--pd-transfer-contention` on vs. off
- THEN disaggregation decisions remain what the pre-change baseline would have produced — no built-in reads the new field.

## Changes

- `sim/router_state.go` — add `ActiveTransfers int` to `RouterState` with a comment documenting the gate and the cross-repo follow-on required to adopt in llm-d.
- `sim/cluster/cluster.go` — in `executeDisaggregatedRouting`, immediately before `cs.disaggregationDecider.Decide(...)`, set `state.ActiveTransfers = cs.activeTransfers` when `cs.config.PDTransferContention` is true.
- `sim/cluster/transfer_contention_test.go` — unit tests (direct `executeDisaggregatedRouting` invocation with a preset counter, contention on/off) + one end-to-end test (overlapping arrivals) + a built-in-parity law test.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./... -count=1` — passes (all existing tests + 4 new)
- [x] `go vet ./...` — clean
- [x] New tests (`TestRouterState_ActiveTransfers_*`) all pass locally
- [x] Behavioral rigor: unit tests assert exact snapshot equality; end-to-end test asserts `max > 0` (invariant-style, not golden); parity test asserts the law that built-in Disaggregate decisions are a pure function of their existing inputs across a range of `ActiveTransfers` values

## Cross-path parity (INV-13)

`executeDisaggregatedRouting` is cluster-scoped and applies equally to `blis run` and `blis replay` (`cmd/replay.go` already threads `PDTransferContention`). `blis observe` is HTTP-only and unaffected.

## Invariants

- **INV-1** (conservation): reading `activeTransfers` does not mutate it; no new events.
- **INV-6** (determinism): no new RNG, no wall-clock reads, no map iteration; field is a deterministic integer read.
- **INV-13** (run/replay parity): preserved; no observable output changes under the three built-in deciders.

## Discovered Issues

- `sim/cluster/cluster_event.go` defines `DisaggregationDecisionEvent` with a duplicate `DisaggregationDecider.Decide` call path, but nothing in the codebase schedules this event (confirmed by `grep -rn 'DisaggregationDecisionEvent{'`). The comment in `disaggregation_test.go:1896` explicitly refers to "the old DisaggregationDecisionEvent" in past tense, and all production routing flows through `RoutingDecisionEvent → executeDisaggregatedRouting`. Because the event type is dead at runtime, this PR deliberately does not replicate the `ActiveTransfers` plumbing there — replicating would add a latent divergence if someone later resurrects it in place. Filing as a separate cleanup issue is recommended.

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)