### PR TITLE
Simplify blis-pr-review skill to delegate to pr-review-toolkit

### DIFF
--- a/.claude/skills/blis-pr-review/SKILL.md
+++ b/.claude/skills/blis-pr-review/SKILL.md
@@ -5,248 +5,79 @@ description: Project-specific PR self-review for BLIS. Evaluates correctness, in
 
 # BLIS PR Self-Review
 
-Perform a thorough review of the current PR with respect to both the original issue and its tracking parent issue.
+Invoke the `/pr-review-toolkit:review-pr` skill with the following BLIS-specific review prompt:
 
----
-
-## Step 0 — Identify the PR
-
-Resolve the PR to review:
-
-1. **Current branch**: if on a feature branch with an open PR, use that.
-2. **Skill argument**: if a PR number or URL was passed, use that.
-3. **GitHub Actions context**: if running inside `claude-code-action` on a PR trigger, use the current PR.
-
-Fetch PR context:
-
-```bash
-gh pr view --json number,title,body,baseRefName,headRefName,url
-gh pr diff
 ```
+/pr-review-toolkit:review-pr Please perform a thorough review of this PR with respect to both the original issue and its tracking parent issue.
 
-If the PR body references an issue (`Closes #N`), fetch the issue:
+Evaluate whether the PR fully and correctly addresses all requirements and reviewer concerns. In particular, assess:
 
-```bash
-gh issue view <N> --json title,body,labels
-```
+Correctness and preservation of invariants
+Separation of concerns and overall design discipline
+Modularity and clarity of API boundaries/contracts
+Behavioral integrity, including both behavioral and non-structural tests
+Test coverage and quality (not just structure, but meaningful validation of behavior)
+Performance implications and potential regressions
+Adherence to our @docs/contributing/standards,
+Documentation quality, completeness, and accuracy (both user-facing and developer-facing)
+All reviews and comments in this PR are addressed
 
-If the issue references a parent/tracking issue, fetch that too.
-
----
-
-## Step 1 — Standards Compliance
-
-Read and check against all project standards:
-
-```bash
-cat docs/contributing/standards/rules.md
-cat docs/contributing/standards/invariants.md
-cat docs/contributing/standards/principles.md
-```
-
-For every file in the diff, verify:
-
-- **R1-R23 antipattern rules**: check each applicable rule against the changed code
-- **INV-1 through INV-12**: verify no invariant is violated by the change
-- **Engineering principles**: separation of concerns, interface design, factory validation, config grouping
-
----
-
-## Step 2 — Correctness and Design
-
-Evaluate:
-
-1. **Correctness**: Does the implementation correctly solve the stated problem?
-2. **Preservation of invariants**: Are all affected invariants maintained with evidence?
-3. **Separation of concerns**: Does `sim/` remain a library? Do cluster policies only see `*RouterState`? Instance policies only local data?
-4. **Modularity and API boundaries**: Are interfaces single-method? Are factory signatures narrow?
-5. **Behavioral integrity**: Do tests verify observable behavior, not internal structure?
-
----
-
-## Step 3 — Test Quality
-
-For each test added or modified:
-
-1. **Refactor survival**: Would this test still pass if the implementation were completely rewritten but behavior preserved?
-2. **Table-driven**: Are related scenarios in table-driven format?
-3. **Laws not just values**: Do golden tests have companion invariant tests?
-4. **THEN clauses**: Do assertions describe observable behavior, not internal state?
-5. **Coverage**: Are edge cases covered (empty input, boundary values, error paths)?
-
----
-
-## Step 4 — Cross-Path Parity
+--- CROSS-PATH PARITY (run / replay / observe) ---
 
 BLIS has three command paths that must maintain behavioral parity:
 
-- `blis run` (DES with synthetic workload)
-- `blis replay` (DES with trace-driven workload)
-- `blis observe` (real HTTP dispatch to live server)
+blis run (DES with synthetic workload)
+blis replay (DES with trace-driven workload)
+blis observe (real HTTP dispatch to live server)
 
 For every feature, flag, or behavioral change in this PR:
 
-| Check | Question |
-|-------|----------|
-| Applicability | Does this feature logically apply to the other two paths? |
-| Implementation | If yes: does the PR implement it for all applicable paths, or at minimum file a follow-up issue? |
-| Justification | If only one path: is there an explicit justification for why parity is not needed? |
+Does this feature logically apply to the other two paths?
+If yes: does the PR implement it for all applicable paths, or at minimum file a follow-up issue?
+If the PR only covers one path: is there an explicit justification for why parity is not needed?
 
-**Common parity gaps to check:**
+Common parity gaps to check:
 
-- CLI flags added to one command but not others (e.g., `--timeout`, `--think-time-dist`)
-- Workload spec fields consumed by one path but ignored by others
-- Metrics computed differently across paths (e.g., timeout counting)
-- Default values that differ between paths without justification
+CLI flags added to one command but not others (e.g., --timeout, --think-time-dist)
+Workload spec fields consumed by one path but ignored by others
+Metrics computed differently across paths (e.g., timeout counting)
+Default values that differ between paths without justification
 
----
+--- PREEMPTION SAFETY ---
 
-## Step 5 — Preemption Safety
+Preemption (request evicted from RunningBatch, ProgressIndex reset to 0, re-queued) is the #1 source of metric bugs. For any change that touches:
 
-Preemption (request evicted from RunningBatch, ProgressIndex reset to 0, re-queued) is the #1 source of metric bugs.
+Per-request metrics (TTFT, ITL, E2E, TotalOutputTokens, TTFTSum)
+Request state transitions (StateQueued, StateRunning, StateCompleted, StateTimedOut)
+Aggregate counters (CompletedRequests, TimedOutRequests)
 
-For any change that touches:
-- Per-request metrics (TTFT, ITL, E2E, TotalOutputTokens, TTFTSum)
-- Request state transitions (StateQueued, StateRunning, StateCompleted, StateTimedOut)
-- Aggregate counters (CompletedRequests, TimedOutRequests)
+Verify: what happens when the request is preempted mid-execution and re-runs? Specifically:
 
-Verify: what happens when the request is preempted mid-execution and re-runs?
+Are inline metrics (recorded during execution) overwrite-safe or accumulate-and-double-count?
+Are aggregate sums deferred to completion time (recordRequestCompletion) to avoid double-counting?
+Does the TimeoutEvent for a preempted-then-completed request get lazily cancelled?
 
-| Check | Question |
-|-------|----------|
-| Overwrite safety | Are inline metrics (recorded during execution) overwrite-safe or accumulate-and-double-count? |
-| Deferred aggregation | Are aggregate sums deferred to completion time (`recordRequestCompletion`) to avoid double-counting? |
-| Timeout cancellation | Does the `TimeoutEvent` for a preempted-then-completed request get lazily cancelled? |
-
----
-
-## Step 6 — Timeout / Deadline Consistency
+--- TIMEOUT / DEADLINE CONSISTENCY ---
 
 BLIS has two distinct timeout mechanisms:
 
-- **DES TimeoutEvent**: fires at `req.Deadline` (simulation ticks), enforced by the event loop
-- **HTTP client timeout**: `--timeout` flag (wall-clock seconds), enforced by Go `http.Client`
+DES TimeoutEvent: fires at req.Deadline (simulation ticks), enforced by the event loop
+HTTP client timeout: --timeout flag (wall-clock seconds), enforced by Go http.Client
 
 For any change that touches timeout, deadline, or horizon:
 
-| Check | Question |
-|-------|----------|
-| Equivalence | Are DES deadlines and HTTP timeouts producing equivalent observable behavior? |
-| Trace pipeline | Does the trace pipeline preserve deadline semantics end-to-end (observe -> trace -> replay)? |
-| Default consistency | Is the 300s default consistent across both mechanisms (`DefaultTimeoutUs` in generator.go vs `defaultHTTPTimeoutSeconds` in observe.go)? |
+Are DES deadlines and HTTP timeouts producing equivalent observable behavior?
+Does the trace pipeline preserve deadline semantics end-to-end (observe → trace → replay)?
+Is the 300s default consistent across both mechanisms (DefaultTimeoutUs in generator.go:676 vs defaultHTTPTimeoutSeconds in observe.go:22)?
 
----
+Also identify any risks, edge cases, or missing considerations.
 
-## Step 7 — Performance and Documentation
-
-1. **Performance implications**: Are there O(n^2) loops, unbounded allocations, or hot-path lock contention introduced?
-2. **Documentation**: Are user-facing docs updated if behavior changes? Are developer-facing comments accurate?
-3. **All prior review comments addressed**: If this is a revision, are all previous reviewer concerns resolved?
-
----
-
-## Step 8 — Verdict
-
-Produce a structured verdict:
-
-```markdown
-## Self-Review Verdict
-
-**Status**: READY TO MERGE | CHANGES REQUIRED | NEEDS DISCUSSION
-
-### Findings
-
-#### Critical (must fix before merge)
-- <finding with file:line reference>
-
-#### Important (should fix before merge)
-- <finding with file:line reference>
-
-#### Suggestions (optional improvements)
-- <finding with file:line reference>
-
-### Cross-Path Parity Summary
-| Path | Applies | Implemented | Gap |
-|------|---------|-------------|-----|
-| run | ... | ... | ... |
-| replay | ... | ... | ... |
-| observe | ... | ... | ... |
-
-### Preemption Safety: PASS / FAIL / N/A
-### Timeout Consistency: PASS / FAIL / N/A
-### Invariants Preserved: <list affected INVs with status>
+Finally, provide a clear verdict: Is this PR ready to merge? If not, what specific changes are required?
 ```
 
----
+After the review completes, if the verdict is **CHANGES REQUIRED**:
 
-## Step 9 — Fix-and-Re-Review Loop (max 3 rounds)
-
-If the verdict is **CHANGES REQUIRED**, enter a convergence loop:
-
-**For each round:**
-
-1. **Fix findings:**
-   - CRITICAL: Fix immediately — these block merge.
-   - IMPORTANT: Fix if straightforward. If complex, add a TODO comment with issue reference.
-   - Suggestions: Skip — these are optional.
-
-2. **Re-run verification:**
-   ```bash
-   go build ./...
-   go test ./... -count=1
-   golangci-lint run ./...
-   ```
-   All three must pass before continuing.
-
-3. **Commit and push:**
-   ```bash
-   git add <fixed-files>
-   git commit -m "fix: address self-review findings (round N)"
-   git push
-   ```
-
-4. **Re-review:** Go back to Step 1 and perform the full review again on the updated diff.
-   ```bash
-   gh pr diff
-   ```
-
-5. **Produce a new verdict (Step 8).** If READY TO MERGE → exit loop. If CHANGES REQUIRED → next round.
-
-**Exit conditions:**
-- Verdict is **READY TO MERGE** → proceed to Step 10.
-- Max rounds (3) reached → proceed to Step 10 with remaining findings noted.
-
----
-
-## Step 10 — Post Final Verdict
-
-Post the final verdict as a PR comment:
-
-```bash
-gh pr comment --body "$(cat <<'EOF'
-## Self-Review Complete (Round N/3)
-
-<final verdict markdown from Step 8>
-
----
-*Automated self-review by Claude. All critical/important findings addressed.*
-EOF
-)"
-```
-
-If findings remain after max rounds, note them explicitly:
-
-```bash
-gh pr comment --body "$(cat <<'EOF'
-## Self-Review Complete (3/3 rounds exhausted)
-
-<final verdict markdown>
-
-### Unresolved Findings
-- <remaining items that need human judgment>
-
----
-*Automated self-review by Claude. Some findings require human review.*
-EOF
-)"
-```
+1. Fix CRITICAL findings immediately. Fix IMPORTANT findings if straightforward.
+2. Re-run verification: `go build ./... && go test ./... -count=1 && golangci-lint run ./...`
+3. Commit: `git commit -m "fix: address review findings (round N)"` and push.
+4. Re-invoke this skill for another round (max 3 rounds total).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           claude_args: '--model claude-sonnet-4-6 --allowed-tools Skill Agent Bash Read Edit Write'
+          show_full_output: true
           prompt: |
             When the trigger comment contains /implement-issue, you MUST follow the implement-issue skill exactly and create the pull request yourself using `gh pr create`. Do NOT just push to a branch and leave it — always open the PR programmatically, then invoke /blis-pr-review for self-review and iterate until READY TO MERGE.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,10 +69,6 @@ jobs:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           claude_args: '--model claude-sonnet-4-6 --allowed-tools Skill Agent Bash Read Edit Write'
           show_full_output: true
-          prompt: |
-            When the trigger comment contains /implement-issue, you MUST follow the implement-issue skill exactly and create the pull request yourself using `gh pr create`. Do NOT just push to a branch and leave it — always open the PR programmatically, then invoke /blis-pr-review for self-review and iterate until READY TO MERGE.
-
-            For all other triggers (questions, reviews, debugging, etc.), respond normally without creating a PR unless explicitly asked.
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
             https://github.com/obra/superpowers-marketplace.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,12 @@ Run lint locally before pushing: `golangci-lint run ./...`
 
 The following instructions are for Claude Code and other AI assistants working on this codebase. Human contributors can skip this section.
 
+### GitHub Action: Implementing Issues
+
+When triggered via `@claude /implement-issue` on a GitHub issue, you MUST invoke the `implement-issue` skill and follow it exactly. After implementation, you MUST create the pull request yourself using `gh pr create` — do NOT just push to a branch and leave it. Always open the PR programmatically, then invoke `/blis-pr-review` for self-review and iterate until READY TO MERGE.
+
+For all other triggers (questions, reviews, debugging, etc.), respond normally without creating a PR unless explicitly asked.
+
 ### Context Management
 
 When running multi-agent PR reviews, keep individual agent scopes narrow and summarize results concisely. Never try to synthesize all parallel agent outputs into one massive prompt. If hitting context limits, deliver incremental summaries per agent rather than a consolidated report.


### PR DESCRIPTION
## Summary

- Rewrites `.claude/skills/blis-pr-review/SKILL.md` from a 250-line inline review process to a thin wrapper that invokes `/pr-review-toolkit:review-pr` with the BLIS-specific review prompt baked in
- Removes `prompt` field from Claude GitHub Action workflow (was overriding issue/PR context)
- Adds agent behavioral instruction to CLAUDE.md for the action

Users now just run `/blis-pr-review` instead of copy-pasting the long review prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)