### PR TITLE
feat(cluster): make in-flight eviction opt-in via --in-flight-eviction flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ go build -o blis main.go
 ./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
   --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 \
   --dispatch-tick-interval 5000
+
+# Run with opt-in in-flight eviction of sheddable requests (BLIS-extra, not in llm-d)
+./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \
+  --queue-depth-threshold 5 --kv-cache-util-threshold 0.8 --in-flight-eviction
 ```
 
 ## Testing

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -505,6 +505,7 @@ Example:
 			FlowControlRequestTTL:           flowControlRequestTTL,
 			FlowControlQueueShedding:        flowControlQueueShedding,
 			FlowControlDispatchTickInterval: flowControlDispatchTickInterval,
+			FlowControlInFlightEviction:     flowControlInFlightEviction,
 			TierShedThreshold:               tierShedThreshold,
 			TierShedMinPriority:             tierShedMinPriority,
 			GAIEQDThreshold:                 gaieQDThreshold,

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -136,6 +136,7 @@ func TestReplayCmd_SimConfigFlags_Registered(t *testing.T) {
 		"kv-cache-util-threshold", "max-concurrency",
 		"per-band-capacity", "usage-limit-threshold",
 		"queue-shedding", "dispatch-tick-interval",
+		"in-flight-eviction",
 
 		// replay-specific: results
 		"results-path",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,6 +168,7 @@ var (
 	flowControlRequestTTL           int64
 	flowControlQueueShedding        bool
 	flowControlDispatchTickInterval int64
+	flowControlInFlightEviction     bool
 
 	// Per-pool hardware override config
 	prefillTP           int
@@ -903,6 +904,9 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 	if flowControlQueueShedding && !flowControlEnabled {
 		logrus.Warnf("--queue-shedding has no effect without --flow-control")
 	}
+	if flowControlInFlightEviction && !flowControlEnabled {
+		logrus.Warnf("--in-flight-eviction has no effect without --flow-control")
+	}
 
 	logrus.Infof("Policy config: admission=%s, routing=%s, scheduler=%s, preemption=%s",
 		admissionPolicy, routingPolicy, scheduler, preemptionPolicy)
@@ -1037,6 +1041,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(&flowControlRequestTTL, "request-ttl", 0, "Gateway queue request TTL in microseconds (0=disabled). Requires --flow-control.")
 	cmd.Flags().BoolVar(&flowControlQueueShedding, "queue-shedding", false, "Enable cross-band victim shedding when gateway queue is full (BLIS-extra, not in llm-d; default: reject)")
 	cmd.Flags().Int64Var(&flowControlDispatchTickInterval, "dispatch-tick-interval", 1000, "Microseconds between periodic gateway dispatch ticks (0 = use default 1ms; llm-d parity)")
+	cmd.Flags().BoolVar(&flowControlInFlightEviction, "in-flight-eviction", false, "Enable in-flight eviction of sheddable requests when saturated (BLIS-extra, not in llm-d; requires --flow-control)")
 
 	// Per-pool hardware overrides
 	cmd.Flags().IntVar(&prefillTP, "prefill-tp", 0, "Tensor parallelism degree for prefill pool instances (0 = use global --tensor-parallelism)")
@@ -1651,6 +1656,7 @@ var runCmd = &cobra.Command{
 			FlowControlRequestTTL:           flowControlRequestTTL,
 			FlowControlQueueShedding:        flowControlQueueShedding,
 			FlowControlDispatchTickInterval: flowControlDispatchTickInterval,
+			FlowControlInFlightEviction:     flowControlInFlightEviction,
 			ModelAutoscalerIntervalUs:       bundleAutoscalerIntervalUs,
 			ScaleUpStabilizationWindowUs:    bundleScaleUpStabilizationWindowUs,
 			ScaleDownStabilizationWindowUs:  bundleScaleDownStabilizationWindowUs,

--- a/cmd/simconfig_shared_test.go
+++ b/cmd/simconfig_shared_test.go
@@ -168,6 +168,7 @@ func TestBothCommands_SimConfigFlagsHaveIdenticalDefaults(t *testing.T) {
 		"kv-cache-util-threshold", "max-concurrency",
 		"per-band-capacity", "usage-limit-threshold",
 		"queue-shedding", "dispatch-tick-interval",
+		"in-flight-eviction",
 	}
 	for _, name := range sharedFlags {
 		runFlag := runCmd.Flags().Lookup(name)

--- a/docs/guide/admission.md
+++ b/docs/guide/admission.md
@@ -291,7 +291,7 @@ With `--dispatch-order slo-deadline`, the gateway queue dispatches the request w
 
 ### In-Flight Eviction
 
-When flow control is enabled and the system is saturated, BLIS can evict sheddable requests that are already running on instances to free capacity for higher-priority waiting requests. This matches GIE's eviction architecture.
+When flow control is enabled and the system is saturated, BLIS can evict sheddable requests that are already running on instances to free capacity for higher-priority waiting requests. This is a BLIS-extra feature, not present in llm-d (llm-d's `RequestEvictor`/`EvictN` exists in code but has zero non-test callers in the production dispatch path).
 
 **How it works:**
 
@@ -305,7 +305,7 @@ When flow control is enabled and the system is saturated, BLIS can evict sheddab
 **Key properties:**
 
 - Only sheddable requests (priority < 0) can be evicted — critical and standard are always protected
-- Eviction is automatic when `--flow-control` is active — no additional flag needed
+- Disabled by default (llm-d parity). Enable with `--in-flight-eviction` (requires `--flow-control`)
 - Evicted requests appear in the `Gateway Evicted (in-flight)` anomaly counter
 - This is a terminal state — evicted requests are not requeued
 - Eviction is distinct from instance-level KV preemption (`--preemption-policy`), which handles memory pressure and requeues victims

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -39,7 +39,7 @@ type ClusterSimulator struct {
 	trace                 *trace.SimulationTrace    // nil when trace-level is "none" (BC-1: zero overhead)
 	preGeneratedRequests  []*sim.Request            // Pre-generated requests (all workload paths unified)
 	inFlightRequests      map[string]int            // instance ID → dispatched-but-not-completed count (#463)
-	evictionTracker       *EvictionTracker          // tracks routed sheddable requests for in-flight eviction (nil when flow control disabled)
+	evictionTracker       *EvictionTracker          // tracks routed sheddable requests for in-flight eviction (nil unless --in-flight-eviction set)
 	gatewayEvicted        int                       // count of requests evicted in-flight from instances (INV-1: gw_evicted)
 	gatewayExpired        int                       // count of requests expired from gateway queue via TTL (INV-1: gw_expired)
 	requestTTL            int64                     // gateway queue request TTL in microseconds; 0 = disabled
@@ -498,7 +498,9 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		fcAdmission := NewFlowControlAdmission(gq)
 		cs.flowControlAdmission = fcAdmission
 		cs.admissionPolicy = fcAdmission
-		cs.evictionTracker = NewEvictionTracker()
+		if config.FlowControlInFlightEviction {
+			cs.evictionTracker = NewEvictionTracker()
+		}
 		fairness := config.FlowControlFairnessPolicy
 		if fairness == "" {
 			fairness = "global-strict"

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -505,8 +505,8 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		if fairness == "" {
 			fairness = "global-strict"
 		}
-		logrus.Infof("[cluster] flow control enabled: detector=%q, dispatch=%q, fairness=%q, maxDepth=%d, perBandCapacity=%d, requestTTL=%d",
-			config.FlowControlDetector, dispatchOrder, fairness, config.FlowControlMaxQueueDepth, config.FlowControlPerBandCapacity, config.FlowControlRequestTTL)
+		logrus.Infof("[cluster] flow control enabled: detector=%q, dispatch=%q, fairness=%q, maxDepth=%d, perBandCapacity=%d, requestTTL=%d, queueShedding=%v, inFlightEviction=%v",
+			config.FlowControlDetector, dispatchOrder, fairness, config.FlowControlMaxQueueDepth, config.FlowControlPerBandCapacity, config.FlowControlRequestTTL, config.FlowControlQueueShedding, config.FlowControlInFlightEviction)
 	}
 
 	// Phase 1B-2a: initialize TenantTracker when TenantBudgets is configured (issue #811).

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -3143,6 +3143,10 @@ func TestClusterSimulator_FlowControl_NoEviction_Default(t *testing.T) {
 	if injected != accounted {
 		t.Errorf("INV-1 violated: injected=%d != accounted=%d", injected, accounted)
 	}
+
+	if m.CompletedRequests != len(requests) {
+		t.Errorf("expected all %d requests to complete when eviction disabled, got %d completed", len(requests), m.CompletedRequests)
+	}
 }
 
 // TestClusterSimulator_FlowControl_Eviction_PD verifies that eviction tracking

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -3002,6 +3002,7 @@ func TestClusterSimulator_FlowControl_Eviction_Conservation(t *testing.T) {
 	config.FlowControlMaxConcurrency = 1
 	config.FlowControlDispatchOrder = "priority"
 	config.FlowControlMaxQueueDepth = 100
+	config.FlowControlInFlightEviction = true
 
 	// Mix of sheddable and critical requests. Sheddable arrive first to fill capacity,
 	// then critical arrive and trigger eviction.
@@ -3084,6 +3085,66 @@ func TestClusterSimulator_FlowControl_Eviction_Conservation(t *testing.T) {
 		m.CompletedRequests, gwEvicted, gwShed, gwDepth, criticalCompleted)
 }
 
+// TestClusterSimulator_FlowControl_NoEviction_Default verifies that in-flight
+// eviction does not fire when FlowControlInFlightEviction is false (default, llm-d parity).
+func TestClusterSimulator_FlowControl_NoEviction_Default(t *testing.T) {
+	config := newTestDeploymentConfig(1)
+	config.FlowControlEnabled = true
+	config.FlowControlDetector = "concurrency"
+	config.FlowControlMaxConcurrency = 1
+	config.FlowControlDispatchOrder = "priority"
+	config.FlowControlMaxQueueDepth = 100
+	// FlowControlInFlightEviction defaults to false
+
+	requests := make([]*sim.Request, 0, 6)
+	longOutput := make([]int, 200)
+	for j := range longOutput {
+		longOutput[j] = j + 1
+	}
+	for i := 0; i < 3; i++ {
+		out := make([]int, len(longOutput))
+		copy(out, longOutput)
+		requests = append(requests, &sim.Request{
+			ID:           fmt.Sprintf("shed-%d", i),
+			ArrivalTime:  int64(i * 1000),
+			SLOClass:     "sheddable",
+			InputTokens:  []int{1, 2, 3, 4, 5},
+			OutputTokens: out,
+		})
+	}
+	for i := 0; i < 3; i++ {
+		requests = append(requests, &sim.Request{
+			ID:           fmt.Sprintf("crit-%d", i),
+			ArrivalTime:  int64(50000 + i*1000),
+			SLOClass:     "critical",
+			InputTokens:  []int{1, 2, 3},
+			OutputTokens: []int{1, 2, 3},
+		})
+	}
+
+	cs := NewClusterSimulator(config, requests, nil)
+	mustRun(t, cs)
+
+	gwEvicted := cs.GatewayEvicted()
+	if gwEvicted != 0 {
+		t.Errorf("expected gwEvicted=0 when in-flight eviction disabled (llm-d parity), got %d", gwEvicted)
+	}
+
+	m := cs.AggregatedMetrics()
+	gwDepth := cs.GatewayQueueDepth()
+	gwShed := cs.GatewayQueueShed()
+	gwRejected := cs.GatewayQueueRejected()
+	gwExpired := cs.GatewayExpired()
+	encRej := cs.EncodeRoutingRejections()
+	injected := len(requests) - cs.RejectedRequests()
+	accounted := m.CompletedRequests + m.StillQueued + m.StillRunning +
+		m.DroppedUnservable + m.TimedOutRequests + cs.RoutingRejections() +
+		gwDepth + gwShed + gwRejected + gwEvicted + gwExpired + encRej
+	if injected != accounted {
+		t.Errorf("INV-1 violated: injected=%d != accounted=%d", injected, accounted)
+	}
+}
+
 // TestClusterSimulator_FlowControl_Eviction_PD verifies that eviction tracking
 // works when requests are routed through the PD disaggregation path (non-disaggregated).
 func TestClusterSimulator_FlowControl_Eviction_PD(t *testing.T) {
@@ -3093,6 +3154,7 @@ func TestClusterSimulator_FlowControl_Eviction_PD(t *testing.T) {
 	config.FlowControlMaxConcurrency = 1 // saturation = totalInFlight / (numInstances * maxConcurrency) — saturates at 2 in-flight
 	config.FlowControlDispatchOrder = "priority"
 	config.FlowControlMaxQueueDepth = 100
+	config.FlowControlInFlightEviction = true
 	config.PDDecider = "never" // non-disaggregated: requests go directly to decode pod
 
 	longOutput := make([]int, 200)

--- a/sim/cluster/deployment.go
+++ b/sim/cluster/deployment.go
@@ -134,6 +134,7 @@ type DeploymentConfig struct {
 	FlowControlRequestTTL           int64   `yaml:"flow_control_request_ttl,omitempty"`             // microseconds; 0 = disabled (default). GIE parity: DefaultRequestTTL.
 	FlowControlQueueShedding        bool    `yaml:"flow_control_queue_shedding,omitempty"`          // BLIS-extra: cross-band shedding on full queue (not in llm-d). Default false.
 	FlowControlDispatchTickInterval int64   `yaml:"flow_control_dispatch_tick_interval,omitempty"`  // µs between periodic dispatch ticks (default 1000 = 1ms, llm-d parity). 0 = use default.
+	FlowControlInFlightEviction     bool    `yaml:"flow_control_in_flight_eviction,omitempty"`      // BLIS-extra: evict sheddable in-flight requests when saturated (not in llm-d). Default false.
 
 	// Issue #893: per-GPU-type hardware calibration for roofline and trained-physics backends.
 	// Key: GPU type string (e.g., "A100", "H100"). Value: HardwareCalib for that GPU.


### PR DESCRIPTION
## Summary

- Make in-flight eviction of sheddable requests opt-in (default off) for llm-d parity
- Add `--in-flight-eviction` CLI flag gating `EvictionTracker` creation
- Add test verifying zero evictions when flag is off

## Context

Issue #1371: In-flight eviction silently activates with `--flow-control`, but llm-d's `EvictN()` has zero callers — the eviction infrastructure is scaffolding, not wired. Default behavior must match llm-d (no eviction).

## Behavioral Contracts

```
BC-1: GIVEN --flow-control enabled AND --in-flight-eviction NOT set
      WHEN saturation >= 1.0 and sheddable requests are running
      THEN no in-flight eviction occurs (gwEvicted == 0)

BC-2: GIVEN --flow-control enabled AND --in-flight-eviction set
      WHEN saturation >= 1.0 and sheddable requests are running
      THEN eviction fires as before (existing behavior preserved)
```

## Test plan

- [x] `TestClusterSimulator_FlowControl_NoEviction_Default` — verifies BC-1 (zero evictions, INV-1 conservation)
- [x] `TestClusterSimulator_FlowControl_Eviction_Conservation` — verifies BC-2 (eviction fires with flag set)
- [x] `TestClusterSimulator_FlowControl_Eviction_PD` — verifies PD path with flag set
- [x] Flag parity tests updated (`replay_test.go`, `simconfig_shared_test.go`)
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] Build passes, zero new lint issues

Fixes #1371

🤖 Generated with [Claude Code](https://claude.com/claude-code)