### PR TITLE
feat(bundle): expose instance_lifecycle.loading_delay and warm_start_initial_instances in policy bundle

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -205,12 +205,20 @@ Example:
 		if cmd.Flags().Changed("model-autoscaler-interval-us") {
 			logrus.Fatalf("--model-autoscaler-interval-us is not supported in blis replay; remove this flag or use blis run instead")
 		}
+		var bundleInstanceLifecycle cluster.InstanceLifecycleConfig
 		if bundle != nil {
 			if bundle.Autoscaler.IntervalUs > 0 {
 				logrus.Fatalf("blis replay does not support autoscaler config (policy bundle interval_us=%g); remove the autoscaler section from the policy bundle or use blis run instead", bundle.Autoscaler.IntervalUs)
 			}
 			if len(bundle.NodePools) > 0 {
 				logrus.Fatalf("blis replay does not support node_pools config (%d pool(s) in policy bundle); remove the node_pools section from the policy bundle or use blis run instead", len(bundle.NodePools))
+			}
+			bundleInstanceLifecycle = cluster.InstanceLifecycleConfig{
+				LoadingDelay: cluster.DelaySpec{
+					Mean:   bundle.InstanceLifecycle.LoadingDelay.Mean,
+					Stddev: bundle.InstanceLifecycle.LoadingDelay.Stddev,
+				},
+				WarmStartInitialInstances: bundle.InstanceLifecycle.WarmStartInitialInstances,
 			}
 		}
 
@@ -500,6 +508,7 @@ Example:
 			GAIEQDThreshold:                 gaieQDThreshold,
 			GAIEKVThreshold:                 gaieKVThreshold,
 			TenantBudgets:                   tenantBudgets,
+			InstanceLifecycle:               bundleInstanceLifecycle,
 		}
 
 		// Run simulation — wire SessionManager for closed-loop, nil for fixed mode

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1439,6 +1439,7 @@ var runCmd = &cobra.Command{
 					Mean:   bundle.InstanceLifecycle.LoadingDelay.Mean,
 					Stddev: bundle.InstanceLifecycle.LoadingDelay.Stddev,
 				},
+				WarmStartInitialInstances: bundle.InstanceLifecycle.WarmStartInitialInstances,
 			}
 		}
 		// CLI flag overrides bundle value when explicitly set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1402,6 +1402,7 @@ var runCmd = &cobra.Command{
 			bundleHPAScrapeDelayStddev           float64
 			bundleAnalyzerCfg                    cluster.V2SaturationAnalyzerConfig
 			bundleNodePools                      []cluster.NodePoolConfig
+			bundleInstanceLifecycle              cluster.InstanceLifecycleConfig
 		)
 		if bundle != nil {
 			if bundle.Autoscaler.IntervalUs > 0 {
@@ -1432,6 +1433,12 @@ var runCmd = &cobra.Command{
 					},
 					CostPerHour: np.CostPerHour,
 				})
+			}
+			bundleInstanceLifecycle = cluster.InstanceLifecycleConfig{
+				LoadingDelay: cluster.DelaySpec{
+					Mean:   bundle.InstanceLifecycle.LoadingDelay.Mean,
+					Stddev: bundle.InstanceLifecycle.LoadingDelay.Stddev,
+				},
 			}
 		}
 		// CLI flag overrides bundle value when explicitly set.
@@ -1637,6 +1644,7 @@ var runCmd = &cobra.Command{
 			HPAScrapeDelay:                  cluster.DelaySpec{Mean: bundleHPAScrapeDelayMean, Stddev: bundleHPAScrapeDelayStddev},
 			AutoscalerAnalyzerConfig:        bundleAnalyzerCfg,
 			NodePools:                       bundleNodePools,
+			InstanceLifecycle:               bundleInstanceLifecycle,
 		}
 		// Session callback installation (Constraint 3 fix):
 		// Follow-up collection must be UNCONDITIONAL for saturation analysis correctness.

--- a/docs/configs/phase2-autoscaler.yaml
+++ b/docs/configs/phase2-autoscaler.yaml
@@ -1,0 +1,50 @@
+# Phase 2 autoscaling experiment — WVA-realistic parameters, H100 TP=1
+#
+# Timing parameters:
+#   interval_us: 30s — matches production WVA autoscaler tick rate
+#   scale_up_stabilization_window_us: 240s — matches production HPA default
+#   scale_down_stabilization_window_us: 240s — matches production HPA default
+#   hpa_scrape_delay: 0s — SIMPLIFIED (production value: 15s); set in Phase 3
+#   loading_delay: mean=240s (4 min), stddev=30s — observed K8s node-to-serving latency
+#
+# Node pool:
+#   5 H100 nodes pre-provisioned (initial_nodes=5): 1 consumed by --num-instances 1
+#   at startup, 4 free for the autoscaler to grow into. No provisioning delay since
+#   nodes are pre-provisioned; the model loading delay is modeled via instance_lifecycle.
+#
+# Required horizon: 900s per run (--horizon 900000000).
+#   - t=240s: scale-up actuation fires (8 ticks x 30s = stabilization satisfied)
+#   - t~=480s: new instance active (240s mean loading delay)
+#   - t=480-900s: ~420s observation window for 2-replica steady state
+
+node_pools:
+  - name: h100-tp1
+    gpu_type: H100           # must match --hardware H100
+    gpus_per_node: 1         # 1 GPU per instance at TP=1
+    gpu_memory_gib: 80.0     # H100 80 GiB
+    initial_nodes: 5         # 5 nodes pre-provisioned: 1 for startup, 4 for autoscaler
+    min_nodes: 0
+    max_nodes: 5
+    cost_per_hour: 0.0
+    provisioning_delay:
+      mean: 0.0              # nodes are pre-provisioned -- no provisioning delay
+      stddev: 0.0
+
+instance_lifecycle:
+  loading_delay:
+    mean: 240.0              # 4 min mean -- observed K8s node-to-serving latency
+    stddev: 30.0             # +/-30s variance
+  warm_start_initial_instances: true  # startup replicas are pre-deployed; only autoscaler-added replicas load
+
+autoscaler:
+  interval_us: 30000000                        # 30s tick -- WVA production parity
+  scale_up_stabilization_window_us: 240000000  # 240s -- HPA production parity
+  scale_down_stabilization_window_us: 240000000 # 240s -- HPA production parity
+  hpa_scrape_delay:
+    mean: 0.0                # SIMPLIFIED -- production value is 15s; add in Phase 3
+    stddev: 0.0
+  analyzer:
+    kv_cache_threshold: 0.8
+    scale_up_threshold: 0.8
+    scale_down_boundary: 0.4
+    avg_input_tokens: 512.0

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -478,6 +478,7 @@ instance_lifecycle:
   warm_up_request_count: 5    # requests served before leaving WarmingUp state
   warm_up_ttft_factor: 2.0    # TTFT multiplier applied to warm-up requests (≥ 1.0)
   drain_policy: "WAIT"        # IMMEDIATE | WAIT | REDIRECT
+  warm_start_initial_instances: false  # true = startup instances skip loading_delay (model pre-deployed); autoscaler-added instances always pay loading_delay
 
 # SLO priority overrides (optional; omit for GAIE defaults)
 # GAIE defaults: critical=4, standard=3, batch=-1, sheddable=-2, background=-3

--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -21,8 +21,9 @@ type PolicyBundle struct {
 	Scheduler     string                 `yaml:"scheduler"`
 	Preemption    PreemptionConfig       `yaml:"preemption"`
 	TenantBudgets map[string]float64     `yaml:"tenant_budgets"`  // nil = no tenant enforcement
-	NodePools     []NodePoolBundleConfig `yaml:"node_pools"`      // nil = no node pools
-	Autoscaler    AutoscalerBundleConfig `yaml:"autoscaler"`      // IntervalUs=0 = disabled
+	NodePools         []NodePoolBundleConfig        `yaml:"node_pools"`         // nil = no node pools
+	Autoscaler        AutoscalerBundleConfig        `yaml:"autoscaler"`         // IntervalUs=0 = disabled
+	InstanceLifecycle InstanceLifecycleBundleConfig `yaml:"instance_lifecycle"` // zero = instant loading
 }
 
 // AdmissionConfig holds admission policy configuration.
@@ -85,6 +86,12 @@ type AnalyzerBundleConfig struct {
 	ScaleUpThreshold  float64 `yaml:"scale_up_threshold"`
 	ScaleDownBoundary float64 `yaml:"scale_down_boundary"`
 	AvgInputTokens    float64 `yaml:"avg_input_tokens"`
+}
+
+// InstanceLifecycleBundleConfig holds instance lifecycle timing for YAML loading.
+// Mean and Stddev are in seconds; converted to microseconds when building DeploymentConfig.
+type InstanceLifecycleBundleConfig struct {
+	LoadingDelay DelayBundleSpec `yaml:"loading_delay"`
 }
 
 // AutoscalerBundleConfig holds autoscaler pipeline configuration.
@@ -351,6 +358,21 @@ func (b *PolicyBundle) Validate() error {
 		if np.CostPerHour < 0 {
 			return fmt.Errorf("node_pools[%d] %q: cost_per_hour must be >= 0, got %v", i, np.Name, np.CostPerHour)
 		}
+	}
+	// Validate instance lifecycle config.
+	lm := b.InstanceLifecycle.LoadingDelay.Mean
+	if math.IsNaN(lm) || math.IsInf(lm, 0) {
+		return fmt.Errorf("instance_lifecycle.loading_delay.mean must be a finite number, got %v", lm)
+	}
+	if lm < 0 {
+		return fmt.Errorf("instance_lifecycle.loading_delay.mean must be >= 0, got %v", lm)
+	}
+	ls := b.InstanceLifecycle.LoadingDelay.Stddev
+	if math.IsNaN(ls) || math.IsInf(ls, 0) {
+		return fmt.Errorf("instance_lifecycle.loading_delay.stddev must be a finite number, got %v", ls)
+	}
+	if ls < 0 {
+		return fmt.Errorf("instance_lifecycle.loading_delay.stddev must be >= 0, got %v", ls)
 	}
 	return nil
 }

--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -91,7 +91,8 @@ type AnalyzerBundleConfig struct {
 // InstanceLifecycleBundleConfig holds instance lifecycle timing for YAML loading.
 // Mean and Stddev are in seconds; converted to microseconds when building DeploymentConfig.
 type InstanceLifecycleBundleConfig struct {
-	LoadingDelay DelayBundleSpec `yaml:"loading_delay"`
+	LoadingDelay               DelayBundleSpec `yaml:"loading_delay"`
+	WarmStartInitialInstances  bool            `yaml:"warm_start_initial_instances"`
 }
 
 // AutoscalerBundleConfig holds autoscaler pipeline configuration.

--- a/sim/bundle_test.go
+++ b/sim/bundle_test.go
@@ -638,6 +638,7 @@ instance_lifecycle:
   loading_delay:
     mean: 270.0
     stddev: 30.0
+  warm_start_initial_instances: true
 `
 	path := writeTempYAML(t, yaml)
 	bundle, err := LoadPolicyBundle(path)
@@ -649,6 +650,9 @@ instance_lifecycle:
 	}
 	if bundle.InstanceLifecycle.LoadingDelay.Stddev != 30.0 {
 		t.Errorf("LoadingDelay.Stddev = %v, want 30.0", bundle.InstanceLifecycle.LoadingDelay.Stddev)
+	}
+	if !bundle.InstanceLifecycle.WarmStartInitialInstances {
+		t.Errorf("WarmStartInitialInstances = false, want true")
 	}
 }
 

--- a/sim/bundle_test.go
+++ b/sim/bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -628,5 +629,89 @@ func TestPreemptionPolicy_ValidNames(t *testing.T) {
 	}
 	if IsValidPreemptionPolicy("random") {
 		t.Error("IsValidPreemptionPolicy(\"random\") = true, want false")
+	}
+}
+
+func TestLoadPolicyBundle_InstanceLifecycleSection(t *testing.T) {
+	yaml := `
+instance_lifecycle:
+  loading_delay:
+    mean: 270.0
+    stddev: 30.0
+`
+	path := writeTempYAML(t, yaml)
+	bundle, err := LoadPolicyBundle(path)
+	if err != nil {
+		t.Fatalf("LoadPolicyBundle: %v", err)
+	}
+	if bundle.InstanceLifecycle.LoadingDelay.Mean != 270.0 {
+		t.Errorf("LoadingDelay.Mean = %v, want 270.0", bundle.InstanceLifecycle.LoadingDelay.Mean)
+	}
+	if bundle.InstanceLifecycle.LoadingDelay.Stddev != 30.0 {
+		t.Errorf("LoadingDelay.Stddev = %v, want 30.0", bundle.InstanceLifecycle.LoadingDelay.Stddev)
+	}
+}
+
+func TestLoadPolicyBundle_InstanceLifecycleAbsent_IsZero(t *testing.T) {
+	yaml := `
+admission:
+  policy: always-admit
+`
+	path := writeTempYAML(t, yaml)
+	bundle, err := LoadPolicyBundle(path)
+	if err != nil {
+		t.Fatalf("LoadPolicyBundle: %v", err)
+	}
+	if bundle.InstanceLifecycle.LoadingDelay.Mean != 0.0 {
+		t.Errorf("LoadingDelay.Mean = %v, want 0.0 (absent section should default to zero)", bundle.InstanceLifecycle.LoadingDelay.Mean)
+	}
+}
+
+func TestPolicyBundle_Validate_InstanceLifecycle(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "negative mean",
+			yaml: `instance_lifecycle:
+  loading_delay:
+    mean: -1.0`,
+			wantErr: "loading_delay.mean must be >= 0",
+		},
+		{
+			name: "negative stddev",
+			yaml: `instance_lifecycle:
+  loading_delay:
+    stddev: -1.0`,
+			wantErr: "loading_delay.stddev must be >= 0",
+		},
+		{
+			name: "zero mean is valid",
+			yaml: `instance_lifecycle:
+  loading_delay:
+    mean: 0.0`,
+			wantErr: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempYAML(t, tc.yaml)
+			bundle, err := LoadPolicyBundle(path)
+			if err != nil {
+				t.Fatalf("LoadPolicyBundle: %v", err)
+			}
+			err = bundle.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -321,8 +321,18 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 			inst.TPDegree = tpDegree
 			inst.CostPerHour = poolCostPerHour
 			inst.warmUpRemaining = config.InstanceLifecycle.WarmUpRequestCount
-			inst.TransitionTo(sim.InstanceStateLoading)
-			cs.scheduleInstanceLoadedEvent(inst)
+			if config.InstanceLifecycle.WarmStartInitialInstances {
+				// Pre-deployed cluster: startup instances skip loading delay and start Active.
+				// Autoscaler-added instances (via direct_actuator.go) still use LoadingDelay.
+				if inst.warmUpRemaining > 0 {
+					inst.TransitionTo(sim.InstanceStateWarmingUp)
+				} else {
+					inst.TransitionTo(sim.InstanceStateActive)
+				}
+			} else {
+				inst.TransitionTo(sim.InstanceStateLoading)
+				cs.scheduleInstanceLoadedEvent(inst)
+			}
 			cs.instances = append(cs.instances, inst)
 			instanceMap[id] = inst
 			cs.inFlightRequests[string(id)] = 0

--- a/sim/cluster/infra_config.go
+++ b/sim/cluster/infra_config.go
@@ -143,6 +143,12 @@ type InstanceLifecycleConfig struct {
 	WarmUpRequestCount int       `yaml:"warm_up_request_count"`
 	WarmUpTTFTFactor   float64   `yaml:"warm_up_ttft_factor"`
 	DrainPolicy        string    `yaml:"drain_policy"` // "IMMEDIATE", "WAIT", or "REDIRECT"
+
+	// WarmStartInitialInstances, when true, bypasses LoadingDelay for instances
+	// created at simulation startup (--num-instances N). Autoscaler-added instances
+	// always use LoadingDelay regardless of this flag. Set true when modeling a
+	// pre-deployed cluster where the initial replicas are already serving.
+	WarmStartInitialInstances bool `yaml:"warm_start_initial_instances"`
 }
 
 // IsValid validates all fields in the InstanceLifecycleConfig.


### PR DESCRIPTION
Supersedes #1338 (closed prematurely — feature was not in upstream/main).

## Summary

- Adds `instance_lifecycle` section to `PolicyBundle` with `loading_delay` (mean/stddev seconds) and `warm_start_initial_instances` (bool)
- `loading_delay` wires through to `InstanceLifecycleConfig.LoadingDelay`, controlling the delay between scale-up actuation and a new replica becoming Active (models K8s model-loading latency)
- `warm_start_initial_instances: true` causes startup instances (`--num-instances N`) to skip loading delay and start Active immediately; only autoscaler-added replicas pay the loading cost
- Adds `InstanceLifecycleBundleConfig` struct + validation in `bundle.Validate()`; wires through `cmd/root.go` and `cmd/replay.go` into `DeploymentConfig`
- Adds `warm_start_initial_instances` to `docs/reference/configuration.md` instance_lifecycle example

## Example config

```yaml
instance_lifecycle:
  loading_delay:
    mean: 240.0   # 4 min — observed K8s node-to-serving latency
    stddev: 30.0
  warm_start_initial_instances: true
```

## Test plan

- [x] `go test ./sim/... ./cmd/... -count=1` passes
- [x] `bundle_test.go` covers `loading_delay` parsing, `warm_start_initial_instances` parsing, and validation errors
- [x] `docs/configs/phase2-autoscaler.yaml` included as a worked example
- [x] `blis replay` correctly wires `instance_lifecycle` from policy bundle (INV-13 parity fix)

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)