### PR TITLE
feat(metrics): goodput wiring — CLI flags, MetricsOutput, run/replay/observe/calibrate (#1413, PR2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,24 @@ go build -o blis main.go
 # Run with default model
 ./blis run --model qwen/qwen3-14b
 
+# Run with goodput SLO targets (#1413). --slo-ttft / --slo-itl / --slo-e2e accept
+# class=duration[,class=duration...] using Go duration syntax. Precedence:
+# CLI > trace header > workload spec. Distinct from --slo-targets (dispatch ordering).
+./blis run --model qwen/qwen3-14b \
+  --slo-ttft "critical=100ms,standard=500ms" \
+  --slo-itl  "critical=50ms,standard=150ms" \
+  --slo-e2e  "critical=5s,standard=30s"
+
 # Run and export workload as TraceV2 (prefix auto-appends .yaml/.csv)
 ./blis run --model qwen/qwen3-14b --trace-output traces/run1
 
 # Replay a captured TraceV2 file through the DES (fixed timing from trace)
 ./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b
+
+# Replay with goodput SLO targets (#1413). When the trace header carries
+# goodput_slo_targets the CLI flags are not required (header is the fallback).
+./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b \
+  --slo-ttft "critical=100ms" --slo-e2e "critical=5s"
 
 # Replay and re-export trace with simulation-computed timing (mode: replayed)
 ./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b \
@@ -38,6 +51,14 @@ go build -o blis main.go
 # Observe real server latency and record timing into TraceV2
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
   --workload-spec workload.yaml --trace-header trace.yaml --trace-data trace.csv
+
+# Observe with goodput SLO targets (#1413). Resolved targets are persisted into
+# the exported TraceHeader so downstream replay/calibrate inherit them. ITL
+# attainment requires --record-itl; otherwise it's skipped with a warning.
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --workload chatbot --rate 10 --num-requests 100 \
+  --slo-ttft "critical=100ms" --slo-e2e "critical=5s" \
+  --trace-header trace.yaml --trace-data trace.csv
 
 # Observe with chat completions endpoint and network RTT
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
@@ -76,6 +97,12 @@ go build -o blis main.go
 # Compare with ITL metric included (requires observe --record-itl)
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
   --itl-data trace.itl.csv --report calibration.json
+
+# Compare goodput per SLO class (#1413). Targets default to the trace header's
+# goodput_slo_targets; CLI flags override per-dimension. Skipped with a warning
+# when ITL is configured but absent.
+./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
+  --slo-ttft "critical=100ms" --slo-e2e "critical=5s" --report calibration.json
 
 # Convert workload formats
 ./blis convert preset --name chatbot --rate 10 --num-requests 100

--- a/cmd/calibrate.go
+++ b/cmd/calibrate.go
@@ -20,6 +20,11 @@ var (
 	calibrateNetworkRTTUs         int64
 	calibrateNetworkBandwidthMbps float64
 	calibrateITLDataPath          string
+	// Goodput SLO targets (#1413). CLI > trace header precedence in calibrate
+	// (no workload spec on calibrate path).
+	calibrateGoodputSLOTTFT string
+	calibrateGoodputSLOITL  string
+	calibrateGoodputSLOE2E  string
 )
 
 var calibrateCmd = &cobra.Command{
@@ -145,6 +150,59 @@ Example:
 			logrus.Fatalf("Failed to build calibration report: %v", err)
 		}
 
+		// Step 6.5: Goodput comparison (#1413, BC-9). Resolve targets from CLI > trace header.
+		cliTTFT, cliITL, cliE2E, gpErr := resolveGoodputCLIFlags(calibrateGoodputSLOTTFT, calibrateGoodputSLOITL, calibrateGoodputSLOE2E)
+		if gpErr != nil {
+			logrus.Fatalf("%v", gpErr)
+		}
+		goodputTargets := mergeGoodputTargets(cliTTFT, cliITL, cliE2E, trace.Header.GoodputSLOTargets, nil)
+		if len(goodputTargets) > 0 {
+			// Build matched-set: trace records whose RequestID has a matching SimResult
+			// AND that survived warm-up exclusion. Also need an ITL index by RequestID.
+			simByID := make(map[int]workload.SimResult, len(simResults))
+			for _, sr := range simResults {
+				simByID[sr.RequestID] = sr
+			}
+			matched := make(map[int]bool, pairs.MatchedCount)
+			for _, rec := range trace.Records {
+				if rec.RequestID < warmUp {
+					continue
+				}
+				if _, ok := simByID[rec.RequestID]; ok {
+					matched[rec.RequestID] = true
+				}
+			}
+			itlByRequest := make(map[int][]workload.ITLRecord)
+			for _, r := range itlRecords {
+				itlByRequest[r.RequestID] = append(itlByRequest[r.RequestID], r)
+			}
+			// Real-side runtime: span from earliest send to latest last-chunk over matched set.
+			var firstSend, lastChunk int64
+			firstSend = -1
+			for _, rec := range trace.Records {
+				if !matched[rec.RequestID] {
+					continue
+				}
+				if firstSend == -1 || rec.SendTimeUs < firstSend {
+					firstSend = rec.SendTimeUs
+				}
+				if rec.LastChunkTimeUs > lastChunk {
+					lastChunk = rec.LastChunkTimeUs
+				}
+			}
+			runtimeSec := 0.0
+			if firstSend >= 0 && lastChunk > firstSend {
+				runtimeSec = float64(lastChunk-firstSend) / 1e6
+			}
+
+			report.Goodput = workload.ComputeGoodputComparison(
+				trace.Records, simByID, matched, itlByRequest, goodputTargets, runtimeSec,
+			)
+			if report.Goodput != nil && report.Goodput.SkippedITL {
+				logrus.Warn("calibrate goodput: ITL gating skipped — ITL data missing on real or sim side; TTFT/E2E rows still computed.")
+			}
+		}
+
 		// Step 7: Write report JSON
 		reportData, err := json.MarshalIndent(report, "", "  ")
 		if err != nil {
@@ -232,6 +290,21 @@ Example:
 					workload.MapePct(p.E2E.Real, p.E2E.Sim)*100)
 			}
 		}
+		// Per-class goodput summary (#1413, BC-9)
+		if report.Goodput != nil && len(report.Goodput.PerClass) > 0 {
+			logrus.Infof("Per-SLO-class goodput (real vs sim):")
+			classKeys := make([]string, 0, len(report.Goodput.PerClass))
+			for k := range report.Goodput.PerClass {
+				classKeys = append(classKeys, k)
+			}
+			sort.Strings(classKeys)
+			for _, cls := range classKeys {
+				gc := report.Goodput.PerClass[cls]
+				logrus.Infof("  %s: count=%d real_attain=%.3f sim_attain=%.3f real_rps=%.3f sim_rps=%.3f",
+					cls, gc.Count, gc.RealSLOAttainment, gc.SimSLOAttainment, gc.RealGoodputRPS, gc.SimGoodputRPS)
+			}
+		}
+
 		// Per-model breakdown (when data present)
 		if len(pairs.ByModel) > 0 {
 			modelKeys := make([]string, 0, len(pairs.ByModel))
@@ -263,5 +336,8 @@ func init() {
 	calibrateCmd.Flags().Int64Var(&calibrateNetworkRTTUs, "network-rtt-us", -1, "Network RTT in microseconds added to sim-side latencies (default: from trace header network.measured_rtt_ms)")
 	calibrateCmd.Flags().Float64Var(&calibrateNetworkBandwidthMbps, "network-bandwidth-mbps", 0, "Network bandwidth in Mbps for upload/download delay calculation (default: 0 = no delay)")
 	calibrateCmd.Flags().StringVar(&calibrateITLDataPath, "itl-data", "", "Optional path to ITL CSV file (from blis observe --record-itl) to include ITL metric in calibration report")
+	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header.")
+	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds. Skipped with a warning when ITL data is absent on either side.")
+	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
 	rootCmd.AddCommand(calibrateCmd)
 }

--- a/cmd/goodput.go
+++ b/cmd/goodput.go
@@ -501,6 +501,41 @@ func safeFraction(num, denom int) float64 {
 	return float64(num) / float64(denom)
 }
 
+// stripITLForObserveFallback returns a copy of targets with ITL stripped from
+// every class, when --record-itl was not set. Used by the observe path
+// (#1413, BC-6): without recorded ITL data, in-process goodput attainment
+// cannot be computed for ITL, so we drop it from the in-process targets while
+// leaving the unmodified user-supplied targets to flow into the exported
+// TraceHeader for downstream replay/calibrate.
+//
+// Returns (targets-unchanged, hasITL=false) when targets is empty, recordITL
+// is true, or no class has a non-zero ITL threshold — letting the caller
+// distinguish a no-op from an actual strip and decide whether to emit a warning.
+// The first return is always safe to pass to emitObserveGoodput; the returned
+// map is a fresh allocation when stripped (never mutates the input).
+func stripITLForObserveFallback(
+	targets map[string]workload.SLODimTargets,
+	recordITL bool,
+) (map[string]workload.SLODimTargets, bool) {
+	if len(targets) == 0 || recordITL {
+		return targets, false
+	}
+	var hasITL bool
+	stripped := make(map[string]workload.SLODimTargets, len(targets))
+	for cls, t := range targets {
+		if t.ITLMs > 0 {
+			hasITL = true
+			t.ITLMs = 0
+		}
+		stripped[cls] = t
+	}
+	if !hasITL {
+		// No ITL was configured — return the original map, no copy needed.
+		return targets, false
+	}
+	return stripped, true
+}
+
 // resolveGoodputCLIFlags parses the three CLI string flags into duration maps.
 // Returns nil maps when the flag is empty. On parse error it returns the
 // per-flag error so callers can logrus.Fatalf with the right flag name.

--- a/cmd/goodput.go
+++ b/cmd/goodput.go
@@ -1,0 +1,523 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/cluster"
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// parseSLODurationFlag parses comma-separated key=duration pairs (e.g.
+// "critical=100ms,standard=500ms"). Empty input returns (nil, nil) — the
+// caller treats this as "no signal at this tier" in the merger. Empty class
+// keys, unparseable durations, and non-positive durations return an error
+// so cmd/ wrappers can logrus.Fatalf with consistent context.
+func parseSLODurationFlag(s string) (map[string]time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	out := make(map[string]time.Duration)
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			return nil, fmt.Errorf("empty pair in %q (expected key=duration)", s)
+		}
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid pair %q (expected key=duration)", pair)
+		}
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, fmt.Errorf("empty class key in pair %q", pair)
+		}
+		d, err := time.ParseDuration(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, fmt.Errorf("unparseable duration in pair %q: %w", pair, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("non-positive duration in pair %q", pair)
+		}
+		out[key] = d
+	}
+	return out, nil
+}
+
+// mergeGoodputTargets composes the resolved per-class SLODimTargets map from
+// up to three sources, with precedence: CLI > traceHeader > spec. Each
+// dimension is merged independently; a class is included if it appears in ANY
+// source. A nil source map means "no signal at that tier".
+//
+// Determinism (R2): the result map's iteration is up to the caller, but the
+// classes considered come from a sorted union so the per-class merge order
+// is stable for any future logging.
+func mergeGoodputTargets(
+	cliTTFT, cliITL, cliE2E map[string]time.Duration,
+	traceHeader, spec map[string]workload.SLODimTargets,
+) map[string]workload.SLODimTargets {
+	classes := make(map[string]struct{})
+	for k := range cliTTFT {
+		classes[k] = struct{}{}
+	}
+	for k := range cliITL {
+		classes[k] = struct{}{}
+	}
+	for k := range cliE2E {
+		classes[k] = struct{}{}
+	}
+	for k := range traceHeader {
+		classes[k] = struct{}{}
+	}
+	for k := range spec {
+		classes[k] = struct{}{}
+	}
+	if len(classes) == 0 {
+		return nil
+	}
+
+	// Sort the union for stable ordering of any future log/diagnostic output.
+	keys := make([]string, 0, len(classes))
+	for k := range classes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make(map[string]workload.SLODimTargets, len(keys))
+	for _, cls := range keys {
+		var t workload.SLODimTargets
+		if v, ok := spec[cls]; ok {
+			t = v
+		}
+		if v, ok := traceHeader[cls]; ok {
+			if v.TTFTMs > 0 {
+				t.TTFTMs = v.TTFTMs
+			}
+			if v.ITLMs > 0 {
+				t.ITLMs = v.ITLMs
+			}
+			if v.E2EMs > 0 {
+				t.E2EMs = v.E2EMs
+			}
+		}
+		if d, ok := cliTTFT[cls]; ok {
+			t.TTFTMs = float64(d) / float64(time.Millisecond)
+		}
+		if d, ok := cliITL[cls]; ok {
+			t.ITLMs = float64(d) / float64(time.Millisecond)
+		}
+		if d, ok := cliE2E[cls]; ok {
+			t.E2EMs = float64(d) / float64(time.Millisecond)
+		}
+		// Drop a class entirely when no dimension survived the merge — this
+		// can only happen if a tier carried an explicit zero, which is
+		// effectively "not gated" anyway.
+		if t.TTFTMs == 0 && t.ITLMs == 0 && t.E2EMs == 0 {
+			continue
+		}
+		out[cls] = t
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// emitGoodput populates MetricsOutput goodput fields from aggregated metrics,
+// per-class injection counts, and the resolved targets. No-op when targets is
+// empty (BC-3: byte-identical output when goodput is not configured).
+//
+// The per_class payload is built as map[string]map[string]any so it serializes
+// cleanly through MetricsOutput.PerClass (typed as interface{} to avoid
+// importing sim/cluster from sim).
+func emitGoodput(
+	output *sim.MetricsOutput,
+	aggregated *sim.Metrics,
+	injectedByClass map[string]int64,
+	runtimeSec float64,
+	targets map[string]workload.SLODimTargets,
+) {
+	if output == nil || aggregated == nil || len(targets) == 0 {
+		return
+	}
+	results := cluster.BuildLatencyResults(aggregated)
+	overall, perClass := cluster.SLOAttainmentMultiDim(results, injectedByClass, targets)
+
+	totalGood := 0
+	classKeys := make([]string, 0, len(perClass))
+	for k := range perClass {
+		classKeys = append(classKeys, k)
+	}
+	sort.Strings(classKeys)
+
+	per := make(map[string]map[string]any, len(perClass))
+	for _, cls := range classKeys {
+		sca := perClass[cls]
+		totalGood += sca.Good
+
+		entry := map[string]any{
+			"slo_attainment": safeRatio(int64(sca.Good), sca.Injected),
+			"count":          sca.Injected,
+		}
+		if runtimeSec > 0 {
+			entry["goodput_rps"] = float64(sca.Good) / runtimeSec
+		} else {
+			entry["goodput_rps"] = 0.0
+		}
+
+		// slo_attainment_by_dim: deterministic iteration via sorted keys.
+		if len(sca.ByDim) > 0 {
+			dimKeys := make([]string, 0, len(sca.ByDim))
+			for d := range sca.ByDim {
+				dimKeys = append(dimKeys, d)
+			}
+			sort.Strings(dimKeys)
+			byDim := make(map[string]float64, len(sca.ByDim))
+			for _, d := range dimKeys {
+				byDim[d] = sca.ByDim[d]
+			}
+			entry["slo_attainment_by_dim"] = byDim
+		}
+
+		// Per-class TTFT P99, mean ITL, E2E P99, count from aggregated metrics.
+		ttftP99, itlMean, e2eP99 := perClassLatencyStats(aggregated, cls)
+		if ttftP99 > 0 {
+			entry["ttft_p99_ms"] = ttftP99
+		}
+		if itlMean > 0 {
+			entry["itl_mean_ms"] = itlMean
+		}
+		if e2eP99 > 0 {
+			entry["e2e_p99_ms"] = e2eP99
+		}
+
+		per[cls] = entry
+	}
+
+	output.SLOAttainment = overall
+	output.PerClass = per
+	if runtimeSec > 0 {
+		output.GoodputRPS = float64(totalGood) / runtimeSec
+	}
+}
+
+// perClassLatencyStats computes per-class TTFT P99, mean ITL, and E2E P99
+// from aggregated metrics. SLOClass is read from m.Requests; an empty class
+// folds into "default" to mirror cluster.SLOAttainmentMultiDim's lookup.
+//
+// Returned values are in milliseconds (consistent with MetricsOutput's other
+// latency fields). All accumulation iterates request IDs in sorted order
+// (R2 / INV-6 determinism).
+func perClassLatencyStats(m *sim.Metrics, cls string) (ttftP99, itlMean, e2eP99 float64) {
+	if m == nil {
+		return 0, 0, 0
+	}
+	ids := make([]string, 0, len(m.RequestE2Es))
+	for id := range m.RequestE2Es {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	var ttftUs, e2eUs []float64
+	var itlSumUs float64
+	var itlCount int
+	for _, id := range ids {
+		rm, ok := m.Requests[id]
+		if !ok {
+			continue
+		}
+		c := rm.SLOClass
+		if c == "" {
+			c = "default"
+		}
+		if c != cls {
+			continue
+		}
+		if e2e, ok := m.RequestE2Es[id]; ok {
+			e2eUs = append(e2eUs, e2e)
+		}
+		if t, ok := m.RequestTTFTs[id]; ok {
+			ttftUs = append(ttftUs, t)
+		}
+		if i, ok := m.RequestITLs[id]; ok {
+			itlSumUs += i
+			itlCount++
+		}
+	}
+
+	sort.Float64s(ttftUs)
+	sort.Float64s(e2eUs)
+	ttftP99 = sim.CalculatePercentile(ttftUs, 99)
+	e2eP99 = sim.CalculatePercentile(e2eUs, 99)
+	if itlCount > 0 {
+		itlMean = (itlSumUs / float64(itlCount)) / 1e3 // µs → ms
+	}
+	return ttftP99, itlMean, e2eP99
+}
+
+// safeRatio returns num/denom or 0 when denom is zero.
+func safeRatio(num, denom int64) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
+}
+
+// emitObserveGoodput populates goodput fields on a MetricsOutput from real-server
+// trace records (and optional ITL records). Used by `blis observe` to mirror the
+// run/replay JSON shape over a record-driven (rather than DES-driven) data path.
+//
+// Numerator semantics (BC-2 on observe path):
+//   - Denominator per class: count of dispatched records with Status ∈ {ok, error, timeout}.
+//   - Numerator per class:  records with Status == "ok" whose TTFT/E2E (and ITL when
+//     configured) meet every non-zero threshold for that class. error and timeout
+//     records are counted in the denominator (consistent with INV-1) but never count
+//     toward goodput.
+//
+// runtimeSec is wall-clock duration in seconds; goodput_rps = good / runtimeSec.
+// No-op when targets is empty (BC-3).
+func emitObserveGoodput(
+	output *sim.MetricsOutput,
+	records []workload.TraceRecord,
+	itlRecords []workload.ITLRecord,
+	runtimeSec float64,
+	targets map[string]workload.SLODimTargets,
+) {
+	if output == nil || len(targets) == 0 {
+		return
+	}
+
+	// Index ITL records by RequestID and compute per-request mean ITL in ms.
+	itlMeanByRequest := make(map[int]float64)
+	if len(itlRecords) > 0 {
+		grouped := make(map[int][]workload.ITLRecord)
+		for _, r := range itlRecords {
+			grouped[r.RequestID] = append(grouped[r.RequestID], r)
+		}
+		for id, chunks := range grouped {
+			if len(chunks) < 2 {
+				continue
+			}
+			sort.Slice(chunks, func(i, j int) bool { return chunks[i].ChunkIndex < chunks[j].ChunkIndex })
+			var sumDeltaUs float64
+			var n int
+			for i := 1; i < len(chunks); i++ {
+				d := chunks[i].TimestampUs - chunks[i-1].TimestampUs
+				if d > 0 {
+					sumDeltaUs += float64(d)
+					n++
+				}
+			}
+			if n > 0 {
+				itlMeanByRequest[id] = (sumDeltaUs / float64(n)) / 1000.0 // µs → ms
+			}
+		}
+	}
+
+	type acc struct {
+		good      int
+		ttftMet   int
+		ttftCount int
+		itlMet    int
+		itlCount  int
+		e2eMet    int
+		e2eCount  int
+		injected  int64
+		// per-class latency accumulators (in ms)
+		ttftMs []float64
+		itlMs  []float64
+		e2eMs  []float64
+	}
+	accs := make(map[string]*acc, len(targets))
+	for cls := range targets {
+		accs[cls] = &acc{}
+	}
+
+	classOf := func(rec workload.TraceRecord) (string, bool) {
+		c := rec.SLOClass
+		if c == "" {
+			c = "default"
+		}
+		if _, ok := targets[c]; !ok {
+			return c, false
+		}
+		return c, true
+	}
+
+	for _, rec := range records {
+		if rec.Status != "ok" && rec.Status != "error" && rec.Status != "timeout" {
+			continue
+		}
+		cls, gated := classOf(rec)
+		if !gated {
+			continue
+		}
+		a := accs[cls]
+		a.injected++
+
+		// Failed/timeout records count in denominator only.
+		if rec.Status != "ok" {
+			continue
+		}
+		ttftUs := rec.FirstChunkTimeUs - rec.SendTimeUs
+		e2eUs := rec.LastChunkTimeUs - rec.SendTimeUs
+		if ttftUs <= 0 || e2eUs <= 0 || e2eUs < ttftUs {
+			continue
+		}
+		ttftMs := float64(ttftUs) / 1000.0
+		e2eMs := float64(e2eUs) / 1000.0
+		a.ttftMs = append(a.ttftMs, ttftMs)
+		a.e2eMs = append(a.e2eMs, e2eMs)
+
+		t := targets[cls]
+		good := true
+		if t.TTFTMs > 0 {
+			a.ttftCount++
+			if ttftMs <= t.TTFTMs {
+				a.ttftMet++
+			} else {
+				good = false
+			}
+		}
+		if t.E2EMs > 0 {
+			a.e2eCount++
+			if e2eMs <= t.E2EMs {
+				a.e2eMet++
+			} else {
+				good = false
+			}
+		}
+		if t.ITLMs > 0 {
+			a.itlCount++
+			if itlMean, ok := itlMeanByRequest[rec.RequestID]; ok {
+				a.itlMs = append(a.itlMs, itlMean)
+				if itlMean <= t.ITLMs {
+					a.itlMet++
+				} else {
+					good = false
+				}
+			} else {
+				good = false
+			}
+		} else if itlMean, ok := itlMeanByRequest[rec.RequestID]; ok {
+			a.itlMs = append(a.itlMs, itlMean)
+		}
+		if good {
+			a.good++
+		}
+	}
+
+	classKeys := make([]string, 0, len(targets))
+	for k := range targets {
+		classKeys = append(classKeys, k)
+	}
+	sort.Strings(classKeys)
+
+	per := make(map[string]map[string]any, len(targets))
+	var totalGood int
+	var totalInjected int64
+	for _, cls := range classKeys {
+		a := accs[cls]
+		t := targets[cls]
+		entry := map[string]any{
+			"slo_attainment": safeRatio(int64(a.good), a.injected),
+			"count":          a.injected,
+		}
+		if runtimeSec > 0 {
+			entry["goodput_rps"] = float64(a.good) / runtimeSec
+		} else {
+			entry["goodput_rps"] = 0.0
+		}
+		byDim := map[string]float64{}
+		if t.TTFTMs > 0 {
+			byDim["ttft"] = safeFraction(a.ttftMet, a.ttftCount)
+		}
+		if t.ITLMs > 0 {
+			byDim["itl"] = safeFraction(a.itlMet, a.itlCount)
+		}
+		if t.E2EMs > 0 {
+			byDim["e2e"] = safeFraction(a.e2eMet, a.e2eCount)
+		}
+		if len(byDim) > 0 {
+			entry["slo_attainment_by_dim"] = byDim
+		}
+		// Per-class latency stats (ms) from the trace records.
+		if len(a.ttftMs) > 0 {
+			sort.Float64s(a.ttftMs)
+			entry["ttft_p99_ms"] = percentile(a.ttftMs, 99)
+		}
+		if len(a.itlMs) > 0 {
+			sort.Float64s(a.itlMs)
+			var sum float64
+			for _, v := range a.itlMs {
+				sum += v
+			}
+			entry["itl_mean_ms"] = sum / float64(len(a.itlMs))
+		}
+		if len(a.e2eMs) > 0 {
+			sort.Float64s(a.e2eMs)
+			entry["e2e_p99_ms"] = percentile(a.e2eMs, 99)
+		}
+		per[cls] = entry
+		totalGood += a.good
+		totalInjected += a.injected
+	}
+
+	output.SLOAttainment = safeRatio(int64(totalGood), totalInjected)
+	output.PerClass = per
+	if runtimeSec > 0 {
+		output.GoodputRPS = float64(totalGood) / runtimeSec
+	}
+}
+
+// percentile returns the p-th percentile of an already-sorted []float64
+// using linear interpolation. Returns 0 when data is empty.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	rank := p / 100.0 * float64(n-1)
+	lo := int(rank)
+	hi := lo + 1
+	if hi >= n {
+		return sorted[n-1]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + (sorted[hi]-sorted[lo])*frac
+}
+
+// safeFraction is the int variant of safeRatio.
+func safeFraction(num, denom int) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
+}
+
+// resolveGoodputCLIFlags parses the three CLI string flags into duration maps.
+// Returns nil maps when the flag is empty. On parse error it returns the
+// per-flag error so callers can logrus.Fatalf with the right flag name.
+func resolveGoodputCLIFlags(ttftFlag, itlFlag, e2eFlag string) (
+	cliTTFT, cliITL, cliE2E map[string]time.Duration, err error,
+) {
+	cliTTFT, err = parseSLODurationFlag(ttftFlag)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("--slo-ttft: %w", err)
+	}
+	cliITL, err = parseSLODurationFlag(itlFlag)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("--slo-itl: %w", err)
+	}
+	cliE2E, err = parseSLODurationFlag(e2eFlag)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("--slo-e2e: %w", err)
+	}
+	return cliTTFT, cliITL, cliE2E, nil
+}

--- a/cmd/goodput_test.go
+++ b/cmd/goodput_test.go
@@ -295,7 +295,7 @@ func TestStripITLForObserveFallback_EmptyTargetsNoOp(t *testing.T) {
 	if stripped || got != nil {
 		t.Errorf("nil input: expected (nil, false), got (%v, %v)", got, stripped)
 	}
-	got, stripped = stripITLForObserveFallback(map[string]workload.SLODimTargets{}, false)
+	_, stripped = stripITLForObserveFallback(map[string]workload.SLODimTargets{}, false)
 	if stripped {
 		t.Errorf("empty input: expected stripped=false, got true")
 	}

--- a/cmd/goodput_test.go
+++ b/cmd/goodput_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -226,6 +227,80 @@ func TestEmitObserveGoodput_OkErrorTimeoutDenominator(t *testing.T) {
 	}
 }
 
+// TestStripITLForObserveFallback_StripsAndSignals verifies BC-6: when
+// --record-itl is false and any class carries an ITL threshold, the helper
+// returns a fresh map with ITL zeroed and signals the strip so the caller can
+// emit the warning. The TTFT/E2E thresholds on the same class must be preserved.
+func TestStripITLForObserveFallback_StripsAndSignals(t *testing.T) {
+	in := map[string]workload.SLODimTargets{
+		"critical": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
+		"batch":    {E2EMs: 60000}, // no ITL configured for this class
+	}
+	got, stripped := stripITLForObserveFallback(in, false /* recordITL */)
+	if !stripped {
+		t.Fatalf("expected stripped=true when at least one class has ITL configured")
+	}
+	if got["critical"].ITLMs != 0 {
+		t.Errorf("critical ITLMs: got %v, want 0 (stripped)", got["critical"].ITLMs)
+	}
+	if got["critical"].TTFTMs != 100 {
+		t.Errorf("critical TTFTMs: got %v, want 100 (preserved)", got["critical"].TTFTMs)
+	}
+	if got["critical"].E2EMs != 5000 {
+		t.Errorf("critical E2EMs: got %v, want 5000 (preserved)", got["critical"].E2EMs)
+	}
+	if got["batch"].E2EMs != 60000 {
+		t.Errorf("batch E2EMs: got %v, want 60000 (preserved)", got["batch"].E2EMs)
+	}
+	// Critical: input map must NOT be mutated (header still carries original ITL).
+	if in["critical"].ITLMs != 50 {
+		t.Errorf("input map mutated: in[critical].ITLMs = %v, want 50", in["critical"].ITLMs)
+	}
+}
+
+// TestStripITLForObserveFallback_NoOpWhenRecordITL verifies BC-6: with
+// --record-itl true, targets pass through unchanged and stripped=false.
+func TestStripITLForObserveFallback_NoOpWhenRecordITL(t *testing.T) {
+	in := map[string]workload.SLODimTargets{
+		"critical": {TTFTMs: 100, ITLMs: 50, E2EMs: 5000},
+	}
+	got, stripped := stripITLForObserveFallback(in, true /* recordITL */)
+	if stripped {
+		t.Errorf("expected stripped=false when recordITL is true")
+	}
+	if got["critical"].ITLMs != 50 {
+		t.Errorf("ITLMs should pass through when recordITL is true; got %v, want 50", got["critical"].ITLMs)
+	}
+}
+
+// TestStripITLForObserveFallback_NoOpWhenNoITLConfigured verifies BC-6: when
+// targets exist but no class has an ITL threshold, the helper returns the
+// original map (no copy) and stripped=false (no warning needed).
+func TestStripITLForObserveFallback_NoOpWhenNoITLConfigured(t *testing.T) {
+	in := map[string]workload.SLODimTargets{
+		"default": {E2EMs: 5000}, // no ITLMs
+	}
+	got, stripped := stripITLForObserveFallback(in, false)
+	if stripped {
+		t.Errorf("expected stripped=false when no class has ITL configured")
+	}
+	if got["default"].E2EMs != 5000 {
+		t.Errorf("default E2EMs: got %v, want 5000", got["default"].E2EMs)
+	}
+}
+
+// TestStripITLForObserveFallback_EmptyTargetsNoOp verifies the empty-input edge case.
+func TestStripITLForObserveFallback_EmptyTargetsNoOp(t *testing.T) {
+	got, stripped := stripITLForObserveFallback(nil, false)
+	if stripped || got != nil {
+		t.Errorf("nil input: expected (nil, false), got (%v, %v)", got, stripped)
+	}
+	got, stripped = stripITLForObserveFallback(map[string]workload.SLODimTargets{}, false)
+	if stripped {
+		t.Errorf("empty input: expected stripped=false, got true")
+	}
+}
+
 // TestEmitObserveGoodput_NoOpWhenTargetsEmpty verifies BC-3 on observe path.
 func TestEmitObserveGoodput_NoOpWhenTargetsEmpty(t *testing.T) {
 	out := sim.MetricsOutput{}
@@ -263,6 +338,58 @@ func TestRunReplayParity_SameTargets_SameOutput(t *testing.T) {
 	}
 	if runOut.SLOAttainment != replayOut.SLOAttainment {
 		t.Errorf("BC-4: SLOAttainment differs (run=%v replay=%v)", runOut.SLOAttainment, replayOut.SLOAttainment)
+	}
+}
+
+// TestGoodputTargets_ObserveExportReplayLoad_RoundTrip verifies BC-7 end-to-end:
+// CLI flags → merger → exported TraceHeader (via observe path) → loaded TraceHeader
+// (via replay path) → merger again. The downstream merger sees the same per-class
+// thresholds without requiring CLI flags on the replay side.
+//
+// This is the contract that makes a captured-real-server trace replayable for
+// goodput measurement out-of-the-box: the observe-side intent is preserved.
+func TestGoodputTargets_ObserveExportReplayLoad_RoundTrip(t *testing.T) {
+	// Step 1: simulate the observe-side merger from CLI flags + (no) workload spec.
+	cliTTFT := map[string]time.Duration{"critical": 100 * time.Millisecond, "standard": 500 * time.Millisecond}
+	cliE2E := map[string]time.Duration{"critical": 5 * time.Second}
+	observeMerged := mergeGoodputTargets(cliTTFT, nil, cliE2E, nil, nil)
+
+	// Step 2: write a TraceV2 carrying these targets in its header (observe export path).
+	tmp := t.TempDir()
+	headerPath := filepath.Join(tmp, "trace.yaml")
+	dataPath := filepath.Join(tmp, "trace.csv")
+	exportHeader := &workload.TraceHeader{
+		Version:           3,
+		TimeUnit:          "us",
+		Mode:              "real",
+		GoodputSLOTargets: observeMerged,
+	}
+	if err := workload.ExportTraceV2(exportHeader, []workload.TraceRecord{}, headerPath, dataPath); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+
+	// Step 3: load the trace as replay/calibrate would.
+	loaded, err := workload.LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("LoadTraceV2: %v", err)
+	}
+
+	// Step 4: replay-side merger (no CLI overrides) — header must be the only source.
+	replayMerged := mergeGoodputTargets(nil, nil, nil, loaded.Header.GoodputSLOTargets, nil)
+	if !reflect.DeepEqual(replayMerged, observeMerged) {
+		t.Fatalf("BC-7 round-trip drift:\n  observe-side: %#v\n  replay-side:  %#v", observeMerged, replayMerged)
+	}
+
+	// Spot-check: per-class per-dimension values match the original CLI input
+	// (proves the merger isn't silently coercing values).
+	if replayMerged["critical"].TTFTMs != 100 {
+		t.Errorf("critical TTFTMs: got %v, want 100", replayMerged["critical"].TTFTMs)
+	}
+	if replayMerged["critical"].E2EMs != 5000 {
+		t.Errorf("critical E2EMs: got %v, want 5000", replayMerged["critical"].E2EMs)
+	}
+	if replayMerged["standard"].TTFTMs != 500 {
+		t.Errorf("standard TTFTMs: got %v, want 500", replayMerged["standard"].TTFTMs)
 	}
 }
 

--- a/cmd/goodput_test.go
+++ b/cmd/goodput_test.go
@@ -1,0 +1,321 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// TestParseSLODurationFlag_HappyPath verifies BC-8: comma-separated key=duration pairs parse correctly.
+func TestParseSLODurationFlag_HappyPath(t *testing.T) {
+	got, err := parseSLODurationFlag("critical=100ms,standard=500ms")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]time.Duration{
+		"critical": 100 * time.Millisecond,
+		"standard": 500 * time.Millisecond,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestParseSLODurationFlag_Empty verifies BC-8: empty input returns (nil, nil).
+func TestParseSLODurationFlag_Empty(t *testing.T) {
+	got, err := parseSLODurationFlag("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+	got, err = parseSLODurationFlag("   ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("whitespace-only: got %v, want nil", got)
+	}
+}
+
+// TestParseSLODurationFlag_RejectInvalid verifies BC-8: invalid inputs error.
+func TestParseSLODurationFlag_RejectInvalid(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty key", "=100ms"},
+		{"missing equals", "critical"},
+		{"unparseable duration", "critical=not-a-duration"},
+		{"negative duration", "critical=-100ms"},
+		{"zero duration", "critical=0s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSLODurationFlag(tc.input); err == nil {
+				t.Errorf("input %q: expected error, got nil", tc.input)
+			}
+		})
+	}
+}
+
+// TestMergeGoodputTargets_PrecedenceCLIWins verifies BC-1: CLI > trace header > spec.
+func TestMergeGoodputTargets_PrecedenceCLIWins(t *testing.T) {
+	cliE2E := map[string]time.Duration{"critical": 100 * time.Millisecond}
+	header := map[string]workload.SLODimTargets{"critical": {E2EMs: 200}}
+	spec := map[string]workload.SLODimTargets{"critical": {E2EMs: 300}}
+	got := mergeGoodputTargets(nil, nil, cliE2E, header, spec)
+	if got["critical"].E2EMs != 100 {
+		t.Errorf("E2EMs: got %v, want 100 (CLI should win)", got["critical"].E2EMs)
+	}
+}
+
+// TestMergeGoodputTargets_PrecedenceHeaderOverSpec verifies BC-1: trace header > spec.
+func TestMergeGoodputTargets_PrecedenceHeaderOverSpec(t *testing.T) {
+	header := map[string]workload.SLODimTargets{"critical": {E2EMs: 200}}
+	spec := map[string]workload.SLODimTargets{"critical": {E2EMs: 300}}
+	got := mergeGoodputTargets(nil, nil, nil, header, spec)
+	if got["critical"].E2EMs != 200 {
+		t.Errorf("E2EMs: got %v, want 200 (header should win over spec)", got["critical"].E2EMs)
+	}
+}
+
+// TestMergeGoodputTargets_PartialDimensionOverride verifies BC-1: each dim merges
+// independently; CLI TTFT does not erase header E2E.
+func TestMergeGoodputTargets_PartialDimensionOverride(t *testing.T) {
+	cliTTFT := map[string]time.Duration{"critical": 50 * time.Millisecond}
+	header := map[string]workload.SLODimTargets{"critical": {E2EMs: 5000}}
+	got := mergeGoodputTargets(cliTTFT, nil, nil, header, nil)
+	if got["critical"].TTFTMs != 50 {
+		t.Errorf("TTFTMs: got %v, want 50", got["critical"].TTFTMs)
+	}
+	if got["critical"].E2EMs != 5000 {
+		t.Errorf("E2EMs: got %v, want 5000 (header E2E should survive CLI TTFT)", got["critical"].E2EMs)
+	}
+}
+
+// TestMergeGoodputTargets_ClassUnion verifies BC-1: classes from any tier are included.
+func TestMergeGoodputTargets_ClassUnion(t *testing.T) {
+	cliE2E := map[string]time.Duration{"critical": 100 * time.Millisecond}
+	header := map[string]workload.SLODimTargets{"standard": {E2EMs: 500}}
+	spec := map[string]workload.SLODimTargets{"batch": {E2EMs: 30000}}
+	got := mergeGoodputTargets(nil, nil, cliE2E, header, spec)
+	if len(got) != 3 {
+		t.Errorf("got %d classes, want 3 (critical, standard, batch)", len(got))
+	}
+	if got["critical"].E2EMs != 100 {
+		t.Errorf("critical E2EMs: got %v, want 100", got["critical"].E2EMs)
+	}
+	if got["standard"].E2EMs != 500 {
+		t.Errorf("standard E2EMs: got %v, want 500", got["standard"].E2EMs)
+	}
+	if got["batch"].E2EMs != 30000 {
+		t.Errorf("batch E2EMs: got %v, want 30000", got["batch"].E2EMs)
+	}
+}
+
+// TestMergeGoodputTargets_AllNil verifies BC-3: nil sources produce nil result
+// so the no-targets path stays byte-identical.
+func TestMergeGoodputTargets_AllNil(t *testing.T) {
+	if got := mergeGoodputTargets(nil, nil, nil, nil, nil); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+// TestEmitGoodput_NoOpWhenTargetsEmpty verifies BC-3: empty targets leaves
+// the output struct's goodput fields unchanged (zero/omitempty preserved).
+func TestEmitGoodput_NoOpWhenTargetsEmpty(t *testing.T) {
+	out := sim.MetricsOutput{}
+	m := sim.NewMetrics()
+	emitGoodput(&out, m, nil, 1.0, nil)
+	if out.GoodputRPS != 0 || out.SLOAttainment != 0 || out.PerClass != nil {
+		t.Errorf("expected zero/nil goodput fields, got GoodputRPS=%v SLOAttainment=%v PerClass=%v",
+			out.GoodputRPS, out.SLOAttainment, out.PerClass)
+	}
+}
+
+// TestEmitGoodput_OneClassE2EOnly verifies BC-2: a single configured dimension
+// produces only that dim in slo_attainment_by_dim and a complete per-class entry.
+func TestEmitGoodput_OneClassE2EOnly(t *testing.T) {
+	m := sim.NewMetrics()
+	// Two requests under "default": one meets E2E=5s threshold, one does not.
+	m.Requests["r1"] = sim.RequestMetrics{ID: "r1", SLOClass: "default"}
+	m.Requests["r2"] = sim.RequestMetrics{ID: "r2", SLOClass: "default"}
+	m.RequestE2Es["r1"] = 1_000_000   // 1s in µs (passes 5s threshold)
+	m.RequestE2Es["r2"] = 10_000_000  // 10s in µs (fails)
+
+	targets := map[string]workload.SLODimTargets{
+		"default": {E2EMs: 5000},
+	}
+	injected := map[string]int64{"default": 2}
+
+	out := sim.MetricsOutput{}
+	emitGoodput(&out, m, injected, 10.0, targets)
+
+	if out.SLOAttainment != 0.5 {
+		t.Errorf("SLOAttainment: got %v, want 0.5", out.SLOAttainment)
+	}
+	if out.GoodputRPS != 0.1 {
+		t.Errorf("GoodputRPS: got %v, want 0.1 (1 good / 10s)", out.GoodputRPS)
+	}
+	per, ok := out.PerClass.(map[string]map[string]any)
+	if !ok {
+		t.Fatalf("PerClass type: got %T, want map[string]map[string]any", out.PerClass)
+	}
+	def := per["default"]
+	if def["slo_attainment"] != 0.5 {
+		t.Errorf("default slo_attainment: got %v, want 0.5", def["slo_attainment"])
+	}
+	byDim, ok := def["slo_attainment_by_dim"].(map[string]float64)
+	if !ok {
+		t.Fatalf("slo_attainment_by_dim type: got %T, want map[string]float64", def["slo_attainment_by_dim"])
+	}
+	if _, hasTTFT := byDim["ttft"]; hasTTFT {
+		t.Errorf("byDim should not contain ttft when only E2E is configured")
+	}
+	if _, hasITL := byDim["itl"]; hasITL {
+		t.Errorf("byDim should not contain itl when only E2E is configured")
+	}
+	if v, hasE2E := byDim["e2e"]; !hasE2E || v != 0.5 {
+		t.Errorf("byDim e2e: got %v (present=%v), want 0.5", v, hasE2E)
+	}
+}
+
+// TestEmitObserveGoodput_OkErrorTimeoutDenominator verifies BC-2 on observe path:
+// error and timeout records count in the denominator but never count toward goodput;
+// only ok records can contribute to the numerator.
+func TestEmitObserveGoodput_OkErrorTimeoutDenominator(t *testing.T) {
+	records := []workload.TraceRecord{
+		// "ok" with E2E 1s — meets 5s threshold (numerator)
+		{RequestID: 1, SLOClass: "default", Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 100_000, LastChunkTimeUs: 1_000_000},
+		// "ok" with E2E 10s — fails 5s threshold
+		{RequestID: 2, SLOClass: "default", Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 100_000, LastChunkTimeUs: 10_000_000},
+		// "error" — denominator only, never numerator
+		{RequestID: 3, SLOClass: "default", Status: "error"},
+		// "timeout" — denominator only
+		{RequestID: 4, SLOClass: "default", Status: "timeout"},
+		// "incomplete" — neither denominator nor numerator (workload still in flight)
+		{RequestID: 5, SLOClass: "default", Status: "incomplete"},
+	}
+	targets := map[string]workload.SLODimTargets{"default": {E2EMs: 5000}}
+
+	out := sim.MetricsOutput{}
+	emitObserveGoodput(&out, records, nil, 10.0, targets)
+
+	if out.SLOAttainment != 0.25 {
+		t.Errorf("SLOAttainment: got %v, want 0.25 (1 ok-met out of 4 dispatched: ok+ok+error+timeout)", out.SLOAttainment)
+	}
+	per, ok := out.PerClass.(map[string]map[string]any)
+	if !ok {
+		t.Fatalf("PerClass type: got %T", out.PerClass)
+	}
+	def := per["default"]
+	if def["count"] != int64(4) {
+		t.Errorf("count: got %v, want 4 (denominator excludes incomplete)", def["count"])
+	}
+	if def["slo_attainment"] != 0.25 {
+		t.Errorf("default slo_attainment: got %v, want 0.25", def["slo_attainment"])
+	}
+	// goodput_rps: 1 good / 10s
+	if def["goodput_rps"] != 0.1 {
+		t.Errorf("goodput_rps: got %v, want 0.1", def["goodput_rps"])
+	}
+}
+
+// TestEmitObserveGoodput_NoOpWhenTargetsEmpty verifies BC-3 on observe path.
+func TestEmitObserveGoodput_NoOpWhenTargetsEmpty(t *testing.T) {
+	out := sim.MetricsOutput{}
+	emitObserveGoodput(&out, nil, nil, 1.0, nil)
+	if out.GoodputRPS != 0 || out.SLOAttainment != 0 || out.PerClass != nil {
+		t.Errorf("expected zero goodput fields, got %+v", out)
+	}
+}
+
+// TestRunReplayParity_SameTargets_SameOutput verifies BC-4 (INV-13): identical
+// metrics + identical resolved targets produce identical goodput numbers
+// regardless of whether the targets came from CLI or trace header.
+func TestRunReplayParity_SameTargets_SameOutput(t *testing.T) {
+	m := sim.NewMetrics()
+	m.Requests["r1"] = sim.RequestMetrics{ID: "r1", SLOClass: "default"}
+	m.Requests["r2"] = sim.RequestMetrics{ID: "r2", SLOClass: "default"}
+	m.RequestE2Es["r1"] = 1_000_000
+	m.RequestE2Es["r2"] = 6_000_000
+	injected := map[string]int64{"default": 2}
+
+	// "Run" path: CLI flag provided 5s threshold → resolved targets {default: {E2EMs: 5000}}.
+	cliE2E := map[string]time.Duration{"default": 5 * time.Second}
+	runTargets := mergeGoodputTargets(nil, nil, cliE2E, nil, nil)
+
+	// "Replay" path: trace header carried 5s threshold → resolved targets {default: {E2EMs: 5000}}.
+	header := map[string]workload.SLODimTargets{"default": {E2EMs: 5000}}
+	replayTargets := mergeGoodputTargets(nil, nil, nil, header, nil)
+
+	var runOut, replayOut sim.MetricsOutput
+	emitGoodput(&runOut, m, injected, 10.0, runTargets)
+	emitGoodput(&replayOut, m, injected, 10.0, replayTargets)
+
+	if runOut.GoodputRPS != replayOut.GoodputRPS {
+		t.Errorf("BC-4: GoodputRPS differs (run=%v replay=%v)", runOut.GoodputRPS, replayOut.GoodputRPS)
+	}
+	if runOut.SLOAttainment != replayOut.SLOAttainment {
+		t.Errorf("BC-4: SLOAttainment differs (run=%v replay=%v)", runOut.SLOAttainment, replayOut.SLOAttainment)
+	}
+}
+
+// TestEmitGoodput_BCThreeByteIdenticalNoTargets verifies BC-3: when no targets
+// are configured the goodput-related JSON keys remain absent (omitempty), so
+// a `blis run` invocation without --slo-* flags or spec.GoodputSLOTargets emits
+// stdout JSON byte-identical to a current-`main` build.
+func TestEmitGoodput_BCThreeByteIdenticalNoTargets(t *testing.T) {
+	m := sim.NewMetrics()
+	m.Requests["r1"] = sim.RequestMetrics{ID: "r1", SLOClass: "default"}
+	m.RequestE2Es["r1"] = 1_000_000
+
+	out := sim.MetricsOutput{}
+	emitGoodput(&out, m, map[string]int64{"default": 1}, 1.0, nil)
+
+	// All three goodput JSON slots must remain at zero values (omitempty suppresses).
+	if out.GoodputRPS != 0 {
+		t.Errorf("GoodputRPS: got %v, want 0", out.GoodputRPS)
+	}
+	if out.SLOAttainment != 0 {
+		t.Errorf("SLOAttainment: got %v, want 0", out.SLOAttainment)
+	}
+	if out.PerClass != nil {
+		t.Errorf("PerClass: got %v, want nil", out.PerClass)
+	}
+}
+
+// TestEmitGoodput_DeterministicAcrossRuns verifies INV-6: per-class JSON shape
+// is identical across repeated calls (sorted keys).
+func TestEmitGoodput_DeterministicAcrossRuns(t *testing.T) {
+	m := sim.NewMetrics()
+	for i, cls := range []string{"critical", "standard", "batch"} {
+		id := string(rune('a' + i))
+		m.Requests[id] = sim.RequestMetrics{ID: id, SLOClass: cls}
+		m.RequestE2Es[id] = 500_000
+	}
+	targets := map[string]workload.SLODimTargets{
+		"critical": {E2EMs: 1000},
+		"standard": {E2EMs: 2000},
+		"batch":    {E2EMs: 60000},
+	}
+	injected := map[string]int64{"critical": 1, "standard": 1, "batch": 1}
+
+	var first sim.MetricsOutput
+	emitGoodput(&first, m, injected, 1.0, targets)
+	for i := 0; i < 5; i++ {
+		var got sim.MetricsOutput
+		emitGoodput(&got, m, injected, 1.0, targets)
+		if got.SLOAttainment != first.SLOAttainment {
+			t.Errorf("iteration %d: SLOAttainment changed (%v vs %v)", i, got.SLOAttainment, first.SLOAttainment)
+		}
+		if got.GoodputRPS != first.GoodputRPS {
+			t.Errorf("iteration %d: GoodputRPS changed (%v vs %v)", i, got.GoodputRPS, first.GoodputRPS)
+		}
+	}
+}

--- a/cmd/kv_metrics_output_test.go
+++ b/cmd/kv_metrics_output_test.go
@@ -48,8 +48,8 @@ func TestPrintPerSLOMetrics_MultipleClasses_PrintsSorted(t *testing.T) {
 		},
 	}
 
-	// WHEN we print per-SLO metrics
-	printPerSLOMetrics(&buf, sloMetrics)
+	// WHEN we print per-SLO metrics (no goodput configured; multi-class path always prints)
+	printPerSLOMetrics(&buf, sloMetrics, false)
 
 	// THEN output must contain the section and classes in sorted order
 	output := buf.String()
@@ -58,6 +58,8 @@ func TestPrintPerSLOMetrics_MultipleClasses_PrintsSorted(t *testing.T) {
 	batchIdx := bytes.Index([]byte(output), []byte("batch"))
 	realtimeIdx := bytes.Index([]byte(output), []byte("realtime"))
 	assert.True(t, batchIdx < realtimeIdx, "SLO classes must be sorted alphabetically")
+	// ITL line is part of the section now (#1413, BC-5)
+	assert.Contains(t, output, "ITL:", "ITL line must be present")
 }
 
 func TestPrintPerSLOMetrics_SingleClass_NoOutput(t *testing.T) {
@@ -70,11 +72,24 @@ func TestPrintPerSLOMetrics_SingleClass_NoOutput(t *testing.T) {
 		},
 	}
 
-	// WHEN we print per-SLO metrics
-	printPerSLOMetrics(&buf, sloMetrics)
+	// WHEN we print per-SLO metrics (no goodput configured)
+	printPerSLOMetrics(&buf, sloMetrics, false)
 
-	// THEN no output (single class = no differentiation)
+	// THEN no output (single class = no differentiation, legacy suppression preserved)
 	assert.Empty(t, buf.String())
+
+	// WHEN we print again with goodput configured (#1413, BC-5)
+	buf.Reset()
+	printPerSLOMetrics(&buf, sloMetrics, true)
+
+	// THEN the section prints even for a single class so operators can see
+	// the dimensions gating their goodput score.
+	output := buf.String()
+	assert.Contains(t, output, "=== Per-SLO Metrics ===")
+	assert.Contains(t, output, "default")
+	assert.Contains(t, output, "TTFT:")
+	assert.Contains(t, output, "ITL:")
+	assert.Contains(t, output, "E2E:")
 }
 
 // BC-T6: printPerTenantMetrics is a no-op when map is nil.

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -174,6 +174,11 @@ func init() {
 	// Backlog-drift saturation flags (run/replay parity)
 	registerSaturationFlags(observeCmd)
 
+	// Goodput SLO targets (#1413)
+	observeCmd.Flags().StringVar(&goodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Persisted in trace header for downstream replay/calibrate.")
+	observeCmd.Flags().StringVar(&goodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds. Requires --record-itl for in-process attainment; otherwise dropped from observe-side goodput with a warning. Header export still carries the user-supplied value.")
+	observeCmd.Flags().StringVar(&goodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
+
 	rootCmd.AddCommand(observeCmd)
 }
 
@@ -470,13 +475,26 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	runObserveOrchestrator(ctx, client, recorder, sessionMgr, wl.Requests, observeNoStreaming, observeMaxConcur, observeWarmup, prefixes, prefixLengths, observeUnconstrainedOutput, observeRecordITL, tokensPerWord)
 	logrus.Infof("Observation wall-clock time: %.3fs", time.Since(startTime).Seconds())
 
+	// Resolve goodput SLO targets (#1413, BC-1, BC-7). Observe has no trace
+	// header at invocation; precedence is CLI > workload spec.
+	cliTTFT, cliITL, cliE2E, gpErr := resolveGoodputCLIFlags(goodputSLOTTFT, goodputSLOITL, goodputSLOE2E)
+	if gpErr != nil {
+		logrus.Fatalf("%v", gpErr)
+	}
+	var specTargets map[string]workload.SLODimTargets
+	if spec != nil {
+		specTargets = spec.GoodputSLOTargets
+	}
+	headerGoodputTargets := mergeGoodputTargets(cliTTFT, cliITL, cliE2E, nil, specTargets)
+
 	// Export trace (BC-4)
 	header := &workload.TraceHeader{
-		Version:        3,
-		TimeUnit:       "us",
-		CreatedAt:      time.Now().UTC().Format(time.RFC3339),
-		Mode:           "real",
-		WarmUpRequests: observeWarmup,
+		Version:           3,
+		TimeUnit:          "us",
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339),
+		Mode:              "real",
+		WarmUpRequests:    observeWarmup,
+		GoodputSLOTargets: headerGoodputTargets, // BC-7: persist user-supplied targets so downstream replay/calibrate inherit them
 		Server: &workload.TraceServerConfig{
 			Type:  observeServerType,
 			Model: observeModel,
@@ -590,7 +608,27 @@ func runObserve(cmd *cobra.Command, _ []string) {
 		logrus.Infof("Saturation report written to %s (detector: backlog-drift, classification: %s)", saturationReport, report.Classification)
 	}
 
-	printObserveMetrics(os.Stdout, records, wallClockDurationSec, itlRecords, saturationResult)
+	// In-process goodput targets (BC-6): if --record-itl was not set but the user
+	// specified ITL thresholds, drop ITL from the in-process attainment copy and
+	// warn. The trace header still carries the original user-supplied targets.
+	inProcGoodputTargets := headerGoodputTargets
+	if len(headerGoodputTargets) > 0 && !observeRecordITL {
+		var hasITL bool
+		stripped := make(map[string]workload.SLODimTargets, len(headerGoodputTargets))
+		for cls, t := range headerGoodputTargets {
+			if t.ITLMs > 0 {
+				hasITL = true
+				t.ITLMs = 0
+			}
+			stripped[cls] = t
+		}
+		if hasITL {
+			logrus.Warnf("--slo-itl set without --record-itl: ITL goodput attainment cannot be computed; using TTFT/E2E only for in-process goodput. Trace header still carries the original ITL thresholds for downstream replay/calibrate.")
+			inProcGoodputTargets = stripped
+		}
+	}
+
+	printObserveMetrics(os.Stdout, records, wallClockDurationSec, itlRecords, saturationResult, inProcGoodputTargets)
 
 	// Print session metrics if any record carries a session label (#1058)
 	sessionMetrics := computeSessionMetricsFromTrace(records)
@@ -628,7 +666,9 @@ type completionEvent struct {
 // as blis run and blis replay (=== Simulation Metrics === header + JSON body).
 // Always emits the header even when no valid records exist (BC-5).
 // saturationResult is optional (can be nil); when provided, it's populated in output.Saturation field.
-func printObserveMetrics(w io.Writer, records []workload.TraceRecord, wallClockDurationSec float64, itlRecords []workload.ITLRecord, saturationResult interface{}) {
+// goodputTargets is optional; when non-empty, emits goodput_rps/slo_attainment/per_class fields
+// computed from records and itlRecords (#1413, BC-2).
+func printObserveMetrics(w io.Writer, records []workload.TraceRecord, wallClockDurationSec float64, itlRecords []workload.ITLRecord, saturationResult interface{}, goodputTargets map[string]workload.SLODimTargets) {
 	var ttftsUs, e2esUs []int64
 	totalOutputTokens := 0
 
@@ -740,6 +780,9 @@ func printObserveMetrics(w io.Writer, records []workload.TraceRecord, wallClockD
 		output.ITLP95Ms = sim.CalculatePercentile(itlsUs, 95)
 		output.ITLP99Ms = sim.CalculatePercentile(itlsUs, 99)
 	}
+
+	// Emit goodput fields when targets are configured (#1413, BC-2).
+	emitObserveGoodput(&output, records, itlRecords, wallClockDurationSec, goodputTargets)
 
 	// Marshal to JSON
 	jsonBytes, err := json.MarshalIndent(output, "", "  ")

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -611,21 +611,9 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	// In-process goodput targets (BC-6): if --record-itl was not set but the user
 	// specified ITL thresholds, drop ITL from the in-process attainment copy and
 	// warn. The trace header still carries the original user-supplied targets.
-	inProcGoodputTargets := headerGoodputTargets
-	if len(headerGoodputTargets) > 0 && !observeRecordITL {
-		var hasITL bool
-		stripped := make(map[string]workload.SLODimTargets, len(headerGoodputTargets))
-		for cls, t := range headerGoodputTargets {
-			if t.ITLMs > 0 {
-				hasITL = true
-				t.ITLMs = 0
-			}
-			stripped[cls] = t
-		}
-		if hasITL {
-			logrus.Warnf("--slo-itl set without --record-itl: ITL goodput attainment cannot be computed; using TTFT/E2E only for in-process goodput. Trace header still carries the original ITL thresholds for downstream replay/calibrate.")
-			inProcGoodputTargets = stripped
-		}
+	inProcGoodputTargets, strippedITL := stripITLForObserveFallback(headerGoodputTargets, observeRecordITL)
+	if strippedITL {
+		logrus.Warnf("--slo-itl set without --record-itl: ITL goodput attainment cannot be computed; using TTFT/E2E only for in-process goodput. Trace header still carries the original ITL thresholds for downstream replay/calibrate.")
 	}
 
 	printObserveMetrics(os.Stdout, records, wallClockDurationSec, itlRecords, saturationResult, inProcGoodputTargets)

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -1883,7 +1883,7 @@ func TestPrintObserveMetrics_ValidRecords(t *testing.T) {
 		{Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 60000, LastChunkTimeUs: 210000, OutputTokens: 120},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, nil)
+	printObserveMetrics(&buf, records, 1.0, nil, nil, nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "=== Simulation Metrics ===") {
@@ -1925,7 +1925,7 @@ func TestPrintObserveMetrics_ValidRecords(t *testing.T) {
 
 func TestPrintObserveMetrics_ZeroRecords(t *testing.T) {
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, []workload.TraceRecord{}, 1.0, nil, nil)
+	printObserveMetrics(&buf, []workload.TraceRecord{}, 1.0, nil, nil, nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "=== Simulation Metrics ===") {
@@ -1960,7 +1960,7 @@ func TestPrintObserveMetrics_ErrorOnlyRecords(t *testing.T) {
 		{Status: "timeout", SendTimeUs: 0, FirstChunkTimeUs: 0, LastChunkTimeUs: 0, OutputTokens: 0},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, nil)
+	printObserveMetrics(&buf, records, 1.0, nil, nil, nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "=== Simulation Metrics ===") {
@@ -1996,7 +1996,7 @@ func TestPrintObserveMetrics_ITLPresent(t *testing.T) {
 		{RequestID: 0, ChunkIndex: 2, TimestampUs: 83000},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, itlRecords, nil)
+	printObserveMetrics(&buf, records, 1.0, itlRecords, nil, nil)
 
 	var metrics map[string]interface{}
 	lines := strings.Split(buf.String(), "\n")
@@ -2022,7 +2022,7 @@ func TestPrintObserveMetrics_ITLAbsent(t *testing.T) {
 		{Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 50000, LastChunkTimeUs: 200000, OutputTokens: 100},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, nil)
+	printObserveMetrics(&buf, records, 1.0, nil, nil, nil)
 
 	var metrics map[string]interface{}
 	lines := strings.Split(buf.String(), "\n")
@@ -2055,7 +2055,7 @@ func TestPrintObserveMetrics_WithSaturationResult(t *testing.T) {
 		Signals:    map[string]float64{"rate_deficit": 0.0, "latency_trend": 0.05},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, sat)
+	printObserveMetrics(&buf, records, 1.0, nil, sat, nil)
 
 	// Parse JSON output
 	var metrics map[string]interface{}
@@ -2100,7 +2100,7 @@ func TestPrintObserveMetrics_SaturationAbsentByDefault(t *testing.T) {
 		{Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 50000, LastChunkTimeUs: 200000, OutputTokens: 100},
 	}
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, nil) // nil saturationResult = detector "none"
+	printObserveMetrics(&buf, records, 1.0, nil, nil, nil) // nil saturationResult = detector "none"
 
 	// Parse JSON output
 	var metrics map[string]interface{}
@@ -2155,7 +2155,7 @@ func TestPrintObserveMetrics_EmptyRecordsWithDetector(t *testing.T) {
 
 	// Verify printObserveMetrics doesn't panic with empty metrics + saturation result
 	var buf bytes.Buffer
-	printObserveMetrics(&buf, records, 1.0, nil, satResult)
+	printObserveMetrics(&buf, records, 1.0, nil, satResult, nil)
 
 	// Parse JSON and verify saturation field is present
 	var metrics map[string]interface{}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -534,13 +534,22 @@ Example:
 
 		logrus.Infof("Replay wall-clock time: %.3fs", time.Since(startTime).Seconds())
 
+		// Resolve goodput SLO targets early so the re-export header carries them (#1413, BC-7).
+		// Replay precedence: CLI > trace header. (No workload spec in replay path.)
+		cliTTFT, cliITL, cliE2E, gpErr := resolveGoodputCLIFlags(goodputSLOTTFT, goodputSLOITL, goodputSLOE2E)
+		if gpErr != nil {
+			logrus.Fatalf("%v", gpErr)
+		}
+		goodputTargets := mergeGoodputTargets(cliTTFT, cliITL, cliE2E, traceData.Header.GoodputSLOTargets, nil)
+
 		// Export trace if requested (BC-1, BC-2, BC-3)
 		if replayTraceOutput != "" {
 			records := workload.RequestsToTraceRecords(requests)
 			header := &workload.TraceHeader{
-				Version:  3,
-				TimeUnit: "microseconds",
-				Mode:     "replayed",
+				Version:           3,
+				TimeUnit:          "microseconds",
+				Mode:              "replayed",
+				GoodputSLOTargets: goodputTargets, // #1413, BC-7
 			}
 			if err := workload.ExportTraceV2(header, records, replayTraceOutput+".yaml", replayTraceOutput+".csv"); err != nil {
 				logrus.Fatalf("Trace export failed: %v", err)
@@ -574,7 +583,12 @@ Example:
 			}
 		}
 		// Save aggregate (always print to stdout; SimResult output uses separate file)
-		if err := cs.AggregatedMetrics().SaveResults("cluster", config.Horizon, totalKVBlocks, "", saturationDetector); err != nil {
+		// goodputTargets resolved above for trace re-export; reused here (#1413, BC-1, BC-4).
+		aggregated := cs.AggregatedMetrics()
+		clusterOutput := aggregated.BuildOutput("cluster", saturationDetector)
+		emitGoodput(&clusterOutput, aggregated, cs.InjectedByClass(),
+			float64(aggregated.SimEndedTime)/1e6, goodputTargets)
+		if err := aggregated.EmitOutput(clusterOutput, ""); err != nil {
 			logrus.Fatalf("SaveResults: %v", err)
 		}
 
@@ -649,7 +663,7 @@ Example:
 		printKVCacheMetrics(os.Stdout, rawMetrics.PreemptionRate, rawMetrics.CacheHitRate, rawMetrics.KVThrashingRate)
 
 		sloDistributions := cluster.ComputePerSLODistributions(cs.AggregatedMetrics())
-		printPerSLOMetrics(os.Stdout, sloDistributions)
+		printPerSLOMetrics(os.Stdout, sloDistributions, len(goodputTargets) > 0)
 
 		// Print per-model metrics if requests carry model tags (Phase 1A, FR-011)
 		perModelMetrics := cluster.ComputePerModelMetrics(cs.AggregatedMetrics())
@@ -764,6 +778,9 @@ func init() {
 	replayCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", `Session replay mode: "fixed" (pre-baked arrivals from trace) or "closed-loop" (load-adaptive follow-ups via SessionManager)`)
 	replayCmd.Flags().IntVar(&replayThinkTimeMs, "think-time-ms", 0, "Override think time between session rounds in milliseconds (0 = derive from trace inter-round arrival gaps; mutually exclusive with --think-time-dist; requires --session-mode closed-loop)")
 	replayCmd.Flags().StringVar(&replayThinkTimeDist, "think-time-dist", "", `Think-time distribution spec for closed-loop replay (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" or "constant:value=500ms"). Mutually exclusive with --think-time-ms. Requires --session-mode closed-loop.`)
+	replayCmd.Flags().StringVar(&goodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header > workload spec.")
+	replayCmd.Flags().StringVar(&goodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds (e.g. \"critical=50ms,standard=150ms\").")
+	replayCmd.Flags().StringVar(&goodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
 	rootCmd.AddCommand(replayCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,6 +184,13 @@ var (
 	// per-request timeout override for blis run (seconds; negative = disabled, 0 is rejected)
 	requestTimeoutSecs int
 
+	// Goodput SLO targets (issue #1413). Each is "class=duration[,class=duration...]" using
+	// Go duration syntax. Distinct from --slo-targets (dispatch ordering, µs); these gate
+	// goodput emission. Precedence: CLI > trace header > workload spec.
+	goodputSLOTTFT string
+	goodputSLOITL  string
+	goodputSLOE2E  string
+
 	// output file paths
 	metricsPath      string // File to write MetricsOutput JSON for blis run (--metrics-path)
 	resultsPath      string // File to write []SimResult JSON for blis replay (--results-path)
@@ -1710,6 +1717,19 @@ var runCmd = &cobra.Command{
 		// Wall-clock timing on stderr (BC-6); stdout remains deterministic (BC-7)
 		logrus.Infof("Simulation wall-clock time: %.3fs", time.Since(startTime).Seconds())
 
+		// Resolve goodput SLO targets early so the trace export and aggregate metrics
+		// see the same merged map (#1413, BC-1). Run has no trace header; precedence
+		// here is CLI > workload spec.
+		cliTTFT, cliITL, cliE2E, gpErr := resolveGoodputCLIFlags(goodputSLOTTFT, goodputSLOITL, goodputSLOE2E)
+		if gpErr != nil {
+			logrus.Fatalf("%v", gpErr)
+		}
+		var specTargets map[string]workload.SLODimTargets
+		if spec != nil {
+			specTargets = spec.GoodputSLOTargets
+		}
+		goodputTargets := mergeGoodputTargets(cliTTFT, cliITL, cliE2E, nil, specTargets)
+
 		// Assemble allRequests if trace export or saturation analysis requested (BC-12, issue #1298)
 		var allRequests []*sim.Request
 		if traceOutput != "" || saturationReport != "" {
@@ -1726,10 +1746,11 @@ var runCmd = &cobra.Command{
 		if traceOutput != "" {
 			records := workload.RequestsToTraceRecords(allRequests)
 			header := &workload.TraceHeader{
-				Version:      3,
-				TimeUnit:     "microseconds",
-				Mode:         "generated",
-				WorkloadSeed: &spec.Seed,
+				Version:           3,
+				TimeUnit:          "microseconds",
+				Mode:              "generated",
+				WorkloadSeed:      &spec.Seed,
+				GoodputSLOTargets: goodputTargets, // #1413, BC-7: persist resolved targets for downstream replay/calibrate
 			}
 			if err := workload.ExportTraceV2(header, records, traceOutput+".yaml", traceOutput+".csv"); err != nil {
 				logrus.Fatalf("Trace export failed: %v", err)
@@ -1792,8 +1813,12 @@ var runCmd = &cobra.Command{
 				}
 			}
 		}
-		// Save aggregated metrics (prints to stdout + saves to file if metricsPath set)
-		if err := cs.AggregatedMetrics().SaveResults("cluster", config.Horizon, totalKVBlocks, metricsPath, saturationDetector); err != nil {
+		// Build aggregate output, inject goodput, then emit (#1413).
+		aggregated := cs.AggregatedMetrics()
+		clusterOutput := aggregated.BuildOutput("cluster", saturationDetector)
+		emitGoodput(&clusterOutput, aggregated, cs.InjectedByClass(),
+			float64(aggregated.SimEndedTime)/1e6, goodputTargets)
+		if err := aggregated.EmitOutput(clusterOutput, metricsPath); err != nil {
 			logrus.Fatalf("SaveResults: %v", err)
 		}
 
@@ -1891,9 +1916,11 @@ var runCmd = &cobra.Command{
 		// Print KV cache metrics if any nonzero (BC-1, BC-2)
 		printKVCacheMetrics(os.Stdout, rawMetrics.PreemptionRate, rawMetrics.CacheHitRate, rawMetrics.KVThrashingRate)
 
-		// Print per-SLO metrics if multiple SLO classes present (BC-3, BC-4, BC-10)
+		// Print per-SLO metrics. With goodput targets configured, the section prints
+		// even for a single class (#1413, BC-5). Without goodput, the legacy
+		// suppression for ≤1 class is preserved.
 		sloDistributions := cluster.ComputePerSLODistributions(cs.AggregatedMetrics())
-		printPerSLOMetrics(os.Stdout, sloDistributions)
+		printPerSLOMetrics(os.Stdout, sloDistributions, len(goodputTargets) > 0)
 
 		// Print per-model metrics if requests carry model tags (Phase 1A, FR-011)
 		perModelMetrics := cluster.ComputePerModelMetrics(cs.AggregatedMetrics())
@@ -1948,13 +1975,19 @@ func printKVCacheMetrics(w io.Writer, preemptionRate, cacheHitRate, kvThrashingR
 	_, _ = fmt.Fprintf(w, "KV Thrashing Rate: %.4f\n", kvThrashingRate)
 }
 
-// printPerSLOMetrics prints per-SLO-class latency distributions when multiple classes exist.
-func printPerSLOMetrics(w io.Writer, sloMetrics map[string]*cluster.SLOMetrics) {
-	if len(sloMetrics) <= 1 {
+// printPerSLOMetrics prints per-SLO-class latency distributions. Without
+// goodput targets configured, the section is suppressed for ≤1 class (the
+// legacy no-spurious-section behavior). With goodput targets configured, the
+// section prints even for a single class so operators see the dimensions
+// gating their goodput score (#1413, BC-5).
+func printPerSLOMetrics(w io.Writer, sloMetrics map[string]*cluster.SLOMetrics, goodputConfigured bool) {
+	if len(sloMetrics) == 0 {
+		return
+	}
+	if len(sloMetrics) == 1 && !goodputConfigured {
 		return
 	}
 	_, _ = fmt.Fprintln(w, "=== Per-SLO Metrics ===")
-	// Sort keys for deterministic output (antipattern rule 2)
 	keys := make([]string, 0, len(sloMetrics))
 	for k := range sloMetrics {
 		keys = append(keys, k)
@@ -1967,6 +2000,7 @@ func printPerSLOMetrics(w io.Writer, sloMetrics map[string]*cluster.SLOMetrics) 
 		}
 		_, _ = fmt.Fprintf(w, "  %s:\n", cls)
 		_, _ = fmt.Fprintf(w, "    TTFT: mean=%.2f p99=%.2f (n=%d)\n", m.TTFT.Mean, m.TTFT.P99, m.TTFT.Count)
+		_, _ = fmt.Fprintf(w, "    ITL:  mean=%.2f p99=%.2f (n=%d)\n", m.ITL.Mean, m.ITL.P99, m.ITL.Count)
 		_, _ = fmt.Fprintf(w, "    E2E:  mean=%.2f p99=%.2f (n=%d)\n", m.E2E.Mean, m.E2E.P99, m.E2E.Count)
 	}
 }
@@ -2101,6 +2135,9 @@ func init() {
 	runCmd.Flags().IntVar(&outputTokensMax, "output-tokens-max", defaultOutputMax, "Max Output Token Count")
 	runCmd.Flags().StringVar(&workloadSpecPath, "workload-spec", "", "Path to YAML workload specification file (overrides --workload)")
 	runCmd.Flags().IntVar(&requestTimeoutSecs, "timeout", 300, "Per-request deadline in seconds (default 300s matches the session-client default in computeDeadline). Negative = disabled; 0 is rejected. Consistent with blis observe: both commands reject 0.")
+	runCmd.Flags().StringVar(&goodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header > workload spec.")
+	runCmd.Flags().StringVar(&goodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds (e.g. \"critical=50ms,standard=150ms\").")
+	runCmd.Flags().StringVar(&goodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
 
 	// Run-specific export
 	runCmd.Flags().StringVar(&traceOutput, "trace-output", "", "Export workload as TraceV2 files (<prefix>.yaml + <prefix>.csv)")

--- a/sim/cluster/metrics.go
+++ b/sim/cluster/metrics.go
@@ -397,7 +397,7 @@ type SLOClassAttainment struct {
 // RequestLatency is a per-request latency view consumed by SLOAttainmentMultiDim.
 // All latency fields are in milliseconds — BuildLatencyResults converts from
 // the µs ticks stored in sim.Metrics.{RequestTTFTs,RequestITLs,RequestE2Es}.
-// The struct is exported so PR2's cmd/ wiring can construct fixtures and
+// The struct is exported so cmd/-side goodput wiring can construct fixtures and
 // alternate observe-path views without going through sim.Metrics.
 type RequestLatency struct {
 	Class           string

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -63,12 +63,15 @@ func NewMetrics() *Metrics {
 	}
 }
 
-// SaveResults computes aggregate metrics and optionally runs post-hoc saturation detection.
-// saturationDetector should be a saturation.Detector or nil to skip saturation analysis.
-func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int64, outputFilePath string, saturationDetector BatchClassifier) error {
+// BuildOutput populates and returns a MetricsOutput from m, including aggregate
+// percentiles, per-request rows (sorted by arrival), and an optional saturation
+// classification when saturationDetector is non-nil. It does NOT write anywhere
+// — callers (SaveResults, cmd/-side goodput emitters) handle stdout and file
+// output. Splitting build-from-emit lets cmd/ inject goodput fields between the
+// two steps without changing SaveResults's signature (#1413).
+func (m *Metrics) BuildOutput(instanceID string, saturationDetector BatchClassifier) MetricsOutput {
 	vllmRuntime := float64(m.SimEndedTime) / float64(1e6)
 
-	// Create an instance of our output struct to populate
 	output := MetricsOutput{
 		InstanceID:           instanceID,
 		CompletedRequests:    m.CompletedRequests,
@@ -150,6 +153,15 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 		output.Saturation = saturationDetector.Classify(completedReqs, totalArrivals)
 	}
 
+	return output
+}
+
+// EmitOutput writes a populated MetricsOutput to stdout (always) and an
+// optional file (when outputFilePath != ""). The file variant additionally
+// embeds per-request rows sorted by ArrivedAt for downstream tooling. Callers
+// that want goodput fields populated should call BuildOutput, mutate the
+// returned struct, then call this method (#1413).
+func (m *Metrics) EmitOutput(output MetricsOutput, outputFilePath string) error {
 	// Always emit the metrics section so callers can reliably parse output,
 	// even when CompletedRequests == 0 (e.g., all requests dropped as unservable).
 	fmt.Println("=== Simulation Metrics ===")
@@ -159,21 +171,19 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 	}
 	fmt.Println(string(data))
 
-	// --- Write to JSON File ---
 	if outputFilePath != "" {
 		// request-level metrics for detailed output in file
 		// Iterate over all registered requests (not just completed prefill)
 		// so incomplete requests appear with zero-valued metrics.
 		for _, id := range sortedRequestIDs(m.Requests) {
 			detail := m.Requests[id]
-			detail.TTFT = m.RequestTTFTs[id] / 1e3   // zero if not in map
-			detail.E2E = m.RequestE2Es[id] / 1e3      // zero if not in map
-			detail.ITL = m.RequestITLs[id] / 1e3             // ticks → ms (consistent with TTFT, E2E)
+			detail.TTFT = m.RequestTTFTs[id] / 1e3                               // zero if not in map
+			detail.E2E = m.RequestE2Es[id] / 1e3                                 // zero if not in map
+			detail.ITL = m.RequestITLs[id] / 1e3                                 // ticks → ms (consistent with TTFT, E2E)
 			detail.SchedulingDelay = float64(m.RequestSchedulingDelays[id]) / 1e3 // ticks → ms
 			output.Requests = append(output.Requests, detail)
 		}
 
-		// 2. Sort by ArrivedAt (Ascending)
 		sort.Slice(output.Requests, func(i, j int) bool {
 			return output.Requests[i].ArrivedAt < output.Requests[j].ArrivedAt
 		})
@@ -190,6 +200,19 @@ func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int6
 		logrus.Infof("Metrics written to: %s", outputFilePath)
 	}
 	return nil
+}
+
+// SaveResults computes aggregate metrics and optionally runs post-hoc saturation detection.
+// saturationDetector should be a saturation.Detector or nil to skip saturation analysis.
+// This is a thin wrapper around BuildOutput + EmitOutput; see those methods for the
+// extension hook used by goodput wiring (#1413). The horizon and totalBlocks parameters
+// are retained for backwards compatibility with existing callers but are unused — they
+// were never read by SaveResults.
+func (m *Metrics) SaveResults(instanceID string, horizon int64, totalBlocks int64, outputFilePath string, saturationDetector BatchClassifier) error {
+	_ = horizon
+	_ = totalBlocks
+	output := m.BuildOutput(instanceID, saturationDetector)
+	return m.EmitOutput(output, outputFilePath)
 }
 
 // sortedRequestIDs returns request IDs from the Requests map in sorted order.

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -85,8 +85,10 @@ type MetricsOutput struct {
 	TimedOutRequests        int              `json:"timed_out_requests"`
 	Requests                []RequestMetrics `json:"requests,omitempty"`
 	Saturation              interface{}      `json:"saturation,omitempty"` // saturation.Result, using interface{} to avoid import cycle
-	// Goodput fields (issue #1409). Populated by PR2's CLI/output wiring;
-	// left zero (and omitempty) by PR1. PerClass holds map[string]cluster.SLOClassAttainment;
+	// Goodput fields (issue #1409). Populated by cmd/-side goodput wiring when
+	// --slo-ttft/itl/e2e flags or workload-spec/trace-header goodput_slo_targets
+	// are configured; otherwise left zero and suppressed by omitempty.
+	// PerClass holds map[string]map[string]any (per-class goodput summary);
 	// typed as interface{} to mirror the Saturation field above and avoid a
 	// sim → sim/cluster import cycle.
 	GoodputRPS    float64     `json:"goodput_rps,omitempty"`

--- a/sim/metrics_utils_test.go
+++ b/sim/metrics_utils_test.go
@@ -187,7 +187,7 @@ func TestMetricsOutput_GoodputFields_OmittedWhenZero(t *testing.T) {
 }
 
 // TestMetricsOutput_GoodputFields_PresentWhenSet verifies the schema slot accepts
-// PR2-shaped values: float scalars and a heterogeneous PerClass payload.
+// goodput-shaped values: float scalars and a heterogeneous PerClass payload.
 func TestMetricsOutput_GoodputFields_PresentWhenSet(t *testing.T) {
 	m := MetricsOutput{
 		InstanceID:    "i0",

--- a/sim/workload/calibrate.go
+++ b/sim/workload/calibrate.go
@@ -65,6 +65,32 @@ type CalibrationReport struct {
 	Metrics          map[string]*MetricComparison `json:"metrics"`
 	ConfigMatch      ConfigMatchInfo              `json:"config_match"`
 	KnownLimitations []string                     `json:"known_limitations"`
+	// Goodput holds per-class observed-vs-simulated goodput comparison when
+	// goodput targets were configured (issue #1413, BC-9). Omitted when targets
+	// are absent so old consumers see the legacy report shape unchanged.
+	Goodput *GoodputComparisonReport `json:"goodput,omitempty"`
+}
+
+// GoodputComparisonReport summarizes observed-vs-simulated goodput per SLO class.
+// All ratios are in [0, 1]; absolute counts/RPS use the natural scale.
+type GoodputComparisonReport struct {
+	Targets  map[string]SLODimTargets         `json:"targets"`
+	PerClass map[string]GoodputClassComparison `json:"per_class"`
+	// SkippedITL is true when --slo-itl was configured but ITL data was
+	// missing on either side (real or sim); the ITL row is omitted with a
+	// stderr warning.
+	SkippedITL bool `json:"skipped_itl,omitempty"`
+}
+
+// GoodputClassComparison holds per-class observed/simulated goodput numbers.
+type GoodputClassComparison struct {
+	Count                   int     `json:"count"`
+	RealSLOAttainment       float64 `json:"real_slo_attainment"`
+	SimSLOAttainment        float64 `json:"sim_slo_attainment"`
+	RealGoodputRPS          float64 `json:"real_goodput_rps"`
+	SimGoodputRPS           float64 `json:"sim_goodput_rps"`
+	RealAttainmentByDim     map[string]float64 `json:"real_attainment_by_dim,omitempty"`
+	SimAttainmentByDim      map[string]float64 `json:"sim_attainment_by_dim,omitempty"`
 }
 
 // ConfigMatchInfo documents which sim params matched the trace header.

--- a/sim/workload/goodput_compare.go
+++ b/sim/workload/goodput_compare.go
@@ -1,0 +1,255 @@
+package workload
+
+import "sort"
+
+// ComputeGoodputComparison compares observed (real) and simulated SLO goodput per
+// class for the matched real/sim record set used by `blis calibrate` (issue #1413, BC-9).
+//
+// Inputs:
+//
+//	realRecords — full TraceV2 record slice. Records with Status not in
+//	              {ok, error, timeout} are excluded (matches INV-1 dispatched-set
+//	              semantics). Only records present in matchedReqIDs contribute,
+//	              so warm-up exclusion and token-mismatch filtering follow
+//	              PrepareCalibrationPairs.
+//	simByID     — sim-side results indexed by RequestID.
+//	matchedReqIDs — IDs that appear on BOTH sides (already deduplicated).
+//	itlByRequest — optional per-request ITL deltas (µs, sorted by chunk index).
+//	               When nil/empty, ITL gating is skipped on the real side and
+//	               the report's SkippedITL flag is set.
+//	targets     — per-class SLO thresholds.
+//	runtimeSec  — wall-clock duration of the real-side workload.
+//
+// Returns nil when targets is empty (no goodput configured). Otherwise produces
+// a deterministic per-class breakdown (R2: sorted class iteration).
+func ComputeGoodputComparison(
+	realRecords []TraceRecord,
+	simByID map[int]SimResult,
+	matchedReqIDs map[int]bool,
+	itlByRequest map[int][]ITLRecord,
+	targets map[string]SLODimTargets,
+	runtimeSec float64,
+) *GoodputComparisonReport {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	type acc struct {
+		count                  int
+		realGood, simGood      int
+		realTTFTMet, realTTFTN int
+		realITLMet, realITLN   int
+		realE2EMet, realE2EN   int
+		simTTFTMet, simTTFTN   int
+		simITLMet, simITLN     int
+		simE2EMet, simE2EN     int
+	}
+	accs := make(map[string]*acc, len(targets))
+	for c := range targets {
+		accs[c] = &acc{}
+	}
+
+	itlMissing := false
+
+	classOf := func(rec TraceRecord) (string, bool) {
+		c := rec.SLOClass
+		if c == "" {
+			c = "default"
+		}
+		if _, ok := targets[c]; !ok {
+			return c, false
+		}
+		return c, true
+	}
+
+	itlMeanMs := func(id int) (float64, bool) {
+		chunks, ok := itlByRequest[id]
+		if !ok || len(chunks) < 2 {
+			return 0, false
+		}
+		sortedChunks := make([]ITLRecord, len(chunks))
+		copy(sortedChunks, chunks)
+		sort.Slice(sortedChunks, func(i, j int) bool { return sortedChunks[i].ChunkIndex < sortedChunks[j].ChunkIndex })
+		var sum float64
+		var n int
+		for i := 1; i < len(sortedChunks); i++ {
+			d := sortedChunks[i].TimestampUs - sortedChunks[i-1].TimestampUs
+			if d > 0 {
+				sum += float64(d)
+				n++
+			}
+		}
+		if n == 0 {
+			return 0, false
+		}
+		return (sum / float64(n)) / 1000.0, true
+	}
+
+	for _, rec := range realRecords {
+		if rec.Status != "ok" && rec.Status != "error" && rec.Status != "timeout" {
+			continue
+		}
+		if !matchedReqIDs[rec.RequestID] {
+			continue
+		}
+		cls, gated := classOf(rec)
+		if !gated {
+			continue
+		}
+		a := accs[cls]
+		a.count++
+
+		t := targets[cls]
+		sr, hasSim := simByID[rec.RequestID]
+
+		// Real side — only "ok" records can hit goodput; failed records count
+		// in denominator only.
+		if rec.Status == "ok" {
+			realTTFTMs := float64(rec.FirstChunkTimeUs-rec.SendTimeUs) / 1000.0
+			realE2EMs := float64(rec.LastChunkTimeUs-rec.SendTimeUs) / 1000.0
+			realGood := realTTFTMs > 0 && realE2EMs > 0 && realE2EMs >= realTTFTMs
+			if t.TTFTMs > 0 {
+				if realGood {
+					a.realTTFTN++
+					if realTTFTMs <= t.TTFTMs {
+						a.realTTFTMet++
+					} else {
+						realGood = false
+					}
+				} else {
+					realGood = false
+				}
+			}
+			if t.E2EMs > 0 && realGood {
+				a.realE2EN++
+				if realE2EMs <= t.E2EMs {
+					a.realE2EMet++
+				} else {
+					realGood = false
+				}
+			} else if t.E2EMs > 0 {
+				realGood = false
+			}
+			if t.ITLMs > 0 && realGood {
+				if mean, ok := itlMeanMs(rec.RequestID); ok {
+					a.realITLN++
+					if mean <= t.ITLMs {
+						a.realITLMet++
+					} else {
+						realGood = false
+					}
+				} else {
+					itlMissing = true
+					realGood = false
+				}
+			}
+			if realGood {
+				a.realGood++
+			}
+		}
+
+		// Sim side — only count when matched on this request (always true here).
+		if hasSim {
+			simTTFTMs := sr.TTFT / 1000.0
+			simE2EMs := sr.E2E / 1000.0
+			simGood := simTTFTMs > 0 && simE2EMs > 0 && simE2EMs >= simTTFTMs
+			if t.TTFTMs > 0 {
+				if simGood {
+					a.simTTFTN++
+					if simTTFTMs <= t.TTFTMs {
+						a.simTTFTMet++
+					} else {
+						simGood = false
+					}
+				}
+			}
+			if t.E2EMs > 0 && simGood {
+				a.simE2EN++
+				if simE2EMs <= t.E2EMs {
+					a.simE2EMet++
+				} else {
+					simGood = false
+				}
+			}
+			if t.ITLMs > 0 && simGood {
+				simITLMs := sr.ITLMeanUs / 1000.0
+				if simITLMs > 0 {
+					a.simITLN++
+					if simITLMs <= t.ITLMs {
+						a.simITLMet++
+					} else {
+						simGood = false
+					}
+				} else {
+					itlMissing = true
+					simGood = false
+				}
+			}
+			if simGood {
+				a.simGood++
+			}
+		}
+	}
+
+	classKeys := make([]string, 0, len(targets))
+	for k := range targets {
+		classKeys = append(classKeys, k)
+	}
+	sort.Strings(classKeys)
+
+	per := make(map[string]GoodputClassComparison, len(targets))
+	for _, cls := range classKeys {
+		a := accs[cls]
+		t := targets[cls]
+		entry := GoodputClassComparison{
+			Count:             a.count,
+			RealSLOAttainment: ratio(a.realGood, a.count),
+			SimSLOAttainment:  ratio(a.simGood, a.count),
+		}
+		if runtimeSec > 0 {
+			entry.RealGoodputRPS = float64(a.realGood) / runtimeSec
+			entry.SimGoodputRPS = float64(a.simGood) / runtimeSec
+		}
+		realByDim := map[string]float64{}
+		simByDim := map[string]float64{}
+		if t.TTFTMs > 0 {
+			realByDim["ttft"] = ratioInt(a.realTTFTMet, a.realTTFTN)
+			simByDim["ttft"] = ratioInt(a.simTTFTMet, a.simTTFTN)
+		}
+		if t.ITLMs > 0 {
+			realByDim["itl"] = ratioInt(a.realITLMet, a.realITLN)
+			simByDim["itl"] = ratioInt(a.simITLMet, a.simITLN)
+		}
+		if t.E2EMs > 0 {
+			realByDim["e2e"] = ratioInt(a.realE2EMet, a.realE2EN)
+			simByDim["e2e"] = ratioInt(a.simE2EMet, a.simE2EN)
+		}
+		if len(realByDim) > 0 {
+			entry.RealAttainmentByDim = realByDim
+		}
+		if len(simByDim) > 0 {
+			entry.SimAttainmentByDim = simByDim
+		}
+		per[cls] = entry
+	}
+
+	return &GoodputComparisonReport{
+		Targets:    targets,
+		PerClass:   per,
+		SkippedITL: itlMissing,
+	}
+}
+
+func ratio(num, denom int) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
+}
+
+func ratioInt(num, denom int) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
+}

--- a/sim/workload/goodput_compare_test.go
+++ b/sim/workload/goodput_compare_test.go
@@ -1,0 +1,78 @@
+package workload
+
+import "testing"
+
+// TestComputeGoodputComparison_Empty verifies BC-9 no-op path: no targets => nil report.
+func TestComputeGoodputComparison_Empty(t *testing.T) {
+	got := ComputeGoodputComparison(nil, nil, nil, nil, nil, 1.0)
+	if got != nil {
+		t.Errorf("expected nil report when no targets configured, got %+v", got)
+	}
+}
+
+// TestComputeGoodputComparison_E2EOnly verifies the basic compare path:
+// real-side meets E2E threshold, sim-side does not, both contribute to denominator.
+func TestComputeGoodputComparison_E2EOnly(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 1, SLOClass: "default", Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 100_000, LastChunkTimeUs: 1_000_000}, // 1s real E2E (passes 5s)
+	}
+	simResults := map[int]SimResult{
+		1: {RequestID: 1, TTFT: 100_000, E2E: 10_000_000}, // 10s sim E2E (fails 5s)
+	}
+	matched := map[int]bool{1: true}
+	targets := map[string]SLODimTargets{"default": {E2EMs: 5000}}
+
+	got := ComputeGoodputComparison(records, simResults, matched, nil, targets, 10.0)
+	if got == nil {
+		t.Fatal("expected non-nil report")
+	}
+	def := got.PerClass["default"]
+	if def.Count != 1 {
+		t.Errorf("count: got %d, want 1", def.Count)
+	}
+	if def.RealSLOAttainment != 1.0 {
+		t.Errorf("real attainment: got %v, want 1.0", def.RealSLOAttainment)
+	}
+	if def.SimSLOAttainment != 0.0 {
+		t.Errorf("sim attainment: got %v, want 0.0", def.SimSLOAttainment)
+	}
+	if def.RealGoodputRPS != 0.1 {
+		t.Errorf("real goodput_rps: got %v, want 0.1", def.RealGoodputRPS)
+	}
+	if def.SimGoodputRPS != 0.0 {
+		t.Errorf("sim goodput_rps: got %v, want 0.0", def.SimGoodputRPS)
+	}
+	if got.SkippedITL {
+		t.Errorf("SkippedITL: should be false when ITL not configured")
+	}
+}
+
+// TestComputeGoodputComparison_ITLMissing verifies BC-9 ITL fallback:
+// when ITL is configured but missing on either side, SkippedITL is true and
+// only TTFT/E2E rows are computed.
+func TestComputeGoodputComparison_ITLMissing(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 1, SLOClass: "critical", Status: "ok", SendTimeUs: 0, FirstChunkTimeUs: 50_000, LastChunkTimeUs: 1_000_000},
+	}
+	simResults := map[int]SimResult{
+		1: {RequestID: 1, TTFT: 50_000, E2E: 1_000_000, ITLMeanUs: 0}, // ITL missing on sim side
+	}
+	matched := map[int]bool{1: true}
+	targets := map[string]SLODimTargets{"critical": {TTFTMs: 100, E2EMs: 5000, ITLMs: 50}}
+
+	got := ComputeGoodputComparison(records, simResults, matched, nil /* no ITL records on real side */, targets, 1.0)
+	if got == nil {
+		t.Fatal("expected non-nil report")
+	}
+	if !got.SkippedITL {
+		t.Errorf("SkippedITL: got false, want true")
+	}
+	// real-side ITL missing → real not "good"; sim-side ITL missing → sim not "good"
+	crit := got.PerClass["critical"]
+	if crit.RealSLOAttainment != 0.0 {
+		t.Errorf("real attainment: got %v, want 0.0 (ITL missing fails the AND)", crit.RealSLOAttainment)
+	}
+	if crit.SimSLOAttainment != 0.0 {
+		t.Errorf("sim attainment: got %v, want 0.0 (ITL missing fails the AND)", crit.SimSLOAttainment)
+	}
+}

--- a/sim/workload/spec.go
+++ b/sim/workload/spec.go
@@ -51,8 +51,8 @@ type WorkloadSpec struct {
 	ServeGenData  *ServeGenDataSpec  `yaml:"servegen_data,omitempty"`
 	InferencePerf *InferencePerfSpec `yaml:"inference_perf,omitempty"`
 	// GoodputSLOTargets: per-SLO-class TTFT/ITL/E2E thresholds for goodput
-	// measurement (issue #1409, BC-8). PR1 reserves the schema slot; the
-	// targets are consumed by PR2's CLI/output wiring. Distinct from the
+	// measurement (issue #1409). Consumed by cmd/-side goodput wiring with
+	// CLI > trace header > workload spec precedence. Distinct from the
 	// dispatch-ordering --slo-targets flag.
 	GoodputSLOTargets map[string]SLODimTargets `yaml:"goodput_slo_targets,omitempty"`
 }


### PR DESCRIPTION
## Summary

Wires the goodput foundation built in #1410 (PR1) through the cmd/ layer so per-class SLO goodput becomes user-visible. Verifies the gap on a post-PR1 build:

```bash
$ grep -rn 'SLOAttainmentMultiDim\|GoodputSLOTargets' cmd/ --include='*.go'
# (no hits on main — everything was wired in this PR)
```

This is PR2 of the #1409 series.

## What lands

| File | Change |
|------|--------|
| `cmd/goodput.go` (new) | `parseSLODurationFlag`, `mergeGoodputTargets` (3-source: CLI > trace header > spec), `emitGoodput` (run/replay path), `emitObserveGoodput` (records-driven path) |
| `cmd/goodput_test.go` (new) | Parser, merger, emit, BC-3 byte-identical, BC-4 run/replay parity, deterministic |
| `cmd/root.go` (`blis run`) | New flags `--slo-ttft / --slo-itl / --slo-e2e`. Resolves targets, persists into trace header, emits goodput in `MetricsOutput` JSON, and prints per-SLO section for single-class workloads when configured. |
| `cmd/replay.go` | Same flags. Reads `traceData.Header.GoodputSLOTargets`, CLI overrides per dimension. Re-export header carries the resolved targets. |
| `cmd/observe_cmd.go` | Same flags. Persists user-supplied targets into exported `TraceHeader.GoodputSLOTargets` (BC-7). When `--slo-itl` is set without `--record-itl`, emits a warn and drops ITL from the in-process attainment copy (BC-6); the header copy is unaffected. |
| `cmd/calibrate.go` | Same flags. Computes per-class observed-vs-simulated `slo_attainment` and `goodput_rps` from matched record sets; written to `report.goodput.per_class.<class>` and summarized on stderr. ITL skipped with a warning when ITL data is missing. |
| `sim/workload/goodput_compare.go` (new) | `ComputeGoodputComparison` library function used by `cmd/calibrate`. |
| `sim/workload/calibrate.go` | New optional `Goodput *GoodputComparisonReport` field on `CalibrationReport`. |
| `sim/metrics.go` | `SaveResults` split into `BuildOutput` + `EmitOutput`; `SaveResults` becomes a thin wrapper so all 15+ existing callers stay unaffected. The split lets cmd/ inject goodput between build and emit. |
| `cmd/root.go` (`printPerSLOMetrics`) | Now prints the section for single-class workloads when goodput is configured (BC-5); legacy ≤1-class suppression preserved otherwise. Section gains an ITL line. |
| `CLAUDE.md` | Examples for `--slo-ttft/itl/e2e` on run/replay/observe/calibrate. |

## Behavioral contracts (from the plan)

- **BC-1 — Precedence:** CLI > trace header > workload spec, merged per dimension.
- **BC-2 — JSON shape:** `goodput_rps`, `slo_attainment`, `per_class.<class>.{goodput_rps, slo_attainment, slo_attainment_by_dim, ttft_p99_ms, itl_mean_ms, e2e_p99_ms, count}` when configured.
- **BC-3 — No-targets path is byte-identical:** stdout JSON contains no goodput keys when no flags or spec.
- **BC-4 — Run/replay parity (INV-13):** identical resolved targets ⇒ identical `goodput_rps` and `slo_attainment` regardless of source.
- **BC-5 — `printPerSLOMetrics` fix + ITL line:** prints for single-class workloads when goodput is configured.
- **BC-6 — Observe ITL fallback:** `--slo-itl` without `--record-itl` ⇒ warning, ITL stripped from in-process attainment, header unchanged.
- **BC-7 — Observe writes resolved targets to TraceHeader.**
- **BC-8 — Flag validation:** Go duration syntax; empty key / unparseable / non-positive ⇒ `logrus.Fatalf`.
- **BC-9 — Calibrate goodput compare:** per-class real vs sim attainment + goodput_rps; ITL skipped with warning when ITL data is absent.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` passes (full suite)
- [x] `go vet ./...` clean
- [x] BC-3 smoke: `blis run` without goodput flags produces stdout JSON with no `goodput_*` / `slo_attainment` / `per_class` keys
- [x] BC-2 smoke: `blis run --slo-e2e default=5s` produces `goodput_rps`, `slo_attainment`, `per_class.default.slo_attainment_by_dim.e2e` (no `ttft`/`itl` sub-keys)
- [x] BC-4 unit: `mergeGoodputTargets` from CLI vs trace header path produces identical `emitGoodput` output for the same metrics fixture
- [x] BC-9 unit: `ComputeGoodputComparison` happy path + ITL fallback
- [ ] CI lint (`golangci-lint run ./...`) — local lint not installed; CI will gate

## Out of scope (deferred per issue)

- Per-request SLO targets within sessions (`TraceRecord.SLOTargetUs` is the future hook)
- p99 ITL as a goodput threshold (mean-only)
- llm-d priority-header mapping in `blis observe`

Closes #1413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)