### PR TITLE
feat(metrics): goodput foundation — multi-dim SLO attainment + injection counter (#1409, PR1)

### DIFF
--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -472,7 +472,7 @@ func runObserve(cmd *cobra.Command, _ []string) {
 
 	// Export trace (BC-4)
 	header := &workload.TraceHeader{
-		Version:        2,
+		Version:        3,
 		TimeUnit:       "us",
 		CreatedAt:      time.Now().UTC().Format(time.RFC3339),
 		Mode:           "real",

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -538,7 +538,7 @@ Example:
 		if replayTraceOutput != "" {
 			records := workload.RequestsToTraceRecords(requests)
 			header := &workload.TraceHeader{
-				Version:  2,
+				Version:  3,
 				TimeUnit: "microseconds",
 				Mode:     "replayed",
 			}
@@ -585,6 +585,7 @@ Example:
 			scheduler,
 			cs.RoutingRejections(),
 			cs.EncodeRoutingRejections(),
+			cs.InjectedByClass(),
 		)
 		// INV-13 SYNC POINT (metrics): keep in sync with cmd/root.go post-simulation block.
 		rawMetrics.PD = cluster.CollectPDMetrics(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1726,7 +1726,7 @@ var runCmd = &cobra.Command{
 		if traceOutput != "" {
 			records := workload.RequestsToTraceRecords(allRequests)
 			header := &workload.TraceHeader{
-				Version:      2,
+				Version:      3,
 				TimeUnit:     "microseconds",
 				Mode:         "generated",
 				WorkloadSeed: &spec.Seed,
@@ -1805,6 +1805,7 @@ var runCmd = &cobra.Command{
 			scheduler,
 			cs.RoutingRejections(),
 			cs.EncodeRoutingRejections(),
+			cs.InjectedByClass(),
 		)
 
 		rawMetrics.PD = cluster.CollectPDMetrics(

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -36,6 +36,9 @@ type ClusterSimulator struct {
 	rejectedRequests      int                       // EC-2: count of requests rejected by admission policy
 	routingRejections     int                       // I13: count of requests rejected at routing (no routable instances)
 	shedByTier            map[string]int            // per-SLOClass shedding: admission rejections + gateway queue shed + in-flight evictions
+	// injectedByClass: per-SLOClass arrival counter. Incremented in ClusterArrivalEvent.Execute
+	// before any drop/route/admission decision. Goodput denominator (issue #1409, BC-5).
+	injectedByClass map[string]int64
 	trace                 *trace.SimulationTrace    // nil when trace-level is "none" (BC-1: zero overhead)
 	preGeneratedRequests  []*sim.Request            // Pre-generated requests (all workload paths unified)
 	inFlightRequests      map[string]int            // instance ID → dispatched-but-not-completed count (#463)
@@ -250,6 +253,7 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		trace:                simTrace,
 		inFlightRequests:     make(map[string]int, config.NumInstances),
 		shedByTier:           make(map[string]int),
+		injectedByClass:      make(map[string]int64),
 	}
 
 	// PD disaggregation: set pool membership (topology already validated above).
@@ -1305,6 +1309,21 @@ func (c *ClusterSimulator) ShedByTier() map[string]int {
 	}
 	result := make(map[string]int, len(c.shedByTier))
 	for k, v := range c.shedByTier {
+		result[k] = v
+	}
+	return result
+}
+
+// InjectedByClass returns a defensive copy of the per-SLOClass arrival counter.
+// Incremented in ClusterArrivalEvent.Execute before any drop/route/admission
+// decision; used as the goodput denominator (issue #1409, BC-5/BC-6).
+// Panics if called before Run() completes (R8 mirror of ShedByTier).
+func (c *ClusterSimulator) InjectedByClass() map[string]int64 {
+	if !c.hasRun {
+		panic("ClusterSimulator.InjectedByClass() called before Run()")
+	}
+	result := make(map[string]int64, len(c.injectedByClass))
+	for k, v := range c.injectedByClass {
 		result[k] = v
 	}
 	return result

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -126,8 +126,11 @@ func (e *ClusterArrivalEvent) Timestamp() int64 { return e.time }
 func (e *ClusterArrivalEvent) Priority() int     { return 0 }
 
 // Execute schedules an AdmissionDecisionEvent with the configured admission latency.
+// Records the request as injected on its SLO class BEFORE any admission/routing
+// decision so that drops and timeouts count against goodput (issue #1409, BC-5).
 func (e *ClusterArrivalEvent) Execute(cs *ClusterSimulator) {
 	cs.pendingArrivals--
+	cs.injectedByClass[e.request.SLOClass]++
 	logrus.Debugf("[cluster] req %s arrived at tick %d", e.request.ID, e.time)
 	heap.Push(&cs.clusterEvents, clusterEventEntry{
 		event: &AdmissionDecisionEvent{

--- a/sim/cluster/cluster_injection_test.go
+++ b/sim/cluster/cluster_injection_test.go
@@ -1,0 +1,57 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// TestClusterArrivalEvent_IncrementsInjectedByClass verifies BC-5: every cluster
+// arrival increments injectedByClass keyed by SLOClass before any admission/route
+// decision.
+func TestClusterArrivalEvent_IncrementsInjectedByClass(t *testing.T) {
+	cs := &ClusterSimulator{
+		injectedByClass:  make(map[string]int64),
+		clusterEvents:    make(ClusterEventQueue, 0),
+		admissionLatency: 0,
+		pendingArrivals:  3,
+	}
+	req1 := &sim.Request{ID: "r1", SLOClass: "critical"}
+	req2 := &sim.Request{ID: "r2", SLOClass: "critical"}
+	req3 := &sim.Request{ID: "r3", SLOClass: ""} // empty class — counted under ""
+
+	(&ClusterArrivalEvent{time: 0, request: req1}).Execute(cs)
+	(&ClusterArrivalEvent{time: 1, request: req2}).Execute(cs)
+	(&ClusterArrivalEvent{time: 2, request: req3}).Execute(cs)
+
+	if cs.injectedByClass["critical"] != 2 {
+		t.Errorf(`injectedByClass["critical"] = %d, want 2`, cs.injectedByClass["critical"])
+	}
+	if cs.injectedByClass[""] != 1 {
+		t.Errorf(`injectedByClass[""] = %d, want 1`, cs.injectedByClass[""])
+	}
+}
+
+// TestRawMetrics_InjectedByClass_DefensiveCopy verifies BC-6: CollectRawMetrics
+// produces a defensive copy of the injection counter.
+func TestRawMetrics_InjectedByClass_DefensiveCopy(t *testing.T) {
+	src := map[string]int64{"critical": 10, "batch": 3}
+	raw := CollectRawMetrics(sim.NewMetrics(), nil, 0, "fcfs", 0, 0, src)
+
+	if raw.InjectedByClass["critical"] != 10 || raw.InjectedByClass["batch"] != 3 {
+		t.Errorf("InjectedByClass mismatch: got %v, want critical=10 batch=3", raw.InjectedByClass)
+	}
+	src["critical"] = 999
+	if raw.InjectedByClass["critical"] != 10 {
+		t.Errorf("RawMetrics.InjectedByClass aliased the source map; got critical=%d, want 10", raw.InjectedByClass["critical"])
+	}
+}
+
+// TestRawMetrics_InjectedByClass_NilSourceLeavesFieldEmpty verifies that nil
+// (the test-callsite default) does not allocate an empty map.
+func TestRawMetrics_InjectedByClass_NilSourceLeavesFieldEmpty(t *testing.T) {
+	raw := CollectRawMetrics(sim.NewMetrics(), nil, 0, "fcfs", 0, 0, nil)
+	if raw.InjectedByClass != nil {
+		t.Errorf("InjectedByClass = %v, want nil for nil source", raw.InjectedByClass)
+	}
+}

--- a/sim/cluster/evaluation_test.go
+++ b/sim/cluster/evaluation_test.go
@@ -30,7 +30,7 @@ func TestNewEvaluationResult_WithTraceAndSummary_SummaryAccessible(t *testing.T)
 		t.Fatalf("cs.Run: %v", err)
 	}
 
-	rawMetrics := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0)
+	rawMetrics := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0, nil)
 	traceSummary := trace.Summarize(cs.Trace())
 
 	// WHEN constructing EvaluationResult from real simulation output

--- a/sim/cluster/metrics.go
+++ b/sim/cluster/metrics.go
@@ -394,32 +394,40 @@ type SLOClassAttainment struct {
 	ByDim    map[string]float64 // keys: "ttft", "itl", "e2e" (only non-zero dims present)
 }
 
-// requestLatency is a per-request latency view used by SLOAttainmentMultiDim.
-// Exported via BuildLatencyResults for callers that build it from sim.Metrics.
-type requestLatency struct {
-	class           string
-	ttftMs          float64
-	itlMs           float64
-	e2eMs           float64
-	hasTTFT, hasITL bool
+// RequestLatency is a per-request latency view consumed by SLOAttainmentMultiDim.
+// All latency fields are in milliseconds — BuildLatencyResults converts from
+// the µs ticks stored in sim.Metrics.{RequestTTFTs,RequestITLs,RequestE2Es}.
+// The struct is exported so PR2's cmd/ wiring can construct fixtures and
+// alternate observe-path views without going through sim.Metrics.
+type RequestLatency struct {
+	Class           string
+	TTFTMs          float64
+	ITLMs           float64
+	E2EMs           float64
+	HasTTFT, HasITL bool
 }
 
 // BuildLatencyResults extracts per-request latency views from sim.Metrics for
 // SLOAttainmentMultiDim. Iterates RequestE2Es (E2E is the basic completion signal).
-func BuildLatencyResults(m *sim.Metrics) map[string]requestLatency {
-	out := make(map[string]requestLatency, len(m.RequestE2Es))
+//
+// Unit handling: sim.Metrics stores TTFT/ITL/E2E in µs ticks (see sim/simulator.go
+// :623, :784 and the /1e3 conversions at sim/metrics.go:139-171). This function
+// converts to milliseconds so RequestLatency fields match the ms-denominated
+// thresholds in workload.SLODimTargets.
+func BuildLatencyResults(m *sim.Metrics) map[string]RequestLatency {
+	out := make(map[string]RequestLatency, len(m.RequestE2Es))
 	for id, e2e := range m.RequestE2Es {
-		rl := requestLatency{e2eMs: e2e}
+		rl := RequestLatency{E2EMs: e2e / 1e3}
 		if rm, ok := m.Requests[id]; ok {
-			rl.class = rm.SLOClass
+			rl.Class = rm.SLOClass
 		}
 		if t, ok := m.RequestTTFTs[id]; ok {
-			rl.ttftMs = t
-			rl.hasTTFT = true
+			rl.TTFTMs = t / 1e3
+			rl.HasTTFT = true
 		}
 		if i, ok := m.RequestITLs[id]; ok {
-			rl.itlMs = i
-			rl.hasITL = true
+			rl.ITLMs = i / 1e3
+			rl.HasITL = true
 		}
 		out[id] = rl
 	}
@@ -448,7 +456,7 @@ func BuildLatencyResults(m *sim.Metrics) map[string]requestLatency {
 // Determinism (R2): map iteration mutates only integer counters per class; division
 // happens once at the end on stable integer sums.
 func SLOAttainmentMultiDim(
-	results map[string]requestLatency,
+	results map[string]RequestLatency,
 	injectedByClass map[string]int64,
 	targets map[string]workload.SLODimTargets,
 ) (overall float64, perClass map[string]SLOClassAttainment) {
@@ -458,14 +466,24 @@ func SLOAttainmentMultiDim(
 	}
 
 	type acc struct {
-		good                                                 int
-		ttftMet, ttftCount, itlMet, itlCount, e2eMet, e2eCnt int
+		good      int
+		ttftMet   int
+		ttftCount int
+		itlMet    int
+		itlCount  int
+		e2eMet    int
+		e2eCount  int
 	}
 	accs := make(map[string]*acc, len(targets))
 	for cls := range targets {
 		accs[cls] = &acc{}
 	}
 
+	// lookup folds empty SLOClass to "default" for target lookup. Note that an
+	// explicit "" key in targets is never produced by YAML decoding (map keys
+	// in YAML cannot be empty strings as user values), and a programmatically
+	// supplied "" target would be unreachable here because it never matches —
+	// empty-class requests get their class rewritten to "default" before lookup.
 	lookup := func(cls string) (workload.SLODimTargets, string, bool) {
 		if cls == "" {
 			cls = "default"
@@ -477,7 +495,7 @@ func SLOAttainmentMultiDim(
 	}
 
 	for _, rl := range results {
-		t, cls, ok := lookup(rl.class)
+		t, cls, ok := lookup(rl.Class)
 		if !ok {
 			continue
 		}
@@ -486,7 +504,7 @@ func SLOAttainmentMultiDim(
 
 		if t.TTFTMs > 0 {
 			a.ttftCount++
-			if rl.hasTTFT && rl.ttftMs <= t.TTFTMs {
+			if rl.HasTTFT && rl.TTFTMs <= t.TTFTMs {
 				a.ttftMet++
 			} else {
 				good = false
@@ -494,15 +512,15 @@ func SLOAttainmentMultiDim(
 		}
 		if t.ITLMs > 0 {
 			a.itlCount++
-			if rl.hasITL && rl.itlMs <= t.ITLMs {
+			if rl.HasITL && rl.ITLMs <= t.ITLMs {
 				a.itlMet++
 			} else {
 				good = false
 			}
 		}
 		if t.E2EMs > 0 {
-			a.e2eCnt++
-			if rl.e2eMs <= t.E2EMs {
+			a.e2eCount++
+			if rl.E2EMs <= t.E2EMs {
 				a.e2eMet++
 			} else {
 				good = false
@@ -543,7 +561,7 @@ func SLOAttainmentMultiDim(
 			sca.ByDim["itl"] = safeFrac(a.itlMet, a.itlCount)
 		}
 		if t.E2EMs > 0 {
-			sca.ByDim["e2e"] = safeFrac(a.e2eMet, a.e2eCnt)
+			sca.ByDim["e2e"] = safeFrac(a.e2eMet, a.e2eCount)
 		}
 		perClass[cls] = sca
 		totalGood += a.good

--- a/sim/cluster/metrics.go
+++ b/sim/cluster/metrics.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,6 +82,7 @@ func percentile(sorted []float64, p float64) float64 {
 // SLOMetrics holds per-SLO-class latency distributions.
 type SLOMetrics struct {
 	TTFT Distribution
+	ITL  Distribution // issue #1409: populated alongside TTFT/E2E for goodput ITL gating (BC-7)
 	E2E  Distribution
 }
 
@@ -102,6 +104,10 @@ type RawMetrics struct {
 	HOLBlockingEvents    int
 	RejectedRequests     int            // admission rejections
 	ShedByTier                map[string]int // per-SLOClass breakdown of all shedding events: admission rejections + gateway queue evictions (unconditional)
+	// InjectedByClass: per-SLOClass arrival counter; populated by ClusterArrivalEvent.Execute
+	// before any drop/route decision. Used as the goodput denominator (issue #1409, BC-6).
+	// Empty SLOClass requests appear under the "" key.
+	InjectedByClass map[string]int64
 	// INV-1 extended: injected == completed + running + queued + routing_rejections + dropped + timed_out + gw_depth + gw_shed + gw_rejected + gw_evicted + gw_expired + encode_routing_rejections
 	GatewayQueueDepth       int // Requests still in gateway queue at horizon (issue #882)
 	GatewayQueueShed        int // Requests shed (evicted victims) from gateway queue (issue #882)
@@ -129,7 +135,7 @@ type RawMetrics struct {
 // when "fcfs" or "" (no priority ordering), inversions are
 // suppressed (always 0) since requests are served in arrival order and
 // E2E differences reflect workload variance, not scheduling unfairness.
-func CollectRawMetrics(aggregated *sim.Metrics, perInstance []*sim.Metrics, rejectedRequests int, scheduler string, routingRejections int, encodeRoutingRejections int) *RawMetrics {
+func CollectRawMetrics(aggregated *sim.Metrics, perInstance []*sim.Metrics, rejectedRequests int, scheduler string, routingRejections int, encodeRoutingRejections int, injectedByClass map[string]int64) *RawMetrics {
 	raw := &RawMetrics{
 		RejectedRequests:        rejectedRequests,
 		RoutingRejections:       routingRejections,
@@ -137,6 +143,14 @@ func CollectRawMetrics(aggregated *sim.Metrics, perInstance []*sim.Metrics, reje
 		DroppedUnservable:       aggregated.DroppedUnservable,
 		LengthCappedRequests:    aggregated.LengthCappedRequests,
 		TimedOutRequests:        aggregated.TimedOutRequests,
+	}
+
+	// Defensive copy of per-class injection counter for goodput denominator (BC-6).
+	if len(injectedByClass) > 0 {
+		raw.InjectedByClass = make(map[string]int64, len(injectedByClass))
+		for k, v := range injectedByClass {
+			raw.InjectedByClass[k] = v
+		}
 	}
 
 	// Latency distributions
@@ -290,10 +304,11 @@ func detectHOLBlocking(perInstance []*sim.Metrics) int {
 }
 
 // ComputePerSLODistributions builds per-SLO-class latency distributions.
-// Filters requests by their SLOClass field and computes distributions per class.
+// Filters requests by their SLOClass field and computes TTFT, ITL, and E2E
+// distributions per class (issue #1409, BC-7: ITL added alongside TTFT/E2E).
 func ComputePerSLODistributions(aggregated *sim.Metrics) map[string]*SLOMetrics {
-	// Group TTFT and E2E values by SLO class
 	ttftByClass := make(map[string][]float64)
+	itlByClass := make(map[string][]float64)
 	e2eByClass := make(map[string][]float64)
 
 	droppedTTFT := 0
@@ -311,6 +326,22 @@ func ComputePerSLODistributions(aggregated *sim.Metrics) map[string]*SLOMetrics 
 	}
 	if droppedTTFT > 0 {
 		logrus.Warnf("ComputePerSLODistributions: %d requests in RequestTTFTs missing from Requests map", droppedTTFT)
+	}
+	droppedITL := 0
+	for reqID, itl := range aggregated.RequestITLs {
+		req, ok := aggregated.Requests[reqID]
+		if !ok {
+			droppedITL++
+			continue
+		}
+		sloClass := req.SLOClass
+		if sloClass == "" {
+			sloClass = "default"
+		}
+		itlByClass[sloClass] = append(itlByClass[sloClass], itl)
+	}
+	if droppedITL > 0 {
+		logrus.Warnf("ComputePerSLODistributions: %d requests in RequestITLs missing from Requests map", droppedITL)
 	}
 	droppedE2E := 0
 	for reqID, e2e := range aggregated.RequestE2Es {
@@ -330,9 +361,11 @@ func ComputePerSLODistributions(aggregated *sim.Metrics) map[string]*SLOMetrics 
 	}
 
 	result := make(map[string]*SLOMetrics)
-	// Collect all classes from both maps
 	allClasses := make(map[string]bool)
 	for k := range ttftByClass {
+		allClasses[k] = true
+	}
+	for k := range itlByClass {
 		allClasses[k] = true
 	}
 	for k := range e2eByClass {
@@ -341,48 +374,193 @@ func ComputePerSLODistributions(aggregated *sim.Metrics) map[string]*SLOMetrics 
 	for cls := range allClasses {
 		result[cls] = &SLOMetrics{
 			TTFT: NewDistribution(ttftByClass[cls]),
+			ITL:  NewDistribution(itlByClass[cls]),
 			E2E:  NewDistribution(e2eByClass[cls]),
 		}
 	}
 	return result
 }
 
-// SLOAttainment computes the fraction of requests meeting their SLO target.
-// targets maps SLO class to max acceptable E2E latency (in ticks).
-// Returns a value in [0.0, 1.0].
-// Requests in RequestE2Es that are missing from Requests map are counted
-// as SLO violations (conservative: missing data = violation).
-func SLOAttainment(aggregated *sim.Metrics, targets map[string]float64) float64 {
-	if len(aggregated.RequestE2Es) == 0 {
-		return 0
+// SLOClassAttainment is the per-class result of SLOAttainmentMultiDim.
+//
+//	Good     — number of completed requests for this class that met every non-zero dimension.
+//	Injected — denominator: total arrivals on this class (passed in by the caller from
+//	           ClusterSimulator.injectedByClass). Includes drops/timeouts.
+//	ByDim    — per-dimension attainment fraction (numerator / count of completed-and-class-matched
+//	           requests that had data for that dim). Populated only for non-zero dimensions.
+type SLOClassAttainment struct {
+	Good     int
+	Injected int64
+	ByDim    map[string]float64 // keys: "ttft", "itl", "e2e" (only non-zero dims present)
+}
+
+// requestLatency is a per-request latency view used by SLOAttainmentMultiDim.
+// Exported via BuildLatencyResults for callers that build it from sim.Metrics.
+type requestLatency struct {
+	class           string
+	ttftMs          float64
+	itlMs           float64
+	e2eMs           float64
+	hasTTFT, hasITL bool
+}
+
+// BuildLatencyResults extracts per-request latency views from sim.Metrics for
+// SLOAttainmentMultiDim. Iterates RequestE2Es (E2E is the basic completion signal).
+func BuildLatencyResults(m *sim.Metrics) map[string]requestLatency {
+	out := make(map[string]requestLatency, len(m.RequestE2Es))
+	for id, e2e := range m.RequestE2Es {
+		rl := requestLatency{e2eMs: e2e}
+		if rm, ok := m.Requests[id]; ok {
+			rl.class = rm.SLOClass
+		}
+		if t, ok := m.RequestTTFTs[id]; ok {
+			rl.ttftMs = t
+			rl.hasTTFT = true
+		}
+		if i, ok := m.RequestITLs[id]; ok {
+			rl.itlMs = i
+			rl.hasITL = true
+		}
+		out[id] = rl
 	}
-	met := 0
-	total := 0
-	droppedCount := 0
-	for reqID, e2e := range aggregated.RequestE2Es {
-		total++
-		req, ok := aggregated.Requests[reqID]
+	return out
+}
+
+// SLOAttainmentMultiDim returns overall attainment and per-class breakdown across
+// TTFT, ITL, and E2E dimensions (issue #1409, BC-1..4, BC-N2).
+//
+// Inputs:
+//
+//	results          — completed-request latency views (built by BuildLatencyResults).
+//	injectedByClass  — count of arrivals per class. The denominator. Comes from
+//	                   ClusterSimulator.injectedByClass and includes drops/timeouts.
+//	targets          — per-class thresholds. Empty SLOClass on a request maps to "default".
+//	                   A class missing from targets (and missing a "default" entry) is
+//	                   excluded from BOTH numerator and denominator (BC-N2).
+//
+// Returns:
+//
+//	overall  — sum(perClass[*].Good) / sum(perClass[*].Injected) over configured classes;
+//	           0 if no class is configured or denominator is 0.
+//	perClass — keyed by configured class (only). ByDim populated only for non-zero
+//	           dimensions in that class's target.
+//
+// Determinism (R2): map iteration mutates only integer counters per class; division
+// happens once at the end on stable integer sums.
+func SLOAttainmentMultiDim(
+	results map[string]requestLatency,
+	injectedByClass map[string]int64,
+	targets map[string]workload.SLODimTargets,
+) (overall float64, perClass map[string]SLOClassAttainment) {
+	perClass = make(map[string]SLOClassAttainment, len(targets))
+	if len(targets) == 0 {
+		return 0, perClass
+	}
+
+	type acc struct {
+		good                                                 int
+		ttftMet, ttftCount, itlMet, itlCount, e2eMet, e2eCnt int
+	}
+	accs := make(map[string]*acc, len(targets))
+	for cls := range targets {
+		accs[cls] = &acc{}
+	}
+
+	lookup := func(cls string) (workload.SLODimTargets, string, bool) {
+		if cls == "" {
+			cls = "default"
+		}
+		if t, ok := targets[cls]; ok {
+			return t, cls, true
+		}
+		return workload.SLODimTargets{}, cls, false
+	}
+
+	for _, rl := range results {
+		t, cls, ok := lookup(rl.class)
 		if !ok {
-			droppedCount++
-			continue // counted in total but not in met (= violation)
+			continue
 		}
-		sloClass := req.SLOClass
-		if target, ok := targets[sloClass]; ok {
-			if e2e <= target {
-				met++
+		a := accs[cls]
+		good := true
+
+		if t.TTFTMs > 0 {
+			a.ttftCount++
+			if rl.hasTTFT && rl.ttftMs <= t.TTFTMs {
+				a.ttftMet++
+			} else {
+				good = false
 			}
-		} else {
-			// No target for this class = always meets SLO
-			met++
+		}
+		if t.ITLMs > 0 {
+			a.itlCount++
+			if rl.hasITL && rl.itlMs <= t.ITLMs {
+				a.itlMet++
+			} else {
+				good = false
+			}
+		}
+		if t.E2EMs > 0 {
+			a.e2eCnt++
+			if rl.e2eMs <= t.E2EMs {
+				a.e2eMet++
+			} else {
+				good = false
+			}
+		}
+		if good {
+			a.good++
 		}
 	}
-	if droppedCount > 0 {
-		logrus.Warnf("SLOAttainment: %d requests in RequestE2Es missing from Requests map (counted as violations)", droppedCount)
+
+	// Build per-class result with deterministic key set (R2: sort target keys).
+	targetKeys := make([]string, 0, len(targets))
+	for k := range targets {
+		targetKeys = append(targetKeys, k)
 	}
-	if total == 0 {
+	sort.Strings(targetKeys)
+
+	// Normalize denominator: when a "default" target is configured, fold
+	// the empty-SLOClass injection bucket into it (matches the request-side
+	// fold in `lookup`). Without this, empty-class arrivals would be missing
+	// from the denominator even though their completions count under "default".
+	_, defaultConfigured := targets["default"]
+
+	var totalGood int
+	var totalInjected int64
+	for _, cls := range targetKeys {
+		a := accs[cls]
+		injected := injectedByClass[cls]
+		if cls == "default" && defaultConfigured {
+			injected += injectedByClass[""]
+		}
+		sca := SLOClassAttainment{Good: a.good, Injected: injected, ByDim: make(map[string]float64)}
+		t := targets[cls]
+		if t.TTFTMs > 0 {
+			sca.ByDim["ttft"] = safeFrac(a.ttftMet, a.ttftCount)
+		}
+		if t.ITLMs > 0 {
+			sca.ByDim["itl"] = safeFrac(a.itlMet, a.itlCount)
+		}
+		if t.E2EMs > 0 {
+			sca.ByDim["e2e"] = safeFrac(a.e2eMet, a.e2eCnt)
+		}
+		perClass[cls] = sca
+		totalGood += a.good
+		totalInjected += injected
+	}
+
+	if totalInjected > 0 {
+		overall = float64(totalGood) / float64(totalInjected)
+	}
+	return overall, perClass
+}
+
+func safeFrac(num, denom int) float64 {
+	if denom == 0 {
 		return 0
 	}
-	return float64(met) / float64(total)
+	return float64(num) / float64(denom)
 }
 
 // JainFairnessIndex computes the Jain's fairness index across tenant throughputs.

--- a/sim/cluster/metrics_pr12_test.go
+++ b/sim/cluster/metrics_pr12_test.go
@@ -20,7 +20,7 @@ func TestCollectRawMetrics_IncludesPreemptionRate(t *testing.T) {
 	aggregated.SimEndedTime = 1000000
 
 	// WHEN collecting raw metrics
-	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m1, m2}, 0, "", 0, 0)
+	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m1, m2}, 0, "", 0, 0, nil)
 
 	// THEN PreemptionRate = 4/20 = 0.2
 	expected := 4.0 / 20.0
@@ -43,7 +43,7 @@ func TestCollectRawMetrics_IncludesCacheHitRate(t *testing.T) {
 	aggregated.SimEndedTime = 1000000
 
 	// WHEN collecting raw metrics
-	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m1, m2}, 0, "", 0, 0)
+	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m1, m2}, 0, "", 0, 0, nil)
 
 	// THEN CacheHitRate = average(0.8, 0.6) = 0.7
 	expected := 0.7

--- a/sim/cluster/metrics_slo_test.go
+++ b/sim/cluster/metrics_slo_test.go
@@ -110,14 +110,45 @@ func TestComputePerSLODistributions_MissingRequests_StillComputesPresent(t *test
 	}
 }
 
+// TestBuildLatencyResults_ConvertsTicksToMs is the unit-correctness guard
+// for the µs-ticks → ms conversion. sim.Metrics stores latencies in µs ticks
+// (sim/simulator.go:623, :784); workload.SLODimTargets thresholds are in ms.
+// Without conversion, every request would appear to violate every SLO.
+func TestBuildLatencyResults_ConvertsTicksToMs(t *testing.T) {
+	m := sim.NewMetrics()
+	m.Requests["r1"] = sim.RequestMetrics{ID: "r1", SLOClass: "critical"}
+	m.RequestTTFTs["r1"] = 50_000 // 50 ms in µs ticks
+	m.RequestITLs["r1"] = 30_000  // 30 ms in µs ticks
+	m.RequestE2Es["r1"] = 2_000_000 // 2 s in µs ticks
+
+	rl := BuildLatencyResults(m)["r1"]
+	if rl.TTFTMs != 50 {
+		t.Errorf("TTFTMs = %f, want 50 (50_000 µs / 1e3)", rl.TTFTMs)
+	}
+	if rl.ITLMs != 30 {
+		t.Errorf("ITLMs = %f, want 30", rl.ITLMs)
+	}
+	if rl.E2EMs != 2000 {
+		t.Errorf("E2EMs = %f, want 2000", rl.E2EMs)
+	}
+	if !rl.HasTTFT || !rl.HasITL {
+		t.Error("HasTTFT and HasITL must be true when source maps populate the request")
+	}
+	if rl.Class != "critical" {
+		t.Errorf("Class = %q, want %q", rl.Class, "critical")
+	}
+}
+
 // --- SLOAttainmentMultiDim tests (BC-1..4, BC-N2) -------------------------
 
-// makeMetrics builds a sim.Metrics with the given per-class requests and latencies.
-// Each entry: class string, count int, ttftMs, itlMs, e2eMs float64 (per request).
+// makeMetricsForSLO builds a sim.Metrics with the given per-class requests and
+// latencies. Test-side fields are in milliseconds; the helper multiplies by 1e3
+// to populate sim.Metrics in µs ticks (the production unit), so that
+// BuildLatencyResults' conversion is exercised on every assertion.
 func makeMetricsForSLO(t *testing.T, entries []struct {
-	class                  string
-	count                  int
-	ttftMs, itlMs, e2eMs   float64
+	class                string
+	count                int
+	ttftMs, itlMs, e2eMs float64
 }) *sim.Metrics {
 	t.Helper()
 	m := sim.NewMetrics()
@@ -127,9 +158,9 @@ func makeMetricsForSLO(t *testing.T, entries []struct {
 			id := fmt.Sprintf("%s_%d", e.class, idx)
 			idx++
 			m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: e.class}
-			m.RequestTTFTs[id] = e.ttftMs
-			m.RequestITLs[id] = e.itlMs
-			m.RequestE2Es[id] = e.e2eMs
+			m.RequestTTFTs[id] = e.ttftMs * 1e3
+			m.RequestITLs[id] = e.itlMs * 1e3
+			m.RequestE2Es[id] = e.e2eMs * 1e3
 		}
 	}
 	return m
@@ -192,20 +223,22 @@ func TestSLOAttainmentMultiDim_PartialDims_OnlyConfiguredGate(t *testing.T) {
 func TestSLOAttainmentMultiDim_AndCombination_AllDimsMustPass(t *testing.T) {
 	// BC-4: a request good only if every non-zero dim passes.
 	// 10 requests in class A: 5 with all dims passing, 5 fail TTFT only.
+	// All RequestTTFTs/ITLs/E2Es values are in µs ticks (sim/simulator.go:623, :784).
+	// Helpers below match that unit; thresholds in workload.SLODimTargets are in ms.
 	m := sim.NewMetrics()
 	for i := 0; i < 5; i++ {
 		id := fmt.Sprintf("good_%d", i)
 		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "A"}
-		m.RequestTTFTs[id] = 50
-		m.RequestITLs[id] = 30
-		m.RequestE2Es[id] = 2000
+		m.RequestTTFTs[id] = 50 * 1e3   // 50 ms
+		m.RequestITLs[id] = 30 * 1e3    // 30 ms
+		m.RequestE2Es[id] = 2000 * 1e3  // 2 s
 	}
 	for i := 0; i < 5; i++ {
 		id := fmt.Sprintf("bad_%d", i)
 		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "A"}
-		m.RequestTTFTs[id] = 999 // exceeds threshold
-		m.RequestITLs[id] = 30
-		m.RequestE2Es[id] = 2000
+		m.RequestTTFTs[id] = 999 * 1e3 // 999 ms — exceeds 100 ms threshold
+		m.RequestITLs[id] = 30 * 1e3
+		m.RequestE2Es[id] = 2000 * 1e3
 	}
 	results := BuildLatencyResults(m)
 	injected := map[string]int64{"A": 10}

--- a/sim/cluster/metrics_slo_test.go
+++ b/sim/cluster/metrics_slo_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
 )
 
 func TestComputePerSLODistributions_SegregatesCorrectly(t *testing.T) {
 	m := sim.NewMetrics()
-	// Add requests with different SLO classes
 	for i := 0; i < 50; i++ {
 		id := fmt.Sprintf("rt_%d", i)
 		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "critical"}
@@ -40,6 +40,28 @@ func TestComputePerSLODistributions_SegregatesCorrectly(t *testing.T) {
 	}
 }
 
+func TestComputePerSLODistributions_PopulatesITL(t *testing.T) {
+	// BC-7: ITL distribution populated alongside TTFT/E2E.
+	m := sim.NewMetrics()
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("req_%d", i)
+		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "critical"}
+		m.RequestTTFTs[id] = 100
+		m.RequestE2Es[id] = 1000
+		m.RequestITLs[id] = float64(50 + i)
+	}
+	result := ComputePerSLODistributions(m)
+	if result["critical"] == nil {
+		t.Fatal("expected critical class")
+	}
+	if result["critical"].ITL.Count != 5 {
+		t.Errorf("ITL.Count = %d, want 5", result["critical"].ITL.Count)
+	}
+	if result["critical"].ITL.Min != 50 || result["critical"].ITL.Max != 54 {
+		t.Errorf("ITL min/max = %f/%f, want 50/54", result["critical"].ITL.Min, result["critical"].ITL.Max)
+	}
+}
+
 func TestJainFairnessIndex_EqualThroughput_ReturnsOne(t *testing.T) {
 	throughputs := map[string]float64{"t1": 100, "t2": 100, "t3": 100}
 	jfi := JainFairnessIndex(throughputs)
@@ -49,10 +71,8 @@ func TestJainFairnessIndex_EqualThroughput_ReturnsOne(t *testing.T) {
 }
 
 func TestJainFairnessIndex_UnequalThroughput_LessThanOne(t *testing.T) {
-	// Extreme unfairness: one tenant gets everything
 	throughputs := map[string]float64{"t1": 1000, "t2": 1, "t3": 1}
 	jfi := JainFairnessIndex(throughputs)
-	// Should be close to 1/3 (very unfair)
 	if jfi > 0.5 {
 		t.Errorf("JFI = %f, expected < 0.5 for very unequal throughputs", jfi)
 	}
@@ -65,57 +85,20 @@ func TestJainFairnessIndex_EmptyMap_ReturnsZero(t *testing.T) {
 	}
 }
 
-func TestSLOAttainment_AllMeet_ReturnsOne(t *testing.T) {
-	m := sim.NewMetrics()
-	for i := 0; i < 10; i++ {
-		id := fmt.Sprintf("req_%d", i)
-		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "batch"}
-		m.RequestE2Es[id] = 500 // well under 1000 target
-	}
-	targets := map[string]float64{"batch": 1000}
-	attainment := SLOAttainment(m, targets)
-	if attainment != 1.0 {
-		t.Errorf("attainment = %f, want 1.0 when all meet SLO", attainment)
-	}
-}
-
-func TestSLOAttainment_SomeMiss_FractionalResult(t *testing.T) {
-	m := sim.NewMetrics()
-	for i := 0; i < 10; i++ {
-		id := fmt.Sprintf("req_%d", i)
-		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "critical"}
-		if i < 7 {
-			m.RequestE2Es[id] = 100 // meets 200 target
-		} else {
-			m.RequestE2Es[id] = 300 // exceeds 200 target
-		}
-	}
-	targets := map[string]float64{"critical": 200}
-	attainment := SLOAttainment(m, targets)
-	if math.Abs(attainment-0.7) > 0.01 {
-		t.Errorf("attainment = %f, want 0.7 (7/10 meet SLO)", attainment)
-	}
-}
-
 func TestComputePerSLODistributions_MissingRequests_StillComputesPresent(t *testing.T) {
-	// GIVEN metrics with 10 TTFT entries and 10 E2E entries,
-	// but only 7 have corresponding entries in the Requests map
 	m := sim.NewMetrics()
 	for i := 0; i < 10; i++ {
 		id := fmt.Sprintf("req_%d", i)
 		m.RequestTTFTs[id] = float64(100 + i)
 		m.RequestE2Es[id] = float64(500 + i)
 	}
-	// Only 7 out of 10 have Requests entries
 	for i := 0; i < 7; i++ {
 		id := fmt.Sprintf("req_%d", i)
 		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "batch"}
 	}
 
-	// WHEN computing per-SLO distributions
 	result := ComputePerSLODistributions(m)
 
-	// THEN distributions are computed for the 7 present requests
 	if result["batch"] == nil {
 		t.Fatal("expected batch class in result")
 	}
@@ -127,25 +110,246 @@ func TestComputePerSLODistributions_MissingRequests_StillComputesPresent(t *test
 	}
 }
 
-func TestSLOAttainment_MissingRequests_CountedAsViolation(t *testing.T) {
-	// GIVEN 10 requests in RequestE2Es but only 7 in Requests map
+// --- SLOAttainmentMultiDim tests (BC-1..4, BC-N2) -------------------------
+
+// makeMetrics builds a sim.Metrics with the given per-class requests and latencies.
+// Each entry: class string, count int, ttftMs, itlMs, e2eMs float64 (per request).
+func makeMetricsForSLO(t *testing.T, entries []struct {
+	class                  string
+	count                  int
+	ttftMs, itlMs, e2eMs   float64
+}) *sim.Metrics {
+	t.Helper()
 	m := sim.NewMetrics()
-	for i := 0; i < 10; i++ {
-		id := fmt.Sprintf("req_%d", i)
-		m.RequestE2Es[id] = 100 // all would meet SLO
+	idx := 0
+	for _, e := range entries {
+		for i := 0; i < e.count; i++ {
+			id := fmt.Sprintf("%s_%d", e.class, idx)
+			idx++
+			m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: e.class}
+			m.RequestTTFTs[id] = e.ttftMs
+			m.RequestITLs[id] = e.itlMs
+			m.RequestE2Es[id] = e.e2eMs
+		}
 	}
-	// Only register 7 in Requests map
-	for i := 0; i < 7; i++ {
-		id := fmt.Sprintf("req_%d", i)
-		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "batch"}
+	return m
+}
+
+func TestSLOAttainmentMultiDim_AllDimsMet_ReturnsPerfectScore(t *testing.T) {
+	// BC-1: all configured dimensions met => attainment = 1.0
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"critical", 10, 50, 30, 2000},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"critical": 10}
+	targets := map[string]workload.SLODimTargets{
+		"critical": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
 	}
-	targets := map[string]float64{"batch": 200}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if overall != 1.0 {
+		t.Errorf("overall = %f, want 1.0", overall)
+	}
+	if perClass["critical"].Good != 10 {
+		t.Errorf("Good = %d, want 10", perClass["critical"].Good)
+	}
+	if perClass["critical"].Injected != 10 {
+		t.Errorf("Injected = %d, want 10", perClass["critical"].Injected)
+	}
+	for _, dim := range []string{"ttft", "itl", "e2e"} {
+		if got := perClass["critical"].ByDim[dim]; got != 1.0 {
+			t.Errorf("ByDim[%s] = %f, want 1.0", dim, got)
+		}
+	}
+}
 
-	// WHEN computing SLO attainment
-	attainment := SLOAttainment(m, targets)
+func TestSLOAttainmentMultiDim_PartialDims_OnlyConfiguredGate(t *testing.T) {
+	// BC-3: ITLMs == 0 means ITL is not gated. Request with high ITL is still good.
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"batch", 5, 80, 9999, 4000},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"batch": 5}
+	targets := map[string]workload.SLODimTargets{
+		"batch": {TTFTMs: 100, E2EMs: 5000}, // ITLMs=0 => not gated
+	}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if overall != 1.0 {
+		t.Errorf("overall = %f, want 1.0 (ITL not gated)", overall)
+	}
+	if _, present := perClass["batch"].ByDim["itl"]; present {
+		t.Errorf("ByDim should not contain 'itl' when ITLMs == 0")
+	}
+}
 
-	// THEN attainment should be 7/10 = 0.7 (dropped requests are violations)
-	if math.Abs(attainment-0.7) > 0.01 {
-		t.Errorf("attainment = %f, want 0.7 (3 missing requests should count as violations)", attainment)
+func TestSLOAttainmentMultiDim_AndCombination_AllDimsMustPass(t *testing.T) {
+	// BC-4: a request good only if every non-zero dim passes.
+	// 10 requests in class A: 5 with all dims passing, 5 fail TTFT only.
+	m := sim.NewMetrics()
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("good_%d", i)
+		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "A"}
+		m.RequestTTFTs[id] = 50
+		m.RequestITLs[id] = 30
+		m.RequestE2Es[id] = 2000
+	}
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("bad_%d", i)
+		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: "A"}
+		m.RequestTTFTs[id] = 999 // exceeds threshold
+		m.RequestITLs[id] = 30
+		m.RequestE2Es[id] = 2000
+	}
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"A": 10}
+	targets := map[string]workload.SLODimTargets{
+		"A": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
+	}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if math.Abs(overall-0.5) > 1e-9 {
+		t.Errorf("overall = %f, want 0.5", overall)
+	}
+	if perClass["A"].Good != 5 {
+		t.Errorf("Good = %d, want 5", perClass["A"].Good)
+	}
+	if got := perClass["A"].ByDim["ttft"]; math.Abs(got-0.5) > 1e-9 {
+		t.Errorf("ByDim[ttft] = %f, want 0.5", got)
+	}
+	if got := perClass["A"].ByDim["itl"]; got != 1.0 {
+		t.Errorf("ByDim[itl] = %f, want 1.0", got)
+	}
+	if got := perClass["A"].ByDim["e2e"]; got != 1.0 {
+		t.Errorf("ByDim[e2e] = %f, want 1.0", got)
+	}
+}
+
+func TestSLOAttainmentMultiDim_UnconfiguredClass_ExcludedFromDenominator(t *testing.T) {
+	// BC-N2: unconfigured class contributes neither numerator nor denominator.
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"critical", 10, 50, 30, 2000},
+		{"free", 100, 9999, 9999, 99999}, // would all fail if gated
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"critical": 10, "free": 100}
+	targets := map[string]workload.SLODimTargets{
+		"critical": {TTFTMs: 100, E2EMs: 5000},
+	}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if overall != 1.0 {
+		t.Errorf("overall = %f, want 1.0 (free class excluded)", overall)
+	}
+	if _, ok := perClass["free"]; ok {
+		t.Errorf("perClass must not contain unconfigured class 'free'")
+	}
+	if perClass["critical"].Injected != 10 {
+		t.Errorf("Injected for critical = %d, want 10 (denominator must not include free)", perClass["critical"].Injected)
+	}
+}
+
+func TestSLOAttainmentMultiDim_EmptyClassMapsToDefault(t *testing.T) {
+	// BC-2: SLOClass == "" maps to "default" target.
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"", 8, 50, 30, 2000},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"": 8}
+	targets := map[string]workload.SLODimTargets{
+		"default": {TTFTMs: 100, E2EMs: 5000},
+	}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if overall != 1.0 {
+		t.Errorf("overall = %f, want 1.0", overall)
+	}
+	if perClass["default"].Good != 8 {
+		t.Errorf("Good for 'default' = %d, want 8", perClass["default"].Good)
+	}
+}
+
+func TestSLOAttainmentMultiDim_DenominatorIsInjected_NotCompleted(t *testing.T) {
+	// BC-1 (denominator): saturation drops count as violations.
+	// 10 injected, 7 completed and meeting all dims => attainment = 7/10 = 0.7.
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"critical", 7, 50, 30, 2000},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"critical": 10} // 3 dropped before completion
+	targets := map[string]workload.SLODimTargets{
+		"critical": {TTFTMs: 100, E2EMs: 5000},
+	}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, targets)
+	if math.Abs(overall-0.7) > 1e-9 {
+		t.Errorf("overall = %f, want 0.7", overall)
+	}
+	if perClass["critical"].Good != 7 {
+		t.Errorf("Good = %d, want 7", perClass["critical"].Good)
+	}
+	if perClass["critical"].Injected != 10 {
+		t.Errorf("Injected = %d, want 10", perClass["critical"].Injected)
+	}
+}
+
+func TestSLOAttainmentMultiDim_DeterministicAcrossRuns(t *testing.T) {
+	// INV-6: bit-identical output across iterations (R2 sanity).
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"A", 50, 50, 30, 2000},
+		{"B", 75, 80, 40, 3000},
+		{"C", 25, 90, 100, 4500},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"A": 50, "B": 100, "C": 30}
+	targets := map[string]workload.SLODimTargets{
+		"A": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
+		"B": {TTFTMs: 100, E2EMs: 5000},
+		"C": {E2EMs: 5000},
+	}
+	first, _ := SLOAttainmentMultiDim(results, injected, targets)
+	for i := 0; i < 100; i++ {
+		got, _ := SLOAttainmentMultiDim(results, injected, targets)
+		if got != first {
+			t.Fatalf("iter %d: overall = %v, want %v (non-deterministic)", i, got, first)
+		}
+	}
+}
+
+func TestSLOAttainmentMultiDim_NoConfiguredClasses_ReturnsZero(t *testing.T) {
+	// Edge: empty targets => 0 overall, empty perClass.
+	m := makeMetricsForSLO(t, []struct {
+		class                string
+		count                int
+		ttftMs, itlMs, e2eMs float64
+	}{
+		{"A", 10, 50, 30, 2000},
+	})
+	results := BuildLatencyResults(m)
+	injected := map[string]int64{"A": 10}
+	overall, perClass := SLOAttainmentMultiDim(results, injected, map[string]workload.SLODimTargets{})
+	if overall != 0 {
+		t.Errorf("overall = %f, want 0 (no targets)", overall)
+	}
+	if len(perClass) != 0 {
+		t.Errorf("perClass = %v, want empty", perClass)
 	}
 }

--- a/sim/cluster/metrics_test.go
+++ b/sim/cluster/metrics_test.go
@@ -93,7 +93,7 @@ func TestCollectRawMetrics_BasicAggregation(t *testing.T) {
 	m.SimEndedTime = 1_000_000 // 1 second
 
 	// WHEN collecting RawMetrics
-	raw := CollectRawMetrics(m, nil, 0, "", 0, 0)
+	raw := CollectRawMetrics(m, nil, 0, "", 0, 0, nil)
 
 	// THEN TTFT distribution should be populated
 	if raw.TTFT.Count != 3 {
@@ -117,7 +117,7 @@ func TestCollectRawMetrics_BasicAggregation(t *testing.T) {
 // TestCollectRawMetrics_ZeroCompleted_ReturnsEmptyDistributions verifies edge case.
 func TestCollectRawMetrics_ZeroCompleted_ReturnsEmptyDistributions(t *testing.T) {
 	m := sim.NewMetrics()
-	raw := CollectRawMetrics(m, nil, 0, "", 0, 0)
+	raw := CollectRawMetrics(m, nil, 0, "", 0, 0, nil)
 	if raw.TTFT.Count != 0 {
 		t.Errorf("TTFT.Count: got %d, want 0", raw.TTFT.Count)
 	}
@@ -129,7 +129,7 @@ func TestCollectRawMetrics_ZeroCompleted_ReturnsEmptyDistributions(t *testing.T)
 // TestCollectRawMetrics_RejectedRequests verifies rejected count is captured.
 func TestCollectRawMetrics_RejectedRequests(t *testing.T) {
 	m := sim.NewMetrics()
-	raw := CollectRawMetrics(m, nil, 42, "", 0, 0)
+	raw := CollectRawMetrics(m, nil, 42, "", 0, 0, nil)
 	if raw.RejectedRequests != 42 {
 		t.Errorf("RejectedRequests: got %d, want 42", raw.RejectedRequests)
 	}
@@ -142,7 +142,7 @@ func TestCollectRawMetrics_DroppedUnservable(t *testing.T) {
 	m.DroppedUnservable = 3
 
 	// WHEN collecting raw metrics
-	raw := CollectRawMetrics(m, nil, 0, "", 0, 0)
+	raw := CollectRawMetrics(m, nil, 0, "", 0, 0, nil)
 
 	// THEN DroppedUnservable is captured
 	if raw.DroppedUnservable != 3 {
@@ -347,7 +347,7 @@ func TestCollectRawMetrics_FCFSScheduler_SuppressesInversions(t *testing.T) {
 	aggregated.SimEndedTime = 1_000_000
 
 	// WHEN collecting with constant priority policy
-	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m}, 0, "", 0, 0)
+	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m}, 0, "", 0, 0, nil)
 
 	// THEN priority inversions should be suppressed
 	if raw.PriorityInversions != 0 {
@@ -370,7 +370,7 @@ func TestCollectRawMetrics_PriorityScheduler_DetectsInversions(t *testing.T) {
 	aggregated.SimEndedTime = 1_000_000
 
 	// WHEN collecting with priority-fcfs scheduler
-	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m}, 0, "priority-fcfs", 0, 0)
+	raw := CollectRawMetrics(aggregated, []*sim.Metrics{m}, 0, "priority-fcfs", 0, 0, nil)
 
 	// THEN priority inversions should be detected
 	if raw.PriorityInversions == 0 {
@@ -573,7 +573,7 @@ func TestPathological_RejectAll_AllRejected(t *testing.T) {
 		t.Fatalf("cs.Run: %v", err)
 	}
 
-	raw := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0)
+	raw := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0, nil)
 
 	// ALL requests should be rejected
 	if raw.RejectedRequests == 0 {
@@ -595,7 +595,7 @@ func TestPathological_AlwaysBusiest_CausesImbalance(t *testing.T) {
 		t.Fatalf("cs.Run: %v", err)
 	}
 
-	raw := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0)
+	raw := CollectRawMetrics(cs.AggregatedMetrics(), cs.PerInstanceMetrics(), cs.RejectedRequests(), "", 0, 0, nil)
 
 	// With always-busiest routing, all requests should pile onto one instance.
 	perInstance := cs.PerInstanceMetrics()

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -85,6 +85,13 @@ type MetricsOutput struct {
 	TimedOutRequests        int              `json:"timed_out_requests"`
 	Requests                []RequestMetrics `json:"requests,omitempty"`
 	Saturation              interface{}      `json:"saturation,omitempty"` // saturation.Result, using interface{} to avoid import cycle
+	// Goodput fields (issue #1409). Populated by PR2's CLI/output wiring;
+	// left zero (and omitempty) by PR1. PerClass holds map[string]cluster.SLOClassAttainment;
+	// typed as interface{} to mirror the Saturation field above and avoid a
+	// sim → sim/cluster import cycle.
+	GoodputRPS    float64     `json:"goodput_rps,omitempty"`
+	SLOAttainment float64     `json:"slo_attainment,omitempty"`
+	PerClass      interface{} `json:"per_class,omitempty"`
 }
 
 // CalculatePercentile is a util function that calculates the p-th percentile of a data list

--- a/sim/metrics_utils_test.go
+++ b/sim/metrics_utils_test.go
@@ -1,6 +1,10 @@
 package sim
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 // TestNewRequestMetrics_PropagatesAllFields is intentionally a construction-site guard test
 // (CLAUDE.md antipattern #4). It verifies the canonical constructor propagates all fields,
@@ -163,5 +167,42 @@ func TestCalculatePercentile_SingleElement_ReturnsScaled(t *testing.T) {
 	// THEN it returns the element divided by 1000 (ms conversion)
 	if result != 1.0 {
 		t.Errorf("expected 1.0 for single element 1000.0, got %f", result)
+	}
+}
+
+// TestMetricsOutput_GoodputFields_OmittedWhenZero verifies BC-10: zero-valued
+// goodput fields are absent from the JSON to avoid breaking existing consumers.
+func TestMetricsOutput_GoodputFields_OmittedWhenZero(t *testing.T) {
+	m := MetricsOutput{InstanceID: "i0"}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, f := range []string{"goodput_rps", "slo_attainment", "per_class"} {
+		if strings.Contains(s, f) {
+			t.Errorf("zero-value MetricsOutput emitted %q in JSON: %s", f, s)
+		}
+	}
+}
+
+// TestMetricsOutput_GoodputFields_PresentWhenSet verifies the schema slot accepts
+// PR2-shaped values: float scalars and a heterogeneous PerClass payload.
+func TestMetricsOutput_GoodputFields_PresentWhenSet(t *testing.T) {
+	m := MetricsOutput{
+		InstanceID:    "i0",
+		GoodputRPS:    42.1,
+		SLOAttainment: 0.88,
+		PerClass:      map[string]any{"critical": map[string]float64{"goodput_rps": 18.3}},
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, want := range []string{`"goodput_rps":42.1`, `"slo_attainment":0.88`, `"per_class"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("MetricsOutput JSON missing %q: %s", want, s)
+		}
 	}
 }

--- a/sim/workload/slo.go
+++ b/sim/workload/slo.go
@@ -1,0 +1,11 @@
+package workload
+
+// SLODimTargets holds per-dimension SLO thresholds for one class.
+// A field with value 0 means that dimension is not gated for this class.
+// Used by WorkloadSpec.GoodputSLOTargets and TraceHeader.GoodputSLOTargets,
+// and consumed by sim/cluster.SLOAttainmentMultiDim (issue #1409).
+type SLODimTargets struct {
+	TTFTMs float64 `yaml:"ttft_ms,omitempty"`
+	ITLMs  float64 `yaml:"itl_ms,omitempty"`
+	E2EMs  float64 `yaml:"e2e_ms,omitempty"`
+}

--- a/sim/workload/slo.go
+++ b/sim/workload/slo.go
@@ -5,6 +5,17 @@ package workload
 // Used by WorkloadSpec.GoodputSLOTargets and TraceHeader.GoodputSLOTargets,
 // and consumed by sim/cluster.SLOAttainmentMultiDim (issue #1409).
 //
+// Field semantics:
+//   - TTFTMs: time to first token threshold, in milliseconds.
+//   - ITLMs:  mean inter-token latency (TPOT) threshold, in milliseconds.
+//             Compared against per-request mean ITL stored in
+//             sim.Metrics.RequestITLs, computed in sim/simulator.go as
+//             itlSum / (output_tokens - 1) — the vLLM TPOT convention,
+//             which excludes the first generated token. This is NOT a
+//             per-token cap; a request with one slow inter-token gap can
+//             still pass if its mean is within the threshold.
+//   - E2EMs:  end-to-end latency threshold, in milliseconds.
+//
 // R9 exemption: bare float64 (not *float64) is intentional. R9 requires
 // pointer types when "zero is a valid runtime value the user may explicitly
 // set". Here zero is the disabled-sentinel for a threshold; gating on a 0 ms

--- a/sim/workload/slo.go
+++ b/sim/workload/slo.go
@@ -4,6 +4,12 @@ package workload
 // A field with value 0 means that dimension is not gated for this class.
 // Used by WorkloadSpec.GoodputSLOTargets and TraceHeader.GoodputSLOTargets,
 // and consumed by sim/cluster.SLOAttainmentMultiDim (issue #1409).
+//
+// R9 exemption: bare float64 (not *float64) is intentional. R9 requires
+// pointer types when "zero is a valid runtime value the user may explicitly
+// set". Here zero is the disabled-sentinel for a threshold; gating on a 0 ms
+// latency target is meaningless (no completion has zero latency), so there
+// is no user value distinct from "absent" and pointer types add no signal.
 type SLODimTargets struct {
 	TTFTMs float64 `yaml:"ttft_ms,omitempty"`
 	ITLMs  float64 `yaml:"itl_ms,omitempty"`

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -50,6 +50,11 @@ type WorkloadSpec struct {
 	NumRequests   int64              `yaml:"num_requests,omitempty"` // 0 = unlimited (use horizon only)
 	ServeGenData  *ServeGenDataSpec  `yaml:"servegen_data,omitempty"`
 	InferencePerf *InferencePerfSpec `yaml:"inference_perf,omitempty"`
+	// GoodputSLOTargets: per-SLO-class TTFT/ITL/E2E thresholds for goodput
+	// measurement (issue #1409, BC-8). PR1 reserves the schema slot; the
+	// targets are consumed by PR2's CLI/output wiring. Distinct from the
+	// dispatch-ordering --slo-targets flag.
+	GoodputSLOTargets map[string]SLODimTargets `yaml:"goodput_slo_targets,omitempty"`
 }
 
 // CohortSpec describes a population of clients that share arrival behavior

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -30,6 +30,12 @@ type TraceHeader struct {
 
 	Server  *TraceServerConfig  `yaml:"server,omitempty"`
 	Network *TraceNetworkConfig `yaml:"network,omitempty"`
+	// GoodputSLOTargets: per-SLO-class TTFT/ITL/E2E thresholds for goodput
+	// measurement (issue #1409, BC-8). Persisted in trace headers so observe →
+	// replay → calibrate carry the same SLO definition. Schema bump to trace
+	// version 3; old binaries reading new traces will hard-fail under
+	// KnownFields(true) — intentional, signaled by Version (BC-N3).
+	GoodputSLOTargets map[string]SLODimTargets `yaml:"goodput_slo_targets,omitempty"`
 }
 
 // TraceServerConfig captures server configuration in trace header.

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -11,8 +11,12 @@ import (
 
 func TestTraceV2_RoundTrip_PreservesAllFields(t *testing.T) {
 	header := &TraceHeader{
-		Version: 2, TimeUnit: "microseconds", Mode: "generated",
+		Version: 3, TimeUnit: "microseconds", Mode: "generated",
 		WarmUpRequests: 5, WorkloadSpec: "test.yaml",
+		GoodputSLOTargets: map[string]SLODimTargets{
+			"critical": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
+			"batch":    {E2EMs: 120000},
+		},
 	}
 	records := []TraceRecord{
 		{RequestID: 0, ClientID: "c1", TenantID: "t1", SLOClass: "batch",
@@ -35,11 +39,28 @@ func TestTraceV2_RoundTrip_PreservesAllFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if loaded.Header.Version != 2 {
-		t.Errorf("version = %d, want 2", loaded.Header.Version)
+	if loaded.Header.Version != 3 {
+		t.Errorf("version = %d, want 3", loaded.Header.Version)
 	}
 	if loaded.Header.WarmUpRequests != 5 {
 		t.Errorf("warm_up = %d, want 5", loaded.Header.WarmUpRequests)
+	}
+	// BC-8: GoodputSLOTargets round-trips per (class, dimension).
+	if got := loaded.Header.GoodputSLOTargets["critical"].TTFTMs; got != 100 {
+		t.Errorf("critical.TTFTMs = %f, want 100", got)
+	}
+	if got := loaded.Header.GoodputSLOTargets["critical"].ITLMs; got != 50 {
+		t.Errorf("critical.ITLMs = %f, want 50", got)
+	}
+	if got := loaded.Header.GoodputSLOTargets["critical"].E2EMs; got != 5000 {
+		t.Errorf("critical.E2EMs = %f, want 5000", got)
+	}
+	if got := loaded.Header.GoodputSLOTargets["batch"].E2EMs; got != 120000 {
+		t.Errorf("batch.E2EMs = %f, want 120000", got)
+	}
+	// BC-3 surface: zero is "not gated" — survives round-trip.
+	if got := loaded.Header.GoodputSLOTargets["batch"].ITLMs; got != 0 {
+		t.Errorf("batch.ITLMs = %f, want 0 (not gated)", got)
 	}
 	if len(loaded.Records) != 2 {
 		t.Fatalf("records = %d, want 2", len(loaded.Records))
@@ -68,6 +89,28 @@ func TestTraceV2_RoundTrip_PreservesAllFields(t *testing.T) {
 	}
 	if r1.NumChunks != 5 {
 		t.Errorf("record 1 chunks = %d, want 5", r1.NumChunks)
+	}
+}
+
+// TestTraceV2_LoadHeader_UnknownField_ReturnsError verifies BC-N3: KnownFields(true)
+// causes an old binary reading a header with an unknown field (e.g. a future
+// schema addition past v3) to hard-fail rather than silently dropping the field.
+// Strict parsing is enforced at sim/workload/tracev2.go:223; the trace Version
+// field is the schema-change signal.
+func TestTraceV2_LoadHeader_UnknownField_ReturnsError(t *testing.T) {
+	yamlText := []byte("trace_version: 99\ntime_unit: microseconds\nmode: generated\nwarm_up_requests: 0\nbogus_unknown_field: 42\n")
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	if err := os.WriteFile(headerPath, yamlText, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(dataPath, []byte("request_id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTraceV2(headerPath, dataPath); err == nil ||
+		!strings.Contains(err.Error(), "field") {
+		t.Errorf("expected unknown-field error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR1 of the goodput-and-SLO-attainment series for issue #1409. Establishes the in-library types, attainment function, injection counter, and schema slots needed to compute per-class SLO goodput across TTFT/ITL/E2E latency dimensions. **No user-facing behavior change in this PR** — CLI flag wiring, `MetricsOutput` population, and `printPerSLOMetrics` updates land in PR2 (sub-issue #1413).

This PR implements sub-issue #1412 (PR1: Foundation) of the parent issue #1409. PR2 wiring is tracked at #1413.

## What's added

- `SLODimTargets` (in `sim/workload`): per-class TTFT / ITL / E2E thresholds. Zero on a field means that dimension is **not gated**. Used by both `WorkloadSpec.GoodputSLOTargets` and `TraceHeader.GoodputSLOTargets`.
- `SLOAttainmentMultiDim` (in `sim/cluster`): multi-dimensional AND classifier with a per-class injection denominator. **Replaces the orphaned `SLOAttainment`**:
  - The legacy denominator was completed-only, which understated impact under saturation.
  - The legacy "no target for class = always meets SLO" behavior (`metrics.go:374-377`) inflated overall attainment when mixing configured and unconfigured classes; the new function **excludes unconfigured classes** from both numerator and denominator (BC-N2).
- `SLOClassAttainment` carries `Good`, `Injected`, and per-dimension `ByDim` so PR2 can surface `slo_attainment_by_dim` independently for ttft / itl / e2e.
- `SLOMetrics.ITL` distribution alongside the existing TTFT and E2E. `ComputePerSLODistributions` now populates it from `sim.Metrics.RequestITLs`.
- `ClusterSimulator.injectedByClass map[string]int64`, incremented in `ClusterArrivalEvent.Execute` **before** any admission / routing / shedding decision (BC-5). Exposed to callers via `cs.InjectedByClass()` (mirrors `cs.ShedByTier()`) and copied into `RawMetrics.InjectedByClass` by `CollectRawMetrics`.
- Schema slots: `WorkloadSpec.GoodputSLOTargets`, `TraceHeader.GoodputSLOTargets`. `omitempty` on encode; new field is read by old binaries via the existing `KnownFields(true)` decoder, which **hard-fails** on unknown fields (BC-N3) — intentional, signaled by bumping `trace_version` 2 → 3 in `cmd/{root,replay,observe_cmd}.go`.
- `MetricsOutput` slots: `GoodputRPS`, `SLOAttainment`, `PerClass`. All `omitempty`; populated by PR2. `PerClass interface{}` mirrors the existing `Saturation interface{}` pattern (`sim/metrics_utils.go:87`) to avoid a `sim → sim/cluster` import cycle.

## Behavioral contracts

10 positive contracts (BC-1 through BC-10) and 3 negative contracts (BC-N1 through BC-N3) all unit-tested. Highlights:

- **BC-1**: multi-dim AND, per-class injection denominator
- **BC-2**: empty `SLOClass` folds to `default` in both numerator (request lookup) and denominator (injection counter)
- **BC-3**: zero-valued threshold means "not gated"
- **BC-4**: `slo_attainment_by_dim` reports each dimension independently
- **BC-5**: injection counter increments before any drop / route / admission decision
- **BC-N2**: unconfigured classes excluded from denominator (legacy inflation bug fixed)
- **BC-N3**: old binaries reading new traces hard-fail under `KnownFields(true)`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (cmd, sim, sim/cluster, sim/workload, plus all subpackages)
- [x] All 13 pre-existing `CollectRawMetrics` call sites updated for the new `injectedByClass` parameter (production passes `cs.InjectedByClass()`, tests pass `nil`)
- [x] Determinism: `TestSLOAttainmentMultiDim_DeterministicAcrossRuns` runs the function 100 times on the same input and asserts bit-identical output (R2 / INV-6)
- [x] BC-N3: `TestTraceV2_LoadHeader_UnknownField_ReturnsError` confirms strict-parsing protects against silent schema drift
- [x] `omitempty` JSON behavior: `TestMetricsOutput_GoodputFields_OmittedWhenZero` ensures zero-value goodput fields stay absent from JSON for existing consumers
- [x] No `golangci-lint` available locally, but `go vet ./...` is clean. CI will run the lint step.

## Out of scope (deferred to PR2)

- `--slo-ttft`, `--slo-itl`, `--slo-e2e` CLI flags on `run` / `replay` / `observe` / `calibrate`
- `MetricsOutput` field population (CLI computes goodput, fills `GoodputRPS` / `SLOAttainment` / `PerClass`)
- `printPerSLOMetrics` ITL line + suppression-guard fix for single-class workloads
- `blis calibrate` real-vs-sim goodput comparison
- INV-13 parity assertion across run / replay for goodput

## Closes

- Closes #1412 (PR1 sub-issue)
- Refs #1409 (parent — PR2 / #1413 will close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)