### PR TITLE
Switch default --latency-model from roofline to trained-physics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,11 +363,13 @@ For the full annotated file tree, see [`docs/reference/project-structure.md`](do
 
 ### Latency Estimation
 
-Two latency model modes (roofline, trained-physics), selected via `--latency-model` flag. **Trained-physics** is the recommended default for new models.
+Two latency model modes (trained-physics, roofline), selected via `--latency-model` flag. **Trained-physics is the default** — it provides better out-of-box accuracy by combining roofline basis functions with learned correction coefficients.
 
 **Migration note:** The deprecated `blackbox`, `crossmodel`, and `trained-roofline` backends have been removed. Use `--latency-model trained-physics` for modern physics-informed estimation with MoE-aware overhead modeling.
 
-**Trained-physics model**: Roofline basis functions with learned correction coefficients. Generalizes across model architectures, workloads, and TP configurations. No per-model calibration needed.
+**Trained-physics model** (default): Roofline basis functions with learned correction coefficients. Generalizes across model architectures, workloads, and TP configurations. No per-model calibration needed.
+
+**Roofline model**: Pure analytical model available via explicit `--latency-model roofline` flag. Useful when you want FLOPs/bandwidth-based estimation without learned corrections.
 
 See [`docs/guide/latency-models.md`](docs/guide/latency-models.md) for details.
 

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -358,6 +358,23 @@ func TestExtractSimResults_DeterminismInvariant(t *testing.T) {
 	}
 }
 
+func TestReplayCmd_LatencyModelDefault_IsTrainedPhysics(t *testing.T) {
+	// GIVEN the replay command with its registered flags
+	flag := replayCmd.Flags().Lookup("latency-model")
+
+	// WHEN we check the default value
+	// THEN it MUST be "trained-physics" (BC-1: CLI default switched)
+	// This test ensures run/replay parity for the latency model default.
+	// Both commands share registerSimConfigFlags, but explicit per-command
+	// assertions match the project's flag testing pattern.
+	if flag == nil {
+		t.Fatal("replayCmd missing --latency-model flag")
+	}
+	if flag.DefValue != "trained-physics" {
+		t.Errorf("default latency model must be 'trained-physics', got %q (#1383)", flag.DefValue)
+	}
+}
+
 // TestReplayCmd_TraceOutputFlag_Registered verifies BC-6:
 // --trace-output is registered with empty default (flag is optional).
 func TestReplayCmd_TraceOutputFlag_Registered(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -973,7 +973,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&gpu, "hardware", "", "GPU type")
 	cmd.Flags().IntVar(&tensorParallelism, "tp", 0, "Tensor parallelism")
 	cmd.Flags().StringVar(&vllmVersion, "vllm-version", "", "vLLM version")
-	cmd.Flags().StringVar(&latencyModelBackend, "latency-model", "roofline", "Latency model backend: roofline (default), trained-physics")
+	cmd.Flags().StringVar(&latencyModelBackend, "latency-model", "trained-physics", "Latency model backend: trained-physics (default), roofline")
 	cmd.Flags().Int64Var(&maxModelLen, "max-model-len", 0, "Max total sequence length (input + output); 0 = unlimited. Auto-derived from HF config for analytical backends when not set.")
 
 	// Cluster config

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -469,7 +469,7 @@ func resolveLatencyConfig(cmd *cobra.Command) latencyResolution {
 			missing = append(missing, "--tp (tensor parallelism)")
 		}
 		if len(missing) > 0 {
-			logrus.Fatalf("Roofline mode (the default) requires %s. No defaults found in defaults.yaml for model=%s. "+
+			logrus.Fatalf("Roofline mode requires %s. No defaults found in defaults.yaml for model=%s. "+
 				"Provide these flags explicitly, or use --latency-model trained-physics for coefficient-based estimation",
 				strings.Join(missing, " and "), model)
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,6 +32,20 @@ func TestRunCmd_DefaultLogLevel_RemainsWarn(t *testing.T) {
 		"default log level must remain 'warn'; simulation results use fmt.Println to bypass logrus")
 }
 
+func TestRunCmd_LatencyModelDefault_IsTrainedPhysics(t *testing.T) {
+	// GIVEN the run command with its registered flags
+	flag := runCmd.Flags().Lookup("latency-model")
+
+	// WHEN we check the default value
+	// THEN it MUST be "trained-physics" (BC-1: CLI default switched)
+	// Trained-physics provides better out-of-box accuracy with learned correction
+	// coefficients on top of roofline basis functions. Users can still explicitly
+	// pass --latency-model roofline for pure analytical estimation.
+	assert.NotNil(t, flag, "latency-model flag must be registered")
+	assert.Equal(t, "trained-physics", flag.DefValue,
+		"default latency model must be 'trained-physics' for better out-of-box accuracy (#1383)")
+}
+
 func TestSaveResults_MetricsPrintedToStdout(t *testing.T) {
 	// GIVEN a Metrics struct with completed requests
 	m := sim.NewMetrics()

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,7 +14,7 @@ export HF_TOKEN=your_token_here
 ./blis run --model qwen/qwen3-14b
 ```
 
-This runs 100 requests through a single inference instance using roofline mode (analytical estimation) for Qwen3 14B on an H100 GPU with TP=1.
+This runs 100 requests through a single inference instance using the default trained-physics latency model for Qwen3 14B on an H100 GPU with TP=1.
 
 !!! note "First-run HuggingFace fetch"
     On first use, BLIS auto-fetches the model's `config.json` from HuggingFace (~1 second for public models). Subsequent runs use the cached config in `model_configs/`. For air-gapped environments, pre-populate `model_configs/<model>/config.json` and use `--model-config-folder`.

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -97,16 +97,9 @@ When choosing between TP and replication (more instances): TP reduces per-reques
 !!! note "Automatic MaxModelLen derivation"
     When using roofline or trained-physics mode and `--max-model-len` is not explicitly set, BLIS auto-derives it from `max_position_embeddings` in the HuggingFace `config.json`. For models with `rope_scaling`, the scaling factor is applied based on vLLM's blacklist approach: types `linear`, `dynamic`, `yarn`, `default`, and `mrope` apply the factor; types `su`, `longrope`, and `llama3` are excluded (these encode the full context in `max_position_embeddings`). For `yarn`, `original_max_position_embeddings` is used as the base when present. `gemma3` models skip `rope_scaling` entirely (`max_position_embeddings` is pre-scaled). The derived value is then capped at the KV-feasible maximum (`total_kv_blocks * block_size`) to prevent context windows from exceeding GPU memory capacity. Override with `--max-model-len <N>` when needed.
 
-## Trained-Physics Mode (Recommended for New Models)
+### How Trained-Physics Works
 
 Trained-physics mode applies **learned correction factors** to analytical roofline basis functions, combining the physical grounding of roofline with the accuracy of data-driven fitting. Coefficients are fitted from real vLLM measurements and generalize across model architectures, workloads, and TP configurations.
-
-```bash
-./blis run --model qwen/qwen3-14b \
-  --latency-model trained-physics --hardware H100 --tp 1
-```
-
-Same auto-fetch chain as roofline mode (HuggingFace config + hardware config resolution).
 
 **StepTime formula** (10 beta coefficients in bundled defaults):
 
@@ -183,9 +176,9 @@ Trained-physics uses **13 coefficients** (10 beta: prefill compute/memory split,
 
 ## When to Use Which
 
-| Aspect | Roofline (default) | Trained-Physics (recommended) |
-|--------|-------------------|-------------------------------|
-| **When to use** | Quick analytical estimate | **Recommended** for new models (generalizes across architectures, workloads, TP) |
+| Aspect | Roofline | Trained-Physics (default) |
+|--------|----------|---------------------------|
+| **When to use** | Quick analytical estimate | Default (generalizes across architectures, workloads, TP) |
 | **Data required** | HF `config.json` + `--hardware` + `--tp` | HF `config.json` + `--hardware` + `--tp` (global coefficients bundled) |
 | **GPU step time accuracy** | Good (analytical) | Better (13 global params, physics-informed basis functions) |
 | **MoE support** | Yes (per-expert FLOPs + effective expert count) | Yes (per-expert FLOPs + effective expert count + β₈ per-MoE-layer overhead) |
@@ -193,7 +186,7 @@ Trained-physics uses **13 coefficients** (10 beta: prefill compute/memory split,
 | **PostDecodeFixedOverhead** | 0 | α₁ (~777µs) |
 
 !!! tip "Choosing the right mode"
-    **Trained-physics** is the recommended default for any model with a HuggingFace `config.json` (generalizes across architectures, workloads, and TP configurations without per-model calibration). **Roofline** for pure analytical estimates when no learned corrections are desired.
+    **Trained-physics** is the default for any model with a HuggingFace `config.json` (generalizes across architectures, workloads, and TP configurations without per-model calibration). **Roofline** for pure analytical estimates when no learned corrections are desired.
 
 !!! warning "Current limitations"
     All analytical latency models support tensor parallelism (TP). Data parallelism (DP) and expert parallelism (EP) scheduling overhead are not yet modeled. Quantized weight precision (GPTQ, AWQ, FP8, compressed-tensors) is auto-detected from `quantization_config`, model name conventions (e.g., `w4a16`, `FP8`), or `torch_dtype` fallback, and is used for weight bandwidth and KV capacity calculations. MFU calibration values are still derived from FP16/BF16 measurements.

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -1,21 +1,32 @@
 # Latency Models
 
-The `LatencyModel` interface determines how BLIS estimates GPU step time for each batch iteration. BLIS ships two backends -- roofline (analytical) and trained-physics (physics-informed roofline with MoE-aware corrections) -- and the pluggable architecture supports adding custom backends.
+The `LatencyModel` interface determines how BLIS estimates GPU step time for each batch iteration. BLIS ships two backends -- **trained-physics** (default, physics-informed roofline with MoE-aware corrections) and **roofline** (pure analytical) -- and the pluggable architecture supports adding custom backends.
 
 **Migration note:** Three legacy backends have been removed (`blackbox`, `crossmodel`, `trained-roofline`). Use `--latency-model trained-physics` instead, which supersedes all three with improved accuracy and MoE support.
 
 ```bash
-# Roofline mode (default) — analytical estimation from model architecture
+# Trained-physics mode (default) — roofline × architecture-aware basis functions × learned corrections
 ./blis run --model qwen/qwen3-14b \
   --num-instances 4 --rate 100 --num-requests 500
 
-# Trained-physics mode (recommended) — roofline × architecture-aware basis functions × learned corrections
+# Roofline mode — pure analytical estimation from model architecture (explicit flag)
 ./blis run --model qwen/qwen3-14b \
-  --latency-model trained-physics --hardware H100 --tp 1 \
+  --latency-model roofline --hardware H100 --tp 1 \
   --num-instances 4 --rate 100 --num-requests 500
 ```
 
-## Roofline Mode (Default)
+## Trained-Physics Mode (Default)
+
+Trained-physics mode combines roofline basis functions with learned correction coefficients. It provides better out-of-box accuracy than pure roofline by capturing architecture-specific overheads (MoE routing, memory access patterns) that analytical models miss.
+
+**Benefits:**
+- Better generalization across model architectures and TP configurations
+- Lower MAPE in practice compared to pure roofline
+- No per-model calibration needed
+
+Use this for capacity planning and what-if analysis unless you specifically need pure analytical estimates.
+
+## Roofline Mode
 
 Roofline mode computes step time analytically from model architecture (FLOPs, parameter count) and hardware specifications (compute throughput, memory bandwidth). It does not require pre-trained coefficients, making it suitable for new models.
 

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -95,9 +95,9 @@ When choosing between TP and replication (more instances): TP reduces per-reques
     For both latency backends (roofline, trained-physics), `--total-kv-blocks` is automatically derived from model architecture and GPU memory if not explicitly set. The auto-calculated value accounts for TP (KV heads are sharded across ranks; total GPU memory scales with GPU count). Override with `--total-kv-blocks <N>` for non-standard deployments. The auto-calculation uses reference constants (90% GPU utilization, standard activation/overhead budgets matching the llm-d-benchmark capacity planner) and requires SwiGLU-family activations.
 
 !!! note "Automatic MaxModelLen derivation"
-    When using roofline or trained-physics mode and `--max-model-len` is not explicitly set, BLIS auto-derives it from `max_position_embeddings` in the HuggingFace `config.json`. For models with `rope_scaling`, the scaling factor is applied based on vLLM's blacklist approach: types `linear`, `dynamic`, `yarn`, `default`, and `mrope` apply the factor; types `su`, `longrope`, and `llama3` are excluded (these encode the full context in `max_position_embeddings`). For `yarn`, `original_max_position_embeddings` is used as the base when present. `gemma3` models skip `rope_scaling` entirely (`max_position_embeddings` is pre-scaled). The derived value is then capped at the KV-feasible maximum (`total_kv_blocks * block_size`) to prevent context windows from exceeding GPU memory capacity. Override with `--max-model-len <N>` when needed.
+    When using roofline or trained-physics mode and `--max-model-len` is not explicitly set, BLIS auto-derives it from `max_position_embeddings` in the HuggingFace `config.json`. For models with `rope_scaling`, the scaling factor is applied based on vLLM's blacklist approach: types `linear`, `dynamic`, `yarn`, `default`, and `mrope` apply the factor; types `su`, `longrope`, and `llama3` are excluded (these encode the full context in `max_position_embeddings`). For `yarn`, `original_max_position_embeddings` is used as the base when present. `gemma3` models skip `rope_scaling` entirely (`max_position_embeddings` is pre-scaled). The derived value is then capped at the KV-feasible maximum (`total_kv_blocks * block_size`) to prevent context windows from exceeding GPU memory capacity. Override with `--max-model-len` <N>` when needed.
 
-### How Trained-Physics Works
+## How Trained-Physics Works
 
 Trained-physics mode applies **learned correction factors** to analytical roofline basis functions, combining the physical grounding of roofline with the accuracy of data-driven fitting. Coefficients are fitted from real vLLM measurements and generalize across model architectures, workloads, and TP configurations.
 
@@ -167,7 +167,7 @@ The model automatically detects MoE configuration from `config.json` (`num_local
 - **Mixed batches** (concurrent prefill/decode): Production serving with heterogeneous requests
 - **TP configurations**: TP=1, TP=2, TP=4, TP=8 (All-Reduce overhead scales via β₄)
 
-**Why "recommended" over roofline:**
+**Why trained-physics over roofline:**
 
 Trained-physics uses **13 coefficients** (10 beta: prefill compute/memory split, decode compute/memory split, weight, TP, layer overhead, batch overhead, step overhead, MoE overhead; 3 alpha: queueing, post-decode, per-token) that capture more architectural detail than pure roofline (no learned corrections). The prefill/decode split (β₁ₐ/β₁ᵦ, β₂ₐ/β₂ᵦ) and MoE-specific overhead (β₈) enable better generalization to unseen model architectures (especially interleaved MoE) and batch compositions (mixed prefill/decode).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -561,7 +561,7 @@ Before any backend-specific logic runs, BLIS loads hardware/TP/vLLM-version defa
 
 **Backend-specific resolution:**
 
-1. If `--latency-model roofline` (default) or `trained-physics`:
+1. If `--latency-model trained-physics` (default) or `roofline`:
    - Auto-resolve model config: check `model_configs/` for existing `config.json`, fetch from HuggingFace on miss (set `HF_TOKEN` for gated models)
    - Auto-resolve hardware config from bundled `hardware_config.json`
    - For roofline: beta coefficients are computed analytically from model architecture and hardware specs

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -154,7 +154,7 @@ For analytical step time estimation without trained coefficients.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--latency-model` | string | "roofline" | Latency model backend: `roofline` (default), `trained-physics`. Both backends auto-fetch HuggingFace config.json for KV block auto-calculation (may require network access). Both require `config.json` for latency estimation and KV sizing. Requires `--hardware` and `--tp`. Set `HF_TOKEN` for gated models. `trained-physics` is recommended for new models. |
+| `--latency-model` | string | "trained-physics" | Latency model backend: `trained-physics` (default), `roofline`. Both backends auto-fetch HuggingFace config.json for KV block auto-calculation (may require network access). Both require `config.json` for latency estimation and KV sizing. Requires `--hardware` and `--tp`. Set `HF_TOKEN` for gated models. |
 | `--model-config-folder` | string | "" | Path to folder containing HuggingFace `config.json`. Overrides `--latency-model` auto-resolution. |
 | `--hardware-config` | string | "" | Path to `hardware_config.json` with GPU specifications. Overrides `--latency-model` auto-resolution. |
 
@@ -164,8 +164,8 @@ See [Roofline Estimation](../concepts/roofline.md) for details on the analytical
 
 The latency model mode is selected based on available configuration:
 
-1. **Roofline mode** (default): Auto-resolves model config from HuggingFace and hardware config from bundled `hardware_config.json`. Requires `--hardware` and `--tp` (loaded from `defaults.yaml` when available).
-2. **Trained-physics mode** (recommended for new models): If `--latency-model trained-physics` is set with `--hardware` and `--tp`. Uses 13 globally-fitted coefficients (10 beta for roofline corrections with architecture-aware MoE scaling + 3 alpha for CPU overhead) from `trained_physics_coefficients` in `defaults.yaml`. Physics-informed basis functions with learned corrections.
+1. **Trained-physics mode** (default): Auto-resolves model config from HuggingFace and hardware config from bundled `hardware_config.json`. Requires `--hardware` and `--tp` (loaded from `defaults.yaml` when available). Uses 13 globally-fitted coefficients (10 beta for roofline corrections with architecture-aware MoE scaling + 3 alpha for CPU overhead) from `trained_physics_coefficients` in `defaults.yaml`. Physics-informed basis functions with learned corrections.
+2. **Roofline mode**: If `--latency-model roofline` is explicitly set with `--hardware` and `--tp`. Pure analytical estimation from model architecture and hardware specifications.
 
 ## Cluster Configuration
 


### PR DESCRIPTION
## Summary

Changes the CLI default for `--latency-model` from `roofline` to `trained-physics` to align with documentation recommendations and provide better out-of-box accuracy.

## Motivation

- **trained-physics generalizes better**: Physics-informed with learned correction coefficients. Works across model architectures, workloads, and TP configurations without per-model calibration.
- **roofline is a subset**: trained-physics uses roofline basis functions as its foundation but adds learned corrections, giving lower MAPE in practice.
- **Documentation already recommends it**: CLAUDE.md says "Trained-physics is the recommended default for new models" — the CLI should match.

## Behavioral Contracts

**BC-1: CLI default switched**
- **GIVEN** user runs `blis run --model qwen/qwen3-14b` without `--latency-model` flag
- **WHEN** latency estimation backend is initialized
- **THEN** trained-physics backend is selected

**BC-2: Explicit roofline still works**
- **GIVEN** user runs `blis run --model qwen/qwen3-14b --latency-model roofline`
- **WHEN** latency estimation backend is initialized
- **THEN** roofline backend is selected (explicit flag overrides default)

**BC-3: Documentation consistency**
- **GIVEN** user reads CLI help, CLAUDE.md, quickstart examples, configuration reference
- **WHEN** checking what the default latency model is
- **THEN** all sources state trained-physics is the default

## Changes

### Code
- `cmd/root.go`: Changed flag default from `"roofline"` to `"trained-physics"` and updated help string
- `cmd/root_test.go`: Added behavioral test `TestRunCmd_LatencyModelDefault_IsTrainedPhysics` following TDD

### Documentation
- `CLAUDE.md`: Reordered backends (trained-physics first), emphasized default
- `docs/guide/latency-models.md`: Added trained-physics section first, updated examples
- `docs/getting-started/quickstart.md`: Updated first-run description
- `docs/reference/configuration.md`: Updated flag default and mode selection order

## Testing

All tests pass (including new test):
- ✅ `TestRunCmd_LatencyModelDefault_IsTrainedPhysics`: Verifies flag default
- ✅ All existing tests pass (no regressions)
- ✅ Smoke tests confirmed:
  - Default (no flag) uses trained-physics
  - Explicit `--latency-model roofline` works
  - Explicit `--latency-model trained-physics` works

## Review

- ✅ Step 4.5 (Code Review): Converged Round 1, 0 CRITICAL, 0 IMPORTANT
- ✅ Step 4.75 (Self-Audit): All 10 dimensions passed

Fixes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)