### PR TITLE
feat: flow control gateway queue llm-d parity (shedding + dispatch triggers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ go build -o blis main.go
 ./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
   --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
   --dispatch-order slo-deadline --slo-targets "critical=100000,standard=500000"
+
+# Run with flow control and opt-in queue shedding (BLIS-extra, not in llm-d)
+./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
+  --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
+  --max-gateway-queue-depth 1000 --queue-shedding
+
+# Run with custom dispatch tick interval (default 1000µs = 1ms, llm-d parity)
+./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
+  --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
+  --dispatch-tick-interval 5000
 ```
 
 ## Testing

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -503,6 +503,8 @@ Example:
 			FlowControlUsageLimitThreshold:  flowControlUsageLimitThreshold,
 			FlowControlFairnessPolicy:       flowControlFairnessPolicy,
 			FlowControlRequestTTL:           flowControlRequestTTL,
+			FlowControlQueueShedding:        flowControlQueueShedding,
+			FlowControlDispatchTickInterval: flowControlDispatchTickInterval,
 			TierShedThreshold:               tierShedThreshold,
 			TierShedMinPriority:             tierShedMinPriority,
 			GAIEQDThreshold:                 gaieQDThreshold,

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -135,6 +135,7 @@ func TestReplayCmd_SimConfigFlags_Registered(t *testing.T) {
 		"max-gateway-queue-depth", "queue-depth-threshold",
 		"kv-cache-util-threshold", "max-concurrency",
 		"per-band-capacity", "usage-limit-threshold",
+		"queue-shedding", "dispatch-tick-interval",
 
 		// replay-specific: results
 		"results-path",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1036,7 +1036,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&flowControlFairnessPolicy, "fairness-policy", "global-strict", "Intra-band dispatch fairness: global-strict, round-robin")
 	cmd.Flags().Int64Var(&flowControlRequestTTL, "request-ttl", 0, "Gateway queue request TTL in microseconds (0=disabled). Requires --flow-control.")
 	cmd.Flags().BoolVar(&flowControlQueueShedding, "queue-shedding", false, "Enable cross-band victim shedding when gateway queue is full (BLIS-extra, not in llm-d; default: reject)")
-	cmd.Flags().Int64Var(&flowControlDispatchTickInterval, "dispatch-tick-interval", 1000, "Microseconds between periodic gateway dispatch ticks (llm-d parity: 1000µs = 1ms)")
+	cmd.Flags().Int64Var(&flowControlDispatchTickInterval, "dispatch-tick-interval", 1000, "Microseconds between periodic gateway dispatch ticks (0 = use default 1ms; llm-d parity)")
 
 	// Per-pool hardware overrides
 	cmd.Flags().IntVar(&prefillTP, "prefill-tp", 0, "Tensor parallelism degree for prefill pool instances (0 = use global --tensor-parallelism)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,6 +166,8 @@ var (
 	flowControlUsageLimitThreshold  float64
 	flowControlFairnessPolicy       string
 	flowControlRequestTTL           int64
+	flowControlQueueShedding        bool
+	flowControlDispatchTickInterval int64
 
 	// Per-pool hardware override config
 	prefillTP           int
@@ -895,6 +897,12 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 	if flowControlRequestTTL > 0 && !flowControlEnabled {
 		logrus.Warnf("--request-ttl %d has no effect without --flow-control", flowControlRequestTTL)
 	}
+	if flowControlDispatchTickInterval < 0 {
+		logrus.Fatalf("--dispatch-tick-interval must be >= 0, got %d", flowControlDispatchTickInterval)
+	}
+	if flowControlQueueShedding && !flowControlEnabled {
+		logrus.Warnf("--queue-shedding has no effect without --flow-control")
+	}
 
 	logrus.Infof("Policy config: admission=%s, routing=%s, scheduler=%s, preemption=%s",
 		admissionPolicy, routingPolicy, scheduler, preemptionPolicy)
@@ -1027,6 +1035,8 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().Float64Var(&flowControlUsageLimitThreshold, "usage-limit-threshold", 1.0, "Per-band saturation ceiling for HoL blocking (1.0=no HoL, <1.0 gates lower-priority bands earlier)")
 	cmd.Flags().StringVar(&flowControlFairnessPolicy, "fairness-policy", "global-strict", "Intra-band dispatch fairness: global-strict, round-robin")
 	cmd.Flags().Int64Var(&flowControlRequestTTL, "request-ttl", 0, "Gateway queue request TTL in microseconds (0=disabled). Requires --flow-control.")
+	cmd.Flags().BoolVar(&flowControlQueueShedding, "queue-shedding", false, "Enable cross-band victim shedding when gateway queue is full (BLIS-extra, not in llm-d; default: reject)")
+	cmd.Flags().Int64Var(&flowControlDispatchTickInterval, "dispatch-tick-interval", 1000, "Microseconds between periodic gateway dispatch ticks (llm-d parity: 1000µs = 1ms)")
 
 	// Per-pool hardware overrides
 	cmd.Flags().IntVar(&prefillTP, "prefill-tp", 0, "Tensor parallelism degree for prefill pool instances (0 = use global --tensor-parallelism)")
@@ -1639,6 +1649,8 @@ var runCmd = &cobra.Command{
 			FlowControlUsageLimitThreshold:  flowControlUsageLimitThreshold,
 			FlowControlFairnessPolicy:       flowControlFairnessPolicy,
 			FlowControlRequestTTL:           flowControlRequestTTL,
+			FlowControlQueueShedding:        flowControlQueueShedding,
+			FlowControlDispatchTickInterval: flowControlDispatchTickInterval,
 			ModelAutoscalerIntervalUs:       bundleAutoscalerIntervalUs,
 			ScaleUpStabilizationWindowUs:    bundleScaleUpStabilizationWindowUs,
 			ScaleDownStabilizationWindowUs:  bundleScaleDownStabilizationWindowUs,

--- a/cmd/simconfig_shared_test.go
+++ b/cmd/simconfig_shared_test.go
@@ -167,6 +167,7 @@ func TestBothCommands_SimConfigFlagsHaveIdenticalDefaults(t *testing.T) {
 		"max-gateway-queue-depth", "queue-depth-threshold",
 		"kv-cache-util-threshold", "max-concurrency",
 		"per-band-capacity", "usage-limit-threshold",
+		"queue-shedding", "dispatch-tick-interval",
 	}
 	for _, name := range sharedFlags {
 		runFlag := runCmd.Flags().Lookup(name)

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -246,7 +246,7 @@ shedding of sheddable entries is enabled (BLIS-extra experimental feature).
 
 **Queue shedding** (`--queue-shedding`): When enabled, a full queue searches all bands for the lowest-priority sheddable request and evicts it to make room. This feature is not present in llm-d and is provided as an experimental option. Without this flag, full queues simply reject incoming requests.
 
-**Dispatch tick** (`--dispatch-tick-interval`): The periodic DES event that triggers dispatch attempts from the gateway queue. Matches llm-d's 1ms `dispatchTicker`. The tick is demand-driven — only active while the queue is non-empty, and only when flow control is enabled. Set to 0 to disable periodic ticking (on-enqueue dispatch only).
+**Dispatch tick** (`--dispatch-tick-interval`): The periodic DES event that triggers dispatch attempts from the gateway queue. Matches llm-d's 1ms `dispatchTicker`. The tick is demand-driven — only active while the queue is non-empty, and only when flow control is enabled. Default is 1000µs (1ms); omitting the flag or setting 0 in YAML both use this default.
 
 ### Example
 

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -188,6 +188,25 @@ When `--flow-control` is enabled, the `FlowControlAdmission` policy replaces the
 admission policy. In this mode, admission and queuing are a single step -- the queue IS the
 admission decision, matching llm-d's `FlowControlAdmissionController`.
 
+### llm-d Parity Summary
+
+BLIS's default flow control behavior matches llm-d's `ShardProcessor`. BLIS-extra features are off by default and require explicit flags.
+
+| Behavior | llm-d | BLIS default | BLIS opt-in flag |
+|----------|-------|-------------|-----------------|
+| Queue full → reject | Yes | **Yes** | — |
+| Queue full → shed victim | No | No | `--queue-shedding` |
+| Dispatch on enqueue | Yes | **Yes** | — |
+| Dispatch via periodic tick (1ms) | Yes | **Yes** | `--dispatch-tick-interval` to tune |
+| Dispatch on completion | No | No | — |
+| Dispatch on eviction/TTL | No | No | — |
+| Band ceilings: constant | Yes | **Yes** | — |
+| Band ceilings: interpolated | Interface only, no impl | No | `--usage-limit-threshold < 1.0` |
+| Fairness: global-strict | Yes (plugin) | **Yes** | — |
+| Fairness: round-robin | Yes (plugin) | No | `--fairness-policy round-robin` |
+
+**Bold** = llm-d parity. BLIS-extra features are documented in code comments and only activate when explicitly enabled.
+
 ### How It Works
 
 1. Incoming request is enqueued into a per-priority-band, per-flow queue

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -91,7 +91,7 @@ Priorities affect three components:
 
 2. **Tenant budget enforcement** (`sim/cluster/cluster_event.go`): When a tenant exceeds their capacity budget, only sheddable requests (`IsSheddable = priority < 0`) are shed. Critical and standard traffic is always protected regardless of budget.
 
-3. **Gateway queue dispatch** (`sim/cluster/gateway_queue.go`): In `priority` dispatch mode, higher-priority requests are dequeued first. When the queue is at capacity, the lowest-priority request is evicted.
+3. **Gateway queue dispatch** (`sim/cluster/gateway_queue.go`): In `priority` dispatch mode, higher-priority requests are dequeued first. When the queue is at capacity, the request is **rejected** by default (llm-d parity). With `--queue-shedding`, the lowest-priority sheddable request is evicted instead (BLIS-extra experimental feature, not in llm-d).
 
 ## Tier-Shed Admission
 
@@ -195,7 +195,7 @@ admission decision, matching llm-d's `FlowControlAdmissionController`.
 3. Dispatch order follows `--dispatch-order`: with `priority`, iterates bands highest-priority first; with `fifo` (default), picks the globally-earliest arrival across all bands; with `slo-deadline`, dispatches the request with the earliest SLO deadline within each flow (see [SLO-Deadline Dispatch Ordering](#slo-deadline-dispatch-ordering) below)
 4. Within a band, `--fairness-policy` controls flow selection: `global-strict` (default) picks the earliest arrival (lowest sequence ID); `round-robin` cycles through tenants in sorted key order
 5. Saturation gating: dispatch only when cluster saturation < 1.0
-6. Completion-triggered dispatch: each completion frees capacity and tries to dispatch from the queue
+6. Dispatch triggers (llm-d parity): on-enqueue dispatch + periodic dispatch tick (default 1ms, configurable via `--dispatch-tick-interval`). The tick is demand-driven — only active while the queue is non-empty.
 
 ### Fairness Policy
 
@@ -214,8 +214,20 @@ admission decision, matching llm-d's `FlowControlAdmissionController`.
 
 When a band reaches its capacity limit, incoming requests for that band are rejected
 (all entries in a band share the same priority, so displacement is never possible).
-The global `--max-gateway-queue-depth` limit applies across all bands with cross-band
-shedding of sheddable entries.
+The global `--max-gateway-queue-depth` limit applies across all bands. When at capacity,
+requests are **rejected** by default (llm-d parity). With `--queue-shedding`, cross-band
+shedding of sheddable entries is enabled (BLIS-extra experimental feature).
+
+### Queue Shedding and Dispatch Tick
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--queue-shedding` | Enable cross-band victim shedding when queue is full (BLIS-extra, not in llm-d) | `false` |
+| `--dispatch-tick-interval` | Microseconds between periodic dispatch ticks | `1000` (1ms, llm-d parity) |
+
+**Queue shedding** (`--queue-shedding`): When enabled, a full queue searches all bands for the lowest-priority sheddable request and evicts it to make room. This feature is not present in llm-d and is provided as an experimental option. Without this flag, full queues simply reject incoming requests.
+
+**Dispatch tick** (`--dispatch-tick-interval`): The periodic DES event that triggers dispatch attempts from the gateway queue. Matches llm-d's 1ms `dispatchTicker`. The tick is demand-driven — only active while the queue is non-empty, and only when flow control is enabled. Set to 0 to disable periodic ticking (on-enqueue dispatch only).
 
 ### Example
 

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -483,6 +483,9 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 			gq.SetSheddingEnabled(true)
 		}
 		cs.dispatchTickInterval = config.FlowControlDispatchTickInterval
+		if cs.dispatchTickInterval < 0 {
+			panic(fmt.Sprintf("ClusterSimulator: FlowControlDispatchTickInterval must be >= 0, got %d", cs.dispatchTickInterval))
+		}
 		if cs.dispatchTickInterval == 0 {
 			cs.dispatchTickInterval = 1000 // default 1ms (llm-d parity)
 		}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -43,6 +43,8 @@ type ClusterSimulator struct {
 	gatewayEvicted        int                       // count of requests evicted in-flight from instances (INV-1: gw_evicted)
 	gatewayExpired        int                       // count of requests expired from gateway queue via TTL (INV-1: gw_expired)
 	requestTTL            int64                     // gateway queue request TTL in microseconds; 0 = disabled
+	dispatchTickInterval  int64                     // µs between periodic dispatch ticks (default 1000 = 1ms, llm-d parity)
+	dispatchTickPending   bool                      // true when a GatewayDispatchTickEvent is already scheduled
 	poolMembership        map[string]PoolRole       // instance ID → pool role (nil when disaggregation disabled)
 	disaggregationDecider sim.DisaggregationDecider // PD disaggregation decider (nil when disabled)
 
@@ -477,6 +479,13 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		if cs.requestTTL < 0 {
 			panic(fmt.Sprintf("ClusterSimulator: FlowControlRequestTTL must be >= 0, got %d", cs.requestTTL))
 		}
+		if config.FlowControlQueueShedding {
+			gq.SetSheddingEnabled(true)
+		}
+		cs.dispatchTickInterval = config.FlowControlDispatchTickInterval
+		if cs.dispatchTickInterval == 0 {
+			cs.dispatchTickInterval = 1000 // default 1ms (llm-d parity)
+		}
 		cs.saturationDetector = sim.NewSaturationDetector(
 			config.FlowControlDetector,
 			config.FlowControlQueueDepthThreshold,
@@ -710,20 +719,6 @@ func (c *ClusterSimulator) Run() error {
 					}
 				}
 
-				// Flow control: completion-triggered dispatch (BC-4).
-				// Each completion opens capacity — try to dequeue from gateway queue.
-				// Loop up to delta times so batch completions can dispatch multiple requests.
-				// Early-exit when saturated or queue empty to avoid redundant buildRouterState calls.
-				if c.flowControlEnabled {
-					for i := 0; i < delta; i++ {
-						if c.gatewayQueue.Len() == 0 {
-							break
-						}
-						if !c.tryDispatchFromGatewayQueue() {
-							break // saturated — no point rebuilding state for remaining iterations
-						}
-					}
-				}
 			}
 
 			// T042: drain completion accounting (Phase 1A).
@@ -1416,12 +1411,24 @@ func (c *ClusterSimulator) GatewayExpired() int {
 }
 
 // tryDispatchFromGatewayQueue attempts to dispatch one request from the gateway queue.
-// Called after each completion (BC-4) and after each enqueue (for NeverSaturated pass-through).
+// Called on enqueue and by the periodic GatewayDispatchTickEvent (llm-d parity).
 // Builds fresh RouterState at dispatch time for late binding (BC-3).
 // Returns true if a request was dispatched, false if saturated or queue empty.
 func (c *ClusterSimulator) tryDispatchFromGatewayQueue() bool {
 	if c.gatewayQueue == nil || c.gatewayQueue.Len() == 0 {
 		return false
+	}
+	// Schedule periodic dispatch tick if not already pending (BC-3).
+	// Demand-driven: only active while queue is non-empty.
+	if c.dispatchTickInterval > 0 && !c.dispatchTickPending {
+		c.dispatchTickPending = true
+		heap.Push(&c.clusterEvents, clusterEventEntry{
+			event: &GatewayDispatchTickEvent{
+				At:       c.clock + c.dispatchTickInterval,
+				Interval: c.dispatchTickInterval,
+			},
+			seqID: c.nextSeqID(),
+		})
 	}
 	// Build fresh state for late binding (BC-3)
 	state := buildRouterState(c, nil)

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -321,8 +321,6 @@ func (e *GatewayEvictionEvent) Execute(cs *ClusterSimulator) {
 	}
 	cs.shedByTier[tier]++
 
-	// Re-trigger dispatch: freed capacity may allow waiting request to dispatch.
-	cs.tryDispatchFromGatewayQueue()
 }
 
 // GatewayQueueTTLEvent fires when a request's TTL expires while queued.
@@ -349,7 +347,39 @@ func (e *GatewayQueueTTLEvent) Execute(cs *ClusterSimulator) {
 		tier = "standard"
 	}
 	cs.shedByTier[tier]++
-	cs.tryDispatchFromGatewayQueue()
+}
+
+// GatewayDispatchTickEvent is a periodic dispatch trigger for the gateway queue.
+// DES equivalent of llm-d's 1ms dispatchTicker (processor.go:179).
+// Demand-driven: only active when flow control enabled AND queue non-empty.
+// Self-scheduling: reschedules while queue has requests, stops when drained.
+// Priority 7: after TTL expiry (6), before scaling (8).
+type GatewayDispatchTickEvent struct {
+	At       int64
+	Interval int64
+}
+
+func (e *GatewayDispatchTickEvent) Timestamp() int64 { return e.At }
+func (e *GatewayDispatchTickEvent) Priority() int     { return 7 }
+
+func (e *GatewayDispatchTickEvent) Execute(cs *ClusterSimulator) {
+	if cs.gatewayQueue == nil {
+		cs.dispatchTickPending = false
+		return
+	}
+
+	if cs.gatewayQueue.Len() > 0 {
+		cs.tryDispatchFromGatewayQueue()
+	}
+
+	if cs.gatewayQueue.Len() > 0 {
+		heap.Push(&cs.clusterEvents, clusterEventEntry{
+			event: &GatewayDispatchTickEvent{At: e.At + e.Interval, Interval: e.Interval},
+			seqID: cs.nextSeqID(),
+		})
+	} else {
+		cs.dispatchTickPending = false
+	}
 }
 
 // DisaggregationDecisionEvent represents the PD disaggregation decision point for a request.

--- a/sim/cluster/deployment.go
+++ b/sim/cluster/deployment.go
@@ -132,6 +132,8 @@ type DeploymentConfig struct {
 	FlowControlUsageLimitThreshold  float64 `yaml:"flow_control_usage_limit_threshold,omitempty"`   // per-band HoL blocking ceiling (1.0=no HoL, <1.0 gates lower bands earlier)
 	FlowControlFairnessPolicy       string  `yaml:"flow_control_fairness_policy,omitempty"`         // "global-strict" (default), "round-robin"
 	FlowControlRequestTTL           int64   `yaml:"flow_control_request_ttl,omitempty"`             // microseconds; 0 = disabled (default). GIE parity: DefaultRequestTTL.
+	FlowControlQueueShedding        bool    `yaml:"flow_control_queue_shedding,omitempty"`          // BLIS-extra: cross-band shedding on full queue (not in llm-d). Default false.
+	FlowControlDispatchTickInterval int64   `yaml:"flow_control_dispatch_tick_interval,omitempty"`  // µs between periodic dispatch ticks (default 1000 = 1ms, llm-d parity). 0 = use default.
 
 	// Issue #893: per-GPU-type hardware calibration for roofline and trained-physics backends.
 	// Key: GPU type string (e.g., "A100", "H100"). Value: HardwareCalib for that GPU.

--- a/sim/cluster/flow_control_admission_test.go
+++ b/sim/cluster/flow_control_admission_test.go
@@ -56,6 +56,7 @@ func TestFlowControlAdmission_QueueRejection(t *testing.T) {
 func TestFlowControlAdmission_ShedVictim(t *testing.T) {
 	pm := sim.DefaultSLOPriorityMap()
 	q := NewGatewayQueue("priority", 1, pm) // maxDepth=1
+	q.SetSheddingEnabled(true)
 	fc := NewFlowControlAdmission(q)
 
 	fc.Admit(&sim.Request{ID: "r1", SLOClass: "batch"}, &sim.RouterState{Clock: 100})

--- a/sim/cluster/gateway_queue.go
+++ b/sim/cluster/gateway_queue.go
@@ -151,6 +151,7 @@ type GatewayQueue struct {
 	usageLimitThreshold  float64            // per-band HoL blocking ceiling (default 1.0 = no HoL)
 	fairnessPolicy       FairnessPolicy
 	requestIndex         map[string]requestLocation // request ID → flow coordinates for TTL removal
+	sheddingEnabled      bool                       // BLIS-extra: cross-band shedding on enqueue (not in llm-d). Requires --queue-shedding.
 }
 
 // NewGatewayQueue creates a gateway queue with the given dispatch order and max depth.
@@ -200,6 +201,13 @@ func (q *GatewayQueue) SetPerBandCapacity(n int) {
 		panic(fmt.Sprintf("GatewayQueue: maxBandCapacity must be >= 0, got %d", n))
 	}
 	q.maxBandCapacity = n
+}
+
+// SetSheddingEnabled enables or disables cross-band victim shedding on enqueue.
+// BLIS-extra feature not present in llm-d. When false (default), global capacity full → reject.
+// When true, the queue searches all bands for a sheddable victim (--queue-shedding).
+func (q *GatewayQueue) SetSheddingEnabled(enabled bool) {
+	q.sheddingEnabled = enabled
 }
 
 // SetUsageLimitThreshold sets the per-band saturation ceiling for HoL blocking.
@@ -265,10 +273,15 @@ func (q *GatewayQueue) Enqueue(req *sim.Request, seqID int64) (EnqueueOutcome, *
 		return Rejected, nil
 	}
 
-	// Step 2: Global capacity check (cross-band shedding).
-	// Evict the lowest-priority sheddable entry globally to make room.
+	// Step 2: Global capacity check.
+	// Default (llm-d parity): reject when full.
+	// With --queue-shedding (BLIS-extra, not in llm-d): search all bands for a sheddable victim.
 	var shedVictim *sim.Request
 	if q.maxDepth > 0 && q.totalLen >= q.maxDepth {
+		if !q.sheddingEnabled {
+			q.rejectedCount++
+			return Rejected, nil
+		}
 		victim, victimFlow, victimBand, victimIdx := q.findGlobalShedVictim(priority, seqID)
 		if victim == nil {
 			q.rejectedCount++

--- a/sim/cluster/gateway_queue_test.go
+++ b/sim/cluster/gateway_queue_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -130,6 +131,7 @@ func TestGatewayQueue_CriticalityProtection_NonSheddableNeverEvicted(t *testing.
 func TestGatewayQueue_CriticalityProtection_SheddableEvicted(t *testing.T) {
 	pm := sim.DefaultSLOPriorityMap()
 	q := NewGatewayQueue("priority", 2, pm)
+	q.SetSheddingEnabled(true)
 
 	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "batch"}, 1)    // priority=-1 (sheddable)
 	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard"}, 2) // priority=3
@@ -178,6 +180,7 @@ func TestGatewayQueue_CriticalityProtection_LowerSheddableDoesNotEvictHigherShed
 func TestGatewayQueue_CriticalityProtection_HigherSheddableDisplacesLowerSheddable(t *testing.T) {
 	pm := sim.DefaultSLOPriorityMap()
 	q := NewGatewayQueue("priority", 2, pm)
+	q.SetSheddingEnabled(true)
 
 	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "background"}, 1) // priority=-3 (sheddable)
 	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "standard"}, 2)   // priority=3 (non-sheddable)
@@ -203,6 +206,7 @@ func TestGatewayQueue_CriticalityProtection_HigherSheddableDisplacesLowerSheddab
 func TestGatewayQueue_CriticalityProtection_EqualPrioritySheddableTieBreak(t *testing.T) {
 	pm := sim.DefaultSLOPriorityMap()
 	q := NewGatewayQueue("priority", 2, pm)
+	q.SetSheddingEnabled(true)
 
 	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "batch"}, 10) // priority=-1, seqID=10
 	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "batch"}, 20) // priority=-1, seqID=20
@@ -223,6 +227,55 @@ func TestGatewayQueue_CriticalityProtection_EqualPrioritySheddableTieBreak(t *te
 	}
 	if victim != nil {
 		t.Error("no victim expected for rejection")
+	}
+}
+
+func TestGatewayQueue_SheddingDisabled_RejectsInsteadOfShed(t *testing.T) {
+	q := NewGatewayQueue("priority", 2, nil) // maxDepth=2, sheddingEnabled=false (default)
+	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard"}, 1)
+	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "sheddable"}, 2)
+
+	outcome, victim := q.Enqueue(&sim.Request{ID: "r3", SLOClass: "critical"}, 3)
+	if outcome != Rejected {
+		t.Errorf("shedding disabled: expected Rejected, got %v", outcome)
+	}
+	if victim != nil {
+		t.Error("shedding disabled: expected nil victim")
+	}
+	if q.ShedCount() != 0 {
+		t.Errorf("shedding disabled: ShedCount should be 0, got %d", q.ShedCount())
+	}
+	if q.RejectedCount() != 1 {
+		t.Errorf("shedding disabled: RejectedCount should be 1, got %d", q.RejectedCount())
+	}
+}
+
+func TestGatewayQueue_SheddingEnabled_ShedsVictim(t *testing.T) {
+	q := NewGatewayQueue("priority", 2, nil)
+	q.SetSheddingEnabled(true)
+	_, _ = q.Enqueue(&sim.Request{ID: "r1", SLOClass: "standard"}, 1)
+	_, _ = q.Enqueue(&sim.Request{ID: "r2", SLOClass: "sheddable"}, 2)
+
+	outcome, victim := q.Enqueue(&sim.Request{ID: "r3", SLOClass: "critical"}, 3)
+	if outcome != ShedVictim {
+		t.Errorf("shedding enabled: expected ShedVictim, got %v", outcome)
+	}
+	if victim == nil || victim.ID != "r2" {
+		t.Errorf("shedding enabled: expected victim r2, got %v", victim)
+	}
+	if q.ShedCount() != 1 {
+		t.Errorf("shedding enabled: ShedCount should be 1, got %d", q.ShedCount())
+	}
+}
+
+func TestGatewayQueue_SheddingEnabled_DefaultFalse(t *testing.T) {
+	q := NewGatewayQueue("fifo", 10, nil)
+	for i := 0; i < 10; i++ {
+		q.Enqueue(&sim.Request{ID: fmt.Sprintf("r%d", i), SLOClass: "sheddable"}, int64(i))
+	}
+	outcome, _ := q.Enqueue(&sim.Request{ID: "overflow", SLOClass: "critical"}, 100)
+	if outcome != Rejected {
+		t.Errorf("default queue should reject (not shed) when full, got %v", outcome)
 	}
 }
 
@@ -901,6 +954,7 @@ func TestGatewayQueue_RemoveByRequestID_WithShed(t *testing.T) {
 	// RemoveByRequestID for the victim returns nil (no double-counting).
 	pm := sim.DefaultSLOPriorityMap()
 	q := NewGatewayQueue("fifo", 2, pm) // maxDepth=2
+	q.SetSheddingEnabled(true)
 
 	r1 := &sim.Request{ID: "r1", SLOClass: "sheddable", TenantID: "t1"}
 	r2 := &sim.Request{ID: "r2", SLOClass: "standard", TenantID: "t1"}


### PR DESCRIPTION
## Summary

- **GAP-1**: Queue shedding now opt-in via `--queue-shedding` (default: reject when full, llm-d parity)
- **GAP-2**: Completion/eviction/TTL dispatch callbacks replaced by demand-driven periodic DES tick event (`GatewayDispatchTickEvent`, default 1ms interval matching llm-d's `dispatchTicker`)
- **GAP-3**: Per-band ceiling interpolation already correctly gated (no change needed)

## Behavioral Contracts

- **BC-1**: Shedding disabled by default — full queue → reject (no victim search)
- **BC-2**: `--queue-shedding` enables cross-band victim eviction (BLIS-extra, not in llm-d)
- **BC-3**: Periodic dispatch tick scheduled demand-driven (only while queue non-empty)
- **BC-4**: Tick self-reschedules while queue has requests
- **BC-5**: Tick stops when queue drains to zero
- **BC-6**: Completion dispatch callback removed from `ClusterSimulator.Run()`
- **BC-7**: Eviction/TTL dispatch callbacks removed from event handlers
- **BC-8**: `ShedCount()` stays 0 unless `--queue-shedding` explicitly set
- **BC-9**: No dispatch tick events when flow control disabled
- **BC-10**: INV-1 request conservation preserved (full suite passes)

## Test plan

- [x] New unit tests: `TestGatewayQueue_SheddingDisabled_RejectsInsteadOfShed`, `TestGatewayQueue_SheddingEnabled_ShedsVictim`, `TestGatewayQueue_SheddingEnabled_DefaultFalse`
- [x] Existing shedding tests updated with `SetSheddingEnabled(true)`
- [x] Full `go test ./...` passes (all packages)
- [x] Shared flag parity tests updated (`simconfig_shared_test.go`, `replay_test.go`)
- [x] CLI validation: `--dispatch-tick-interval >= 0`, `--queue-shedding` warns without `--flow-control`

Fixes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)