### PR TITLE
fix(cmd): lower default --pd-prefix-threshold from 512 to 16 for llm-d parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Separate prefill (prompt processing) and decode (token generation) onto dedicate
   --model qwen/qwen3-14b \
   --num-instances 4 \
   --prefill-instances 2 --decode-instances 2 \
-  --pd-decider prefix-threshold --pd-prefix-threshold 512 \
+  --pd-decider prefix-threshold --pd-prefix-threshold 16 \
   --rate 100 --num-requests 1000
 
 # Heterogeneous pools: prefill on A100-80 (high compute), decode on H100 (high memory)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1018,7 +1018,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().Float64Var(&pdTransferBandwidth, "pd-transfer-bandwidth", 25.0, "PD KV transfer bandwidth in GB/s (NIXL RDMA default)")
 	cmd.Flags().Float64Var(&pdTransferBaseLatency, "pd-transfer-base-latency", 0.05, "PD KV transfer base latency in ms")
 	cmd.Flags().BoolVar(&pdTransferContention, "pd-transfer-contention", false, "Enable fair-share bandwidth contention model for concurrent KV transfers (INV-P2-2)")
-	cmd.Flags().IntVar(&pdPrefixThreshold, "pd-prefix-threshold", 512, "Non-cached token threshold for prefix-threshold decider (>= 0); disaggregate when non-cached tokens exceed this value")
+	cmd.Flags().IntVar(&pdPrefixThreshold, "pd-prefix-threshold", 16, "Non-cached token threshold for prefix-threshold decider (>= 0); disaggregate when non-cached tokens exceed this value. Default 16 matches llm-d's shipped P/D configs (deploy/config/pd-epp-config.yaml).")
 	cmd.Flags().StringVar(&prefillRoutingScorers, "prefill-routing-scorers", "", "Scorer weights for prefill pool routing (e.g., queue-depth:2,kv-utilization:2)")
 	cmd.Flags().StringVar(&decodeRoutingScorers, "decode-routing-scorers", "", "Scorer weights for decode pool routing (e.g., queue-depth:2,kv-utilization:2)")
 


### PR DESCRIPTION
## Summary

Changes the default value of `--pd-prefix-threshold` from `512` to `16` so BLIS's prefix-aware PD disaggregation default matches llm-d's shipped reference configs.

The previous default of 512 was 32× higher than llm-d's shipped P/D configs (which all use `nonCachedTokens: 16`) and 64× higher than the docs example (8). That caused users running `--pd-decider prefix-threshold` with defaults to under-disaggregate relative to upstream behavior.

**Sources of truth in llm-d:**
- [`deploy/config/pd-epp-config.yaml`](https://github.com/llm-d/llm-d-router/blob/main/deploy/config/pd-epp-config.yaml): `nonCachedTokens: 16`
- `deploy/config/sim-pd-epp-config.yaml`: `nonCachedTokens: 16`
- `deploy/config/sim-e-p-d-epp-config.yaml`: `nonCachedTokens: 16`
- [`docs/disaggregation.md`](https://github.com/llm-d/llm-d-router/blob/main/docs/disaggregation.md): example `nonCachedTokens: 8` (illustrative)
- [`prefix_based_pd_decider.go`](https://github.com/llm-d/llm-d-router/blob/main/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go) factory: `0` (sentinel meaning "disabled")

The shipped configs are the most authoritative reference (production deployments), so 16 was selected.

## What this PR does

1. `cmd/root.go`: changes the `--pd-prefix-threshold` default from 512 to 16 (single registration site in `registerSimConfigFlags`, used by both `runCmd` and `replayCmd`). Updates help text to cite the llm-d source.
2. `README.md`: updates the prefix-threshold example invocation from `--pd-prefix-threshold 512` to `--pd-prefix-threshold 16` so the example matches the new default.

## Behavioral Contracts

**BC-1: Default flag value matches llm-d shipped configs**
- GIVEN the user invokes `blis run` (or `blis replay`) without `--pd-prefix-threshold`
- WHEN `--pd-decider prefix-threshold` is set and the user inspects `--help`
- THEN the documented default for `--pd-prefix-threshold` is `16`, and a request whose non-cached suffix is exactly 17 tokens is disaggregated while one with 16 tokens is colocated. (BLIS's strict `>` comparison is preserved.)

**BC-2: Documented example reflects the new default**
- GIVEN a reader copying the README PD example verbatim
- WHEN they run it
- THEN the threshold value shown matches the new flag default.

**BC-3: No regression**
- GIVEN existing tests that construct `NewPrefixThresholdDecider(threshold, blockSize, cacheQuery)` with explicit thresholds
- WHEN they run after this change
- THEN they produce the same observable result as before (tests are not coupled to the CLI default).

## What is NOT changed

- The decision formula: `nonCachedTokens = inputTokens − cachedBlocks × blockSize; Disaggregate = (nonCachedTokens > threshold)`. Untouched.
- The strict `>` comparison. (llm-d's plugin README documents the rule as `>=` — an off-by-one boundary divergence noted in #1375 as out-of-scope; will file a follow-up issue if/when this PR merges.)
- The flag's validation guard `>= 0`. Untouched.
- Per-pod cache-query plumbing. Untouched.
- All existing PD unit tests in `sim/disaggregation_test.go`. They pass an explicit threshold and remain valid.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./... -count=1` — all packages pass (`cmd`, `sim`, `sim/cluster`, `sim/kv`, `sim/latency`, `sim/trace`, `sim/workload`, etc.)
- [x] `go vet ./...` — clean
- [x] `gofmt -l cmd/root.go` — clean
- [x] `TestBothCommands_SimConfigFlagsHaveIdenticalDefaults` (`cmd/simconfig_shared_test.go`) — PASS (enforces R23 run/replay flag-default parity automatically with the new value)
- [x] `TestRunCmd_SimConfigFlagsParity` — PASS
- [x] `./blis run --help | grep pd-prefix-threshold` shows `(default 16)` and the new help text including the llm-d source citation
- [ ] `golangci-lint run ./...` — could not run locally (binary not installed in dev env); CI will verify

## Files changed

```
 README.md   | 2 +-
 cmd/root.go | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## Standards / invariants impact

- **R4 (canonical constructors):** single registration site (`registerSimConfigFlags`).
- **R23 (run/replay parity):** preserved automatically — both commands share the registration; verified by existing parity test.
- **INV-1 to INV-13:** not affected (no event, lifecycle, conservation, causality, determinism, signal, work-conserving, oracle, session, batch-formation, or run/replay invariant changes — only a control-plane tunable default).

Fixes #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)