### PR TITLE
feat(saturation): pluggable BacklogClassifier with DrainRatio default

### DIFF
--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -565,14 +565,25 @@ func runObserve(cmd *cobra.Command, _ []string) {
 			simEndUs = observeHorizon
 		}
 
+		// Validate classifier name (CLI gate; library factory panics on unknown).
+		if !sim.IsValidBacklogClassifier(saturationClassifier) {
+			logrus.Fatalf("Unknown --saturation-classifier %q. Valid: %s",
+				saturationClassifier, strings.Join(sim.ValidBacklogClassifierNames(), ", "))
+		}
+		classifier := workload.NewBacklogClassifier(saturationClassifier)
+
 		cfg := workload.NewBacklogDriftConfig(
 			time.Duration(saturationWindowSec)*time.Second,
 			saturationMinWindows,
 			saturationPeakRatio,
 			saturationPeakBand,
 			saturationConfidence,
+			saturationWarmupWindows,
+			saturationTailWindows,
+			saturationSaturatedRatio,
+			saturationTransientRatio,
 		)
-		report := workload.AnalyzeBacklogDrift(requests, simEndUs, cfg)
+		report := workload.AnalyzeBacklogDriftWithClassifier(requests, simEndUs, cfg, classifier)
 		if err := workload.WriteBacklogDriftReportJSON(saturationReport, report); err != nil {
 			logrus.Fatalf("Failed to write saturation report: %v", err)
 		}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -704,7 +704,7 @@ Example:
 			logrus.Infof("SimResults written to %s (%d entries)", resultsPath, len(simResults))
 		}
 
-		// Saturation analysis if requested (issue #1298)
+		// Saturation analysis if requested (issue #1298, #1391, #1392)
 		if saturationReport != "" {
 			// Assemble all requests (original + follow-ups)
 			allRequests := make([]*sim.Request, 0, len(requests)+len(followUpRequests))
@@ -716,6 +716,13 @@ Example:
 
 			simEndUs := workload.ComputeSimEndUs(allRequests, config.Horizon)
 
+			// Validate classifier name (CLI gate; library factory panics on unknown).
+			if !sim.IsValidBacklogClassifier(saturationClassifier) {
+				logrus.Fatalf("Unknown --saturation-classifier %q. Valid: %s",
+					saturationClassifier, strings.Join(sim.ValidBacklogClassifierNames(), ", "))
+			}
+			classifier := workload.NewBacklogClassifier(saturationClassifier)
+
 			// Build saturation analysis config from flags (or defaults if not set)
 			cfg := workload.NewBacklogDriftConfig(
 				time.Duration(saturationWindowSec)*time.Second,
@@ -723,8 +730,12 @@ Example:
 				saturationPeakRatio,
 				saturationPeakBand,
 				saturationConfidence,
+				saturationWarmupWindows,
+				saturationTailWindows,
+				saturationSaturatedRatio,
+				saturationTransientRatio,
 			)
-			report := workload.AnalyzeBacklogDrift(allRequests, simEndUs, cfg)
+			report := workload.AnalyzeBacklogDriftWithClassifier(allRequests, simEndUs, cfg, classifier)
 			if err := workload.WriteBacklogDriftReportJSON(saturationReport, report); err != nil {
 				logrus.Fatalf("Failed to write saturation report: %v", err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,6 +196,13 @@ var (
 	saturationPeakBand   float64 // Confidence band around peak ratio threshold (--saturation-peak-band)
 	saturationConfidence float64 // Confidence level for slope CI (--saturation-ci)
 
+	// post-hoc backlog classifier policy (#1391, #1392)
+	saturationClassifier      string  // Classifier name: "drain-ratio" (default) or "slope-based" (--saturation-classifier)
+	saturationWarmupWindows   int     // Inject windows skipped as warmup (drain-ratio only) (--saturation-warmup-windows)
+	saturationTailWindows     int     // Inject windows skipped as tail (drain-ratio only) (--saturation-tail-windows)
+	saturationSaturatedRatio  float64 // DrainRatio < this → PERSISTENTLY_SATURATED (--saturation-drain-ratio-saturated)
+	saturationTransientRatio  float64 // DrainRatio < this → TRANSIENT_BACKLOG (--saturation-drain-ratio-transient)
+
 	// post-hoc saturation detector configuration (#1369)
 	postHocDetector      string  // Post-hoc saturation detector: "composite", "threshold", "none" (--post-hoc-detector)
 	saturationThreshold float64 // Threshold in ms for threshold detector (--saturation-threshold-ms)
@@ -204,14 +211,24 @@ var (
 	traceOutput string // File prefix for TraceV2 export (<prefix>.yaml + <prefix>.csv)
 )
 
-// registerSaturationFlags registers the 5 saturation analysis config flags on the given command.
-// These flags control backlog-drift analysis behavior and are shared across run, replay, and observe.
+// registerSaturationFlags registers backlog-drift analysis flags on the given command.
+// These flags control post-hoc saturation classification and are shared across run, replay, and observe.
+//
+// Two classifier families are supported (#1391, #1392):
+//   - "drain-ratio" (default): mean per-window NumLeft/NumEntered → quantified ρ = 1/DrainRatio
+//   - "slope-based": OLS regression CI on ActiveEnd over inject-phase windows
 func registerSaturationFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&saturationWindowSec, "saturation-window", 60, "Window size in seconds for backlog-drift analysis")
 	cmd.Flags().IntVar(&saturationMinWindows, "saturation-min-windows", 5, "Minimum number of complete windows required for reliable classification")
-	cmd.Flags().Float64Var(&saturationPeakRatio, "saturation-peak-ratio", 2.0, "Peak/mean in-flight ratio threshold for TRANSIENT_BACKLOG detection")
-	cmd.Flags().Float64Var(&saturationPeakBand, "saturation-peak-band", 0.2, "Confidence band around peak-ratio threshold (creates borderline zone using slope as tiebreaker)")
-	cmd.Flags().Float64Var(&saturationConfidence, "saturation-ci", 0.95, "Confidence level for slope significance test (0.90, 0.95, or 0.99)")
+	cmd.Flags().Float64Var(&saturationPeakRatio, "saturation-peak-ratio", 2.0, "Peak/mean in-flight ratio threshold for TRANSIENT_BACKLOG detection (slope-based classifier only)")
+	cmd.Flags().Float64Var(&saturationPeakBand, "saturation-peak-band", 0.2, "Confidence band around peak-ratio threshold (slope-based classifier only)")
+	cmd.Flags().Float64Var(&saturationConfidence, "saturation-ci", 0.95, "Confidence level for slope significance test (0.90, 0.95, or 0.99) (slope-based classifier only)")
+	cmd.Flags().StringVar(&saturationClassifier, "saturation-classifier", "drain-ratio",
+		"Backlog classifier: "+strings.Join(sim.ValidBacklogClassifierNames(), ", "))
+	cmd.Flags().IntVar(&saturationWarmupWindows, "saturation-warmup-windows", 2, "Inject windows skipped as warmup (drain-ratio classifier only)")
+	cmd.Flags().IntVar(&saturationTailWindows, "saturation-tail-windows", 1, "Inject windows skipped as tail boundary (drain-ratio classifier only)")
+	cmd.Flags().Float64Var(&saturationSaturatedRatio, "saturation-drain-ratio-saturated", 0.95, "Mean DrainRatio threshold below which run is PERSISTENTLY_SATURATED (drain-ratio classifier only)")
+	cmd.Flags().Float64Var(&saturationTransientRatio, "saturation-drain-ratio-transient", 0.98, "Mean DrainRatio threshold below which run is TRANSIENT_BACKLOG (drain-ratio classifier only)")
 }
 
 // applyRopeScaling applies rope_scaling factor to maxPosEmb if applicable.
@@ -1720,9 +1737,16 @@ var runCmd = &cobra.Command{
 			logrus.Infof("Trace exported: %s.yaml, %s.csv (%d records)", traceOutput, traceOutput, len(records))
 		}
 
-		// Saturation analysis if requested (issue #1298)
+		// Saturation analysis if requested (issue #1298, #1391, #1392)
 		if saturationReport != "" {
 			simEndUs := workload.ComputeSimEndUs(allRequests, config.Horizon)
+
+			// Validate classifier name (CLI gate; library factory panics on unknown).
+			if !sim.IsValidBacklogClassifier(saturationClassifier) {
+				logrus.Fatalf("Unknown --saturation-classifier %q. Valid: %s",
+					saturationClassifier, strings.Join(sim.ValidBacklogClassifierNames(), ", "))
+			}
+			classifier := workload.NewBacklogClassifier(saturationClassifier)
 
 			// Build saturation analysis config from flags (or defaults if not set)
 			cfg := workload.NewBacklogDriftConfig(
@@ -1731,8 +1755,12 @@ var runCmd = &cobra.Command{
 				saturationPeakRatio,
 				saturationPeakBand,
 				saturationConfidence,
+				saturationWarmupWindows,
+				saturationTailWindows,
+				saturationSaturatedRatio,
+				saturationTransientRatio,
 			)
-			report := workload.AnalyzeBacklogDrift(allRequests, simEndUs, cfg)
+			report := workload.AnalyzeBacklogDriftWithClassifier(allRequests, simEndUs, cfg, classifier)
 			if err := workload.WriteBacklogDriftReportJSON(saturationReport, report); err != nil {
 				logrus.Fatalf("Failed to write saturation report: %v", err)
 			}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,144 @@
+# scripts/
+
+Reproducible analysis scripts for BLIS. Each script runs `blis` end-to-end and
+emits a single CSV summary alongside per-run raw outputs, so anyone can
+re-validate a published claim without manually reconstructing the command set.
+
+## find-saturation.sh — Rate-sweep saturation finder
+
+Drives `blis run` across a configurable rate sweep against a chosen
+`(model, hardware, TP, workload)` configuration. For each rate it:
+
+1. Runs `blis run` with the **drain-ratio** classifier (the default since #1392).
+2. Runs the same workload/seed again with the **slope-based** classifier so both
+   verdicts are recorded side-by-side.
+3. Extracts throughput, latency, and classifier verdicts into a single CSV row.
+
+The output reproduces the validation table from PR #1395 against the bundled
+`model_configs/llama-3.1-70b-instruct/`. Pointing it at any other configuration
+should produce a comparable table with the same column shape.
+
+### Quick start
+
+```bash
+# Default: Llama-3.1-70B / TP=8 / H100 / chatbot, sweeps 0.5..100 req/s
+./scripts/find-saturation.sh
+
+# Llama-2-7B / TP=1, narrower sweep
+MODEL=meta-llama/Llama-2-7b-hf \
+  MODEL_CONFIG_FOLDER=model_configs/llama-2-7b-hf \
+  TP=1 RATES="2 4 6 8 10 12 16 20" \
+  ./scripts/find-saturation.sh
+
+# Custom workload, slower coarse sweep
+WORKLOAD=summarization NUM_REQUESTS=2000 RATES="4 6 8 10 12" \
+  ./scripts/find-saturation.sh
+
+# No bundled config — let blis fetch from HuggingFace
+MODEL=qwen/qwen3-14b MODEL_CONFIG_FOLDER="" TP=1 \
+  ./scripts/find-saturation.sh
+```
+
+### Inputs (all environment variables)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MODEL` | `meta-llama/Llama-3.1-70B-Instruct` | HuggingFace-style model name |
+| `MODEL_CONFIG_FOLDER` | `model_configs/llama-3.1-70b-instruct` | Path to bundled `config.json`; set to `""` to force HF auto-fetch |
+| `HARDWARE` | `H100` | GPU type passed to `--hardware` |
+| `TP` | `8` | Tensor parallelism degree |
+| `WORKLOAD` | `chatbot` | Built-in preset (chatbot/summarization/contentgen/multidoc) |
+| `LATENCY_MODEL` | `trained-physics` | `--latency-model` backend |
+| `NUM_REQUESTS` | `6000` | `--num-requests` per rate |
+| `HORIZON_US` | `600000000` (600s) | `--horizon` per rate |
+| `SATURATION_WINDOW_S` | `10` | `--saturation-window` (seconds) |
+| `RATES` | `0.5 1 2 4 6 8 10 12 14 16 20 30 40 50 60 80 100` | Space-separated rate sweep |
+| `SEED` | `42` | RNG seed (held constant across both classifier runs) |
+| `OUT_DIR` | `results/saturation-<ts>-<pid>` | Output directory |
+
+### Outputs
+
+```
+$OUT_DIR/
+├── summary.csv                          # one row per rate (12 columns)
+├── rate-{R}.json                        # blis run stdout (metrics)
+├── rate-{R}.stderr                      # blis run stderr (progress logs)
+├── rate-{R}.drain-ratio.json            # BacklogDriftReport (drain-ratio classifier)
+└── rate-{R}.slope-based.json            # BacklogDriftReport (slope-based classifier)
+```
+
+`summary.csv` columns:
+
+| Column | Source | Meaning |
+|---|---|---|
+| `intended_rate` | input flag | What `--rate` was set to |
+| `sustained_throughput` | `injected_requests / vllm_estimated_duration_s` | Actual req/s injected over total sim time |
+| `goodput_rps` | `responses_per_sec` | Completed req/s |
+| `goodput_vs_intended` | `goodput_rps / intended_rate` | Ratio; <100% indicates the engine couldn't sustain intended load |
+| `timeout_frac` | `timed_out_requests / injected_requests` | Fraction culled by client timeout |
+| `e2e_p99_ms` / `ttft_p99_ms` | metrics | Tail latencies |
+| `still_queued` / `still_running` | metrics | End-state residue |
+| `drain_ratio_verdict` | `--saturation-classifier drain-ratio` report | UNSATURATED / TRANSIENT_BACKLOG / PERSISTENTLY_SATURATED |
+| `drain_ratio_rho` | drain-ratio note (parsed) | Quantified `ρ ≈ 1/DrainRatio` from steady-state windows |
+| `slope_based_verdict` | `--saturation-classifier slope-based` report | Same three verdicts via OLS regression |
+
+### Reading the output
+
+A clean read of "where does this configuration saturate?" looks like:
+
+```
+intended_rate  goodput_rps  ratio  ρ      drain-ratio              slope-based
+0.5            0.50         100%   1.00   UNSATURATED              UNSATURATED
+…
+60             56.29        94%    1.00   UNSATURATED              PERSISTENTLY_SATURATED
+80             64.49        81%    1.16   PERSISTENTLY_SATURATED   PERSISTENTLY_SATURATED   ← knee
+100            64.76        65%    1.45   PERSISTENTLY_SATURATED   PERSISTENTLY_SATURATED
+```
+
+The saturation knee is the first rate where `ratio` falls below ~100%, `ρ`
+crosses 1.05, OR a classifier flips to PERSISTENTLY_SATURATED. Drain-ratio is
+the cleanest signal — it gives a quantified ρ. Slope-based is more sensitive
+and may surface TRANSIENT_BACKLOG at moderate load (peak/mean burstiness even
+when average ρ < 1) — that's a feature when planning for tail latency.
+
+### Tips
+
+- **Build once.** The script auto-builds `./blis` if absent. Subsequent runs
+  reuse it; remove the binary to force a rebuild.
+- **Pin the seed.** Two seeds at the same rate land in different parts of
+  Poisson variance and look noisy. Default `SEED=42` keeps every step of the
+  sweep on the same noise realization.
+- **Don't trust a single rate.** Saturation curves are smoother than they look;
+  the knee is a transition zone (~3-5 rate steps wide). Look at three rates
+  before and after the suspected knee.
+- **Fine sweep after coarse.** First pass with the default 17 rates spanning
+  200×; identify the knee zone (e.g., between 60 and 80); then re-run with
+  `RATES="62 64 66 68 70 72 74 76 78"` to pin the exact transition.
+
+### Running on a custom configuration
+
+The script's defaults match the PR validation experiment so anyone can
+reproduce that exact table. To validate any other configuration, override the
+relevant variables:
+
+```bash
+# Example: probe Mixtral-8x7B FP8 on 4×H100 TP=4 with summarization workload
+MODEL=mistralai/Mixtral-8x7B-Instruct-v0.1 \
+  MODEL_CONFIG_FOLDER=model_configs/mixtral-8x7b-instruct \
+  TP=4 WORKLOAD=summarization \
+  RATES="2 4 8 16 24 32 40 48" \
+  ./scripts/find-saturation.sh
+```
+
+If your model isn't in `model_configs/`, either:
+- Drop a `config.json` into `model_configs/<your-model-slug>/` and point
+  `MODEL_CONFIG_FOLDER` at it, or
+- Set `MODEL_CONFIG_FOLDER=""` to let `blis` fetch from HuggingFace at startup.
+
+### Dependencies
+
+- `bash` 4+
+- `jq` (for JSON parsing)
+- `bc` (for ratio arithmetic)
+- `column` (for the final pretty-print; falls back gracefully if missing)
+- `go` (auto-builds `./blis` on first run)

--- a/scripts/find-saturation.sh
+++ b/scripts/find-saturation.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# find-saturation.sh — Rate-sweep saturation finder.
+#
+# Drives `blis run` across a configurable rate sweep, records throughput and
+# both classifier verdicts (drain-ratio + slope-based) per rate, and prints a
+# single table summarizing the saturation envelope. Reproduces the Llama-3.1-70B
+# / TP=8 / H100 / chatbot reference validation from PR #1395.
+#
+# All inputs are environment variables; defaults match the PR's reference run.
+# See scripts/README.md for the full input table and worked examples.
+#
+# Output:
+#   - $OUT_DIR/summary.csv — one row per rate
+#   - $OUT_DIR/rate-{R}.{json,stderr} — raw blis run output
+#   - $OUT_DIR/rate-{R}.{drain-ratio,slope-based}.json — classifier reports
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODEL="${MODEL:-meta-llama/Llama-3.1-70B-Instruct}"
+MODEL_CONFIG_FOLDER="${MODEL_CONFIG_FOLDER:-model_configs/llama-3.1-70b-instruct}"
+HARDWARE="${HARDWARE:-H100}"
+TP="${TP:-8}"
+WORKLOAD="${WORKLOAD:-chatbot}"
+LATENCY_MODEL="${LATENCY_MODEL:-trained-physics}"
+NUM_REQUESTS="${NUM_REQUESTS:-6000}"
+HORIZON_US="${HORIZON_US:-600000000}"   # 600s
+SATURATION_WINDOW_S="${SATURATION_WINDOW_S:-10}"
+RATES="${RATES:-0.5 1 2 4 6 8 10 12 14 16 20 30 40 50 60 80 100}"
+SEED="${SEED:-42}"
+
+# Pass --model-config-folder only if non-empty (allows MODEL_CONFIG_FOLDER="" to disable
+# and force HuggingFace auto-fetch — useful for non-bundled models).
+CFG_ARGS=()
+[[ -n "$MODEL_CONFIG_FOLDER" ]] && CFG_ARGS=(--model-config-folder "$MODEL_CONFIG_FOLDER")
+
+OUT_DIR="${OUT_DIR:-results/saturation-$(date +%Y%m%d-%H%M%S)-$$}"
+mkdir -p "$OUT_DIR"
+SUMMARY="$OUT_DIR/summary.csv"
+
+# Build blis once if needed
+if [[ ! -x ./blis ]]; then
+  echo "Building blis..."
+  go build -o blis main.go
+fi
+
+echo "intended_rate,sustained_throughput,goodput_rps,goodput_vs_intended,timeout_frac,e2e_p99_ms,ttft_p99_ms,still_queued,still_running,drain_ratio_verdict,drain_ratio_rho,slope_based_verdict" > "$SUMMARY"
+printf "Model:    %s (TP=%d, %s)\n" "$MODEL" "$TP" "$HARDWARE"
+printf "Workload: %s\n" "$WORKLOAD"
+printf "Sweeping: %s req/s\n" "$RATES"
+printf "Output:   %s\n\n" "$OUT_DIR"
+
+run_blis() {
+  local rate="$1" classifier="$2" report_path="$3" raw_path="$4" log_path="$5"
+  ./blis run \
+    --model "$MODEL" \
+    "${CFG_ARGS[@]}" \
+    --hardware "$HARDWARE" \
+    --tp "$TP" \
+    --latency-model "$LATENCY_MODEL" \
+    --workload "$WORKLOAD" \
+    --rate "$rate" \
+    --num-requests "$NUM_REQUESTS" \
+    --horizon "$HORIZON_US" \
+    --seed "$SEED" \
+    --saturation-window "$SATURATION_WINDOW_S" \
+    --saturation-classifier "$classifier" \
+    --saturation-report "$report_path" \
+    > "$raw_path" 2> "$log_path"
+}
+
+for R in $RATES; do
+  RAW="$OUT_DIR/rate-${R}.json"
+  LOG="$OUT_DIR/rate-${R}.stderr"
+  DR_REPORT="$OUT_DIR/rate-${R}.drain-ratio.json"
+  SB_REPORT="$OUT_DIR/rate-${R}.slope-based.json"
+
+  printf "rate=%-5s ... " "$R"
+
+  # Run with drain-ratio (default classifier; throughput numbers come from this run)
+  run_blis "$R" "drain-ratio" "$DR_REPORT" "$RAW" "$LOG"
+
+  # Run again with slope-based classifier — same workload + seed, only verdict differs
+  run_blis "$R" "slope-based" "$SB_REPORT" "$OUT_DIR/.tmp.raw" "$OUT_DIR/.tmp.log"
+  rm -f "$OUT_DIR/.tmp.raw" "$OUT_DIR/.tmp.log"
+
+  # Extract throughput stats from the drain-ratio run's stdout JSON
+  METRICS=$(awk '/^=== Simulation Metrics ===/{flag=1; next} flag' "$RAW")
+  read -r OFF GOOD TIMEOUT_FRAC E2E_P99 TTFT_P99 SQ SR <<<"$(jq -r '
+    def n: . // 0;
+    [
+      (if (.vllm_estimated_duration_s | n) > 0 then ((.injected_requests | n) / .vllm_estimated_duration_s) else 0 end),
+      (.responses_per_sec | n),
+      (if (.injected_requests | n) > 0 then ((.timed_out_requests | n) / .injected_requests) else 0 end),
+      (.e2e_p99_ms | n),
+      (.ttft_p99_ms | n),
+      (.still_queued | n),
+      (.still_running | n)
+    ] | @tsv' <<<"$METRICS")"
+
+  # Extract verdicts from the saturation reports
+  DR_VERDICT=$(jq -r .classification "$DR_REPORT")
+  DR_RHO=$(jq -r '.note | capture("ρ ≈ (?<r>[0-9.]+)").r // "n/a"' "$DR_REPORT")
+  SB_VERDICT=$(jq -r .classification "$SB_REPORT")
+
+  RATIO=$(echo "scale=4; $GOOD / $R" | bc -l)
+  printf "goodput=%6.2f  ratio=%5.1f%%  ρ=%-5s  drain-ratio: %-23s  slope-based: %s\n" \
+    "$GOOD" "$(echo "$RATIO * 100" | bc -l)" "$DR_RHO" "$DR_VERDICT" "$SB_VERDICT"
+
+  echo "$R,$OFF,$GOOD,$RATIO,$TIMEOUT_FRAC,$E2E_P99,$TTFT_P99,$SQ,$SR,$DR_VERDICT,$DR_RHO,$SB_VERDICT" >> "$SUMMARY"
+done
+
+printf "\nDone. Summary CSV: %s\n" "$SUMMARY"
+printf "Per-rate raw + classifier reports in: %s/\n\n" "$OUT_DIR"
+printf "Saturation knee = first rate where:\n"
+printf "  - goodput_rps stops tracking intended_rate (ratio drops below 100%%), OR\n"
+printf "  - drain_ratio_verdict flips to PERSISTENTLY_SATURATED, OR\n"
+printf "  - slope_based_verdict flips to PERSISTENTLY_SATURATED.\n\n"
+column -t -s, "$SUMMARY"

--- a/sim/bundle.go
+++ b/sim/bundle.go
@@ -135,6 +135,9 @@ var (
 	validDisaggregationDeciders   = map[string]bool{"": true, "never": true, "always": true, "prefix-threshold": true}
 	validEncodeDeciders           = map[string]bool{"": true, "never": true, "always": true, "multimodal": true}
 	validSaturationDetectors      = map[string]bool{"": true, "never": true, "utilization": true, "concurrency": true}
+	// Post-hoc backlog classifiers selected via --saturation-classifier (#1391, #1392).
+	// Distinct from validSaturationDetectors (runtime, used by --flow-control).
+	validBacklogClassifiers       = map[string]bool{"": true, "slope-based": true, "drain-ratio": true}
 )
 
 // IsValidAdmissionPolicy returns true if name is a recognized admission policy.
@@ -184,6 +187,12 @@ func IsValidSaturationDetector(name string) bool { return validSaturationDetecto
 
 // ValidSaturationDetectorNames returns sorted valid saturation detector names (excluding empty).
 func ValidSaturationDetectorNames() []string { return validNamesList(validSaturationDetectors) }
+
+// IsValidBacklogClassifier returns true if name is a recognized post-hoc backlog classifier (#1391).
+func IsValidBacklogClassifier(name string) bool { return validBacklogClassifiers[name] }
+
+// ValidBacklogClassifierNames returns sorted valid backlog classifier names (excluding empty).
+func ValidBacklogClassifierNames() []string { return validNamesList(validBacklogClassifiers) }
 
 // validNamesList returns sorted non-empty keys from a validity map.
 func validNamesList(m map[string]bool) []string {

--- a/sim/saturation/backlog_drift.go
+++ b/sim/saturation/backlog_drift.go
@@ -6,18 +6,40 @@ import (
 	"github.com/inference-sim/inference-sim/sim/workload"
 )
 
-// BacklogDriftDetector wraps the workload.AnalyzeBacklogDrift logic
+// BacklogDriftDetector wraps the workload.AnalyzeBacklogDriftWithClassifier logic
 // as a post-hoc saturation detector (Issue #7).
 // This detector is stateless - it performs regression analysis over
 // completed request intervals during Classify().
+//
+// The classifier is configurable (#1392): defaults to drain-ratio (matching the
+// CLI default for --saturation-classifier) so that the post-hoc detector path
+// stays consistent with the primary --saturation-report path. Pass an explicit
+// classifier via NewBacklogDriftDetectorWithClassifier when slope-based behavior
+// is preferred.
 type BacklogDriftDetector struct {
-	config workload.BacklogDriftConfig
+	config     workload.BacklogDriftConfig
+	classifier workload.BacklogClassifier
 }
 
-// NewBacklogDriftDetector creates a BacklogDriftDetector with default configuration.
+// NewBacklogDriftDetector creates a BacklogDriftDetector with default configuration
+// and the default classifier (drain-ratio, matching --saturation-classifier default).
 func NewBacklogDriftDetector() Detector {
 	return &BacklogDriftDetector{
-		config: workload.DefaultBacklogDriftConfig(),
+		config:     workload.DefaultBacklogDriftConfig(),
+		classifier: workload.NewBacklogClassifier(""), // empty string → drain-ratio default
+	}
+}
+
+// NewBacklogDriftDetectorWithClassifier creates a BacklogDriftDetector with an
+// explicit classifier. Use this for callers that want to opt into slope-based
+// or any future BacklogClassifier implementation.
+func NewBacklogDriftDetectorWithClassifier(classifier workload.BacklogClassifier) Detector {
+	if classifier == nil {
+		classifier = workload.NewBacklogClassifier("")
+	}
+	return &BacklogDriftDetector{
+		config:     workload.DefaultBacklogDriftConfig(),
+		classifier: classifier,
 	}
 }
 
@@ -78,8 +100,8 @@ func (b *BacklogDriftDetector) Classify(requests []sim.RequestMetrics, totalArri
 		}
 	}
 
-	// Run backlog-drift analysis
-	report := workload.AnalyzeBacklogDrift(reqs, simEndUs, b.config)
+	// Run backlog-drift analysis with the configured classifier (#1392).
+	report := workload.AnalyzeBacklogDriftWithClassifier(reqs, simEndUs, b.config, b.classifier)
 
 	// Map classification to Level
 	var level Level

--- a/sim/workload/saturation.go
+++ b/sim/workload/saturation.go
@@ -51,11 +51,29 @@ type BacklogDriftConfig struct {
 	PeakRatio       float64       // Peak-to-mean threshold for TRANSIENT_BACKLOG detection (BC-6)
 	PeakRatioBand   float64       // Confidence band around PeakRatio (±band creates borderline zone)
 	ConfidenceCI    float64       // Confidence level for slope significance test (BC-3)
+
+	// Drain-ratio classifier knobs (#1392). Used only by drainRatioClassifier; ignored
+	// by slopeBasedClassifier. Validation in NewBacklogDriftConfig enforces the relation
+	// SaturatedDrainRatio <= TransientDrainRatio so classification regions don't overlap.
+	WarmupWindows       int     // Inject windows skipped at the start (engine ramp-up)
+	TailWindows         int     // Inject windows skipped at the end (rate ramp-down boundary)
+	SaturatedDrainRatio float64 // Mean DrainRatio < this → PERSISTENTLY_SATURATED
+	TransientDrainRatio float64 // Mean DrainRatio < this → TRANSIENT_BACKLOG
 }
 
 // NewBacklogDriftConfig creates a BacklogDriftConfig with validation (BC-10, BC-14, R3).
 // Panics if any parameter is invalid (NaN, Inf, out of range).
-func NewBacklogDriftConfig(windowSize time.Duration, minWindows int, peakRatio, peakRatioBand, confidenceCI float64) BacklogDriftConfig {
+//
+// warmupWindows must be >= 0. saturatedDrainRatio and transientDrainRatio must each be
+// in (0, 1]; saturatedDrainRatio <= transientDrainRatio so PERSISTENTLY_SATURATED and
+// TRANSIENT_BACKLOG regions form a contiguous partition of [0, 1].
+func NewBacklogDriftConfig(
+	windowSize time.Duration,
+	minWindows int,
+	peakRatio, peakRatioBand, confidenceCI float64,
+	warmupWindows, tailWindows int,
+	saturatedDrainRatio, transientDrainRatio float64,
+) BacklogDriftConfig {
 	if windowSize <= 0 {
 		panic(fmt.Sprintf("BacklogDriftConfig: WindowSize must be > 0, got %v", windowSize))
 	}
@@ -71,24 +89,58 @@ func NewBacklogDriftConfig(windowSize time.Duration, minWindows int, peakRatio, 
 	if confidenceCI <= 0 || confidenceCI >= 1 || math.IsNaN(confidenceCI) || math.IsInf(confidenceCI, 0) {
 		panic(fmt.Sprintf("BacklogDriftConfig: ConfidenceCI must be in (0, 1), got %f", confidenceCI))
 	}
+	if warmupWindows < 0 {
+		panic(fmt.Sprintf("BacklogDriftConfig: WarmupWindows must be >= 0, got %d", warmupWindows))
+	}
+	if tailWindows < 0 {
+		panic(fmt.Sprintf("BacklogDriftConfig: TailWindows must be >= 0, got %d", tailWindows))
+	}
+	if saturatedDrainRatio <= 0 || saturatedDrainRatio > 1 || math.IsNaN(saturatedDrainRatio) || math.IsInf(saturatedDrainRatio, 0) {
+		panic(fmt.Sprintf("BacklogDriftConfig: SaturatedDrainRatio must be in (0, 1], got %f", saturatedDrainRatio))
+	}
+	if transientDrainRatio <= 0 || transientDrainRatio > 1 || math.IsNaN(transientDrainRatio) || math.IsInf(transientDrainRatio, 0) {
+		panic(fmt.Sprintf("BacklogDriftConfig: TransientDrainRatio must be in (0, 1], got %f", transientDrainRatio))
+	}
+	if saturatedDrainRatio > transientDrainRatio {
+		panic(fmt.Sprintf("BacklogDriftConfig: SaturatedDrainRatio (%f) must be <= TransientDrainRatio (%f); regions would overlap", saturatedDrainRatio, transientDrainRatio))
+	}
 	return BacklogDriftConfig{
-		WindowSize:     windowSize,
-		MinWindows:     minWindows,
-		PeakRatio:      peakRatio,
-		PeakRatioBand:  peakRatioBand,
-		ConfidenceCI:   confidenceCI,
+		WindowSize:          windowSize,
+		MinWindows:          minWindows,
+		PeakRatio:           peakRatio,
+		PeakRatioBand:       peakRatioBand,
+		ConfidenceCI:        confidenceCI,
+		WarmupWindows:       warmupWindows,
+		TailWindows:         tailWindows,
+		SaturatedDrainRatio: saturatedDrainRatio,
+		TransientDrainRatio: transientDrainRatio,
 	}
 }
 
-// DefaultBacklogDriftConfig returns the default configuration per issue #1298.
+// DefaultBacklogDriftConfig returns the default configuration per issues #1298, #1392.
+//
+// WarmupWindows=2 and TailWindows=1 are empirical defaults from a Llama-3.1-70B
+// reference experiment (rate=80, num_requests=6000):
+//   - Window 1 was a clear engine ramp-up (DrainRatio ≈ 0.6) before steady state.
+//   - The window where inject ends mid-bucket has artificially low NumEntered
+//     and full NumLeft (engine continues draining backlog), pushing DrainRatio > 1
+//     and biasing the steady-state mean upward toward "unsaturated".
+//
+// Routes through NewBacklogDriftConfig so the defaults are self-validating; if a
+// future change introduces an inter-field invariant, this function will panic at
+// init time rather than silently producing an inconsistent default config.
 func DefaultBacklogDriftConfig() BacklogDriftConfig {
-	return BacklogDriftConfig{
-		WindowSize:     60 * time.Second,
-		MinWindows:     5,
-		PeakRatio:      2.0,
-		PeakRatioBand:  0.2, // ±10% confidence band around threshold
-		ConfidenceCI:   0.95,
-	}
+	return NewBacklogDriftConfig(
+		60*time.Second, // WindowSize
+		5,              // MinWindows
+		2.0,            // PeakRatio
+		0.2,            // PeakRatioBand (absolute, ≈ 10% of PeakRatio)
+		0.95,           // ConfidenceCI
+		2,              // WarmupWindows
+		1,              // TailWindows
+		0.95,           // SaturatedDrainRatio: mean DrainRatio < this → PERSISTENTLY_SATURATED
+		0.98,           // TransientDrainRatio: mean DrainRatio < this → TRANSIENT_BACKLOG
+	)
 }
 
 // WindowMetrics captures per-window saturation metrics (BC-1).
@@ -104,7 +156,8 @@ type WindowMetrics struct {
 }
 
 // BacklogDriftReport contains saturation classification results (BC-4, BC-5, BC-6, BC-7).
-// CLI uses AnalyzeBacklogDrift() directly for saturation analysis.
+// Returned by both AnalyzeBacklogDriftWithClassifier (preferred, classifier-aware) and
+// AnalyzeBacklogDrift (backward-compat shim defaulting to slope-based).
 type BacklogDriftReport struct {
 	Classification string          `json:"classification"` // "UNSATURATED", "TRANSIENT_BACKLOG", "PERSISTENTLY_SATURATED"
 	Slope          float64         `json:"slope"`          // Linear regression slope (req/µs)
@@ -120,10 +173,19 @@ type BacklogDriftReport struct {
 }
 
 // RequestsToIntervals converts sim.Request slices to RequestInterval slices for
-// saturation analysis. Applies eligibility filter per BC-2:
-//   - Exclude: TTFTSet==false AND (State==StateTimedOut OR State==StateQueued) (never executed)
-//   - Include with simEndUs: TTFTSet==false AND State==StateRunning (horizon-truncated)
-//   - Include with computed time: TTFTSet==true (completed)
+// saturation analysis. Applies eligibility filter per BC-2 (#1389):
+//   - Exclude: TTFTSet==false AND State==StateTimedOut (never executed and gave up)
+//   - Include with simEndUs+1: TTFTSet==false AND State IN (StateRunning, StateQueued)
+//     (still in-flight at horizon — for backlog analysis, what matters is that the
+//     request arrived and never finished, regardless of whether it was scheduled)
+//   - Include with computed time: TTFTSet==true (completed normally OR timed out
+//     mid-generation — the latter is rare since BLIS deadlines fire at req.Deadline,
+//     not mid-step, but its computed completion is still meaningful for backlog
+//     accounting because the request occupied the engine for ITL duration)
+//
+// Including queued-at-horizon requests is essential for backlog analysis (#1389):
+// they are precisely the evidence of saturation. Excluding them silently drops
+// the proof that the engine couldn't keep up with arrivals.
 //
 // Logs included and excluded counts per BC-13 (R1: no silent discard).
 func RequestsToIntervals(requests []*sim.Request, simEndUs int64) []RequestInterval {
@@ -137,12 +199,13 @@ func RequestsToIntervals(requests []*sim.Request, simEndUs int64) []RequestInter
 	for _, req := range requests {
 		if !req.TTFTSet {
 			// No valid TTFT — check state
-			if req.State == sim.StateTimedOut || req.State == sim.StateQueued {
-				// Case 1: Timed out before generating any output, or still queued at horizon — exclude
+			if req.State == sim.StateTimedOut {
+				// Case 1: Timed out before generating any output — exclude
+				// (the request gave up, so it's not in-flight at horizon)
 				excluded++
 				continue
 			}
-			// Case 2: Horizon-truncated (StateRunning without TTFT) — still in-flight at horizon.
+			// Case 2: Still in-flight at horizon (StateRunning or StateQueued).
 			// Use simEndUs+1 so half-open interval [arrival, simEndUs+1) is active at simEndUs.
 			// This ensures these requests are correctly counted in ActiveEnd of the last window.
 			intervals = append(intervals, RequestInterval{
@@ -164,7 +227,7 @@ func RequestsToIntervals(requests []*sim.Request, simEndUs int64) []RequestInter
 	}
 
 	// BC-13: Log counts (R1 no silent discard)
-	logrus.Infof("Saturation analysis: %d requests eligible, %d excluded (timed out or still queued)", len(intervals), excluded)
+	logrus.Infof("Saturation analysis: %d requests eligible, %d excluded (timed out)", len(intervals), excluded)
 
 	return intervals
 }
@@ -305,9 +368,218 @@ func fitSlopeRegression(samples []struct {
 	return slopeOrig, slopeOrig - marginOrig, slopeOrig + marginOrig
 }
 
-// classifyBacklogDrift determines saturation classification per BC-4/5/6/7.
-// Returns (classification, note, recommendation).
-func classifyBacklogDrift(slope, slopeLower, slopeUpper float64,
+// NewBacklogClassifier returns a BacklogClassifier by name (#1391).
+//
+// Names: "slope-based" (historical CI-on-slope predicate), "drain-ratio" (new default,
+// queueing-theory ρ from per-window NumLeft/NumEntered). The empty string maps to the
+// current default — drain-ratio.
+//
+// Panics on unknown name. CLI is expected to validate via sim.IsValidBacklogClassifier
+// upstream and emit a friendly logrus.Fatalf — this panic is a backstop that should
+// only trigger from misuse in library code.
+func NewBacklogClassifier(name string) BacklogClassifier {
+	switch name {
+	case "", "drain-ratio":
+		return drainRatioClassifier{}
+	case "slope-based":
+		return slopeBasedClassifier{}
+	default:
+		panic(fmt.Sprintf("unknown backlog classifier %q", name))
+	}
+}
+
+// SlopeStats bundles the slope regression output for classifiers that want it.
+// Computed once in AnalyzeBacklogDriftWithClassifier and passed to Classify.
+// Reserved for additive extension — adding fields does not break existing implementations.
+type SlopeStats struct {
+	Slope      float64 // req/µs (slope of ActiveEnd over inject-phase window-midpoint times)
+	SlopeLower float64 // CI lower bound at cfg.ConfidenceCI
+	SlopeUpper float64 // CI upper bound at cfg.ConfidenceCI
+}
+
+// BacklogClassifier produces a saturation classification from per-window backlog
+// metrics and slope statistics. Implementations may use any combination of inputs.
+//
+// Registered via NewBacklogClassifier(name); validate names with IsValidBacklogClassifier.
+// Used by AnalyzeBacklogDriftWithClassifier to decide the final classification string.
+type BacklogClassifier interface {
+	Classify(
+		windows []WindowMetrics,
+		slope SlopeStats,
+		initialBacklog, finalBacklog, peakInFlight int,
+		meanInFlight float64,
+		cfg BacklogDriftConfig,
+	) (classification, note, recommendation string)
+}
+
+// slopeBasedClassifier preserves the historical classification logic (BC-4/5/6/7).
+// Decides among UNSATURATED / TRANSIENT_BACKLOG / PERSISTENTLY_SATURATED based on
+// the slope CI of ActiveEnd over inject-phase windows and the peak/mean ratio.
+type slopeBasedClassifier struct{}
+
+// Classify implements BacklogClassifier. See classifyBacklogDriftSlopeBased docstring.
+//
+// Practical-significance guard: with many windows the OLS CI shrinks proportionally
+// to 1/√N, so even floating-point noise can produce a "statistically significant"
+// positive slope. We require the projected drift over the observed duration to
+// exceed a noise floor before firing PERSISTENTLY_SATURATED.
+//
+// The noise floor scales as max(1, sqrt(durationSec)) — heuristically motivated by
+// random-walk variance in queueing systems (cumulative drift from Poisson
+// fluctuation grows ~ sqrt(t)). This filters false-positive PERSISTENTLY_SATURATED
+// at very low offered rates where finite-budget BLIS sims have long inject
+// durations (e.g., rate=2 with num_requests=6000 → inject ≈ 3000s; even tiny per-µs
+// slopes accumulate to >1 request). Genuine saturation produces drift orders of
+// magnitude above this floor.
+func (slopeBasedClassifier) Classify(
+	windows []WindowMetrics,
+	slope SlopeStats,
+	initialBacklog, finalBacklog, peakInFlight int,
+	meanInFlight float64,
+	cfg BacklogDriftConfig,
+) (classification, note, recommendation string) {
+	// Practical-significance guard. If the slope's CI excludes zero but the projected
+	// total drift is below the noise floor, suppress the PERSISTENTLY_SATURATED gate by
+	// passing the equivalent of a slope_lower<=0 sentinel. The peak/mean ratio test
+	// still applies.
+	effectiveSlopeLower := slope.SlopeLower
+	if effectiveSlopeLower > 0 && len(windows) > 0 {
+		observedDurationUs := windows[len(windows)-1].EndUs - windows[0].StartUs
+		projectedDrift := slope.Slope * float64(observedDurationUs)
+		// Noise floor scales with sqrt of observation duration — see docstring above.
+		durationSec := float64(observedDurationUs) / 1e6
+		driftThreshold := math.Max(1.0, math.Sqrt(durationSec))
+		if projectedDrift < driftThreshold {
+			effectiveSlopeLower = 0
+		}
+	}
+	return classifyBacklogDriftSlopeBased(
+		slope.Slope, effectiveSlopeLower, slope.SlopeUpper,
+		initialBacklog, finalBacklog, peakInFlight, meanInFlight, cfg,
+	)
+}
+
+// drainRatioClassifier classifies saturation by averaging per-window DrainRatio over
+// steady-state inject windows (#1392). DrainRatio = NumLeft / NumEntered is a direct
+// measurement of μ/λ per window; its inverse is utilization ρ.
+//
+// Logic:
+//  1. Identify "inject windows" via the last_arrival_window predicate — every window
+//     up to and including the highest-indexed window with NumEntered > 0. This
+//     classifies interior gaps (closed-loop / bursty workloads with intermittent
+//     arrivals) as inject-phase, only the trailing all-zero tail as drain.
+//  2. Discard the first cfg.WarmupWindows inject windows (engine ramp-up).
+//  3. Compute mean DrainRatio over remaining steady-state inject windows.
+//  4. Threshold against cfg.SaturatedDrainRatio (PERSISTENTLY_SATURATED) and
+//     cfg.TransientDrainRatio (TRANSIENT_BACKLOG); else UNSATURATED.
+//
+// Robust to NaN/Inf DrainRatio values from windows with NumEntered==0 (skipped).
+type drainRatioClassifier struct{}
+
+// Classify implements BacklogClassifier for the drain-ratio policy.
+func (drainRatioClassifier) Classify(
+	windows []WindowMetrics,
+	_ SlopeStats, // slope unused — drain-ratio decides from per-window NumLeft/NumEntered
+	_, _, _ int, // initialBacklog, finalBacklog, peakInFlight unused
+	_ float64, // meanInFlight unused
+	cfg BacklogDriftConfig,
+) (classification, note, recommendation string) {
+	// Step 1: identify inject windows via the last_arrival_window predicate.
+	// Find the highest index with NumEntered > 0; include windows up to and including it.
+	// Interior windows with NumEntered==0 (closed-loop think-time gaps) remain in the
+	// inject phase — only trailing all-zero windows are excluded as drain.
+	lastInjectIdx := -1
+	for i, w := range windows {
+		if w.NumEntered > 0 {
+			lastInjectIdx = i
+		}
+	}
+	if lastInjectIdx < 0 {
+		return "UNSATURATED",
+			"No arrivals observed in any window.",
+			"Check workload spec — synthetic workloads should always emit arrivals."
+	}
+	injectWindows := windows[:lastInjectIdx+1]
+
+	// Step 2: discard warmup windows (engine ramp-up) at the start AND tail windows
+	// at the end. The tail filter handles the boundary case where inject ends mid-window:
+	// that window has reduced NumEntered (only partial inject) but full NumLeft (engine
+	// continues draining backlog from prior windows), so DrainRatio exceeds 1 and biases
+	// the mean upward. Symmetric warmup/tail trim isolates the true steady state.
+	//
+	// Note: AnalyzeBacklogDriftWithClassifier independently applies the same warmup/tail
+	// trim to its slope-regression samples. The duplication is intentional: each classifier
+	// owns the per-window granularity it needs (drain-ratio averages over windows; the
+	// orchestrator regresses on ActiveEnd of windows). A future classifier that wants
+	// different windowing can override locally without coordinating with the orchestrator.
+	warmup := cfg.WarmupWindows
+	if warmup < 0 {
+		warmup = 0
+	}
+	tail := cfg.TailWindows
+	if tail < 0 {
+		tail = 0
+	}
+	if warmup+tail >= len(injectWindows) {
+		return "UNSATURATED",
+			fmt.Sprintf("Insufficient steady-state inject windows for analysis (have %d, need > %d).",
+				len(injectWindows), warmup+tail),
+			"Increase --num-requests, --rate, or decrease --saturation-warmup-windows / --saturation-tail-windows."
+	}
+	steady := injectWindows[warmup : len(injectWindows)-tail]
+
+	// Step 3: mean DrainRatio over steady-state inject windows.
+	// NaN/Inf entries can occur for interior NumEntered==0 windows (closed-loop
+	// think-time gaps) that survive the inject-phase predicate; track and surface
+	// the skip count per R1 (no silent discard).
+	var sum float64
+	var n, skipped int
+	for _, w := range steady {
+		if math.IsNaN(w.DrainRatio) || math.IsInf(w.DrainRatio, 0) {
+			skipped++
+			continue
+		}
+		sum += w.DrainRatio
+		n++
+	}
+	if n == 0 {
+		return "UNSATURATED",
+			fmt.Sprintf("No usable steady-state inject windows (all %d DrainRatio NaN/Inf).", skipped),
+			"Check workload spec — every inject window should have NumEntered > 0."
+	}
+	mean := sum / float64(n)
+
+	// Step 4: classify by thresholds. ρ ≈ 1/DrainRatio is the queueing-theory utilization.
+	// Defensive: mean is sum-of-non-negative DrainRatios over positive count; mean > 0
+	// unless every steady window had NumLeft==0 (engine fully stalled).
+	rhoEstimate := math.Inf(1)
+	if mean > 0 {
+		rhoEstimate = 1.0 / mean
+	}
+	note = fmt.Sprintf(
+		"Steady-state mean DrainRatio = %.3f over %d windows (warmup=%d skipped, total inject windows=%d). "+
+			"Estimated utilization ρ ≈ %.3f.",
+		mean, n, warmup, len(injectWindows), rhoEstimate)
+	if skipped > 0 {
+		note += fmt.Sprintf(" (skipped %d windows with NaN/Inf DrainRatio)", skipped)
+	}
+
+	switch {
+	case mean < cfg.SaturatedDrainRatio:
+		return "PERSISTENTLY_SATURATED", note,
+			fmt.Sprintf("System is overloaded (ρ ≈ %.2f). Add capacity or reduce load.", rhoEstimate)
+	case mean < cfg.TransientDrainRatio:
+		return "TRANSIENT_BACKLOG", note,
+			"Borderline congestion. Monitor closely; consider provisioning headroom."
+	default:
+		return "UNSATURATED", note,
+			"System handled load with healthy headroom."
+	}
+}
+
+// classifyBacklogDriftSlopeBased determines saturation classification per BC-4/5/6/7.
+// Returns (classification, note, recommendation). Internal helper used by slopeBasedClassifier.
+func classifyBacklogDriftSlopeBased(slope, slopeLower, slopeUpper float64,
 	initialBacklog, finalBacklog, peakInFlight int, meanInFlight float64,
 	cfg BacklogDriftConfig) (classification, note, recommendation string) {
 
@@ -380,10 +652,28 @@ func classifyBacklogDrift(slope, slopeLower, slopeUpper float64,
 	return
 }
 
-// AnalyzeBacklogDrift performs end-to-end backlog-drift saturation analysis (BC-8).
+// AnalyzeBacklogDrift is a backward-compatible shim that uses the slope-based classifier.
+//
+// Deprecated: New code should call AnalyzeBacklogDriftWithClassifier with an explicit
+// classifier from NewBacklogClassifier. This shim is preserved for callers that haven't
+// yet been migrated to choose a classifier; the slope-based default does NOT match the
+// new CLI default (drain-ratio after #1392). Calling this function will silently produce
+// slope-based results regardless of the user's configured `--saturation-classifier`.
+func AnalyzeBacklogDrift(requests []*sim.Request, simEndUs int64, cfg BacklogDriftConfig) BacklogDriftReport {
+	return AnalyzeBacklogDriftWithClassifier(requests, simEndUs, cfg, slopeBasedClassifier{})
+}
+
+// AnalyzeBacklogDriftWithClassifier performs end-to-end backlog-drift saturation analysis (BC-8).
 // Orchestrates: eligibility filter → window metrics → regression → classification.
 // Returns UNSATURATED with note if observation has fewer than MinWindows complete windows (BC-7).
-func AnalyzeBacklogDrift(requests []*sim.Request, simEndUs int64, cfg BacklogDriftConfig) BacklogDriftReport {
+//
+// The classifier parameter selects the classification policy. Pass slopeBasedClassifier{}
+// for historical behavior, drainRatioClassifier{} for the new default, or any custom
+// BacklogClassifier implementation. A nil classifier defaults to slopeBasedClassifier{}.
+func AnalyzeBacklogDriftWithClassifier(requests []*sim.Request, simEndUs int64, cfg BacklogDriftConfig, classifier BacklogClassifier) BacklogDriftReport {
+	if classifier == nil {
+		classifier = slopeBasedClassifier{}
+	}
 	// Step 1: Filter eligible requests (BC-2, BC-13)
 	intervals := RequestsToIntervals(requests, simEndUs)
 
@@ -413,18 +703,63 @@ func AnalyzeBacklogDrift(requests []*sim.Request, simEndUs int64, cfg BacklogDri
 		}
 	}
 
-	// Step 3: Prepare time series samples for regression
+	// Step 3: Prepare time series samples for regression — restrict to STEADY-STATE
+	// inject windows (#1390). Saturation is observable only while load is being offered
+	// AND after the engine has reached steady state; warmup ramp-up windows (queue
+	// rising from 0 to steady-state) and the boundary tail window (where inject ends
+	// mid-bucket) bias the slope estimate. Symmetric warmup/tail trim isolates the
+	// regime where both slope-based and drain-ratio classifiers are well-defined.
+	//
+	// last_arrival_window predicate: include every window up to and including the
+	// highest-indexed window with NumEntered > 0. Robust to closed-loop and bursty
+	// workloads where interior inject windows can have NumEntered==0 (think-time gaps).
+	lastInjectIdx := -1
+	for i, w := range windows {
+		if w.NumEntered > 0 {
+			lastInjectIdx = i
+		}
+	}
+	// Fall back to all windows if no arrivals at all (defensive — RequestsToIntervals
+	// would have produced an empty intervals slice and we'd have early-returned by now,
+	// but the inject-phase predicate must remain well-defined).
+	injectWindows := windows
+	if lastInjectIdx >= 0 {
+		injectWindows = windows[:lastInjectIdx+1]
+	}
+
+	// Trim warmup/tail symmetrically. If insufficient steady windows remain, fall
+	// back to all inject windows AND log a warning so the slope estimate's bias is
+	// observable — drainRatioClassifier returns UNSATURATED in this regime via its
+	// own short-data check, so symmetry of behavior across classifiers requires the
+	// orchestrator to surface this case explicitly. (Pure orchestrator-level diagnostic;
+	// classifier itself can still apply its own logic on the broader slice.)
+	steadySamples := injectWindows
+	warmup := cfg.WarmupWindows
+	if warmup < 0 {
+		warmup = 0
+	}
+	tail := cfg.TailWindows
+	if tail < 0 {
+		tail = 0
+	}
+	if warmup+tail < len(injectWindows) {
+		steadySamples = injectWindows[warmup : len(injectWindows)-tail]
+	} else {
+		logrus.Warnf("Saturation analysis: warmup(%d) + tail(%d) >= inject windows(%d); slope regression uses unfiltered inject phase, may be biased by ramp-up/boundary effects",
+			warmup, tail, len(injectWindows))
+	}
+
 	samples := make([]struct {
 		timeUs int64
 		count  int
-	}, len(windows))
-	for i, w := range windows {
+	}, len(steadySamples))
+	for i, w := range steadySamples {
 		// Use window midpoint as time coordinate
 		samples[i].timeUs = (w.StartUs + w.EndUs) / 2
 		samples[i].count = w.ActiveEnd
 	}
 
-	// Step 4: Fit linear regression (BC-3)
+	// Step 4: Fit linear regression on steady-state inject windows (BC-3, #1390)
 	slope, slopeLower, slopeUpper := fitSlopeRegression(samples, simEndUs, cfg.ConfidenceCI)
 
 	// Step 5: Compute summary statistics
@@ -440,11 +775,11 @@ func AnalyzeBacklogDrift(requests []*sim.Request, simEndUs int64, cfg BacklogDri
 	}
 	meanInFlight := float64(sumInFlight) / float64(len(windows))
 
-	// Step 6: Classify saturation state (BC-4/5/6)
-	classification, note, recommendation := classifyBacklogDrift(
-		slope, slopeLower, slopeUpper,
-		initialBacklog, finalBacklog, peakInFlight, meanInFlight,
-		cfg,
+	// Step 6: Classify saturation state via the supplied classifier (BC-3 / #1391)
+	classification, note, recommendation := classifier.Classify(
+		windows,
+		SlopeStats{Slope: slope, SlopeLower: slopeLower, SlopeUpper: slopeUpper},
+		initialBacklog, finalBacklog, peakInFlight, meanInFlight, cfg,
 	)
 
 	return BacklogDriftReport{

--- a/sim/workload/saturation_drainratio_test.go
+++ b/sim/workload/saturation_drainratio_test.go
@@ -1,0 +1,416 @@
+// sim/workload/saturation_drainratio_test.go
+//
+// Behavioral tests for drainRatioClassifier (#1392). These complement the
+// classifier-agnostic property tests in saturation_properties_test.go by
+// pinning specific outputs for canonical inputs.
+package workload
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+)
+
+// makeWindow constructs a WindowMetrics with the given counts and a non-NaN DrainRatio.
+// Used by the table-driven tests below.
+func makeWindow(start, end int64, entered, left int) WindowMetrics {
+	w := WindowMetrics{
+		StartUs:    start,
+		EndUs:      end,
+		NumEntered: entered,
+		NumLeft:    left,
+	}
+	if entered > 0 {
+		w.DrainRatio = float64(left) / float64(entered)
+	}
+	return w
+}
+
+func TestDrainRatioClassifier_Unsaturated(t *testing.T) {
+	// GIVEN steady-state windows with DrainRatio ≈ 1.0 (engine drains all arrivals)
+	// WHEN drain-ratio classifier runs
+	// THEN classifies UNSATURATED with low ρ.
+	cfg := DefaultBacklogDriftConfig()
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 50),  // warmup window 0
+		makeWindow(10_000_000, 20_000_000, 100, 100), // warmup window 1
+		makeWindow(20_000_000, 30_000_000, 100, 100), // steady
+		makeWindow(30_000_000, 40_000_000, 100, 100), // steady
+		makeWindow(40_000_000, 50_000_000, 100, 100), // steady
+	}
+	c := drainRatioClassifier{}
+	classification, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if classification != "UNSATURATED" {
+		t.Errorf("Expected UNSATURATED, got %s. Note: %s", classification, note)
+	}
+}
+
+func TestDrainRatioClassifier_PersistentlySaturated(t *testing.T) {
+	// GIVEN steady-state windows with DrainRatio = 0.866 (μ/λ ≈ 0.87, ρ ≈ 1.15)
+	// WHEN drain-ratio classifier runs
+	// THEN classifies PERSISTENTLY_SATURATED with ρ ≈ 1.15 in note.
+	cfg := DefaultBacklogDriftConfig()
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 800, 500),         // warmup
+		makeWindow(10_000_000, 20_000_000, 800, 680), // warmup
+		makeWindow(20_000_000, 30_000_000, 800, 692), // steady (DrainRatio=0.865)
+		makeWindow(30_000_000, 40_000_000, 800, 692),
+		makeWindow(40_000_000, 50_000_000, 800, 692),
+		makeWindow(50_000_000, 60_000_000, 800, 692),
+	}
+	c := drainRatioClassifier{}
+	classification, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if classification != "PERSISTENTLY_SATURATED" {
+		t.Errorf("Expected PERSISTENTLY_SATURATED, got %s. Note: %s", classification, note)
+	}
+	// Verify the note reports a ρ ≈ 1.15
+	if !strings.Contains(note, "ρ") {
+		t.Errorf("Expected ρ in note, got: %s", note)
+	}
+}
+
+func TestDrainRatioClassifier_TransientBacklog(t *testing.T) {
+	// GIVEN steady-state windows with DrainRatio just under TransientDrainRatio (0.96 < 0.98)
+	// WHEN drain-ratio classifier runs
+	// THEN classifies TRANSIENT_BACKLOG.
+	cfg := DefaultBacklogDriftConfig() // SaturatedDrainRatio=0.95, TransientDrainRatio=0.98
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 50),  // warmup
+		makeWindow(10_000_000, 20_000_000, 100, 96), // warmup
+		makeWindow(20_000_000, 30_000_000, 100, 96), // steady DrainRatio=0.96
+		makeWindow(30_000_000, 40_000_000, 100, 96),
+		makeWindow(40_000_000, 50_000_000, 100, 96),
+	}
+	c := drainRatioClassifier{}
+	classification, _, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if classification != "TRANSIENT_BACKLOG" {
+		t.Errorf("Expected TRANSIENT_BACKLOG, got %s", classification)
+	}
+}
+
+func TestDrainRatioClassifier_NoArrivals_Unsaturated(t *testing.T) {
+	// GIVEN windows where every NumEntered == 0 (degenerate — no workload)
+	// WHEN drain-ratio classifier runs
+	// THEN classifies UNSATURATED with explanatory note.
+	cfg := DefaultBacklogDriftConfig()
+	windows := []WindowMetrics{
+		{StartUs: 0, EndUs: 10_000_000, NumEntered: 0, NumLeft: 0},
+		{StartUs: 10_000_000, EndUs: 20_000_000, NumEntered: 0, NumLeft: 0},
+	}
+	c := drainRatioClassifier{}
+	classification, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if classification != "UNSATURATED" {
+		t.Errorf("Expected UNSATURATED with no arrivals, got %s", classification)
+	}
+	if !strings.Contains(note, "No arrivals") {
+		t.Errorf("Expected 'No arrivals' in note, got: %s", note)
+	}
+}
+
+func TestDrainRatioClassifier_AllWarmup_Unsaturated(t *testing.T) {
+	// GIVEN fewer inject windows than WarmupWindows
+	// WHEN drain-ratio classifier runs
+	// THEN classifies UNSATURATED with insufficient-data note.
+	cfg := DefaultBacklogDriftConfig() // WarmupWindows=2
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 50),
+		makeWindow(10_000_000, 20_000_000, 100, 100),
+	}
+	c := drainRatioClassifier{}
+	classification, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if classification != "UNSATURATED" {
+		t.Errorf("Expected UNSATURATED with all-warmup, got %s", classification)
+	}
+	if !strings.Contains(note, "Insufficient") {
+		t.Errorf("Expected 'Insufficient' in note, got: %s", note)
+	}
+}
+
+func TestDrainRatioClassifier_LastArrivalWindow_TrailingDrainExcluded(t *testing.T) {
+	// GIVEN windows where the last 3 have NumEntered=0 (drain phase)
+	// WHEN drain-ratio classifier runs
+	// THEN drain windows are excluded; only inject windows contribute to mean.
+	// Verifies the last_arrival_window predicate.
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WarmupWindows = 0 // skip warmup so we test the inject-phase truncation directly
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 50),  // inject DrainRatio=0.50
+		makeWindow(10_000_000, 20_000_000, 100, 100), // inject DrainRatio=1.0
+		// drain phase (NumEntered=0)
+		{StartUs: 20_000_000, EndUs: 30_000_000, NumEntered: 0, NumLeft: 80},
+		{StartUs: 30_000_000, EndUs: 40_000_000, NumEntered: 0, NumLeft: 70},
+		{StartUs: 40_000_000, EndUs: 50_000_000, NumEntered: 0, NumLeft: 0},
+	}
+	c := drainRatioClassifier{}
+	classification, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	// Mean DrainRatio over inject = (0.50 + 1.0) / 2 = 0.75 → PERSISTENTLY_SATURATED
+	if classification != "PERSISTENTLY_SATURATED" {
+		t.Errorf("Expected PERSISTENTLY_SATURATED (drain excluded → mean=0.75), got %s. Note: %s", classification, note)
+	}
+}
+
+func TestDrainRatioClassifier_InteriorEmptyWindow_RemainsInject(t *testing.T) {
+	// GIVEN windows with an interior NumEntered=0 (closed-loop think-time gap)
+	// followed by more arrivals
+	// WHEN drain-ratio classifier runs
+	// THEN the interior empty window is part of inject phase (last_arrival_window
+	// predicate), and is skipped only because DrainRatio is NaN — the surrounding
+	// windows still contribute correctly.
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WarmupWindows = 0
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 95),       // DrainRatio=0.95
+		// interior empty window — DrainRatio NaN matches what computeWindowMetrics sets when NumEntered==0
+		{StartUs: 10_000_000, EndUs: 20_000_000, NumEntered: 0, NumLeft: 5, DrainRatio: math.NaN()},
+		makeWindow(20_000_000, 30_000_000, 100, 95), // DrainRatio=0.95
+	}
+	c := drainRatioClassifier{}
+	classification, _, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	// Mean over n=2 valid windows = 0.95; threshold for PERSISTENTLY_SATURATED is < 0.95.
+	// 0.95 is NOT < 0.95, so → TRANSIENT_BACKLOG (mean < TransientDrainRatio=0.98).
+	if classification != "TRANSIENT_BACKLOG" {
+		t.Errorf("Expected TRANSIENT_BACKLOG (interior empty window doesn't truncate inject phase), got %s", classification)
+	}
+}
+
+func TestNewBacklogClassifier_DefaultIsDrainRatio(t *testing.T) {
+	// BC-5 (#1392): empty-string name and "drain-ratio" both return drainRatioClassifier.
+	c1 := NewBacklogClassifier("")
+	c2 := NewBacklogClassifier("drain-ratio")
+	if _, ok := c1.(drainRatioClassifier); !ok {
+		t.Errorf("Empty string should default to drainRatioClassifier, got %T", c1)
+	}
+	if _, ok := c2.(drainRatioClassifier); !ok {
+		t.Errorf("drain-ratio should return drainRatioClassifier, got %T", c2)
+	}
+}
+
+func TestNewBacklogClassifier_SlopeBased(t *testing.T) {
+	// BC-3 (#1391): "slope-based" returns slopeBasedClassifier (preserved opt-in).
+	c := NewBacklogClassifier("slope-based")
+	if _, ok := c.(slopeBasedClassifier); !ok {
+		t.Errorf("slope-based should return slopeBasedClassifier, got %T", c)
+	}
+}
+
+func TestNewBacklogClassifier_PanicsOnUnknown(t *testing.T) {
+	// BC-3 (#1391): unknown name panics. CLI is expected to validate upstream.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for unknown classifier name")
+		}
+	}()
+	_ = NewBacklogClassifier("nonexistent-classifier")
+}
+
+func TestBacklogDriftConfig_NewBacklogDriftConfig_ValidatesDrainRatioRange(t *testing.T) {
+	// GIVEN SaturatedDrainRatio > TransientDrainRatio (regions would overlap)
+	// WHEN constructing config
+	// THEN panics with descriptive message.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for SaturatedDrainRatio > TransientDrainRatio")
+		}
+	}()
+	_ = NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.99, 0.95)
+}
+
+// TestBacklogDriftConfig_NewBacklogDriftConfig_DrainRatioParamValidation table-tests
+// every panic branch for the new drain-ratio classifier knobs (#1392). Each row
+// constructs an otherwise-valid config with one parameter forced into an invalid
+// value and asserts the constructor panics with a descriptive message.
+func TestBacklogDriftConfig_NewBacklogDriftConfig_DrainRatioParamValidation(t *testing.T) {
+	cases := []struct {
+		name           string
+		warmup, tail   int
+		sat, transient float64
+		wantSubstr     string
+	}{
+		{"warmup_negative", -1, 1, 0.95, 0.98, "WarmupWindows must be >= 0"},
+		{"tail_negative", 2, -1, 0.95, 0.98, "TailWindows must be >= 0"},
+		{"saturated_zero", 2, 1, 0, 0.98, "SaturatedDrainRatio must be in (0, 1]"},
+		{"saturated_negative", 2, 1, -0.5, 0.98, "SaturatedDrainRatio must be in (0, 1]"},
+		{"saturated_above_one", 2, 1, 1.5, 1.6, "SaturatedDrainRatio must be in (0, 1]"},
+		{"saturated_nan", 2, 1, math.NaN(), 0.98, "SaturatedDrainRatio must be in (0, 1]"},
+		{"saturated_inf", 2, 1, math.Inf(1), 0.98, "SaturatedDrainRatio must be in (0, 1]"},
+		{"transient_zero", 2, 1, 0.95, 0, "TransientDrainRatio must be in (0, 1]"},
+		{"transient_above_one", 2, 1, 0.95, 1.2, "TransientDrainRatio must be in (0, 1]"},
+		{"transient_nan", 2, 1, 0.95, math.NaN(), "TransientDrainRatio must be in (0, 1]"},
+		{"saturated_gt_transient", 2, 1, 0.99, 0.95, "SaturatedDrainRatio"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("Expected panic for %s", tc.name)
+				}
+				msg := fmt.Sprint(r)
+				if !strings.Contains(msg, tc.wantSubstr) {
+					t.Errorf("Panic message %q did not contain %q", msg, tc.wantSubstr)
+				}
+			}()
+			_ = NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, tc.warmup, tc.tail, tc.sat, tc.transient)
+		})
+	}
+}
+
+// TestNewBacklogClassifier_FactoryRegistryAgreement enforces that every name in
+// the validBacklogClassifiers registry is constructible via NewBacklogClassifier.
+// Catches drift where a name is added to the registry but the factory's switch
+// statement isn't updated (or vice versa).
+func TestNewBacklogClassifier_FactoryRegistryAgreement(t *testing.T) {
+	for _, name := range sim.ValidBacklogClassifierNames() {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NewBacklogClassifier(%q) panicked: %v", name, r)
+				}
+			}()
+			c := NewBacklogClassifier(name)
+			if c == nil {
+				t.Fatalf("NewBacklogClassifier(%q) returned nil", name)
+			}
+		})
+	}
+}
+
+// TestAnalyzeBacklogDriftWithClassifier_NilClassifier_DefaultsToSlopeBased verifies
+// the nil-defense at the orchestrator level. Calling with classifier=nil should
+// not panic and should produce a report identical to passing slopeBasedClassifier{}
+// explicitly (preserves the documented backward-compat shim semantics).
+func TestAnalyzeBacklogDriftWithClassifier_NilClassifier_DefaultsToSlopeBased(t *testing.T) {
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	requests := []*sim.Request{
+		{ArrivalTime: 0, FirstTokenTime: 100, ITL: []int64{500}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 5_000_000, FirstTokenTime: 100, ITL: []int64{500}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 10_000_000, FirstTokenTime: 100, ITL: []int64{500}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 15_000_000, FirstTokenTime: 100, ITL: []int64{500}, TTFTSet: true, State: sim.StateCompleted},
+	}
+	simEndUs := int64(20_000_000)
+
+	rNil := AnalyzeBacklogDriftWithClassifier(requests, simEndUs, cfg, nil)
+	rExplicit := AnalyzeBacklogDriftWithClassifier(requests, simEndUs, cfg, slopeBasedClassifier{})
+
+	if rNil.Classification != rExplicit.Classification {
+		t.Errorf("Nil classifier produced %s, explicit slope-based produced %s — defense regression",
+			rNil.Classification, rExplicit.Classification)
+	}
+	if rNil.Note != rExplicit.Note {
+		t.Errorf("Nil classifier note differs from explicit slope-based note (defense regression)")
+	}
+}
+
+// TestIsValidBacklogClassifier_RegistryContents asserts the public registry
+// contract used by all three CLI commands (run/replay/observe) for upstream
+// validation before reaching the panic-style factory.
+func TestIsValidBacklogClassifier_RegistryContents(t *testing.T) {
+	tests := []struct {
+		name    string
+		isValid bool
+	}{
+		{"", true},
+		{"drain-ratio", true},
+		{"slope-based", true},
+		{"unknown", false},
+		{"DrainRatio", false}, // case-sensitive
+		{"drain_ratio", false}, // underscore not hyphen
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sim.IsValidBacklogClassifier(tc.name); got != tc.isValid {
+				t.Errorf("IsValidBacklogClassifier(%q) = %v, want %v", tc.name, got, tc.isValid)
+			}
+		})
+	}
+
+	// ValidBacklogClassifierNames excludes the empty string and is sorted.
+	names := sim.ValidBacklogClassifierNames()
+	for _, name := range names {
+		if name == "" {
+			t.Errorf("ValidBacklogClassifierNames() returned empty-string entry")
+		}
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Errorf("ValidBacklogClassifierNames() not sorted: %v", names)
+			break
+		}
+	}
+}
+
+// TestAnalyzeBacklogDriftWithClassifier_OrchestratorFallback_AllInjectWindows verifies
+// the orchestrator-level fallback path: when WarmupWindows + TailWindows >= number of
+// inject windows, the slope-regression sample set falls back to all inject windows
+// (with a logrus.Warnf surfacing the bias). The drain-ratio classifier handles the
+// same regime by returning UNSATURATED with an explicit note. This test asserts both
+// classifiers handle the regime without panic and produce a defensible verdict.
+func TestAnalyzeBacklogDriftWithClassifier_OrchestratorFallback_AllInjectWindows(t *testing.T) {
+	// Synthetic input: 4 inject windows, 0 drain. Engine drains at 100/s, arrivals at 50/s.
+	// → ρ = 0.5, all windows have NumLeft >= NumEntered.
+	// With cfg.WarmupWindows=2 + cfg.TailWindows=2 = 4 (== injectWindows), trim collapses.
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+	cfg.WarmupWindows = 2
+	cfg.TailWindows = 2
+
+	requests := []*sim.Request{
+		{ArrivalTime: 0, FirstTokenTime: 100, ITL: []int64{1000}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 5_000_000, FirstTokenTime: 100, ITL: []int64{1000}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 10_000_000, FirstTokenTime: 100, ITL: []int64{1000}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 15_000_000, FirstTokenTime: 100, ITL: []int64{1000}, TTFTSet: true, State: sim.StateCompleted},
+	}
+	simEndUs := int64(20_000_000)
+
+	// Both classifiers should produce a verdict without panicking. The exact verdict can
+	// differ between classifiers in this fallback regime — we only assert no-panic and
+	// non-empty output, since the meaningful behavior is the orchestrator's logrus.Warnf.
+	for _, name := range []string{"drain-ratio", "slope-based"} {
+		t.Run(name, func(t *testing.T) {
+			c := NewBacklogClassifier(name)
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("classifier=%s panicked in orchestrator fallback regime: %v", name, r)
+				}
+			}()
+			r := AnalyzeBacklogDriftWithClassifier(requests, simEndUs, cfg, c)
+			if r.Classification == "" {
+				t.Errorf("classifier=%s produced empty classification", name)
+			}
+			// At ρ=0.5 and warmup+tail collapse, neither classifier should fire PERSISTENTLY_SATURATED.
+			if r.Classification == "PERSISTENTLY_SATURATED" {
+				t.Errorf("classifier=%s incorrectly fired PERSISTENTLY_SATURATED at ρ=0.5: %s", name, r.Note)
+			}
+		})
+	}
+}
+
+// TestDrainRatioClassifier_NaNSkipCount_SurfacesInNote verifies the post-review
+// fix that the count of skipped NaN/Inf DrainRatio windows is reported in the
+// classifier's note (R1: no silent discard). Asserts BC-1 behavior on closed-loop
+// gaps that surface as NaN per WindowMetrics convention.
+func TestDrainRatioClassifier_NaNSkipCount_SurfacesInNote(t *testing.T) {
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WarmupWindows = 0
+	cfg.TailWindows = 0
+	windows := []WindowMetrics{
+		makeWindow(0, 10_000_000, 100, 95),                                                        // valid
+		{StartUs: 10_000_000, EndUs: 20_000_000, NumEntered: 0, NumLeft: 0, DrainRatio: math.NaN()}, // skipped
+		makeWindow(20_000_000, 30_000_000, 100, 95),                                               // valid
+		{StartUs: 30_000_000, EndUs: 40_000_000, NumEntered: 0, NumLeft: 0, DrainRatio: math.NaN()}, // skipped
+		makeWindow(40_000_000, 50_000_000, 100, 95),                                               // valid
+	}
+	c := drainRatioClassifier{}
+	_, note, _ := c.Classify(windows, SlopeStats{}, 0, 0, 0, 0, cfg)
+	if !strings.Contains(note, "skipped 2 windows") {
+		t.Errorf("Expected note to surface skip count of 2, got: %s", note)
+	}
+}

--- a/sim/workload/saturation_properties_test.go
+++ b/sim/workload/saturation_properties_test.go
@@ -1,0 +1,404 @@
+// sim/workload/saturation_properties_test.go
+//
+// Property tests for BacklogClassifier implementations (#1394). Each test runs
+// against EVERY classifier registered via NewBacklogClassifier — new classifier
+// implementations automatically inherit this suite without modification.
+//
+// Six properties (each one trace below failed for the pre-fix slope-based
+// classifier and motivated this PR):
+//
+//   P1 — Determinism: Classify(x) == Classify(x) on a fresh run (no hidden state).
+//   P2 — Monotonicity in true ρ: at ρ extremes, all classifiers return the
+//        expected category (UNSATURATED for ρ ≤ 0.85; PERSISTENTLY_SATURATED
+//        for ρ ≥ 1.10). Borderline (0.95 ≤ ρ ≤ 1.05) is unconstrained.
+//   P3 — Drain-phase invariance: same inject phase + 0/30s/60s drain → same
+//        classification. The drain phase is not part of saturation.
+//   P4 — Warmup-phase robustness: a warmup ramp does not change steady-state
+//        verdict at ρ extremes.
+//   P5 — Conservation (RequestsToIntervals): every injected request appears in
+//        the interval set unless it timed out. This is the property that
+//        catches #1389; classifier-agnostic.
+//   P6 — Cross-classifier agreement: at ρ extremes, all registered classifiers
+//        return the same classification string.
+
+package workload
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+)
+
+// ────────────────────────────────────────────────────────────────────────────
+// SyntheticTrace — deterministic generator of *sim.Request slices with a known
+// utilization ρ = λ/μ. Used as the input distribution for property tests.
+
+// SyntheticTrace describes a workload with a controllable utilization regime.
+// Build() returns a slice of *sim.Request and the simEndUs to feed into
+// AnalyzeBacklogDriftWithClassifier.
+type SyntheticTrace struct {
+	LambdaPerSec   float64       // arrival rate during inject phase
+	MuPerSec       float64       // engine service rate (completions/sec)
+	InjectDuration time.Duration // length of inject phase
+	DrainDuration  time.Duration // length of drain phase (0 = no drain)
+	WarmupDuration time.Duration // ramp-up at start of inject (linearly grows from 0 to λ)
+	Seed           int64
+}
+
+// Build constructs the request slice and simEndUs.
+//
+// The model is intentionally simple:
+//   - Arrivals are sampled at jittered intervals averaging 1/λ during the
+//     inject phase. Warmup ramps the rate linearly from 0 to λ.
+//   - Each request's TTFT is set to a deterministic constant (1ms) for
+//     completed requests; service time = 1/μ on average.
+//   - At each instant during the simulation, completions are scheduled to
+//     drain backlog at rate μ. If λ > μ, queue grows — late arrivals end up
+//     queued at horizon, with State = StateQueued.
+//   - simEndUs = inject + drain duration.
+//
+// Determinism: identical fields → identical output. (Seed is reserved for future
+// extensions such as Poisson-jittered traces; the baseline implementation uses
+// constant-rate spacing so the slope-based and drain-ratio classifiers see the
+// same low-variance signal.)
+func (st SyntheticTrace) Build() (requests []*sim.Request, simEndUs int64, expectedRho float64) {
+	expectedRho = st.LambdaPerSec / st.MuPerSec
+
+	injectUs := int64(st.InjectDuration / time.Microsecond)
+	drainUs := int64(st.DrainDuration / time.Microsecond)
+	warmupUs := int64(st.WarmupDuration / time.Microsecond)
+	simEndUs = injectUs + drainUs
+
+	const oneMs = int64(1_000)
+	const ttftUs = oneMs
+	muIATUs := int64(1e6 / st.MuPerSec) // service time in µs
+
+	// Constant-rate (deterministic) arrival generation. During warmup, instantaneous
+	// rate ramps linearly from 0 to λ; outside warmup, rate = λ. Walk forward in
+	// time, computing the next arrival's gap from the instantaneous rate.
+	t := int64(0)
+	arrivals := []int64{}
+	for t < injectUs {
+		rate := st.LambdaPerSec
+		if warmupUs > 0 && t < warmupUs {
+			rate = st.LambdaPerSec * float64(t) / float64(warmupUs)
+			if rate < 1e-3 {
+				rate = 1e-3
+			}
+		}
+		gapUs := int64(1e6 / rate)
+		t += gapUs
+		if t >= injectUs {
+			break
+		}
+		arrivals = append(arrivals, t)
+	}
+
+	// Assign completion/queued state. The engine processes at μ, so a request
+	// scheduled to finish before simEndUs is "completed"; the rest are "queued".
+	// For simplicity, FIFO completion: the i-th arrival completes at arrival[i] +
+	// queueing_delay + service_time, where queueing_delay reflects backlog at arrival.
+	requests = make([]*sim.Request, 0, len(arrivals))
+	nextFreeUs := int64(0) // earliest time the engine can start the next request
+	for _, arrUs := range arrivals {
+		startUs := arrUs
+		if nextFreeUs > startUs {
+			startUs = nextFreeUs
+		}
+		completionUs := startUs + muIATUs
+		nextFreeUs = startUs + muIATUs
+
+		req := &sim.Request{
+			ArrivalTime: arrUs,
+		}
+		if completionUs <= simEndUs {
+			// Completed. RequestsToIntervals derives completion as
+			//   ArrivalTime + FirstTokenTime + Σ ITL.
+			// To make that equal startUs + muIATUs, we encode queueing delay
+			// in FirstTokenTime: FirstTokenTime = (startUs - arrUs) + ttftUs.
+			req.TTFTSet = true
+			req.FirstTokenTime = (startUs - arrUs) + ttftUs
+			body := muIATUs - ttftUs
+			if body < 0 {
+				body = 0
+			}
+			req.ITL = []int64{body}
+			req.State = sim.StateCompleted
+		} else if startUs < simEndUs {
+			// Started but not finished by simEnd — Running
+			req.TTFTSet = false
+			req.State = sim.StateRunning
+		} else {
+			// Never started — Queued
+			req.TTFTSet = false
+			req.State = sim.StateQueued
+		}
+		requests = append(requests, req)
+	}
+
+	return requests, simEndUs, expectedRho
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// allClassifiers returns every BacklogClassifier registered in the factory.
+// Used by property tests so adding a new classifier auto-inherits the suite.
+
+func allClassifiers(t *testing.T) map[string]BacklogClassifier {
+	t.Helper()
+	out := map[string]BacklogClassifier{}
+	for _, name := range sim.ValidBacklogClassifierNames() {
+		c := NewBacklogClassifier(name)
+		if c == nil {
+			t.Fatalf("NewBacklogClassifier(%q) returned nil", name)
+		}
+		out[name] = c
+	}
+	if len(out) == 0 {
+		t.Fatal("No registered classifiers — registry is empty?")
+	}
+	return out
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P1: Determinism
+
+func TestProperty_P1_Determinism(t *testing.T) {
+	classifiers := allClassifiers(t)
+	trace := SyntheticTrace{
+		LambdaPerSec:   80,
+		MuPerSec:       100,
+		InjectDuration: 60 * time.Second,
+		DrainDuration:  10 * time.Second,
+		Seed:           42,
+	}
+	reqs, simEnd, _ := trace.Build()
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	for name, c := range classifiers {
+		t.Run(name, func(t *testing.T) {
+			r1 := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+			r2 := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+			if r1.Classification != r2.Classification {
+				t.Errorf("Non-deterministic classification: %s vs %s", r1.Classification, r2.Classification)
+			}
+			if r1.Note != r2.Note {
+				t.Errorf("Non-deterministic note for %s", name)
+			}
+		})
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P2: Monotonicity in true ρ at extremes
+
+func TestProperty_P2_MonotonicityExtremes(t *testing.T) {
+	classifiers := allClassifiers(t)
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	cases := []struct {
+		name        string
+		lambda, mu  float64
+		expectClass string
+	}{
+		{"deeply_unsaturated_rho_0.5", 50, 100, "UNSATURATED"},
+		{"unsaturated_rho_0.85", 85, 100, "UNSATURATED"},
+		{"saturated_rho_1.15", 115, 100, "PERSISTENTLY_SATURATED"},
+		{"deeply_saturated_rho_1.5", 150, 100, "PERSISTENTLY_SATURATED"},
+	}
+
+	for _, tc := range cases {
+		trace := SyntheticTrace{
+			LambdaPerSec:   tc.lambda,
+			MuPerSec:       tc.mu,
+			InjectDuration: 60 * time.Second,
+			DrainDuration:  20 * time.Second,
+			Seed:           42,
+		}
+		reqs, simEnd, rho := trace.Build()
+		_ = rho // for debug
+
+		for name, c := range classifiers {
+			t.Run(fmt.Sprintf("%s/%s", tc.name, name), func(t *testing.T) {
+				report := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+				if report.Classification != tc.expectClass {
+					t.Errorf("classifier=%s ρ=%.2f: expected %s, got %s. Note: %s",
+						name, tc.lambda/tc.mu, tc.expectClass, report.Classification, report.Note)
+				}
+			})
+		}
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P3: Drain-phase invariance
+
+func TestProperty_P3_DrainPhaseInvariance(t *testing.T) {
+	classifiers := allClassifiers(t)
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	// Saturated case — verify that drain length doesn't flip the classification
+	// (the historical bug was tent-shape masking).
+	for _, drain := range []time.Duration{0, 30 * time.Second, 60 * time.Second} {
+		trace := SyntheticTrace{
+			LambdaPerSec:   115,
+			MuPerSec:       100,
+			InjectDuration: 60 * time.Second,
+			DrainDuration:  drain,
+			Seed:           42,
+		}
+		reqs, simEnd, _ := trace.Build()
+
+		for name, c := range classifiers {
+			t.Run(fmt.Sprintf("drain=%s/%s", drain, name), func(t *testing.T) {
+				report := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+				if report.Classification != "PERSISTENTLY_SATURATED" {
+					t.Errorf("classifier=%s drain=%s: drain length should not change classification, got %s. Note: %s",
+						name, drain, report.Classification, report.Note)
+				}
+			})
+		}
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P4: Warmup-phase robustness
+
+func TestProperty_P4_WarmupRobustness(t *testing.T) {
+	classifiers := allClassifiers(t)
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	// At ρ=0.5 (clearly unsaturated), neither warmup nor abrupt-start should change verdict.
+	// Same trace, different warmup durations.
+	for _, warmup := range []time.Duration{0, 10 * time.Second} {
+		trace := SyntheticTrace{
+			LambdaPerSec:   50,
+			MuPerSec:       100,
+			InjectDuration: 60 * time.Second,
+			DrainDuration:  10 * time.Second,
+			WarmupDuration: warmup,
+			Seed:           42,
+		}
+		reqs, simEnd, _ := trace.Build()
+
+		for name, c := range classifiers {
+			t.Run(fmt.Sprintf("warmup=%s/%s", warmup, name), func(t *testing.T) {
+				report := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+				if report.Classification != "UNSATURATED" {
+					t.Errorf("classifier=%s warmup=%s: should remain UNSATURATED at ρ=0.5, got %s",
+						name, warmup, report.Classification)
+				}
+			})
+		}
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P5: Conservation — every injected request shows up in the interval set
+//     unless it timed out. This is the invariant that catches #1389.
+//     Classifier-agnostic.
+
+func TestProperty_P5_Conservation(t *testing.T) {
+	cases := []struct {
+		name           string
+		completed      int
+		running        int
+		queued         int
+		timedOut       int
+	}{
+		{"only_completed", 100, 0, 0, 0},
+		{"completed_plus_running", 80, 20, 0, 0},
+		{"completed_plus_queued", 50, 0, 50, 0},
+		{"all_states_mixed", 40, 20, 30, 10},
+		{"only_timed_out", 0, 0, 0, 50},
+		{"all_queued", 0, 0, 100, 0},
+	}
+
+	const simEndUs = int64(60_000_000)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs := []*sim.Request{}
+			for i := 0; i < tc.completed; i++ {
+				reqs = append(reqs, &sim.Request{
+					ArrivalTime: int64(i * 100), TTFTSet: true,
+					FirstTokenTime: 1000, ITL: []int64{1000}, State: sim.StateCompleted,
+				})
+			}
+			for i := 0; i < tc.running; i++ {
+				reqs = append(reqs, &sim.Request{
+					ArrivalTime: int64(50_000_000 + i*100), TTFTSet: false, State: sim.StateRunning,
+				})
+			}
+			for i := 0; i < tc.queued; i++ {
+				reqs = append(reqs, &sim.Request{
+					ArrivalTime: int64(55_000_000 + i*100), TTFTSet: false, State: sim.StateQueued,
+				})
+			}
+			for i := 0; i < tc.timedOut; i++ {
+				reqs = append(reqs, &sim.Request{
+					ArrivalTime: int64(i * 100), TTFTSet: false, State: sim.StateTimedOut,
+				})
+			}
+			intervals := RequestsToIntervals(reqs, simEndUs)
+			expected := tc.completed + tc.running + tc.queued
+			if len(intervals) != expected {
+				t.Errorf("Conservation violation: got %d intervals, want %d (timed_out=%d excluded)",
+					len(intervals), expected, tc.timedOut)
+			}
+		})
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// P6: Cross-classifier agreement at ρ extremes
+
+func TestProperty_P6_CrossClassifierAgreement(t *testing.T) {
+	classifiers := allClassifiers(t)
+	if len(classifiers) < 2 {
+		t.Skip("Need ≥ 2 registered classifiers for cross-agreement test")
+	}
+	cfg := DefaultBacklogDriftConfig()
+	cfg.WindowSize = 5 * time.Second
+	cfg.MinWindows = 3
+
+	// At ρ=0.5 and ρ=1.5, every classifier should agree on the verdict.
+	for _, lambda := range []float64{50, 150} {
+		trace := SyntheticTrace{
+			LambdaPerSec:   lambda,
+			MuPerSec:       100,
+			InjectDuration: 60 * time.Second,
+			DrainDuration:  20 * time.Second,
+			Seed:           42,
+		}
+		reqs, simEnd, _ := trace.Build()
+
+		verdicts := map[string]string{}
+		for name, c := range classifiers {
+			r := AnalyzeBacklogDriftWithClassifier(reqs, simEnd, cfg, c)
+			verdicts[name] = r.Classification
+		}
+		// Check all verdicts equal
+		var first string
+		for _, v := range verdicts {
+			first = v
+			break
+		}
+		for name, v := range verdicts {
+			if v != first {
+				t.Errorf("ρ=%.2f: classifiers disagree at extremes — %v", lambda/100.0, verdicts)
+				_ = name
+				break
+			}
+		}
+	}
+}

--- a/sim/workload/saturation_test.go
+++ b/sim/workload/saturation_test.go
@@ -23,7 +23,7 @@ func TestBacklogDriftConfig_Validation_ZeroWindow(t *testing.T) {
 			t.Fatalf("Wrong panic message: %v", r)
 		}
 	}()
-	_ = NewBacklogDriftConfig(0, 5, 2.0, 0.2, 0.95)
+	_ = NewBacklogDriftConfig(0, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 }
 
 func TestBacklogDriftConfig_Validation_NegativeMinWindows(t *testing.T) {
@@ -35,7 +35,7 @@ func TestBacklogDriftConfig_Validation_NegativeMinWindows(t *testing.T) {
 			t.Fatal("Expected panic for negative MinWindows")
 		}
 	}()
-	_ = NewBacklogDriftConfig(60*time.Second, 0, 2.0, 0.2, 0.95)
+	_ = NewBacklogDriftConfig(60*time.Second, 0, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 }
 
 func TestBacklogDriftConfig_Validation_NaNPeakRatio(t *testing.T) {
@@ -47,7 +47,7 @@ func TestBacklogDriftConfig_Validation_NaNPeakRatio(t *testing.T) {
 			t.Fatal("Expected panic for NaN PeakRatio")
 		}
 	}()
-	_ = NewBacklogDriftConfig(60*time.Second, 5, math.NaN(), 0.2, 0.95)
+	_ = NewBacklogDriftConfig(60*time.Second, 5, math.NaN(), 0.2, 0.95, 2, 1, 0.95, 0.98)
 }
 
 func TestBacklogDriftConfig_Validation_CIOutOfRange(t *testing.T) {
@@ -59,14 +59,14 @@ func TestBacklogDriftConfig_Validation_CIOutOfRange(t *testing.T) {
 			t.Fatal("Expected panic for CI=1.5")
 		}
 	}()
-	_ = NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 1.5)
+	_ = NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 1.5, 2, 1, 0.95, 0.98)
 }
 
 func TestBacklogDriftConfig_Validation_ValidConfig(t *testing.T) {
 	// GIVEN all parameters valid
 	// WHEN constructing config
 	// THEN succeeds without panic
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 	if cfg.WindowSize != 60*time.Second {
 		t.Errorf("WindowSize mismatch: got %v", cfg.WindowSize)
 	}
@@ -101,6 +101,53 @@ func TestRequestsToIntervals_Eligibility_ThreeCases(t *testing.T) {
 	// Case 3: arrival=300, completion=simEndUs+1=1000001 (still in-flight at horizon)
 	if intervals[1].ArrivalUs != 300 || intervals[1].CompletionUs != simEndUs+1 {
 		t.Errorf("Case 3 mismatch: got (%d, %d)", intervals[1].ArrivalUs, intervals[1].CompletionUs)
+	}
+}
+
+func TestRequestsToIntervals_StateQueued_IncludedAsHorizonTruncated(t *testing.T) {
+	// BC-1 (#1389): GIVEN a request still in StateQueued at horizon (never scheduled)
+	// WHEN building intervals
+	// THEN it is included with CompletionUs = simEndUs+1, exactly like StateRunning,
+	// because for backlog analysis a queued-at-horizon request is in-flight.
+	simEndUs := int64(1_000_000)
+	requests := []*sim.Request{
+		// Queued at horizon: TTFTSet=false, State=Queued — INCLUDED with simEndUs+1
+		{ArrivalTime: 100, TTFTSet: false, State: sim.StateQueued},
+	}
+
+	intervals := RequestsToIntervals(requests, simEndUs)
+
+	if len(intervals) != 1 {
+		t.Fatalf("Expected 1 interval (queued included), got %d", len(intervals))
+	}
+	if intervals[0].ArrivalUs != 100 || intervals[0].CompletionUs != simEndUs+1 {
+		t.Errorf("Queued mismatch: got (%d, %d), want (100, %d)",
+			intervals[0].ArrivalUs, intervals[0].CompletionUs, simEndUs+1)
+	}
+}
+
+func TestRequestsToIntervals_Conservation_QueuedAndRunningBothCounted(t *testing.T) {
+	// BC-1 (#1389) conservation invariant precursor: GIVEN N requests with M timed out
+	// WHEN building intervals
+	// THEN len(intervals) == N - M (only TimedOut is excluded; Queued and Running both included).
+	simEndUs := int64(1_000_000)
+	requests := []*sim.Request{
+		{ArrivalTime: 100, FirstTokenTime: 200, ITL: []int64{50}, TTFTSet: true, State: sim.StateCompleted},
+		{ArrivalTime: 200, TTFTSet: false, State: sim.StateTimedOut},  // excluded
+		{ArrivalTime: 300, TTFTSet: false, State: sim.StateRunning},
+		{ArrivalTime: 400, TTFTSet: false, State: sim.StateQueued},
+		{ArrivalTime: 500, TTFTSet: false, State: sim.StateTimedOut},  // excluded
+		{ArrivalTime: 600, TTFTSet: false, State: sim.StateQueued},
+	}
+	const totalRequests = 6
+	const timedOut = 2
+	const expected = totalRequests - timedOut
+
+	intervals := RequestsToIntervals(requests, simEndUs)
+
+	if len(intervals) != expected {
+		t.Fatalf("Conservation violation: got %d intervals, want %d (N=%d, timed_out=%d)",
+			len(intervals), expected, totalRequests, timedOut)
 	}
 }
 
@@ -299,10 +346,10 @@ func TestClassifyBacklogDrift_UNSATURATED(t *testing.T) {
 	// GIVEN slope CI excludes positive values (upper < 0) or includes zero with low peak
 	// WHEN classifying
 	// THEN returns UNSATURATED
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Case 1: Negative slope (decreasing backlog)
-	classification, note, recommendation := classifyBacklogDrift(-0.01, -0.02, 0.0, 10, 5, 10, 8.0, cfg)
+	classification, note, recommendation := classifyBacklogDriftSlopeBased(-0.01, -0.02, 0.0, 10, 5, 10, 8.0, cfg)
 	if classification != "UNSATURATED" {
 		t.Errorf("Case 1: Expected UNSATURATED, got %s", classification)
 	}
@@ -314,7 +361,7 @@ func TestClassifyBacklogDrift_UNSATURATED(t *testing.T) {
 	}
 
 	// Case 2: Flat slope (CI includes zero) with low peak ratio
-	classification, _, _ = classifyBacklogDrift(0.0, -0.01, 0.01, 10, 10, 15, 12.0, cfg)
+	classification, _, _ = classifyBacklogDriftSlopeBased(0.0, -0.01, 0.01, 10, 10, 15, 12.0, cfg)
 	if classification != "UNSATURATED" {
 		t.Errorf("Case 2: Expected UNSATURATED, got %s", classification)
 	}
@@ -324,10 +371,10 @@ func TestClassifyBacklogDrift_TRANSIENT_BACKLOG(t *testing.T) {
 	// GIVEN slope CI includes zero but peak > PeakRatio * mean
 	// WHEN classifying
 	// THEN returns TRANSIENT_BACKLOG
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Flat slope with high peak: peak=25, mean=10, ratio=2.5 > 2.0
-	classification, note, recommendation := classifyBacklogDrift(0.0, -0.01, 0.01, 10, 10, 25, 10.0, cfg)
+	classification, note, recommendation := classifyBacklogDriftSlopeBased(0.0, -0.01, 0.01, 10, 10, 25, 10.0, cfg)
 	if classification != "TRANSIENT_BACKLOG" {
 		t.Errorf("Expected TRANSIENT_BACKLOG, got %s", classification)
 	}
@@ -343,10 +390,10 @@ func TestClassifyBacklogDrift_PERSISTENTLY_SATURATED(t *testing.T) {
 	// GIVEN slope CI excludes zero (lower > 0) — statistically significant positive drift
 	// WHEN classifying
 	// THEN returns PERSISTENTLY_SATURATED
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Positive slope with CI excluding zero
-	classification, note, recommendation := classifyBacklogDrift(0.05, 0.02, 0.08, 10, 30, 35, 22.0, cfg)
+	classification, note, recommendation := classifyBacklogDriftSlopeBased(0.05, 0.02, 0.08, 10, 30, 35, 22.0, cfg)
 	if classification != "PERSISTENTLY_SATURATED" {
 		t.Errorf("Expected PERSISTENTLY_SATURATED, got %s", classification)
 	}
@@ -362,7 +409,7 @@ func TestAnalyzeBacklogDrift_InsufficientData(t *testing.T) {
 	// GIVEN observation with fewer than MinWindows complete windows (BC-7)
 	// WHEN analyzing
 	// THEN returns UNSATURATED with note explaining insufficient data
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Very short observation: only 2 windows (< MinWindows=5)
 	requests := []*sim.Request{
@@ -389,7 +436,7 @@ func TestAnalyzeBacklogDrift_AllExcluded(t *testing.T) {
 	// GIVEN all requests timed out before TTFT (BC-15: no eligible requests)
 	// WHEN analyzing
 	// THEN returns UNSATURATED with note "no eligible requests for saturation analysis"
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// All requests timed out before TTFT
 	requests := []*sim.Request{
@@ -418,7 +465,7 @@ func TestAnalyzeBacklogDrift_EndToEnd_PERSISTENTLY_SATURATED(t *testing.T) {
 	// THEN returns PERSISTENTLY_SATURATED classification
 
 	// Use same config as RealWorkloads test: 10s windows instead of 60s
-	cfg := NewBacklogDriftConfig(10*time.Second, 4, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(10*time.Second, 4, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Same parameters as RealWorkloads "High rate - persistent saturation" test
 	rate := 500.0
@@ -448,7 +495,7 @@ func TestAnalyzeBacklogDrift_EndToEnd_UNSATURATED(t *testing.T) {
 	// GIVEN requests with stable backlog
 	// WHEN analyzing
 	// THEN returns UNSATURATED classification
-	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95)
+	cfg := NewBacklogDriftConfig(60*time.Second, 5, 2.0, 0.2, 0.95, 2, 1, 0.95, 0.98)
 
 	// Create requests that complete quickly — no backlog buildup
 	var requests []*sim.Request
@@ -608,6 +655,10 @@ func TestSaturationProgression_Demonstration(t *testing.T) {
 		2.0,            // peak ratio threshold
 		0.2,            // peak ratio band
 		0.95,           // confidence level
+		2,              // warmup windows
+		1,              // tail windows
+		0.95,           // saturated drain ratio
+		0.98,           // transient drain ratio
 	)
 
 	// Three scenarios: low, medium, high rate
@@ -748,6 +799,10 @@ func TestSaturationClassification_ManualScenarios(t *testing.T) {
 		2.0,            // peak ratio threshold
 		0.2,            // peak ratio band
 		0.95,           // confidence level
+		2,              // warmup windows
+		1,              // tail windows
+		0.95,           // saturated drain ratio
+		0.98,           // transient drain ratio
 	)
 
 	t.Run("UNSATURATED - stable low backlog", func(t *testing.T) {
@@ -917,6 +972,10 @@ func TestSaturationProgression_RealWorkloads(t *testing.T) {
 		2.0,            // peak ratio threshold
 		0.2,            // peak ratio band
 		0.95,           // confidence level
+		2,              // warmup windows
+		1,              // tail windows
+		0.95,           // saturated drain ratio
+		0.98,           // transient drain ratio
 	)
 
 	// Test cases demonstrate saturation progression
@@ -1078,6 +1137,10 @@ func TestSaturationProgression_TransitionBoundaries(t *testing.T) {
 		2.0,
 		0.2,
 		0.95,
+		2,
+		1,
+		0.95,
+		0.98,
 	)
 
 	// Test rates spanning both transition boundaries


### PR DESCRIPTION
## Summary

Replaces the buggy monolithic `classifyBacklogDrift` with a pluggable `BacklogClassifier` interface (mirroring the runtime `SaturationDetector` pattern). Two implementations: `slope-based` (preserved opt-in) and `drain-ratio` (new default). Fixes two compounding bugs that made `PERSISTENTLY_SATURATED` unreachable for any standard finite-budget BLIS sim, and adds a property-test suite that catches the entire bug class.

**Five issues resolved:** Closes #1389, #1390, #1391, #1392, #1393, #1394.

## Behavioral Contracts

- **BC-1 (#1389) — Conservation of injected requests**

  GIVEN N injected requests, M timed out
  WHEN `RequestsToIntervals` is called
  THEN returned interval count equals `N - M`. Both `StateQueued` and `StateRunning` are now included with synthetic completion at `simEndUs+1`; only `StateTimedOut` is excluded.

- **BC-2 (#1390) — Steady-state inject-phase slope analysis**

  GIVEN a sim with arrivals stopping mid-window plus a drain phase
  WHEN slope regression runs
  THEN it sees only steady-state inject windows (last_arrival_window predicate, then warmup/tail trim). `peak_in_flight` and `mean_in_flight` remain computed over all windows so the peak/mean ratio test is unaffected.

- **BC-3 (#1391) — `BacklogClassifier` interface + registry**

  GIVEN a registered classifier name
  WHEN `NewBacklogClassifier(name)` is called
  THEN it returns the corresponding implementation; panics on unknown name. CLI validates upstream via `sim.IsValidBacklogClassifier`. Mirrors `NewSaturationDetector` at `sim/saturation.go:84`.

- **BC-4/BC-5 (#1392) — DrainRatio classification + default flip**

  GIVEN N inject windows with steady-state mean DrainRatio = D after skipping warmup/tail windows
  WHEN drain-ratio classifier runs
  THEN:
    - D < `SaturatedDrainRatio` (default 0.95) → `PERSISTENTLY_SATURATED`
    - D < `TransientDrainRatio` (default 0.98) → `TRANSIENT_BACKLOG`
    - else → `UNSATURATED`
    - Note field reports D, the number of steady windows, and ρ ≈ 1/D
  Default `--saturation-classifier` flipped to `drain-ratio`.

- **BC-6 (#1394) — Property invariants**

  Six properties run against every registered classifier (so new implementations automatically inherit the suite):
    - **P1 Determinism** — `Classify(x)` returns same result twice
    - **P2 Monotonicity in ρ at extremes** — UNSATURATED at ρ ≤ 0.85, PERSISTENTLY_SATURATED at ρ ≥ 1.10
    - **P3 Drain-phase invariance** — same inject phase + 0/30s/60s drain → same classification
    - **P4 Warmup robustness** — warmup ramp doesn't change steady-state verdict
    - **P5 Conservation** — `sum(NumEntered) == eligible_arrivals`. The property that catches #1389 directly.
    - **P6 Cross-classifier agreement** — at ρ extremes, all classifiers return the same verdict

## Two Layered Bugs Fixed

1. **Implementation (#1389)** — `RequestsToIntervals` (`saturation.go:140-143`) silently excluded `StateQueued` requests. Reproducible: at rate=80 with 6000 num_requests / 70s horizon, 737 of 5599 injected requests (13%) were dropped from analysis, all skewed toward the late inject phase, collapsing late-window `NumEntered` from ~800 to 62.
2. **Design (#1390)** — Slope regression operated over the entire `[0, simEndUs)` interval including the drain phase, producing a tent-shaped `ActiveEnd` time series whose OLS slope was ≈ 0 or negative. PERSISTENTLY_SATURATED could not fire for any sim with a drain phase.

The two bugs compound: fixing only #1389 leaves the slope predicate fragile; fixing only #1390 reads from biased per-window data. Both fixes together make the slope-based classifier correct.

## Validation

End-to-end on Llama-3.1-70B / TP=8 / H100 / chatbot, full sweep across rates spanning the engine's μ_max ≈ 64.5 req/s:

| rate | drain-ratio (default)      | slope-based (opt-in)        |
|------|----------------------------|-----------------------------|
| 4    | UNSATURATED                | UNSATURATED                 |
| 60   | UNSATURATED                | PERSISTENTLY_SATURATED      |
| 80   | PERSISTENTLY_SATURATED     | PERSISTENTLY_SATURATED      |
| 100  | PERSISTENTLY_SATURATED     | PERSISTENTLY_SATURATED      |

The two classifiers agree on the unambiguous extremes (rate=4 unsaturated, rate≥80 saturated). They reasonably differ at borderline ρ ≈ 0.93 (rate=60): slope-based emphasizes the congestion signal (peak/mean = 6.3×), drain-ratio emphasizes steady-state ρ. Drain-ratio's quantified utilization in the `note` field (e.g., "ρ ≈ 1.15" at rate=80) is a side benefit useful for capacity planning.

## Behavior Change

- `--saturation-report` classification can flip from `TRANSIENT_BACKLOG` to `PERSISTENTLY_SATURATED` for saturated runs (intentional — previous classification was wrong due to the two layered bugs).
- Runs with `still_queued > 0` produce different (correct) reports because queued requests are now included in analysis.
- Default `--saturation-classifier` is `drain-ratio`. Pass `--saturation-classifier slope-based` to opt back into the previous classifier philosophy.

Users who pin specific classification strings in scripts/CI must either accept the new verdict or use the opt-out.

## CLI Flags Added

- `--saturation-classifier <drain-ratio|slope-based>` (default: drain-ratio)
- `--saturation-warmup-windows <int>` (default: 2)
- `--saturation-tail-windows <int>` (default: 1)
- `--saturation-drain-ratio-saturated <float>` (default: 0.95)
- `--saturation-drain-ratio-transient <float>` (default: 0.98)

Existing slope-based flags (`--saturation-window`, `--saturation-min-windows`, `--saturation-peak-ratio`, `--saturation-peak-band`, `--saturation-ci`) preserved.

## Client-Side Observability Preserved

Both classifiers remain purely client-side observable: they consume only arrival, first-token, completion, and timeout signals — no engine-internal queue depth, batch size, KV utilization, or scheduling state. A client measuring `(arrival_time, first_token_time, last_token_time, did_timeout_locally)` for each request can reproduce the entire saturation analysis without any server cooperation.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all packages)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] All six property tests P1-P6 pass against both classifiers
- [x] Behavioral tests for drainRatioClassifier (8 new tests in `saturation_drainratio_test.go`)
- [x] Backward-compat tests for slopeBasedClassifier preserved
- [x] End-to-end validation on Llama-3.1-70B reference experiment
- [x] Conservation invariant `len(intervals) == N - timed_out` holds across 6 synthetic-trace cases (P5)
- [x] Drain-phase invariance: ρ=1.15 with 0/30/60s drain → all PERSISTENTLY_SATURATED (P3)
- [x] Cross-classifier agreement at ρ ∈ {0.5, 1.5} (P6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)