### PR TITLE
feat(workload): add min/max clamping to ExponentialSampler

### DIFF
--- a/sim/workload/distribution.go
+++ b/sim/workload/distribution.go
@@ -248,6 +248,9 @@ func NewLengthSampler(spec DistSpec) (LengthSampler, error) {
 		if v, ok := spec.Params["max"]; ok {
 			s.max = int(v)
 		}
+		if s.min > 0 && s.max > 0 && s.min > s.max {
+			return nil, fmt.Errorf("exponential: min (%d) must be <= max (%d)", s.min, s.max)
+		}
 		return s, nil
 
 	case "pareto_lognormal":
@@ -275,6 +278,9 @@ func NewLengthSampler(spec DistSpec) (LengthSampler, error) {
 		}
 		if v, ok := spec.Params["max"]; ok {
 			s.max = int(v)
+		}
+		if s.min > 0 && s.max > 0 && s.min > s.max {
+			return nil, fmt.Errorf("lognormal: min (%d) must be <= max (%d)", s.min, s.max)
 		}
 		return s, nil
 

--- a/sim/workload/distribution.go
+++ b/sim/workload/distribution.go
@@ -35,13 +35,21 @@ func (s *GaussianSampler) Sample(rng *rand.Rand) int {
 }
 
 // ExponentialSampler produces exponentially-distributed token lengths.
+// Optional min/max clamp (0 = no bound). Output is always >= 1.
 type ExponentialSampler struct {
-	mean float64
+	mean     float64
+	min, max int // 0 = no bound; applied after rounding
 }
 
 func (s *ExponentialSampler) Sample(rng *rand.Rand) int {
 	val := rng.ExpFloat64() * s.mean
 	result := int(math.Round(val))
+	if s.min > 0 && result < s.min {
+		result = s.min
+	}
+	if s.max > 0 && result > s.max {
+		result = s.max
+	}
 	if result < 1 {
 		return 1
 	}
@@ -233,9 +241,14 @@ func NewLengthSampler(spec DistSpec) (LengthSampler, error) {
 		if err := requireParam(spec.Params, "mean"); err != nil {
 			return nil, err
 		}
-		return &ExponentialSampler{
-			mean: spec.Params["mean"],
-		}, nil
+		s := &ExponentialSampler{mean: spec.Params["mean"]}
+		if v, ok := spec.Params["min"]; ok {
+			s.min = int(v)
+		}
+		if v, ok := spec.Params["max"]; ok {
+			s.max = int(v)
+		}
+		return s, nil
 
 	case "pareto_lognormal":
 		if err := requireParam(spec.Params, "alpha", "xm", "mu", "sigma", "mix_weight"); err != nil {

--- a/sim/workload/distribution_test.go
+++ b/sim/workload/distribution_test.go
@@ -85,6 +85,85 @@ func TestExponentialSampler_AlwaysPositive(t *testing.T) {
 	}
 }
 
+// TestExponentialSampler_ClampedToRange verifies BC-1: all samples fall within [min, max].
+func TestExponentialSampler_ClampedToRange(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	s, err := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 8000, "min": 500, "max": 32000},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 10000; i++ {
+		v := s.Sample(rng)
+		if v < 500 || v > 32000 {
+			t.Errorf("sample %d: %d outside [500, 32000]", i, v)
+			break
+		}
+	}
+}
+
+// TestExponentialSampler_MinOnly verifies BC-1 subset: only min bound applied.
+func TestExponentialSampler_MinOnly(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	s, err := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 5, "min": 10},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 10000; i++ {
+		v := s.Sample(rng)
+		if v < 10 {
+			t.Errorf("sample %d: %d below min=10", i, v)
+			break
+		}
+	}
+}
+
+// TestExponentialSampler_MaxOnly verifies BC-1 subset: only max bound applied.
+func TestExponentialSampler_MaxOnly(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	s, err := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 100, "max": 50},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 10000; i++ {
+		v := s.Sample(rng)
+		if v > 50 {
+			t.Errorf("sample %d: %d above max=50", i, v)
+			break
+		}
+	}
+}
+
+// TestExponentialSampler_NoBounds_BackwardsCompat verifies BC-2: no min/max means no change.
+func TestExponentialSampler_NoBounds_BackwardsCompat(t *testing.T) {
+	rng1 := rand.New(rand.NewSource(42))
+	s1, _ := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 256},
+	})
+	rng2 := rand.New(rand.NewSource(42))
+	s2, _ := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 256, "min": 0, "max": 0},
+	})
+	for i := 0; i < 1000; i++ {
+		v1 := s1.Sample(rng1)
+		v2 := s2.Sample(rng2)
+		if v1 != v2 {
+			t.Errorf("sample %d: with-zero-bounds=%d, no-bounds=%d; should be identical", i, v2, v1)
+			break
+		}
+	}
+}
+
 func TestParetoLogNormalSampler_ProducesPositiveValues(t *testing.T) {
 	rng := rand.New(rand.NewSource(42))
 	s, err := NewLengthSampler(DistSpec{

--- a/sim/workload/distribution_test.go
+++ b/sim/workload/distribution_test.go
@@ -142,6 +142,36 @@ func TestExponentialSampler_MaxOnly(t *testing.T) {
 	}
 }
 
+// TestExponentialSampler_MinGreaterThanMax_ReturnsError verifies that inverted bounds
+// are rejected rather than silently producing corrupt output (R3).
+func TestExponentialSampler_MinGreaterThanMax_ReturnsError(t *testing.T) {
+	_, err := NewLengthSampler(DistSpec{
+		Type:   "exponential",
+		Params: map[string]float64{"mean": 100, "min": 5000, "max": 50},
+	})
+	if err == nil {
+		t.Fatal("expected error for min > max, got nil")
+	}
+	if !strings.Contains(err.Error(), "min") || !strings.Contains(err.Error(), "max") {
+		t.Errorf("error %q should mention both min and max", err.Error())
+	}
+}
+
+// TestNewLengthSampler_Lognormal_MinGreaterThanMax_ReturnsError verifies the same guard
+// for the lognormal case (consistency with exponential and ParseThinkTimeDist).
+func TestNewLengthSampler_Lognormal_MinGreaterThanMax_ReturnsError(t *testing.T) {
+	_, err := NewLengthSampler(DistSpec{
+		Type:   "lognormal",
+		Params: map[string]float64{"mu": 6.0, "sigma": 0.5, "min": 5000, "max": 50},
+	})
+	if err == nil {
+		t.Fatal("expected error for min > max, got nil")
+	}
+	if !strings.Contains(err.Error(), "min") || !strings.Contains(err.Error(), "max") {
+		t.Errorf("error %q should mention both min and max", err.Error())
+	}
+}
+
 // TestExponentialSampler_NoBounds_BackwardsCompat verifies BC-2: no min/max means no change.
 func TestExponentialSampler_NoBounds_BackwardsCompat(t *testing.T) {
 	rng1 := rand.New(rand.NewSource(42))


### PR DESCRIPTION
## Summary

- Add optional `min`/`max` fields to `ExponentialSampler` (0 = no bound), applied after rounding — matching the pattern already used by `LognormalSampler` and `GaussianSampler`
- Update `NewLengthSampler` case `"exponential"` to read optional `min`/`max` from `spec.Params`
- Add table-driven behavioral tests verifying clamping, one-sided bounds, and backwards-compatibility

## Issue

Closes #1402

## Cross-Path Parity

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | yes | yes | WorkloadSpec drives ExponentialSampler via NewLengthSampler |
| `blis replay` | yes | yes | Same generator path |
| `blis observe` | N/A | N/A | Observe dispatches to real server; no LengthSampler involved |

## Invariants Affected

- None — pure simulation-fidelity fix; no request lifecycle, causality, determinism, or conservation invariants affected

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] `go vet ./sim/workload/...` passes clean
- [x] `TestExponentialSampler_ClampedToRange`: 10,000 samples all within [500, 32000]
- [x] `TestExponentialSampler_MinOnly`: 10,000 samples all ≥ 10
- [x] `TestExponentialSampler_MaxOnly`: 10,000 samples all ≤ 50
- [x] `TestExponentialSampler_NoBounds_BackwardsCompat`: zero-bound spec produces byte-identical output to no-params spec

---

Generated with [Claude Code](https://claude.ai/claude-code)