### PR TITLE
feat(cluster): add optional DisaggregationObserver for outcome feedback (#1340) T2

### DIFF
--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1880,9 +1880,17 @@ func (c *ClusterSimulator) projectPDMetrics() {
 				// guard here in case that loop is refactored.
 				continue
 			}
+			// Deliver the original DisaggregationDecision captured at routing
+			// time (#1340). Falls back to {Disaggregate: true} if the decision
+			// was not recorded (legacy test fixtures that construct parents
+			// directly). For production code the field is always populated.
+			decision := parent.DisaggDecision
+			if !decision.Disaggregate {
+				decision = sim.DisaggregationDecision{Disaggregate: true}
+			}
 			observer.OnOutcome(
 				parent.OriginalRequest,
-				sim.DisaggregationDecision{Disaggregate: true},
+				decision,
 				sim.Outcome{
 					TTFT:               ttft,
 					CompletionTime:     parent.CompletionTime,
@@ -2134,6 +2142,10 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 	if encodeInstanceID != "" {
 		parent.EncodeInstanceID = InstanceID(encodeInstanceID)
 	}
+	// #1340: persist the full DisaggregationDecision so the optional observer
+	// callback at parent completion can receive the original
+	// DecodePodOverride / PrefillPodHint fields (empty for built-ins).
+	parent.DisaggDecision = disaggDecision
 	cs.parentRequests[parent.ID] = parent
 
 	// Create prefill sub-request: same input, no output (completes after prefill).

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -44,7 +44,15 @@ type ClusterSimulator struct {
 	gatewayExpired       int                    // count of requests expired from gateway queue via TTL (INV-1: gw_expired)
 	requestTTL           int64                  // gateway queue request TTL in microseconds; 0 = disabled
 	poolMembership       map[string]PoolRole    // instance ID → pool role (nil when disaggregation disabled)
-	disaggregationDecider sim.DisaggregationDecider // PD disaggregation decider (nil when disabled)
+	disaggregationDecider sim.DisaggregationDecider // PD disaggregation decider (nil when disabled). May optionally implement sim.DisaggregationObserver for outcome-feedback hooks (#1340).
+
+	// nonDisaggObservations tracks requests whose configured disaggregation
+	// decider returned Disaggregate=false, pending their terminal completion on
+	// the decode pod. Populated only when cs.disaggregationDecider implements
+	// sim.DisaggregationObserver (nil otherwise, preserving zero-cost behavior
+	// for built-in deciders — BC-5, INV-6 parity). Keyed by request ID.
+	// See docs/plans/pr1340-disagg-observer-plan.md.
+	nonDisaggObservations map[string]nonDisaggPendingObservation
 
 	// PD disaggregation state (PR2)
 	parentRequests            map[string]*ParentRequest // parent request ID → tracking record
@@ -374,6 +382,14 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		default:
 			cs.disaggregationDecider = sim.NewDisaggregationDecider(config.PDDecider)
 		}
+
+		// Observer-aware deciders (#1340): allocate the non-disagg tracking map
+		// only when the concrete decider implements DisaggregationObserver.
+		// Built-ins do not implement it → map stays nil → every call site short-
+		// circuits → byte-identical behavior (BC-5). Tests that inject a custom
+		// observer decider after construction must also allocate this map (or
+		// rely on the lazy init in executeDisaggregatedRouting).
+		cs.maybeInitNonDisaggObservations()
 	}
 
 	// E/P/D disaggregation (GAP-4, issue #1264): construct the encode decider
@@ -730,6 +746,14 @@ func (c *ClusterSimulator) Run() error {
 					c.detectDecodeCompletions(inst)
 				}
 			}
+
+			// DisaggregationObserver (#1340): fire OnOutcome for non-disagg
+			// requests that have just completed on this instance. No-op when
+			// the configured decider does not implement the observer interface
+			// (built-in default, BC-5). Call unconditionally — the guard is
+			// inside detectNonDisaggObserverCompletions so the map-driven
+			// short-circuit is local.
+			c.detectNonDisaggObserverCompletions(inst)
 		}
 
 		c.maybeDeliverProgressSnapshot(false)
@@ -1233,6 +1257,93 @@ func (c *ClusterSimulator) detectDecodeCompletions(inst *InstanceSimulator) {
 	}
 }
 
+// nonDisaggPendingObservation is the per-request record tracked between a
+// Disaggregate=false decision and the request's terminal completion on the
+// decode pod. Only allocated when the configured DisaggregationDecider
+// implements DisaggregationObserver (#1340).
+type nonDisaggPendingObservation struct {
+	req      *sim.Request
+	decision sim.DisaggregationDecision
+}
+
+// maybeInitNonDisaggObservations lazily allocates the non-disagg observation
+// tracking map iff cs.disaggregationDecider satisfies DisaggregationObserver.
+// Safe to call multiple times (idempotent). Used by both NewClusterSimulator
+// and executeDisaggregatedRouting so tests that inject an observer decider
+// after construction still get tracking.
+func (cs *ClusterSimulator) maybeInitNonDisaggObservations() {
+	if cs.nonDisaggObservations != nil {
+		return
+	}
+	if cs.disaggregationDecider == nil {
+		return
+	}
+	if _, ok := cs.disaggregationDecider.(sim.DisaggregationObserver); !ok {
+		return
+	}
+	cs.nonDisaggObservations = make(map[string]nonDisaggPendingObservation)
+}
+
+// detectNonDisaggObserverCompletions fires DisaggregationObserver.OnOutcome
+// for any non-disaggregated requests that have just completed on this
+// instance (BC-3). A no-op when no observer-aware decider is configured,
+// which is the default for all three built-in deciders (BC-5).
+//
+// Filter symmetry with the disagg path (BC-4): only successful completions
+// fire the callback; timed-out or dropped requests do NOT — the instance
+// never records them in RequestCompletionTimes (see TimeoutEvent.Execute
+// in sim/event.go, which sets StateTimedOut and does not append to the
+// completions map).
+//
+// Determinism (INV-6, R2): the ready-to-fire request IDs are collected into
+// a sorted slice before dispatch so the callback invocation order is a pure
+// function of request IDs — not Go map iteration order.
+func (cs *ClusterSimulator) detectNonDisaggObserverCompletions(inst *InstanceSimulator) {
+	if len(cs.nonDisaggObservations) == 0 {
+		return
+	}
+	observer, ok := cs.disaggregationDecider.(sim.DisaggregationObserver)
+	if !ok {
+		// Defensive: the map is only populated when the decider is an observer.
+		// Reaching here would indicate an observer decider was swapped out after
+		// tracking started — treat as a drop (no callback, no leak beyond sim
+		// lifetime).
+		return
+	}
+	instID := string(inst.ID())
+	m := inst.Metrics()
+
+	var readyIDs []string
+	for reqID, p := range cs.nonDisaggObservations {
+		if p.req.AssignedInstance != instID {
+			continue
+		}
+		if _, completed := m.RequestCompletionTimes[reqID]; !completed {
+			continue
+		}
+		readyIDs = append(readyIDs, reqID)
+	}
+	if len(readyIDs) == 0 {
+		return
+	}
+	sort.Strings(readyIDs)
+
+	for _, reqID := range readyIDs {
+		p := cs.nonDisaggObservations[reqID]
+		completionTime := int64(m.RequestCompletionTimes[reqID])
+		ttft := m.RequestTTFTs[reqID] // zero if absent; callback may choose to ignore
+		observer.OnOutcome(p.req, p.decision, sim.Outcome{
+			TTFT:               ttft,
+			CompletionTime:     completionTime,
+			TransferDurationUs: 0,
+			Disaggregated:      false,
+			DecodeInstanceID:   instID,
+			PrefillInstanceID:  "",
+		})
+		delete(cs.nonDisaggObservations, reqID)
+	}
+}
+
 // Clock returns the cluster's current simulation clock.
 func (c *ClusterSimulator) Clock() int64 {
 	return c.clock
@@ -1629,6 +1740,16 @@ func (c *ClusterSimulator) projectPDMetrics() {
 	}
 	m := c.aggregatedMetrics
 
+	// #1340: collect projected parent TTFTs in the existing pass so the
+	// observer dispatch below reports the SAME value that was written to
+	// m.RequestTTFTs[pid]. Only allocated when the decider is an observer
+	// (zero cost for built-ins — BC-5 parity).
+	observer, hasObserver := c.disaggregationDecider.(sim.DisaggregationObserver)
+	var projectedTTFTs map[string]float64
+	if hasObserver {
+		projectedTTFTs = make(map[string]float64, len(c.parentRequests))
+	}
+
 	for _, parent := range c.parentRequests {
 		pfx := parent.PrefillSubReqID // "req_N_prefill"
 		dec := parent.DecodeSubReqID  // "req_N_decode"
@@ -1670,10 +1791,16 @@ func (c *ClusterSimulator) projectPDMetrics() {
 				m.RequestTTFTs[pid] = newTTFT
 				// BC-3: Keep TTFTSum consistent with the TTFT adjustment.
 				m.TTFTSum += int64(newTTFT - prefillTTFT)
+				if hasObserver {
+					projectedTTFTs[pid] = newTTFT
+				}
 			} else if hasPrefillTTFT {
 				// Defensive fallback: use prefill-only TTFT if decode data unavailable.
 				m.RequestTTFTs[pid] = prefillTTFT
 				logrus.Warnf("[cluster] projectPDMetrics: parent %s missing decode ITL or TransferCompleteTime; using prefill TTFT", pid)
+				if hasObserver {
+					projectedTTFTs[pid] = prefillTTFT
+				}
 			} else {
 				logrus.Warnf("[cluster] projectPDMetrics: completed parent %s has no prefill TTFT (key %s)", pid, pfx)
 			}
@@ -1713,6 +1840,58 @@ func (c *ClusterSimulator) projectPDMetrics() {
 		delete(m.RequestCompletionTimes, dec)
 		if completed {
 			m.RequestCompletionTimes[pid] = float64(parent.CompletionTime)
+		}
+	}
+
+	// DisaggregationObserver (#1340): fire OnOutcome exactly once per
+	// successfully-completed parent request, in sorted parent-ID order for
+	// determinism (INV-6). No-op when the configured decider does not
+	// implement the observer interface — the three built-in deciders never
+	// implement it, so this loop body is skipped and per-request metrics are
+	// byte-identical to pre-#1340 runs (BC-5).
+	if hasObserver {
+		parentIDs := make([]string, 0, len(c.parentRequests))
+		for pid := range c.parentRequests {
+			parentIDs = append(parentIDs, pid)
+		}
+		sort.Strings(parentIDs)
+		for _, pid := range parentIDs {
+			parent := c.parentRequests[pid]
+			// BC-4: fire only on terminal SUCCESS — not on drops or timeouts.
+			// Note: the projection loop above uses a looser `completed` gate
+			// (CompletionTime > 0 && DecodeInstanceID != "") which also matches
+			// timed-out decode sub-requests, because detectDecodeCompletions
+			// stamps parent.CompletionTime on both successful completion AND
+			// timeout (see sim/cluster/cluster.go detectDecodeCompletions
+			// Phase 3). Tightening the observer filter here keeps BC-4
+			// symmetric with the non-disagg path.
+			if parent.DecodeSubReq == nil || parent.DecodeSubReq.State != sim.StateCompleted {
+				continue
+			}
+			ttft, ok := projectedTTFTs[pid]
+			if !ok {
+				// Completed parent with no prefill TTFT (warn-logged above).
+				// Filter out of observer dispatch — firing with a zero TTFT
+				// would misrepresent the outcome to a feedback-driven decider.
+				continue
+			}
+			if parent.OriginalRequest == nil {
+				// Already panicked above in the projection loop; defensive
+				// guard here in case that loop is refactored.
+				continue
+			}
+			observer.OnOutcome(
+				parent.OriginalRequest,
+				sim.DisaggregationDecision{Disaggregate: true},
+				sim.Outcome{
+					TTFT:               ttft,
+					CompletionTime:     parent.CompletionTime,
+					TransferDurationUs: parent.TransferCompleteTime - parent.TransferStartTime,
+					Disaggregated:      true,
+					DecodeInstanceID:   string(parent.DecodeInstanceID),
+					PrefillInstanceID:  string(parent.PrefillInstanceID),
+				},
+			)
 		}
 	}
 }
@@ -1932,6 +2111,19 @@ func (cs *ClusterSimulator) executeDisaggregatedRouting(req *sim.Request, time i
 		decodeInst.InjectRequestOnline(req, time)
 		if cs.evictionTracker != nil {
 			cs.evictionTracker.Track(req, decodeDecision.TargetInstance, cs.priorityMap)
+		}
+
+		// Observer hook (#1340): if the configured decider implements
+		// DisaggregationObserver, track this request so we fire OnOutcome at
+		// terminal completion. The map is nil for built-in deciders (zero
+		// cost). Lazily allocate in case an observer decider was injected
+		// after NewClusterSimulator ran (supported for test wiring).
+		cs.maybeInitNonDisaggObservations()
+		if cs.nonDisaggObservations != nil {
+			cs.nonDisaggObservations[req.ID] = nonDisaggPendingObservation{
+				req:      req,
+				decision: disaggDecision,
+			}
 		}
 		return
 	}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -50,8 +50,8 @@ type ClusterSimulator struct {
 	// decider returned Disaggregate=false, pending their terminal completion on
 	// the decode pod. Populated only when cs.disaggregationDecider implements
 	// sim.DisaggregationObserver (nil otherwise, preserving zero-cost behavior
-	// for built-in deciders — BC-5, INV-6 parity). Keyed by request ID.
-	// See docs/plans/pr1340-disagg-observer-plan.md.
+	// for built-in deciders — BC-5, INV-6 parity). Keyed by request ID. See
+	// issue #1340.
 	nonDisaggObservations map[string]nonDisaggPendingObservation
 
 	// PD disaggregation state (PR2)
@@ -1294,6 +1294,14 @@ func (cs *ClusterSimulator) maybeInitNonDisaggObservations() {
 // never records them in RequestCompletionTimes (see TimeoutEvent.Execute
 // in sim/event.go, which sets StateTimedOut and does not append to the
 // completions map).
+//
+// Map lifetime: tracked entries for requests that never reach terminal
+// success (timeouts, drops, horizon-interrupted runs) remain in
+// cs.nonDisaggObservations until the simulator is garbage-collected at
+// sim end. This is BOUNDED by the total request count — not an unbounded
+// leak — and has no observable effect (no callback fires). A stricter
+// lifetime would require hooking the timeout/drop paths; deliberately
+// deferred for the minimal interface-extension scope of #1340.
 //
 // Determinism (INV-6, R2): the ready-to-fire request IDs are collected into
 // a sorted slice before dispatch so the callback invocation order is a pure

--- a/sim/cluster/disagg_observer_test.go
+++ b/sim/cluster/disagg_observer_test.go
@@ -229,6 +229,8 @@ func TestObserver_BuiltinsDoNotTriggerObserverPath(t *testing.T) {
 
 // TestObserver_Determinism (BC-6) verifies the observer sees the exact same
 // sequence of (ReqID, Outcome) pairs across repeated runs with the same seed.
+// Disagg-path variant: all requests flow through the end-of-run
+// projectPDMetrics dispatch (AlwaysDisaggregate).
 func TestObserver_Determinism(t *testing.T) {
 	run := func() []fakeObserverCall {
 		obs := &fakeObserverDecider{DisaggregationDecider: &sim.AlwaysDisaggregate{}}
@@ -246,6 +248,79 @@ func TestObserver_Determinism(t *testing.T) {
 			t.Errorf("call[%d] differs:\n  run1=%+v\n  run2=%+v", i, got1[i], got2[i])
 		}
 	}
+}
+
+// TestObserver_NonDisagg_Determinism (BC-6) is the symmetric determinism check
+// for the non-disagg path: all requests are routed locally (NeverDisaggregate),
+// so callbacks fire from detectNonDisaggObserverCompletions across per-instance
+// event-loop ticks. Pins the deterministic-dispatch guarantee across runs.
+func TestObserver_NonDisagg_Determinism(t *testing.T) {
+	run := func() []fakeObserverCall {
+		obs := &fakeObserverDecider{DisaggregationDecider: &sim.NeverDisaggregate{}}
+		cs, _ := newPDClusterWithObserver(t, obs, 5)
+		mustRun(t, cs)
+		return obs.Calls
+	}
+	got1 := run()
+	got2 := run()
+	if len(got1) != len(got2) {
+		t.Fatalf("call count differs across runs: run1=%d run2=%d", len(got1), len(got2))
+	}
+	for i := range got1 {
+		if got1[i] != got2[i] {
+			t.Errorf("call[%d] differs:\n  run1=%+v\n  run2=%+v", i, got1[i], got2[i])
+		}
+	}
+}
+
+// TestObserver_DisaggPath_PreservesOriginalDecision (addresses PR #1346 review,
+// finding MODERATE): the DisaggregationDecision delivered to OnOutcome on the
+// disagg path must equal the decision returned by Decide() at routing time —
+// including any DecodePodOverride or PrefillPodHint fields set by a joint D+P
+// decider. Prior to persisting parent.DisaggDecision, the observer dispatch
+// synthesized {Disaggregate: true} and stripped these fields.
+func TestObserver_DisaggPath_PreservesOriginalDecision(t *testing.T) {
+	// A decider that always returns Disaggregate=true AND sets a
+	// PrefillPodHint so we can verify the hint round-trips through
+	// ParentRequest into OnOutcome.
+	obs := &hintedObserverDecider{prefillHint: "instance_0"}
+	cs, _ := newPDClusterWithObserver(t, obs, 3)
+	mustRun(t, cs)
+
+	if len(obs.Calls) == 0 {
+		t.Fatal("no observer callbacks fired; expected at least one")
+	}
+	for i, c := range obs.Calls {
+		if !c.Decision.Disaggregate {
+			t.Errorf("call[%d] decision.Disaggregate = false, want true", i)
+		}
+		if c.Decision.PrefillPodHint != "instance_0" {
+			t.Errorf("call[%d] decision.PrefillPodHint = %q, want %q (decision stripped across projection)",
+				i, c.Decision.PrefillPodHint, "instance_0")
+		}
+	}
+}
+
+// hintedObserverDecider is a test-only decider that records every OnOutcome
+// call and returns Disaggregate=true with a non-empty PrefillPodHint to
+// exercise the decision-round-trip guarantee.
+type hintedObserverDecider struct {
+	prefillHint string
+	mu          sync.Mutex
+	Calls       []fakeObserverCall
+}
+
+func (h *hintedObserverDecider) Decide(_ *sim.Request, _ *sim.RouterState) sim.DisaggregationDecision {
+	return sim.DisaggregationDecision{
+		Disaggregate:   true,
+		PrefillPodHint: h.prefillHint,
+	}
+}
+
+func (h *hintedObserverDecider) OnOutcome(req *sim.Request, d sim.DisaggregationDecision, o sim.Outcome) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.Calls = append(h.Calls, fakeObserverCall{ReqID: req.ID, Decision: d, Outcome: o})
 }
 
 // TestObserver_DisaggAndNonDisaggMixed verifies that a decider that flips

--- a/sim/cluster/disagg_observer_test.go
+++ b/sim/cluster/disagg_observer_test.go
@@ -1,0 +1,338 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// fakeObserverDecider wraps any DisaggregationDecider and records every
+// OnOutcome call for assertion. Thread-safe (the simulator is single-threaded
+// but future parallel runs should remain safe).
+type fakeObserverDecider struct {
+	sim.DisaggregationDecider
+	mu    sync.Mutex
+	Calls []fakeObserverCall
+}
+
+type fakeObserverCall struct {
+	ReqID    string
+	Decision sim.DisaggregationDecision
+	Outcome  sim.Outcome
+}
+
+func (f *fakeObserverDecider) OnOutcome(req *sim.Request, d sim.DisaggregationDecision, o sim.Outcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, fakeObserverCall{ReqID: req.ID, Decision: d, Outcome: o})
+}
+
+// Compile-time: fakeObserverDecider implements both interfaces.
+var (
+	_ sim.DisaggregationDecider = (*fakeObserverDecider)(nil)
+	_ sim.DisaggregationObserver = (*fakeObserverDecider)(nil)
+)
+
+// TestObserver_FakeDecider_ImplementsObserver is a plumbing sanity check.
+func TestObserver_FakeDecider_ImplementsObserver(t *testing.T) {
+	f := &fakeObserverDecider{DisaggregationDecider: &sim.AlwaysDisaggregate{}}
+	if _, ok := interface{}(f).(sim.DisaggregationObserver); !ok {
+		t.Fatal("fakeObserverDecider must implement sim.DisaggregationObserver")
+	}
+	if d := f.Decide(&sim.Request{}, nil); !d.Disaggregate {
+		t.Fatal("delegated Decide should return AlwaysDisaggregate semantics")
+	}
+}
+
+// newPDClusterWithObserver builds a PD-enabled cluster and injects the supplied
+// observer-aware decider in place of the factory-built one, priming the
+// tracking map so the non-disagg path records observations.
+//
+// Reuses newTestDisaggDeploymentConfig(numInstances=4, prefill=2, decode=2) to
+// match the conventions used by sibling disagg integration tests.
+func newPDClusterWithObserver(t *testing.T, obs sim.DisaggregationDecider, numRequests int) (*ClusterSimulator, []*sim.Request) {
+	t.Helper()
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	// Factory default PDDecider is "always"; we replace it below.
+	requests := newTestRequests(numRequests)
+	cs := NewClusterSimulator(config, requests, nil)
+	cs.disaggregationDecider = obs
+	// Mirror the constructor's observer-aware path: if the swapped-in decider
+	// implements DisaggregationObserver, allocate the tracking map so the
+	// non-disagg branch records observations (also exercised via lazy init in
+	// executeDisaggregatedRouting, but we initialize here for clarity).
+	cs.maybeInitNonDisaggObservations()
+	return cs, requests
+}
+
+// TestObserver_DisaggPath_FiresOncePerCompletedParent (BC-2) verifies that
+// when a DisaggregationObserver-implementing decider returns Disaggregate=true,
+// OnOutcome fires exactly once per successfully completed parent request with
+// Disaggregated=true, non-empty decode and prefill instance IDs, a non-negative
+// transfer duration, and TTFT matching the projected parent TTFT written to
+// RequestTTFTs[pid].
+func TestObserver_DisaggPath_FiresOncePerCompletedParent(t *testing.T) {
+	obs := &fakeObserverDecider{DisaggregationDecider: &sim.AlwaysDisaggregate{}}
+	cs, requests := newPDClusterWithObserver(t, obs, 5)
+	mustRun(t, cs)
+
+	// All 5 parents should complete (small workload, generous horizon) — each
+	// fires OnOutcome exactly once.
+	if got, want := len(obs.Calls), len(requests); got != want {
+		t.Fatalf("OnOutcome call count = %d, want %d (one per completed parent); calls=%+v",
+			got, want, obs.Calls)
+	}
+
+	m := cs.AggregatedMetrics()
+	for i, c := range obs.Calls {
+		if !c.Decision.Disaggregate {
+			t.Errorf("call[%d] decision.Disaggregate = false, want true", i)
+		}
+		if !c.Outcome.Disaggregated {
+			t.Errorf("call[%d] outcome.Disaggregated = false, want true", i)
+		}
+		if c.Outcome.DecodeInstanceID == "" {
+			t.Errorf("call[%d] outcome.DecodeInstanceID empty", i)
+		}
+		if c.Outcome.PrefillInstanceID == "" {
+			t.Errorf("call[%d] outcome.PrefillInstanceID empty", i)
+		}
+		if c.Outcome.TransferDurationUs < 0 {
+			t.Errorf("call[%d] outcome.TransferDurationUs = %d, want >= 0",
+				i, c.Outcome.TransferDurationUs)
+		}
+		if c.Outcome.CompletionTime <= 0 {
+			t.Errorf("call[%d] outcome.CompletionTime = %d, want > 0",
+				i, c.Outcome.CompletionTime)
+		}
+		// TTFT reported to observer must match projected parent TTFT.
+		wantTTFT, ok := m.RequestTTFTs[c.ReqID]
+		if !ok {
+			t.Errorf("call[%d] req %q: no projected TTFT in metrics", i, c.ReqID)
+			continue
+		}
+		if c.Outcome.TTFT != wantTTFT {
+			t.Errorf("call[%d] req %q: outcome.TTFT = %f, projected RequestTTFTs = %f",
+				i, c.ReqID, c.Outcome.TTFT, wantTTFT)
+		}
+	}
+
+	// Determinism (INV-6): calls must be ordered by request ID.
+	for i := 1; i < len(obs.Calls); i++ {
+		if obs.Calls[i-1].ReqID >= obs.Calls[i].ReqID {
+			t.Errorf("disagg observer call sequence not sorted by request ID: [%d]=%q [%d]=%q",
+				i-1, obs.Calls[i-1].ReqID, i, obs.Calls[i].ReqID)
+		}
+	}
+}
+
+// TestObserver_NonDisaggPath_FiresOncePerCompletion (BC-3) verifies that when
+// the decider returns Disaggregate=false for requests flowing through the PD
+// routing entry point, OnOutcome fires exactly once on terminal success with
+// Disaggregated=false, PrefillInstanceID="", TransferDurationUs=0, and a
+// DecodeInstanceID matching the pod that handled the request.
+func TestObserver_NonDisaggPath_FiresOncePerCompletion(t *testing.T) {
+	obs := &fakeObserverDecider{DisaggregationDecider: &sim.NeverDisaggregate{}}
+	cs, requests := newPDClusterWithObserver(t, obs, 5)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+
+	// Every successfully completed request (non-disagg path) must fire once.
+	expected := 0
+	for _, req := range requests {
+		if _, ok := m.RequestCompletionTimes[req.ID]; ok {
+			expected++
+		}
+	}
+	if got := len(obs.Calls); got != expected {
+		t.Fatalf("OnOutcome call count = %d, want %d (matching completed requests); calls=%+v",
+			got, expected, obs.Calls)
+	}
+
+	for i, c := range obs.Calls {
+		if c.Decision.Disaggregate {
+			t.Errorf("call[%d] decision.Disaggregate = true, want false (NeverDisaggregate)", i)
+		}
+		if c.Outcome.Disaggregated {
+			t.Errorf("call[%d] outcome.Disaggregated = true, want false", i)
+		}
+		if c.Outcome.PrefillInstanceID != "" {
+			t.Errorf("call[%d] outcome.PrefillInstanceID = %q, want empty (non-disagg)",
+				i, c.Outcome.PrefillInstanceID)
+		}
+		if c.Outcome.TransferDurationUs != 0 {
+			t.Errorf("call[%d] outcome.TransferDurationUs = %d, want 0 (non-disagg)",
+				i, c.Outcome.TransferDurationUs)
+		}
+		if c.Outcome.DecodeInstanceID == "" {
+			t.Errorf("call[%d] outcome.DecodeInstanceID empty", i)
+		}
+		// DecodeInstanceID must be a decode-pool pod.
+		role, ok := cs.poolMembership[c.Outcome.DecodeInstanceID]
+		if !ok {
+			t.Errorf("call[%d] DecodeInstanceID %q not in pool membership",
+				i, c.Outcome.DecodeInstanceID)
+		} else if !role.Has(PoolRoleDecode) {
+			t.Errorf("call[%d] DecodeInstanceID %q has role %v, expected decode",
+				i, c.Outcome.DecodeInstanceID, role)
+		}
+		if c.Outcome.CompletionTime <= 0 {
+			t.Errorf("call[%d] outcome.CompletionTime = %d, want > 0",
+				i, c.Outcome.CompletionTime)
+		}
+	}
+}
+
+// TestObserver_NonObserverDecider_NoCallbacks (BC-5) verifies that a decider
+// not implementing DisaggregationObserver triggers zero callbacks, and no
+// tracking map is allocated.
+func TestObserver_NonObserverDecider_NoCallbacks(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	// Built-in "always" decider does NOT implement DisaggregationObserver.
+	config.PDDecider = "always"
+	requests := newTestRequests(3)
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	if cs.nonDisaggObservations != nil {
+		t.Errorf("nonDisaggObservations should be nil for non-observer decider, got %v",
+			cs.nonDisaggObservations)
+	}
+	// No way to "detect" observer calls without a hook — the strong guarantee
+	// is the nil-map check above plus the type-assertion unit test in sim/.
+}
+
+// TestObserver_BuiltinsDoNotTriggerObserverPath (BC-5) verifies parity: runs
+// with each built-in decider succeed without error and produce a positive
+// CompletedRequests count (not zero — regression guard for a hook that might
+// have inadvertently discarded requests).
+func TestObserver_BuiltinsDoNotTriggerObserverPath(t *testing.T) {
+	cases := []string{"never", "always"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := newTestDisaggDeploymentConfig(4, 2, 2)
+			config.PDDecider = name
+			cs := NewClusterSimulator(config, newTestRequests(5), nil)
+			mustRun(t, cs)
+			if cs.nonDisaggObservations != nil {
+				t.Errorf("PDDecider=%q: nonDisaggObservations = %v, want nil",
+					name, cs.nonDisaggObservations)
+			}
+			if cs.AggregatedMetrics().CompletedRequests == 0 {
+				t.Errorf("PDDecider=%q: CompletedRequests = 0 (regression)", name)
+			}
+		})
+	}
+}
+
+// TestObserver_Determinism (BC-6) verifies the observer sees the exact same
+// sequence of (ReqID, Outcome) pairs across repeated runs with the same seed.
+func TestObserver_Determinism(t *testing.T) {
+	run := func() []fakeObserverCall {
+		obs := &fakeObserverDecider{DisaggregationDecider: &sim.AlwaysDisaggregate{}}
+		cs, _ := newPDClusterWithObserver(t, obs, 5)
+		mustRun(t, cs)
+		return obs.Calls
+	}
+	got1 := run()
+	got2 := run()
+	if len(got1) != len(got2) {
+		t.Fatalf("call count differs across runs: run1=%d run2=%d", len(got1), len(got2))
+	}
+	for i := range got1 {
+		if got1[i] != got2[i] {
+			t.Errorf("call[%d] differs:\n  run1=%+v\n  run2=%+v", i, got1[i], got2[i])
+		}
+	}
+}
+
+// TestObserver_DisaggAndNonDisaggMixed verifies that a decider that flips
+// disaggregate based on request ID fires OnOutcome once per request with
+// the correct path-specific outcome shape.
+func TestObserver_DisaggAndNonDisaggMixed(t *testing.T) {
+	obs := &mixedObserverDecider{}
+	cs, requests := newPDClusterWithObserver(t, obs, 6)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+
+	// Every completed request (either path) fires once.
+	expected := 0
+	for _, req := range requests {
+		if _, ok := m.RequestCompletionTimes[req.ID]; ok {
+			expected++
+		}
+	}
+	if got := len(obs.Calls); got != expected {
+		t.Fatalf("OnOutcome count = %d, want %d", got, expected)
+	}
+
+	// Each call's Disaggregated flag must agree with its decision.
+	for _, c := range obs.Calls {
+		if c.Decision.Disaggregate != c.Outcome.Disaggregated {
+			t.Errorf("req %q: decision.Disaggregate=%v outcome.Disaggregated=%v (mismatch)",
+				c.ReqID, c.Decision.Disaggregate, c.Outcome.Disaggregated)
+		}
+		if c.Outcome.Disaggregated {
+			if c.Outcome.PrefillInstanceID == "" {
+				t.Errorf("req %q: disagg outcome has empty PrefillInstanceID", c.ReqID)
+			}
+		} else {
+			if c.Outcome.PrefillInstanceID != "" {
+				t.Errorf("req %q: non-disagg outcome has PrefillInstanceID=%q",
+					c.ReqID, c.Outcome.PrefillInstanceID)
+			}
+			if c.Outcome.TransferDurationUs != 0 {
+				t.Errorf("req %q: non-disagg outcome has TransferDurationUs=%d",
+					c.ReqID, c.Outcome.TransferDurationUs)
+			}
+		}
+	}
+}
+
+// mixedObserverDecider returns Disaggregate=true for even-numbered request IDs
+// and Disaggregate=false otherwise. Deterministic (keyed on request ID only).
+type mixedObserverDecider struct {
+	mu    sync.Mutex
+	Calls []fakeObserverCall
+}
+
+func (m *mixedObserverDecider) Decide(req *sim.Request, _ *sim.RouterState) sim.DisaggregationDecision {
+	// request IDs are "request_N" with N in [0, numRequests).
+	// Parse the suffix and return Disaggregate=(N%2==0).
+	n := parseTrailingIndex(req.ID)
+	return sim.DisaggregationDecision{Disaggregate: n%2 == 0}
+}
+
+func (m *mixedObserverDecider) OnOutcome(req *sim.Request, d sim.DisaggregationDecision, o sim.Outcome) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Calls = append(m.Calls, fakeObserverCall{ReqID: req.ID, Decision: d, Outcome: o})
+}
+
+// parseTrailingIndex returns the integer suffix of a request ID like
+// "request_7" → 7. Returns 0 for any ID that does not parse (treat as
+// non-disagg for test stability).
+func parseTrailingIndex(id string) int {
+	// Find the last '_' and parse the suffix manually (avoiding strconv import
+	// for a trivial helper).
+	n := 0
+	started := false
+	for i := len(id) - 1; i >= 0; i-- {
+		c := id[i]
+		if c >= '0' && c <= '9' {
+			started = true
+			continue
+		}
+		if started && c == '_' {
+			for j := i + 1; j < len(id); j++ {
+				n = n*10 + int(id[j]-'0')
+			}
+			return n
+		}
+		break
+	}
+	return 0
+}

--- a/sim/cluster/parent_request.go
+++ b/sim/cluster/parent_request.go
@@ -44,6 +44,17 @@ type ParentRequest struct {
 	// when an encode decider approves. Zero value (empty) = encode did not fire for this
 	// request. GAP-4, issue #1264.
 	EncodeInstanceID InstanceID
+
+	// DisaggDecision is the full DisaggregationDecision returned by the decider
+	// at routing time — captured so it can be delivered verbatim to an optional
+	// DisaggregationObserver.OnOutcome callback (#1340). Built-in deciders
+	// always set Disaggregate=true here (parents are only constructed on the
+	// disagg branch) with DecodePodOverride and PrefillPodHint empty. Future
+	// joint D+P deciders may set the override/hint fields; persisting the full
+	// struct avoids stripping those fields across the async prefill → transfer
+	// → decode → completion lifecycle. Zero value means the parent was
+	// constructed without a recorded decision (e.g., legacy test fixtures).
+	DisaggDecision sim.DisaggregationDecision
 }
 
 // NewParentRequest creates a ParentRequest from the original request.

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -156,6 +156,66 @@ var (
 	_ DisaggregationDecider = (*PrefixThresholdDecider)(nil)
 )
 
+// Outcome carries deterministic per-request completion data reported to a
+// DisaggregationObserver at terminal success. All fields are derived from
+// sim-clock counters and request/parent state — no wall-clock or RNG input —
+// preserving INV-6 determinism.
+//
+// Field semantics:
+//   - TTFT:               user-visible time-to-first-token (microseconds as float64,
+//                         matching Metrics.RequestTTFTs).
+//   - CompletionTime:     terminal completion time on the sim clock (microseconds).
+//   - TransferDurationUs: KV transfer duration (microseconds); zero when Disaggregated=false.
+//   - Disaggregated:      true iff the request flowed through prefill → transfer → decode.
+//   - DecodeInstanceID:   ID of the pod that handled decode (non-empty at terminal success).
+//   - PrefillInstanceID:  ID of the pod that handled prefill; empty when Disaggregated=false.
+type Outcome struct {
+	TTFT               float64
+	CompletionTime     int64
+	TransferDurationUs int64
+	Disaggregated      bool
+	DecodeInstanceID   string
+	PrefillInstanceID  string
+}
+
+// DisaggregationObserver is an OPTIONAL second interface a DisaggregationDecider
+// may additionally implement to receive per-request completion feedback. The
+// cluster type-asserts the configured decider against this interface. When the
+// assertion fails, no callback ever fires — this preserves byte-identical
+// behavior for built-in deciders (NeverDisaggregate, AlwaysDisaggregate,
+// PrefixThresholdDecider) which do NOT implement this interface.
+//
+// Invocation contract:
+//   - OnOutcome fires exactly once per request at terminal success.
+//   - OnOutcome does NOT fire for dropped, timed-out, or otherwise non-successful
+//     requests.
+//   - On the disaggregated path, OnOutcome fires once per parent request (after
+//     the cluster projects sub-request metrics to parent granularity).
+//   - On the non-disaggregated path (a request that flowed through the PD
+//     routing entry point but the decider returned Disaggregate=false),
+//     OnOutcome fires once when the request completes on its decode pod.
+//
+// Determinism (INV-6): callback invocations are ordered deterministically by
+// request ID within each phase, so observer-accumulated state remains a pure
+// function of the (ordered) sequence of prior outcomes.
+//
+// Oracle boundary (INV-9): Outcome is populated post-execution, so fields
+// derived from req.OutputTokens (e.g., CompletionTime and TTFT, which depend
+// on the number of tokens generated) are permissible inside Outcome. However,
+// any feedback-driven decider that consumes observer-accumulated state inside
+// Decide(req, state) must still avoid reading req.OutputTokens at decision
+// time; observer state derived from PRIOR requests' outcomes is fine — the
+// oracle boundary applies to the current request being decided.
+//
+// Run/replay parity (INV-13): built-in deciders do not implement this
+// interface, so no callbacks fire and per-request metrics are byte-identical
+// across `blis run` and `blis replay` with identical flags. Feedback-driven
+// observer-aware deciders must reuse the same decider instance (and any
+// learned state) across the two commands for parity; this is follow-up work.
+type DisaggregationObserver interface {
+	OnOutcome(req *Request, decision DisaggregationDecision, observed Outcome)
+}
+
 // ---------------------------------------------------------------------------
 // E/P/D disaggregation (GAP-4, issue #1264)
 // ---------------------------------------------------------------------------

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -163,7 +163,12 @@ var (
 //
 // Field semantics:
 //   - TTFT:               user-visible time-to-first-token (microseconds as float64,
-//                         matching Metrics.RequestTTFTs).
+//                         matching Metrics.RequestTTFTs). Zero when no TTFT was
+//                         recorded for the request — this is rare but can occur
+//                         for prefill-only parents or pathological workloads
+//                         where the first output token was never observed by the
+//                         metrics layer. Observer implementations that drive
+//                         control decisions should guard against TTFT == 0.
 //   - CompletionTime:     terminal completion time on the sim clock (microseconds).
 //   - TransferDurationUs: KV transfer duration (microseconds); zero when Disaggregated=false.
 //   - Disaggregated:      true iff the request flowed through prefill → transfer → decode.
@@ -197,7 +202,13 @@ type Outcome struct {
 //
 // Determinism (INV-6): callback invocations are ordered deterministically by
 // request ID within each phase, so observer-accumulated state remains a pure
-// function of the (ordered) sequence of prior outcomes.
+// function of the (ordered) sequence of prior outcomes. Scope note: ordering
+// by request ID is scoped to a single dispatch site (one per-instance tick on
+// the non-disagg path; one end-of-run pass on the disagg path). Across
+// instances within the same tick, callbacks fire in instance-index order —
+// deterministic across runs (cs.instances is a fixed slice), but not strictly
+// globally ID-sorted. Observer implementations that compare ordered outcomes
+// across pods should sort by request ID themselves.
 //
 // Oracle boundary (INV-9): Outcome is populated post-execution, so fields
 // derived from req.OutputTokens (e.g., CompletionTime and TTFT, which depend

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -674,3 +674,31 @@ func TestNewEncodeDecider(t *testing.T) {
 	}()
 	_ = NewEncodeDecider("bogus")
 }
+
+// TestDisaggregationObserver_BuiltinsDoNotImplement (BC-1, BC-5) verifies that
+// the three built-in deciders do NOT implement the optional DisaggregationObserver
+// interface. This is the load-bearing assertion behind the parity guarantee:
+// the cluster's type assertion returns ok==false, so no callback fires, so
+// per-request metrics are byte-identical to pre-PR runs.
+func TestDisaggregationObserver_BuiltinsDoNotImplement(t *testing.T) {
+	builtins := []DisaggregationDecider{
+		&NeverDisaggregate{},
+		&AlwaysDisaggregate{},
+		NewPrefixThresholdDecider(16, 16, nil),
+	}
+	for _, d := range builtins {
+		if _, ok := d.(DisaggregationObserver); ok {
+			t.Errorf("%T must not implement DisaggregationObserver (BC-1/BC-5)", d)
+		}
+	}
+}
+
+// TestOutcome_FieldsZeroDefault verifies the zero value of Outcome is the
+// documented "no data" state. Feedback-driven deciders can rely on this.
+func TestOutcome_FieldsZeroDefault(t *testing.T) {
+	var o Outcome
+	if o.TTFT != 0 || o.CompletionTime != 0 || o.TransferDurationUs != 0 ||
+		o.Disaggregated || o.DecodeInstanceID != "" || o.PrefillInstanceID != "" {
+		t.Errorf("Outcome zero value must be all-zeroes, got %+v", o)
+	}
+}


### PR DESCRIPTION
## Summary

Tranche 2 / G3 of the A1 disaggregation-decider signal envelope (parent #1336):
adds an **optional** `DisaggregationObserver` interface so stateful / learning /
bandit-style PD deciders can adapt based on observed outcomes of prior decisions.

The three built-in deciders (`NeverDisaggregate`, `AlwaysDisaggregate`,
`PrefixThresholdDecider`) do NOT implement the new interface, so behavior is
**byte-identical** to pre-PR runs — the cluster's type assertion returns
`ok == false` and no callback ever fires.

## Behavioral Contracts

- **BC-1:** `DisaggregationObserver` is defined in `sim/`; built-in deciders do
  not satisfy the type assertion.
- **BC-2 (disagg path):** When a decider implementing `DisaggregationObserver`
  returns `Disaggregate=true`, `OnOutcome` fires exactly once per successfully
  completed parent at the TTFT-recording site in `projectPDMetrics`.
  `Outcome.TTFT` equals the projected parent TTFT written to `m.RequestTTFTs[pid]`.
- **BC-3 (non-disagg path):** When a decider returns `Disaggregate=false` for a
  request flowing through the PD routing entry point, `OnOutcome` fires exactly
  once at terminal completion on the decode pod, with `PrefillInstanceID=""` and
  `TransferDurationUs=0`.
- **BC-4 (no drops/timeouts):** Timed-out and dropped requests do **not** fire
  `OnOutcome` — enforced on both paths (disagg: `DecodeSubReq.State == StateCompleted`
  check; non-disagg: filter is inherent because timed-out requests never enter
  `RequestCompletionTimes`).
- **BC-5 (parity):** Non-observer deciders trigger zero callbacks; the tracking
  map stays `nil`; per-request metrics unchanged.
- **BC-6 (determinism, INV-6):** Observer call sequence is ordered by request
  ID within each phase. `Outcome` fields derive only from sim-clock counters
  and request/parent state — no wall-clock, no RNG.
- **BC-7 (run/replay parity, INV-13):** Preserved — built-in deciders don't
  implement the interface.

## Invariants

- **INV-6 (determinism):** Preserved. Sorted-ID dispatch on both paths; no
  non-deterministic sources in `Outcome`.
- **INV-9 (oracle boundary):** `Outcome` is populated post-execution, so fields
  derived from `req.OutputTokens` are permissible. Future observer-aware
  deciders must still avoid reading `req.OutputTokens` inside `Decide(req, state)`;
  observer state derived from **prior** requests' outcomes is fine.
- **INV-13 (run/replay parity):** Preserved via BC-5.

## Files Changed

- `sim/disaggregation.go` — new `Outcome` struct + `DisaggregationObserver` interface.
- `sim/disaggregation_test.go` — unit tests for BC-1 (built-ins don't implement).
- `sim/cluster/cluster.go` — two invocation sites (disagg projection, non-disagg
  instance completion), a small `nonDisaggObservations` tracking map lazily
  allocated only when the decider is an observer.
- `sim/cluster/disagg_observer_test.go` — behavioral integration tests with a
  `FakeObserverDecider` helper, covering BC-2..BC-6 and a mixed disagg / non-disagg
  decider.

## Non-changes (guaranteed)

- No new CLI flags.
- No default decider changes.
- No changes to the `DisaggregationDecider` interface signature.
- No changes to `DisaggregationDecision` shape.
- No changes to admission, routing, scheduling, or completion order for any
  built-in decider.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` passes (including the new `TestObserver_*` suite
      in `sim/cluster/` and `TestDisaggregationObserver_BuiltinsDoNotImplement`
      / `TestOutcome_FieldsZeroDefault` in `sim/`)
- [x] `TestObserver_Determinism` re-runs the same cluster with
      `AlwaysDisaggregate`-wrapping observer and asserts byte-identical
      `(ReqID, Decision, Outcome)` sequence across runs (BC-6)
- [x] Self-audit (10 dimensions) caught a latent-bug where the disagg path
      would have fired on timed-out decode sub-requests — fixed with an
      explicit `StateCompleted` filter (BC-4 symmetry)

Closes #1340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)