### PR TITLE
chore: gitignore .nous and .nous-experiments orchestration artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ vllm/
 
 # Plans
 docs/plans/
+
+# Nous campaign orchestration (experiment worktrees + state, not committed)
+.nous-experiments/
+.nous/


### PR DESCRIPTION
## Summary
- Add `.nous/` and `.nous-experiments/` to `.gitignore` so the `nous` campaign orchestrator's session-local state and per-experiment worktrees are never committed.
- Placed alongside the existing agent/tooling state entries; uses trailing-slash directory form to match directories only.

## Test plan
- [x] `git status` no longer lists `.nous/` or `.nous-experiments/` as untracked
- [x] No code, build, or simulator behavior touched — `.gitignore`-only change

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)