### PR TITLE
feat(sim,cluster): widen disaggregation decider signal envelope (#1339) T1

### DIFF
--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -33,7 +33,7 @@ inference-sim/
 │   ├── slo_priority.go        # SLOPriorityMap: BLIS/llm-d convention (higher=urgent) for cluster layer; InvertForVLLM() converts to vLLM convention (lower=urgent) at instance entry (EnqueueRequest)
 │   ├── scheduler.go           # InstanceScheduler interface with FCFSScheduler, PriorityFCFSScheduler, SJFScheduler, and ReversePriority templates, NewScheduler factory
 │   ├── latency_model.go       # LatencyModel interface (3 methods), NewLatencyModelFunc registration variable, MustNewLatencyModel nil-guarded wrapper
-│   ├── router_state.go        # RouterState bridge type (Snapshots + Clock) for cluster-level policies
+│   ├── router_state.go        # RouterState bridge type (Snapshots, PrefillSnapshots, LoadingSnapshots, Clock, SelectedDecodeInstance, SelectedPrefillInstance) for cluster-level policies
 │   ├── bundle.go              # PolicyBundle YAML loading, LoadPolicyBundle, Validate
 │   ├── event.go               # Event types (Arrival, Queued, Step, Scheduled, RequestLeft, Timeout) with (timestamp, priority, seqID) ordering
 │   ├── request.go             # RequestState typed constants (StateQueued, StateRunning, StateCompleted, StateTimedOut), Request lifecycle and state machine, Deadline field for client timeout, Priority field for scheduler-aware ordering, AssignedInstance for cluster routing provenance (#181), workload metadata (TenantID, SLOClass, etc.), MaxOutputLen (client output budget for enqueue guard)

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1116,6 +1116,32 @@ func (c *ClusterSimulator) buildPoolFilteredSnapshots(role PoolRole) []sim.Routi
 	return FilterSnapshotsByPool(allSnapshots, c.poolMembership, role)
 }
 
+// annotateCachedBlocks populates RoutingSnapshot.CachedBlocks in place with the
+// per-pod cached-block count for the given request's input tokens (issue #1339 G5).
+// Intended for the disaggregation-decider path only; the standard routing path
+// constructs RouterState via buildRouterState, which does not call this helper.
+//
+// When tokens is empty or cacheFn is nil, the helper is a no-op (every snapshot
+// keeps CachedBlocks = 0). For each snapshot whose instance ID is missing from
+// cacheFn or whose closure is nil, CachedBlocks remains zero — this is the same
+// conservative fallback used by PrefixThresholdDecider.Decide.
+//
+// R2/INV-6 determinism: the helper is a pure function of (cacheFn, tokens) and
+// does not reorder snaps. Callers are responsible for passing a deterministically
+// ordered slice (buildPoolFilteredSnapshots preserves c.instances traversal order).
+func annotateCachedBlocks(snaps []sim.RoutingSnapshot, cacheFn map[string]func([]int) int, tokens []int) {
+	if len(tokens) == 0 || cacheFn == nil {
+		return
+	}
+	for i := range snaps {
+		fn, ok := cacheFn[snaps[i].ID]
+		if !ok || fn == nil {
+			continue
+		}
+		snaps[i].CachedBlocks = fn(tokens)
+	}
+}
+
 // detectPrefillCompletions checks for newly completed prefill sub-requests on the given instance
 // and schedules KV transfer events for each.
 // R2/INV-6: Collects completed IDs into a sorted slice before processing to ensure
@@ -1801,13 +1827,29 @@ func (cs *ClusterSimulator) executeStandardRouting(req *sim.Request, time int64)
 // fire at `time` — no additional offset.
 func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time int64) {
 	// Step 1: route to decode pool first (llm-d parity: decode pod always selected first).
-	filteredSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
-	if len(filteredSnapshots) == 0 {
+	decodeSnapshots := cs.buildPoolFilteredSnapshots(PoolRoleDecode)
+	if len(decodeSnapshots) == 0 {
 		logrus.Warnf("[cluster] req %s: no routable instances in decode pool — request rejected at routing", req.ID)
 		cs.routingRejections++
 		return
 	}
-	state := &sim.RouterState{Snapshots: filteredSnapshots, Clock: cs.clock}
+	// Prefill-pool snapshots expose cross-pool state to the disagg decider
+	// (issue #1339 G1). Empty when no prefill pool is configured; built-in
+	// deciders ignore this slice. Order follows c.instances for R2/INV-6
+	// determinism (same traversal as buildPoolFilteredSnapshots for decode).
+	prefillSnapshots := cs.buildPoolFilteredSnapshots(PoolRolePrefill)
+	// Annotate each snapshot with the per-pod cached-block count for this
+	// request (issue #1339 G5). Populated only on the disagg-decider path so
+	// the standard-routing hot path (buildRouterState) remains allocation-
+	// identical to pre-PR. Zero when cache-query wiring is missing — same
+	// conservative fallback as PrefixThresholdDecider.Decide.
+	annotateCachedBlocks(decodeSnapshots, cs.cacheQueryFn, req.InputTokens)
+	annotateCachedBlocks(prefillSnapshots, cs.cacheQueryFn, req.InputTokens)
+	state := &sim.RouterState{
+		Snapshots:        decodeSnapshots,
+		PrefillSnapshots: prefillSnapshots,
+		Clock:            cs.clock,
+	}
 	policy := cs.decodeRoutingPolicy
 	if policy == nil {
 		policy = cs.routingPolicy
@@ -1818,11 +1860,11 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 	// Step 2: disaggregation decision with decode pod known. Pass the full decode-pool
 	// RouterState so the decider can query per-pod state (cache presence, load) and
 	// optionally reconsider the decode pod via DisaggregationDecision.DecodePodOverride.
-	// state.SelectedInstance tells the decider which snapshot was pre-selected by
+	// state.SelectedDecodeInstance tells the decider which snapshot was pre-selected by
 	// the decode routing policy — PrefixThresholdDecider queries the selected
 	// pod's cacheQueryFn closure for per-pod prefix cache state (matches llm-d's
 	// PrefixBasedPDDecider reading endpoint.Get(PrefixCacheMatchInfoKey)).
-	state.SelectedInstance = decodeDecision.TargetInstance
+	state.SelectedDecodeInstance = decodeDecision.TargetInstance
 	disaggDecision := cs.disaggregationDecider.Decide(req, state)
 	logrus.Debugf("[cluster] req %s: disaggregate=%v", req.ID, disaggDecision.Disaggregate)
 
@@ -1915,7 +1957,7 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 			if cs.trace.Config.CounterfactualK > 0 {
 				record.Candidates, record.Regret = computeCounterfactual(
 					decodeDecision.TargetInstance, decodeDecision.Scores,
-					filteredSnapshots, cs.trace.Config.CounterfactualK,
+					decodeSnapshots, cs.trace.Config.CounterfactualK,
 				)
 			}
 			cs.trace.RecordRouting(record)

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -674,7 +674,7 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 // pod by the same prefix-affinity mechanism BLIS uses in production
 // (precise-prefix-cache scorer queries cacheQueryFn and prefers warm pods).
 // That is the exact mechanism PrefixThresholdDecider then re-queries via
-// state.SelectedInstance — making the per-pod cache hit the real cause of
+// state.SelectedDecodeInstance — making the per-pod cache hit the real cause of
 // the decision, not a round-robin coincidence.
 func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	const threshold = 300
@@ -747,7 +747,7 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	for _, pr := range cs.parentRequests {
 		if pr.ID == "req-follow" {
 			t.Error("req-follow (50 non-cached tokens <= 300 threshold after cache warming) must NOT be disaggregated; " +
-				"check per-pod cacheQueryFn wiring via state.SelectedInstance (sim/cluster/cluster.go)")
+				"check per-pod cacheQueryFn wiring via state.SelectedDecodeInstance (sim/cluster/cluster.go)")
 		}
 	}
 }
@@ -2078,4 +2078,261 @@ func TestDisaggregation_DecodePodOverrideReroutes(t *testing.T) {
 	if overrideCount == 0 {
 		t.Fatal("no requests landed on override target — override logic did not fire")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1339 Tranche 1: PrefillSnapshots + per-pod CachedBlocks exposure
+// ---------------------------------------------------------------------------
+
+// capturingDisaggDecider is a test-only DisaggregationDecider that records every
+// (*sim.RouterState, *sim.Request) pair it observes. Its decision is constant —
+// the point is to inspect the state the cluster handed it, not to exercise
+// decision logic. Must be installed after NewClusterSimulator so it replaces
+// the default decider built from PDDecider.
+type capturingDisaggDecider struct {
+	disaggregate bool
+	states       []*sim.RouterState
+	reqs         []*sim.Request
+}
+
+func (c *capturingDisaggDecider) Decide(req *sim.Request, state *sim.RouterState) sim.DisaggregationDecision {
+	c.states = append(c.states, state)
+	c.reqs = append(c.reqs, req)
+	return sim.DisaggregationDecision{Disaggregate: c.disaggregate}
+}
+
+// poolIDsByRole returns instance IDs whose PoolRole matches role, in
+// c.instances traversal order. Mirrors the deterministic ordering
+// buildPoolFilteredSnapshots preserves (R2/INV-6).
+func poolIDsByRole(cs *ClusterSimulator, role PoolRole) []string {
+	var ids []string
+	for _, inst := range cs.instances {
+		id := string(inst.ID())
+		if cs.poolMembership[id] == role {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestDisaggRouterState_PrefillSnapshotsPopulated verifies BC-1 and BC-2
+// (issue #1339 G1): executeDisaggregatedRouting constructs state.PrefillSnapshots
+// from the prefill pool and state.Snapshots from the decode pool, in deterministic
+// instance-declaration order.
+func TestDisaggRouterState_PrefillSnapshotsPopulated(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2) // 2 prefill + 2 decode
+	requests := newTestRequests(3)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// Replace the built-in decider with a capturing stub. Safe because the test
+	// lives in package cluster and can mutate unexported fields.
+	cap := &capturingDisaggDecider{disaggregate: true}
+	cs.disaggregationDecider = cap
+
+	mustRun(t, cs)
+
+	if len(cap.states) == 0 {
+		t.Fatal("capturing decider was never invoked — executeDisaggregatedRouting did not fire")
+	}
+
+	wantDecode := poolIDsByRole(cs, PoolRoleDecode)
+	wantPrefill := poolIDsByRole(cs, PoolRolePrefill)
+
+	for i, st := range cap.states {
+		if st == nil {
+			t.Fatalf("state[%d] = nil", i)
+		}
+		// Decode-pool membership (unchanged by this PR but asserted as the control).
+		gotDecode := snapshotIDs(st.Snapshots)
+		if !stringSlicesEqual(gotDecode, wantDecode) {
+			t.Errorf("state[%d].Snapshots IDs = %v, want %v", i, gotDecode, wantDecode)
+		}
+		// Prefill-pool membership (new in #1339 G1).
+		gotPrefill := snapshotIDs(st.PrefillSnapshots)
+		if !stringSlicesEqual(gotPrefill, wantPrefill) {
+			t.Errorf("state[%d].PrefillSnapshots IDs = %v, want %v (BC-1: prefill pool must be visible to decider)",
+				i, gotPrefill, wantPrefill)
+		}
+		// SelectedDecodeInstance (BC-5) must be a member of the decode-pool set.
+		if st.SelectedDecodeInstance == "" {
+			t.Errorf("state[%d].SelectedDecodeInstance = empty; BC-5 requires pre-selected decode pod", i)
+		}
+		if st.SelectedPrefillInstance != "" {
+			t.Errorf("state[%d].SelectedPrefillInstance = %q, want empty (reserved field, built-in deciders must not populate)",
+				i, st.SelectedPrefillInstance)
+		}
+	}
+}
+
+// TestDisaggRouterState_PrefillSnapshotsEmpty_WhenFilterReturnsNone verifies
+// BC-2 at the helper layer: FilterSnapshotsByPool(PoolRolePrefill) on a
+// decode-only membership map returns an empty slice, and feeding that into
+// annotateCachedBlocks leaves the (empty) slice untouched.
+//
+// Why not an end-to-end runtime test? ValidatePoolTopology forbids a PD
+// configuration with DecodeInstances > 0 and zero prefill + zero shared
+// pods, so executeDisaggregatedRouting cannot be reached with an empty
+// prefill pool at runtime. This test exercises the BC-2 claim at the
+// contract level of the helper that produces PrefillSnapshots.
+func TestDisaggRouterState_PrefillSnapshotsEmpty_WhenFilterReturnsNone(t *testing.T) {
+	// Decode-only membership map.
+	membership := map[string]PoolRole{
+		"d0": PoolRoleDecode,
+		"d1": PoolRoleDecode,
+	}
+	snapshots := []sim.RoutingSnapshot{{ID: "d0"}, {ID: "d1"}}
+	prefillFiltered := FilterSnapshotsByPool(snapshots, membership, PoolRolePrefill)
+	if len(prefillFiltered) != 0 {
+		t.Errorf("FilterSnapshotsByPool(PoolRolePrefill) length = %d, want 0 (BC-2: empty when no prefill pool)", len(prefillFiltered))
+	}
+	// annotateCachedBlocks must tolerate an empty slice.
+	annotateCachedBlocks(prefillFiltered, map[string]func([]int) int{
+		"d0": func([]int) int { return 99 },
+	}, []int{1, 2, 3})
+	if len(prefillFiltered) != 0 {
+		t.Errorf("annotateCachedBlocks mutated length to %d, want 0", len(prefillFiltered))
+	}
+}
+
+// TestDisaggRouterState_CachedBlocksPopulated verifies BC-3 (issue #1339 G5):
+// every snapshot in state.Snapshots and state.PrefillSnapshots has CachedBlocks
+// set to cacheQueryFn[s.ID](req.InputTokens). Verified by installing a stubbed
+// cacheQueryFn where each pod returns a distinct, ID-derived block count, and
+// asserting the snapshot values match byte-for-byte.
+func TestDisaggRouterState_CachedBlocksPopulated(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	requests := newTestRequests(2)
+	cs := NewClusterSimulator(config, requests, nil)
+
+	// Install a deterministic cacheQueryFn: each pod returns a value derived
+	// from its ID so we can assert snapshot[i].CachedBlocks without guessing.
+	// Map entry ordering is irrelevant — annotateCachedBlocks looks up by ID.
+	idToCount := map[string]int{}
+	for _, inst := range cs.instances {
+		id := string(inst.ID())
+		idToCount[id] = len(id) // stable, nonzero distinguisher
+	}
+	stubCache := map[string]func([]int) int{}
+	for id, want := range idToCount {
+		captured := want // capture loop var
+		stubCache[id] = func([]int) int { return captured }
+	}
+	cs.cacheQueryFn = stubCache
+
+	cap := &capturingDisaggDecider{disaggregate: true}
+	cs.disaggregationDecider = cap
+
+	mustRun(t, cs)
+
+	if len(cap.states) == 0 {
+		t.Fatal("capturing decider was never invoked")
+	}
+
+	for i, st := range cap.states {
+		// Input tokens must be non-empty for annotation to fire; otherwise the
+		// helper's early return leaves CachedBlocks=0 legitimately. Our test
+		// requests have non-empty InputTokens by construction.
+		if len(cap.reqs[i].InputTokens) == 0 {
+			t.Fatalf("test setup bug: reqs[%d].InputTokens empty; annotation is a no-op", i)
+		}
+		for j, s := range st.Snapshots {
+			want := idToCount[s.ID]
+			if s.CachedBlocks != want {
+				t.Errorf("state[%d].Snapshots[%d] (%s).CachedBlocks = %d, want %d (BC-3: per-pod cached block count must match cacheQueryFn)",
+					i, j, s.ID, s.CachedBlocks, want)
+			}
+		}
+		for j, s := range st.PrefillSnapshots {
+			want := idToCount[s.ID]
+			if s.CachedBlocks != want {
+				t.Errorf("state[%d].PrefillSnapshots[%d] (%s).CachedBlocks = %d, want %d (BC-3: prefill-pool snapshot must also carry CachedBlocks)",
+					i, j, s.ID, s.CachedBlocks, want)
+			}
+		}
+	}
+}
+
+// TestAnnotateCachedBlocks_EmptyTokens verifies BC-3 early-return: when the
+// request has no input tokens, annotateCachedBlocks leaves every snapshot's
+// CachedBlocks at zero (no spurious calls to cacheQueryFn).
+func TestAnnotateCachedBlocks_EmptyTokens(t *testing.T) {
+	snaps := []sim.RoutingSnapshot{{ID: "a"}, {ID: "b"}}
+	calls := 0
+	cacheFn := map[string]func([]int) int{
+		"a": func([]int) int { calls++; return 7 },
+		"b": func([]int) int { calls++; return 11 },
+	}
+	annotateCachedBlocks(snaps, cacheFn, nil)
+	annotateCachedBlocks(snaps, cacheFn, []int{})
+	for i, s := range snaps {
+		if s.CachedBlocks != 0 {
+			t.Errorf("snaps[%d].CachedBlocks = %d, want 0 (empty tokens must early-return)", i, s.CachedBlocks)
+		}
+	}
+	if calls != 0 {
+		t.Errorf("cacheFn called %d times, want 0 (empty tokens must not invoke closures)", calls)
+	}
+}
+
+// TestAnnotateCachedBlocks_NilMap verifies BC-3 fallback: a nil cacheQueryFn
+// is a no-op — every snapshot keeps CachedBlocks=0.
+func TestAnnotateCachedBlocks_NilMap(t *testing.T) {
+	snaps := []sim.RoutingSnapshot{{ID: "a", CachedBlocks: 0}, {ID: "b", CachedBlocks: 0}}
+	annotateCachedBlocks(snaps, nil, []int{1, 2, 3})
+	for i, s := range snaps {
+		if s.CachedBlocks != 0 {
+			t.Errorf("snaps[%d].CachedBlocks = %d, want 0 (nil cacheFn must leave CachedBlocks untouched)", i, s.CachedBlocks)
+		}
+	}
+}
+
+// TestAnnotateCachedBlocks_MissingKey verifies BC-3 fallback: snapshots whose
+// ID is missing from cacheQueryFn (or whose closure is nil) keep CachedBlocks=0.
+// Snapshots with a valid closure still get annotated. This mirrors the
+// conservative fallback PrefixThresholdDecider.Decide applies.
+func TestAnnotateCachedBlocks_MissingKey(t *testing.T) {
+	snaps := []sim.RoutingSnapshot{
+		{ID: "known"},
+		{ID: "missing"},
+		{ID: "nil_closure"},
+	}
+	cacheFn := map[string]func([]int) int{
+		"known":       func([]int) int { return 5 },
+		"nil_closure": nil, // present but nil
+	}
+	annotateCachedBlocks(snaps, cacheFn, []int{1, 2, 3})
+	if snaps[0].CachedBlocks != 5 {
+		t.Errorf("known.CachedBlocks = %d, want 5", snaps[0].CachedBlocks)
+	}
+	if snaps[1].CachedBlocks != 0 {
+		t.Errorf("missing.CachedBlocks = %d, want 0 (missing key must keep zero)", snaps[1].CachedBlocks)
+	}
+	if snaps[2].CachedBlocks != 0 {
+		t.Errorf("nil_closure.CachedBlocks = %d, want 0 (nil closure must keep zero)", snaps[2].CachedBlocks)
+	}
+}
+
+// snapshotIDs returns the ordered IDs of a snapshot slice. Helper for
+// membership/ordering assertions.
+func snapshotIDs(snaps []sim.RoutingSnapshot) []string {
+	ids := make([]string, len(snaps))
+	for i, s := range snaps {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// stringSlicesEqual returns true iff a and b have the same length and same
+// elements in the same order. Used instead of reflect.DeepEqual to keep
+// diagnostics small and avoid the nil-vs-empty-slice asymmetry.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -28,15 +28,22 @@ type DisaggregationDecision struct {
 // use len(req.InputTokens) and req.MaxOutputLen only.
 //
 // req is guaranteed non-nil; implementations may assume a non-nil pointer.
-// state carries the decode-pool RouterState — the same snapshots used to
-// pre-select the decode pod. state.SelectedInstance holds the ID of the pod
-// chosen by the decode routing policy. Implementations may read any field of
-// state except Request.OutputTokens. state is guaranteed non-nil at runtime
+// state carries the RouterState built for the disagg-decider path:
+// state.Snapshots is filtered to the decode pool (same snapshots used to
+// pre-select the decode pod), state.PrefillSnapshots carries the prefill pool
+// (empty when no prefill pool is configured; issue #1339 G1), and each
+// snapshot's CachedBlocks field carries cacheQueryFn(req.InputTokens) for
+// that pod (zero when cache-query wiring is not available; issue #1339 G5).
+// state.SelectedDecodeInstance holds the ID of the pod chosen by the decode
+// routing policy. Implementations may read any field of state except
+// Request.OutputTokens. state is guaranteed non-nil at runtime
 // (executeDisaggregatedRouting returns at the empty-decode-pool guard before
 // calling Decide), but implementations must still tolerate a nil pointer for
 // unit-test convenience. Passing the full RouterState (rather than a single
 // snapshot) lets joint D+P policies reconsider the decode pod via
-// DisaggregationDecision.DecodePodOverride.
+// DisaggregationDecision.DecodePodOverride. The three built-in deciders
+// (never, always, prefix-threshold) do not read PrefillSnapshots or
+// CachedBlocks; those fields exist for future cross-pool-aware policies.
 type DisaggregationDecider interface {
 	Decide(req *Request, state *RouterState) DisaggregationDecision
 }
@@ -91,7 +98,7 @@ func NewDisaggregationDecider(name string) DisaggregationDecider {
 //	nonCachedTokens = len(req.InputTokens) − cachedBlocks × blockSize
 //	Disaggregate    = (nonCachedTokens > threshold)
 //
-// where cachedBlocks is obtained by calling cacheQuery[state.SelectedInstance]
+// where cachedBlocks is obtained by calling cacheQuery[state.SelectedDecodeInstance]
 // on req.InputTokens. threshold and blockSize are in token counts, not bytes.
 //
 // cacheQuery shares the same map used by the precise-prefix-cache scorer
@@ -107,7 +114,7 @@ type PrefixThresholdDecider struct {
 // threshold, block size, and per-pod cache-query map.
 // threshold must be >= 0; blockSize must be > 0. Panics otherwise (R3).
 // cacheQuery may be nil (e.g. unit tests without cluster state); when nil or
-// when state.SelectedInstance is missing from the map, Decide returns
+// when state.SelectedDecodeInstance is missing from the map, Decide returns
 // Disaggregate=false (conservative fallback, consistent with llm-d's
 // nil-endpoint guard at prefix_based_pd_decider.go:108-111).
 func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]func([]int) int) *PrefixThresholdDecider {
@@ -130,17 +137,17 @@ func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]f
 // Early returns (all yielding Disaggregate=false):
 //   - len(req.InputTokens) == 0
 //   - state == nil
-//   - state.SelectedInstance == "" (no upstream selection)
+//   - state.SelectedDecodeInstance == "" (no upstream selection)
 //   - cacheQuery is nil, or the selected instance is missing from the map,
 //     or its closure is nil (pod not yet registered / just removed)
 func (p *PrefixThresholdDecider) Decide(req *Request, state *RouterState) DisaggregationDecision {
 	if len(req.InputTokens) == 0 {
 		return DisaggregationDecision{Disaggregate: false}
 	}
-	if state == nil || state.SelectedInstance == "" || p.cacheQuery == nil {
+	if state == nil || state.SelectedDecodeInstance == "" || p.cacheQuery == nil {
 		return DisaggregationDecision{Disaggregate: false}
 	}
-	fn, ok := p.cacheQuery[state.SelectedInstance]
+	fn, ok := p.cacheQuery[state.SelectedDecodeInstance]
 	if !ok || fn == nil {
 		return DisaggregationDecision{Disaggregate: false}
 	}

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -149,7 +149,7 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 	}
 	state := &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
-		SelectedInstance: "decode_0",
+		SelectedDecodeInstance: "decode_0",
 	}
 
 	deciders := []DisaggregationDecider{
@@ -170,7 +170,7 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 // TestDisaggregationDecider_StateAgnostic verifies BC-2 (from PR #1265 / GAP-2):
 // NeverDisaggregate and AlwaysDisaggregate ignore state entirely — nil vs populated
 // state yields identical decisions. PrefixThresholdDecider is intentionally NOT in
-// this list anymore: after GAP-3, its decision depends on state.SelectedInstance
+// this list anymore: after GAP-3, its decision depends on state.SelectedDecodeInstance
 // and the cache query map; it has its own dedicated tests below.
 func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
@@ -181,7 +181,7 @@ func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 			{ID: "decode_1", QueueDepth: 2, KVUtilization: 0.9},
 		},
 		Clock:            12345,
-		SelectedInstance: "decode_1",
+		SelectedDecodeInstance: "decode_1",
 	}
 
 	deciders := []DisaggregationDecider{
@@ -211,7 +211,7 @@ func TestDisaggregationDecider_BuiltinsReturnNoOverrides(t *testing.T) {
 	}
 	state := &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
-		SelectedInstance: "decode_0",
+		SelectedDecodeInstance: "decode_0",
 	}
 
 	deciders := []DisaggregationDecider{
@@ -252,7 +252,7 @@ func TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize(t *testing.T) {
 	NewPrefixThresholdDecider(512, 0, nil)
 }
 
-// coldState builds a RouterState with SelectedInstance set to selectedID.
+// coldState builds a RouterState with SelectedDecodeInstance set to selectedID.
 // Pair with a coldCache(selectedID)-constructed decider to exercise the
 // formula with cachedBlocks=0 (so nonCachedTokens == len(InputTokens)).
 // RouterState itself carries no cache query; the cache query lives on the
@@ -260,7 +260,7 @@ func TestNewPrefixThresholdDecider_PanicsOnZeroBlockSize(t *testing.T) {
 func coldState(selectedID string) *RouterState {
 	return &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: selectedID}},
-		SelectedInstance: selectedID,
+		SelectedDecodeInstance: selectedID,
 	}
 }
 
@@ -362,8 +362,8 @@ func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 //   - Request has 840 input tokens.
 //
 // Expected:
-//   - SelectedInstance="decode_A": nonCached = 840 - 40*16 = 200 ≤ 512 → false.
-//   - SelectedInstance="decode_B": nonCached = 840 - 0*16  = 840 > 512 → true.
+//   - SelectedDecodeInstance="decode_A": nonCached = 840 - 40*16 = 200 ≤ 512 → false.
+//   - SelectedDecodeInstance="decode_B": nonCached = 840 - 0*16  = 840 > 512 → true.
 func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
@@ -394,11 +394,11 @@ func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 					{ID: "decode_A"},
 					{ID: "decode_B"},
 				},
-				SelectedInstance: tc.selectedInstance,
+				SelectedDecodeInstance: tc.selectedInstance,
 			}
 			got := decider.Decide(req, state).Disaggregate
 			if got != tc.wantDisagg {
-				t.Errorf("SelectedInstance=%s: Disaggregate=%v, want %v (%s)",
+				t.Errorf("SelectedDecodeInstance=%s: Disaggregate=%v, want %v (%s)",
 					tc.selectedInstance, got, tc.wantDisagg, tc.reason)
 			}
 		})
@@ -409,9 +409,9 @@ func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 // conservative-cold fallback paths. In any of these five scenarios the decider
 // cannot locate a valid per-pod cache closure, so it returns Disaggregate=false:
 //  1. state == nil
-//  2. state.SelectedInstance == "" (upstream made no selection)
-//  3. state.SelectedInstance is not a key in cacheQuery
-//  4. cacheQuery[SelectedInstance] is nil (closure missing at the key)
+//  2. state.SelectedDecodeInstance == "" (upstream made no selection)
+//  3. state.SelectedDecodeInstance is not a key in cacheQuery
+//  4. cacheQuery[SelectedDecodeInstance] is nil (closure missing at the key)
 //  5. cacheQuery itself is nil (unit tests without cluster state)
 func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
 	const threshold = 100
@@ -438,12 +438,12 @@ func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
 		{
 			name:       "empty_selected_instance",
 			cacheQuery: coldCache("decode_0"),
-			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedInstance: ""},
+			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedDecodeInstance: ""},
 		},
 		{
 			name:       "unknown_selected_instance",
 			cacheQuery: coldCache("decode_0"),
-			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedInstance: "decode_X"},
+			state:      &RouterState{Snapshots: []RoutingSnapshot{{ID: "decode_0"}}, SelectedDecodeInstance: "decode_X"},
 		},
 		{
 			name: "nil_closure_in_map",
@@ -506,7 +506,7 @@ func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
 }
 
 // TestPrefixThresholdDecider_QueriesOnlySelectedPod verifies BC-1 (isolation): when
-// Decide runs, it invokes the closure for SelectedInstance exactly once and does not
+// Decide runs, it invokes the closure for SelectedDecodeInstance exactly once and does not
 // invoke closures for any other instance in the map. This guards against an accidental
 // "scan all pods" regression (option (b) in the #1265 review comment was explicitly
 // rejected; we implement option (a) — query only the selected pod).
@@ -527,7 +527,7 @@ func TestPrefixThresholdDecider_QueriesOnlySelectedPod(t *testing.T) {
 			{ID: "decode_A"},
 			{ID: "decode_B"},
 		},
-		SelectedInstance: "decode_A",
+		SelectedDecodeInstance: "decode_A",
 	}
 	decider.Decide(req, state)
 
@@ -536,6 +536,66 @@ func TestPrefixThresholdDecider_QueriesOnlySelectedPod(t *testing.T) {
 	}
 	if bCalls != 0 {
 		t.Errorf("decode_B closure called %d times, want 0 (must not query non-selected pods)", bCalls)
+	}
+}
+
+// TestDisaggregationDecider_IgnoresNewFields verifies BC-4 (issue #1339):
+// built-in deciders (never, always, prefix-threshold) produce byte-identical
+// decisions regardless of PrefillSnapshots content, per-snapshot CachedBlocks,
+// or SelectedPrefillInstance. This pins the parity contract: the new
+// cross-pool signal envelope is additive, and adopting it cannot regress
+// existing decisions.
+func TestDisaggregationDecider_IgnoresNewFields(t *testing.T) {
+	tokens := make([]int, 200)
+	for i := range tokens {
+		tokens[i] = i + 1
+	}
+	req := &Request{ID: "req-parity", InputTokens: tokens}
+
+	// Decode-pool snapshot with known CachedBlocks=0 (bare) vs non-zero (populated).
+	decodeBare := []RoutingSnapshot{{ID: "decode_0"}, {ID: "decode_1"}}
+	decodePopulated := []RoutingSnapshot{
+		{ID: "decode_0", CachedBlocks: 3, KVUtilization: 0.4},
+		{ID: "decode_1", CachedBlocks: 7, KVUtilization: 0.7},
+	}
+	prefillPopulated := []RoutingSnapshot{
+		{ID: "prefill_0", CachedBlocks: 5, QueueDepth: 2},
+		{ID: "prefill_1", CachedBlocks: 0, QueueDepth: 4},
+	}
+
+	// cacheQuery used only by prefix-threshold. Wire decode_0 to 0 blocks so the
+	// decision depends solely on len(InputTokens) > threshold (200 > 100 → true).
+	cacheQuery := map[string]func([]int) int{
+		"decode_0": func([]int) int { return 0 },
+		"decode_1": func([]int) int { return 0 },
+	}
+
+	stateBare := &RouterState{
+		Snapshots:              decodeBare,
+		SelectedDecodeInstance: "decode_0",
+	}
+	statePopulated := &RouterState{
+		Snapshots:               decodePopulated,
+		PrefillSnapshots:        prefillPopulated,
+		SelectedDecodeInstance:  "decode_0",
+		SelectedPrefillInstance: "prefill_0", // intentionally non-empty to prove built-ins ignore it
+		Clock:                   12345,
+	}
+
+	deciders := []DisaggregationDecider{
+		&NeverDisaggregate{},
+		&AlwaysDisaggregate{},
+		NewPrefixThresholdDecider(100, 16, cacheQuery),
+	}
+	for _, d := range deciders {
+		bare := d.Decide(req, stateBare)
+		populated := d.Decide(req, statePopulated)
+		if bare != populated {
+			t.Errorf("%T: decision differs between bare and populated state "+
+				"(bare=%+v, populated=%+v); BC-4 requires built-in deciders to ignore "+
+				"PrefillSnapshots, per-snapshot CachedBlocks, and SelectedPrefillInstance",
+				d, bare, populated)
+		}
 	}
 }
 

--- a/sim/router_state.go
+++ b/sim/router_state.go
@@ -6,26 +6,48 @@ package sim
 // same pattern as RoutingSnapshot.
 //
 // USAGE BOUNDARY: In production, only constructed by ClusterSimulator's event
-// handlers (via buildRouterState). Tests may construct directly.
-// Single-instance Simulator does not use RouterState — instance-level policies
-// (InstanceScheduler) receive parameters directly.
+// handlers (via buildRouterState or executeDisaggregatedRouting). Tests may
+// construct directly. Single-instance Simulator does not use RouterState —
+// instance-level policies (InstanceScheduler) receive parameters directly.
 // This prevents import cycles: sim/cluster/ imports sim/, not the reverse.
 type RouterState struct {
-	Snapshots        []RoutingSnapshot // One per routable instance (Active + WarmingUp)
-	// One per Loading instance. Populated fields: ID, Model, GPUType, TPDegree, CostPerHour,
-	// TotalKvCapacityTokens. QueueDepth, BatchSize, KVUtilization, FreeKVBlocks, CacheHitRate,
-	// InFlightRequests, KvTokensInUse remain zero.
+	// Snapshots carries the routable instances visible to the current policy
+	// invocation. For the standard routing path this is all routable instances
+	// in the deployment. For the disaggregated routing path this is filtered to
+	// the decode-pool members only (parity with llm-d's EPP handing the PD
+	// decider a pre-selected decode endpoint).
+	Snapshots []RoutingSnapshot
+	// PrefillSnapshots carries the prefill-pool members in the disaggregated
+	// routing path (one per routable instance whose PoolRole == PoolRolePrefill).
+	// Empty for the standard routing path and for disaggregated contexts whose
+	// deployment has no prefill pool configured. The three built-in deciders
+	// (never, always, prefix-threshold) do not read this field; it exists so
+	// future cross-pool-aware and joint D+P policies can observe prefill-pool
+	// load and per-prefill-pod cache hits. Issue #1339 (G1).
+	PrefillSnapshots []RoutingSnapshot
+	// One per Loading instance. Populated fields: ID, Model, GPUType, TPDegree,
+	// CostPerHour, TotalKvCapacityTokens. QueueDepth, BatchSize, KVUtilization,
+	// FreeKVBlocks, CacheHitRate, InFlightRequests, KvTokensInUse remain zero.
 	LoadingSnapshots []RoutingSnapshot
 	Clock            int64 // Current simulation clock in microseconds
-	// SelectedInstance is the instance ID pre-selected by an upstream caller
-	// (typically the decode-routing policy) before invoking a
+	// SelectedDecodeInstance is the decode-pod instance ID pre-selected by an
+	// upstream caller (typically the decode-routing policy) before invoking a
 	// DisaggregationDecider. Empty for contexts where no prior selection has
 	// been made (e.g., RoutingPolicy.Route itself receives RouterState with
-	// SelectedInstance == ""). DisaggregationDecider implementations may use
-	// this ID to locate the selected pod's state (e.g., in a per-pod cache-
+	// SelectedDecodeInstance == ""). DisaggregationDecider implementations may
+	// use this ID to locate the selected pod's state (e.g., in a per-pod cache-
 	// query map). Membership in Snapshots is not structurally guaranteed —
 	// implementations must tolerate both a zero value ("no selection known")
 	// and an ID that has no corresponding entry in Snapshots (e.g., the pod
 	// was removed after routing) and guard accordingly.
-	SelectedInstance string
+	//
+	// Renamed from SelectedInstance in issue #1339 (G6) to disambiguate now
+	// that PrefillSnapshots is visible.
+	SelectedDecodeInstance string
+	// SelectedPrefillInstance is reserved for future joint D+P policies that
+	// select a prefill pod alongside the decode pod. The three built-in
+	// deciders leave this empty and downstream prefill-routing code treats
+	// an empty value as "no hint — apply normal prefill routing". Added in
+	// issue #1339 (G6) to pre-empt a future interface break.
+	SelectedPrefillInstance string
 }

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -32,6 +32,15 @@ type RoutingSnapshot struct {
 	AvgInTokens           float64 // average input tokens per completed request; 0 if not yet available
 	AvgOutTokens          float64 // average output tokens per completed request; 0 if not yet available
 	MaxBatchSize          float64 // server-configured max batch size; 0 if not yet available
+	// CachedBlocks is the number of consecutive cached prefix blocks for a
+	// specific request on this instance. Populated only by the disaggregation-
+	// decider code path (executeDisaggregatedRouting) from
+	// cacheQueryFn(req.InputTokens); zero elsewhere. Scoped to one request —
+	// do not read from snapshots produced by buildRouterState or
+	// CachedSnapshotProvider.Snapshot (their values are always zero). This is
+	// the G5 signal from issue #1339 (per-pod prefix-cache hit count exposed
+	// to DisaggregationDecider implementations).
+	CachedBlocks int
 }
 
 // EffectiveLoad returns the total effective load on this instance:

--- a/sim/routing_constructors_test.go
+++ b/sim/routing_constructors_test.go
@@ -81,4 +81,7 @@ func TestNewRoutingSnapshot_Fields(t *testing.T) {
 	if snap.InFlightRequests != 0 {
 		t.Errorf("InFlightRequests = %d, want 0", snap.InFlightRequests)
 	}
+	if snap.CachedBlocks != 0 {
+		t.Errorf("CachedBlocks = %d, want 0", snap.CachedBlocks)
+	}
 }


### PR DESCRIPTION
## Summary

Tranche 1 from parent #1336's DAG: strictly additive interface extensions that let future cross-pool-aware and joint D+P disaggregation policies see both pools plus per-pod prefix-cache-hit counts. None of the three built-in deciders (`never`, `always`, `prefix-threshold`) read the new fields, so output is byte-identical and llm-d parity is preserved on the golden path.

- **G1 — Prefill-pool snapshots.** `RouterState.PrefillSnapshots []RoutingSnapshot` is populated in `executeDisaggregatedRouting` alongside the existing decode-pool `Snapshots`. Empty for the standard (non-disagg) routing path and for disagg contexts with no prefill pool configured.
- **G5 — Per-pod `CachedBlocks` on snapshots.** `RoutingSnapshot.CachedBlocks int` — populated in place for each pod visible to the decider (both `Snapshots` and `PrefillSnapshots`) by a new `annotateCachedBlocks` helper that calls the existing `cacheQueryFn`. Scoped to the disagg-decider path; zero elsewhere by default.
- **G6 — Rename `SelectedInstance` → `SelectedDecodeInstance`.** Disambiguates the field now that two pools are visible. Adds a reserved `SelectedPrefillInstance` field (empty under the built-in deciders) to pre-empt a future API break when joint D+P policies land.

## Behavioral Contracts

- **BC-1 (G1)** — GIVEN a cluster with a non-empty prefill pool, WHEN `executeDisaggregatedRouting` builds a `RouterState`, THEN `state.PrefillSnapshots` contains one snapshot per routable prefill-pool instance in `c.instances` traversal order.
- **BC-2** — GIVEN no prefill pool is configured (filter returns none), THEN `PrefillSnapshots` is empty and `annotateCachedBlocks` tolerates the empty slice.
- **BC-3 (G5)** — GIVEN a wired `cacheQueryFn`, THEN every snapshot in `Snapshots` and `PrefillSnapshots` has `CachedBlocks == cacheQueryFn[s.ID](req.InputTokens)`; zero when the key is missing or the closure is nil (conservative fallback, same as `PrefixThresholdDecider.Decide`).
- **BC-4 (Parity)** — the three built-in deciders produce byte-identical decisions regardless of `PrefillSnapshots` content, per-snapshot `CachedBlocks`, or `SelectedPrefillInstance`.
- **BC-5 (G6)** — `state.SelectedDecodeInstance` carries the decode routing policy's `TargetInstance`; `state.SelectedPrefillInstance` is left empty by built-in deciders.
- **BC-6** — `CachedBlocks` is zero on snapshots produced by `buildRouterState` and `CachedSnapshotProvider.Snapshot` (non-disagg paths untouched).
- **BC-7 (INV-6)** — determinism preserved: `PrefillSnapshots` order follows `c.instances`; `CachedBlocks` is a pure function of `(cacheQueryFn, req.InputTokens)`.

## Invariants preserved

- **INV-6** — no wall-clock, no RNG, no map iteration producing ordered output.
- **INV-9** — `annotateCachedBlocks` reads only `req.InputTokens` (never `req.OutputTokens`).
- **R1** — `annotateCachedBlocks`'s `continue` keeps `CachedBlocks = 0` (documented fallback), not a silent data-drop.
- **R2/R4** — RouterState and RoutingSnapshot keep single canonical constructors; field-named initializers tolerate the new fields.

## Tests added

- `TestNewRoutingSnapshot_Fields` extended with `CachedBlocks` zero-value assertion.
- `TestDisaggregationDecider_IgnoresNewFields` (sim/) — BC-4 parity: bare vs. fully populated state yields equal `DisaggregationDecision` for all three built-in deciders.
- `TestDisaggRouterState_PrefillSnapshotsPopulated` — BC-1, BC-5.
- `TestDisaggRouterState_PrefillSnapshotsEmpty_WhenFilterReturnsNone` — BC-2 at the helper-contract layer (runtime path is guarded by `ValidatePoolTopology`).
- `TestDisaggRouterState_CachedBlocksPopulated` — BC-3 with a stub `cacheQueryFn` where each pod returns a distinct ID-derived value.
- `TestAnnotateCachedBlocks_EmptyTokens`, `TestAnnotateCachedBlocks_NilMap`, `TestAnnotateCachedBlocks_MissingKey` — helper-level edge cases.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (all packages pass; full suite including `sim/cluster/` at ~3.5 min)
- [x] `go vet ./...`
- [x] No default behavior change; no new CLI flag; no migration required.

Closes #1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)