### PR TITLE
feat(observe): capture x-request-id per request for pod attribution (#1428)

### DIFF
--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inference-sim/inference-sim/sim"
 	"github.com/inference-sim/inference-sim/sim/workload"
 	"github.com/sirupsen/logrus"
@@ -111,6 +112,7 @@ type RequestRecord struct {
 	VLLMPriority      int    // vLLM priority value (0=highest urgency, higher=lower urgency); 0 when not set
 	Status            string // "ok", "error", "timeout"
 	ErrorMessage      string
+	XRequestID        string // client-generated UUID sent as x-request-id header (issue #1428)
 	SendTimeUs        int64
 	FirstChunkTimeUs  int64
 	LastChunkTimeUs   int64
@@ -196,6 +198,13 @@ func (c *RealClient) Send(ctx context.Context, req *PendingRequest) (*RequestRec
 		return record, nil
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	// Per-request UUID for joining client traces to EPP routing logs (issue #1428).
+	// Generated and recorded BEFORE httpClient.Do so timeouts/errors retain the ID
+	// (response-side capture would lose attribution for the requests we most want
+	// to trace).
+	xRequestID := uuid.NewString()
+	httpReq.Header.Set("x-request-id", xRequestID)
+	record.XRequestID = xRequestID
 	if c.apiKey != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
@@ -474,6 +483,7 @@ func (r *Recorder) RecordRequest(pending *PendingRequest, result *RequestRecord,
 		Status:            result.Status,
 		ErrorMessage:      result.ErrorMessage,
 		FinishReason:      result.FinishReason,
+		XRequestID:        result.XRequestID,
 		SessionID:         sessionID,
 		RoundIndex:        roundIndex,
 	})

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -2218,3 +2218,115 @@ func TestObservePostHocDetector_RateDeficitUsesAllArrivals(t *testing.T) {
 	// rate_deficit = 1 - (2 / 2) = 0.0 (WRONG - hides the 2 failures)
 	// This test would catch that regression.
 }
+
+// TestRealClient_SetsXRequestIDHeader verifies issue #1428 AC: every outgoing
+// request carries an x-request-id header whose value matches record.XRequestID.
+func TestRealClient_SetsXRequestIDHeader(t *testing.T) {
+	var capturedHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("x-request-id")
+		resp := map[string]interface{}{
+			"choices": []map[string]interface{}{{"text": "hello"}},
+			"usage":   map[string]interface{}{"prompt_tokens": 10.0, "completion_tokens": 5.0},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm")
+	record, err := client.Send(context.Background(), &PendingRequest{
+		RequestID: 0, InputTokens: 10, Streaming: false,
+		Prompt: "hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.XRequestID == "" {
+		t.Fatal("record.XRequestID is empty; expected a generated UUID")
+	}
+	if capturedHeader == "" {
+		t.Fatal("server did not receive x-request-id header")
+	}
+	if capturedHeader != record.XRequestID {
+		t.Errorf("header (%q) and record.XRequestID (%q) must match", capturedHeader, record.XRequestID)
+	}
+}
+
+// TestRealClient_XRequestID_IsUnique verifies that each request gets a fresh UUID.
+func TestRealClient_XRequestID_IsUnique(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"choices": []map[string]interface{}{{"text": "x"}},
+			"usage":   map[string]interface{}{"prompt_tokens": 5.0, "completion_tokens": 1.0},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm")
+	seen := map[string]struct{}{}
+	for i := 0; i < 5; i++ {
+		record, err := client.Send(context.Background(), &PendingRequest{
+			RequestID: i, InputTokens: 5, Streaming: false, Prompt: "x",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, dup := seen[record.XRequestID]; dup {
+			t.Fatalf("duplicate XRequestID %q on request %d", record.XRequestID, i)
+		}
+		seen[record.XRequestID] = struct{}{}
+	}
+}
+
+// TestRealClient_XRequestID_RetainedOnServerError verifies that the UUID is
+// recorded even when the request fails — this is the "covers timeouts and
+// errors" property from the issue's design rationale.
+func TestRealClient_XRequestID_RetainedOnServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewRealClient(server.URL, "", "test-model", "vllm")
+	record, err := client.Send(context.Background(), &PendingRequest{
+		RequestID: 99, InputTokens: 5, Streaming: false, Prompt: "x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Status != "error" {
+		t.Errorf("status = %q, want error", record.Status)
+	}
+	if record.XRequestID == "" {
+		t.Error("XRequestID must be populated even on server error (issue #1428)")
+	}
+}
+
+// TestRecorder_PropagatesXRequestID verifies issue #1428: Recorder.RecordRequest
+// copies XRequestID from RequestRecord into the workload.TraceRecord.
+func TestRecorder_PropagatesXRequestID(t *testing.T) {
+	recorder := &Recorder{}
+	pending := &PendingRequest{
+		RequestID:   42,
+		InputTokens: 100,
+	}
+	result := &RequestRecord{
+		RequestID:    42,
+		Status:       "ok",
+		OutputTokens: 50,
+		XRequestID:   "uuid-test-value",
+		SendTimeUs:   1000,
+	}
+	recorder.RecordRequest(pending, result, 500, "session-x", 0)
+
+	records := recorder.Records()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].XRequestID != "uuid-test-value" {
+		t.Errorf("TraceRecord.XRequestID: got %q, want %q", records[0].XRequestID, "uuid-test-value")
+	}
+}

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -76,7 +76,7 @@ inference-sim/
 │   ├── client.go              # Rate normalization, prefix group management
 │   ├── generator.go           # GenerateRequests pipeline with client decomposition
 │   ├── servegen.go            # Native ServeGen data file loading (chunk-*-trace.csv + dataset.json)
-│   ├── tracev2.go             # Trace v2 format (YAML header + CSV data); 26-column schema including finish_reason (backward-compat with 25-column pre-finish_reason traces)
+│   ├── tracev2.go             # Trace v2 format (YAML header + CSV data); 27-column schema including finish_reason (backward-compat with 26-column pre-finish_reason traces)
 │   ├── replay.go              # Trace v2 → sim.Request with synthetic token IDs
 │   ├── calibrate.go           # CalibrationReport, PrepareCalibrationPairs, MAPE/Pearson r
 │   ├── multimodal.go          # Multimodal token generation (text+image+audio+video)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -79,6 +79,7 @@ type TraceRecord struct {
 	Status            string // "ok", "error", "timeout"
 	ErrorMessage      string
 	FinishReason      string // server-reported finish_reason ("stop", "length", "abort", etc.); empty = not recorded
+	XRequestID        string // client-generated UUID sent as x-request-id header (real-mode only); empty = not recorded
 }
 
 // TraceV2 combines header and records for a complete trace.
@@ -119,6 +120,29 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
+	// Conditionally include slo_target_us column: present iff any record has non-zero SLO target.
+	includeSLOTarget := false
+	for _, r := range records {
+		if r.SLOTargetUs > 0 {
+			includeSLOTarget = true
+			break
+		}
+	}
+
+	// Conditionally include x_request_id column: present iff any record has a non-empty
+	// UUID AND the trace is from a real run. Mode-gated to ensure replay re-exports never
+	// emit UUIDs (which would no longer correspond to real EPP routing decisions).
+	// Issue #1428.
+	includeXRequestID := false
+	if header.Mode == "real" {
+		for _, r := range records {
+			if r.XRequestID != "" {
+				includeXRequestID = true
+				break
+			}
+		}
+	}
+
 	// Conditionally include vllm_priority column: present iff priority was actually computed.
 	// Include when either:
 	// 1. Any record has non-zero priority (batch, standard, sheddable, background from observe)
@@ -133,17 +157,8 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		}
 	}
 
-	// Conditionally include slo_target_us column: present iff any record has non-zero SLO target.
-	includeSLOTarget := false
-	for _, r := range records {
-		if r.SLOTargetUs > 0 {
-			includeSLOTarget = true
-			break
-		}
-	}
-
 	// Build column header list
-	columns := make([]string, 0, len(traceV2Columns)+2)
+	columns := make([]string, 0, len(traceV2Columns)+3)
 	for i, col := range traceV2Columns {
 		columns = append(columns, col)
 		// Insert vllm_priority immediately after slo_class (index 3)
@@ -154,6 +169,11 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		if col == "deadline_us" && includeSLOTarget {
 			columns = append(columns, "slo_target_us")
 		}
+	}
+	// Append x_request_id at end (issue #1428): trailing position avoids shifting
+	// indices in the positional parser.
+	if includeXRequestID {
+		columns = append(columns, "x_request_id")
 	}
 
 	// Write header row
@@ -204,6 +224,10 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 			r.ErrorMessage,
 			r.FinishReason,
 		)
+		// Append x_request_id at end (issue #1428).
+		if includeXRequestID {
+			row = append(row, r.XRequestID)
+		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("writing CSV row %d: %w", r.RequestID, err)
 		}
@@ -244,12 +268,15 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 	// Detect optional columns from header
 	hasVLLMPriority := false
 	hasSLOTarget := false
-	for _, col := range headerRow {
-		if col == "vllm_priority" {
+	xRequestIDIdx := -1 // header-position lookup; -1 = absent (issue #1428)
+	for i, col := range headerRow {
+		switch col {
+		case "vllm_priority":
 			hasVLLMPriority = true
-		}
-		if col == "slo_target_us" {
+		case "slo_target_us":
 			hasSLOTarget = true
+		case "x_request_id":
+			xRequestIDIdx = i
 		}
 	}
 
@@ -269,11 +296,14 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 		if hasSLOTarget {
 			minCols++
 		}
+		if xRequestIDIdx >= 0 {
+			minCols++
+		}
 		if len(row) < minCols {
 			return nil, fmt.Errorf("CSV row has %d columns, expected at least %d", len(row), minCols)
 		}
 
-		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget)
+		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget, xRequestIDIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -284,8 +314,10 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 }
 
 // parseTraceRecord parses a CSV row. Handles optional columns vllm_priority
-// (after slo_class) and slo_target_us (after deadline_us).
-func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool) (*TraceRecord, error) {
+// (after slo_class), slo_target_us (after deadline_us), and x_request_id
+// (trailing). xRequestIDIdx is the absolute column index in the row, or -1
+// if the column is absent.
+func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx int) (*TraceRecord, error) {
 	// Column offset: optional columns shift subsequent indices.
 	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.
 	// slo_target_us appears after deadline_us → shifts everything after by +1.
@@ -436,6 +468,13 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool) (*TraceR
 	}
 	finishReason := strings.TrimSpace(row[26+offset])
 
+	// Optional x_request_id at trailing column (issue #1428): looked up by
+	// absolute header position so the index math above is unaffected.
+	var xRequestID string
+	if xRequestIDIdx >= 0 && xRequestIDIdx < len(row) {
+		xRequestID = strings.TrimSpace(row[xRequestIDIdx])
+	}
+
 	return &TraceRecord{
 		RequestID:         requestID,
 		ClientID:          row[1],
@@ -466,6 +505,7 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool) (*TraceR
 		Status:            row[24+offset],
 		ErrorMessage:      strings.TrimSpace(row[25+offset]),
 		FinishReason:      finishReason,
+		XRequestID:        xRequestID,
 	}, nil
 }
 

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -269,7 +269,7 @@ func TestParseTraceRecord_InvalidInteger_ReturnsError(t *testing.T) {
 	}
 
 	// WHEN parsing
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -288,7 +288,7 @@ func TestParseTraceRecord_InvalidDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "not_a_number" // deadline_us column (shifted +1 by prefix_length)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric deadline_us, got nil")
@@ -306,7 +306,7 @@ func TestParseTraceRecord_InvalidServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "not_a_number" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric server_input_tokens, got nil")
@@ -326,7 +326,7 @@ func TestParseTraceRecord_InvalidVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "not_a_number" // vllm_priority column (index 4)
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false)
+	_, err := parseTraceRecord(row, true, false, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -347,7 +347,7 @@ func TestParseTraceRecord_NegativeVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "-1" // negative vllm_priority
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false)
+	_, err := parseTraceRecord(row, true, false, -1)
 
 	// THEN error about negative value
 	if err == nil {
@@ -369,7 +369,7 @@ func TestParseTraceRecord_NegativeDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "-1" // negative deadline_us (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative deadline_us, got nil")
@@ -388,7 +388,7 @@ func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[9] = "-1" // input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative input_tokens, got nil")
@@ -407,7 +407,7 @@ func TestParseTraceRecord_NegativeOutputTokens_ReturnsError(t *testing.T) {
 	}
 	row[10] = "-1" // output_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative output_tokens, got nil")
@@ -426,7 +426,7 @@ func TestParseTraceRecord_NegativeServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "-1" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative server_input_tokens, got nil")
@@ -446,7 +446,7 @@ func TestParseTraceRecord_DeadlineBeforeArrival_ReturnsError(t *testing.T) {
 	row[17] = "1000" // deadline_us = 1000 (shifted +1)
 	row[19] = "5000" // arrival_time_us = 5000 (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false)
+	_, err := parseTraceRecord(row, false, false, -1)
 
 	if err == nil {
 		t.Fatal("expected error for deadline before arrival, got nil")
@@ -475,7 +475,7 @@ func TestParseTraceRecord_InvalidReasonRatio_ReturnsError(t *testing.T) {
 		}
 		row[15] = tc.value // reason_ratio column (shifted +1)
 
-		_, err := parseTraceRecord(row, false, false)
+		_, err := parseTraceRecord(row, false, false, -1)
 
 		if err == nil {
 			t.Errorf("reason_ratio=%q: expected error, got nil", tc.value)
@@ -1497,5 +1497,179 @@ func TestTraceRecordsToRequestMetrics_RateDeficitSemantics(t *testing.T) {
 	}
 	if rateDeficitCorrect == rateDeficitWrong {
 		t.Errorf("Correct and wrong totalArrivals should produce different rate_deficit values")
+	}
+}
+
+// TestExportTraceV2_XRequestID_RoundTrip verifies issue #1428: x_request_id
+// is preserved through export/load when present, and absent when no record
+// carries a UUID.
+func TestExportTraceV2_XRequestID_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("real mode with UUIDs → column present, values round-trip", func(t *testing.T) {
+		header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "real"}
+		records := []TraceRecord{
+			{RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000, Status: "ok", XRequestID: "uuid-aaa"},
+			{RequestID: 2, InputTokens: 200, OutputTokens: 100, ArrivalTimeUs: 2000, Status: "ok", XRequestID: "uuid-bbb"},
+		}
+
+		headerPath := filepath.Join(dir, "real_header.yaml")
+		dataPath := filepath.Join(dir, "real_data.csv")
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.Split(string(data), "\n")
+		if !strings.Contains(lines[0], "x_request_id") {
+			t.Fatalf("expected x_request_id in CSV header, got: %s", lines[0])
+		}
+
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(loaded.Records) != 2 {
+			t.Fatalf("expected 2 records, got %d", len(loaded.Records))
+		}
+		if loaded.Records[0].XRequestID != "uuid-aaa" {
+			t.Errorf("record 0 XRequestID: got %q, want %q", loaded.Records[0].XRequestID, "uuid-aaa")
+		}
+		if loaded.Records[1].XRequestID != "uuid-bbb" {
+			t.Errorf("record 1 XRequestID: got %q, want %q", loaded.Records[1].XRequestID, "uuid-bbb")
+		}
+	})
+
+	t.Run("real mode with no UUIDs → column absent", func(t *testing.T) {
+		header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "real"}
+		records := []TraceRecord{
+			{RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000, Status: "ok"},
+		}
+
+		headerPath := filepath.Join(dir, "noid_header.yaml")
+		dataPath := filepath.Join(dir, "noid_data.csv")
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "x_request_id") {
+			t.Errorf("x_request_id should be absent when no record has a UUID")
+		}
+	})
+
+	t.Run("replayed mode with UUIDs → column omitted (mode gate, AC#5)", func(t *testing.T) {
+		// Replay re-export must drop x_request_id even if records carry UUIDs:
+		// the UUIDs would no longer correspond to real EPP routing decisions.
+		header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "replayed"}
+		records := []TraceRecord{
+			{RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000, Status: "ok", XRequestID: "uuid-aaa"},
+		}
+
+		headerPath := filepath.Join(dir, "replayed_header.yaml")
+		dataPath := filepath.Join(dir, "replayed_data.csv")
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "x_request_id") {
+			t.Errorf("x_request_id must not appear in replayed-mode export, got: %s", string(data))
+		}
+	})
+
+	t.Run("synthetic mode with UUIDs → column omitted (mode gate)", func(t *testing.T) {
+		header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "synthetic"}
+		records := []TraceRecord{
+			{RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000, Status: "ok", XRequestID: "uuid-aaa"},
+		}
+
+		headerPath := filepath.Join(dir, "syn_header.yaml")
+		dataPath := filepath.Join(dir, "syn_data.csv")
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "x_request_id") {
+			t.Errorf("x_request_id must not appear in non-real-mode export")
+		}
+	})
+}
+
+// TestLoadTraceV2_BackwardCompat_NoXRequestIDColumn verifies issue #1428 AC#4:
+// older traces without the column load unchanged; XRequestID is empty on records.
+func TestLoadTraceV2_BackwardCompat_NoXRequestIDColumn(t *testing.T) {
+	dir := t.TempDir()
+
+	header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "real"}
+	records := []TraceRecord{
+		{RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000, Status: "ok"},
+	}
+
+	headerPath := filepath.Join(dir, "old_header.yaml")
+	dataPath := filepath.Join(dir, "old_data.csv")
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("loading trace without x_request_id should succeed, got: %v", err)
+	}
+	if len(loaded.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(loaded.Records))
+	}
+	if loaded.Records[0].XRequestID != "" {
+		t.Errorf("record XRequestID: got %q, want empty", loaded.Records[0].XRequestID)
+	}
+}
+
+// TestExportTraceV2_XRequestID_CoexistsWithOtherOptionalColumns verifies that
+// x_request_id at trailing position does not interfere with vllm_priority and
+// slo_target_us positional parsing (issue #1428).
+func TestExportTraceV2_XRequestID_CoexistsWithOtherOptionalColumns(t *testing.T) {
+	dir := t.TempDir()
+
+	header := &TraceHeader{Version: 2, TimeUnit: "us", Mode: "real"}
+	records := []TraceRecord{
+		{
+			RequestID: 1, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 1000,
+			Status: "ok", SLOClass: "batch", VLLMPriority: 5, SLOTargetUs: 100000,
+			XRequestID: "uuid-zzz",
+		},
+	}
+
+	headerPath := filepath.Join(dir, "all_header.yaml")
+	dataPath := filepath.Join(dir, "all_data.csv")
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(loaded.Records))
+	}
+	got := loaded.Records[0]
+	if got.VLLMPriority != 5 {
+		t.Errorf("VLLMPriority: got %d, want 5", got.VLLMPriority)
+	}
+	if got.SLOTargetUs != 100000 {
+		t.Errorf("SLOTargetUs: got %d, want 100000", got.SLOTargetUs)
+	}
+	if got.XRequestID != "uuid-zzz" {
+		t.Errorf("XRequestID: got %q, want %q", got.XRequestID, "uuid-zzz")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1428.

`blis observe` now generates a fresh UUID for each outgoing request, sets it as the `x-request-id` HTTP header, and persists it to a new optional `x_request_id` column in `trace_data.csv`. This enables joining client-side trace data (keyed by integer `request_id`) to EPP-side routing decisions (keyed by UUID `x-request-id`).

## Design choices worth reviewing

1. **UUID generated BEFORE `httpClient.Do`.** This is the key reason for picking client-generate over server-echo: timeouts and errors retain the UUID, and those are exactly the requests we most want to attribute. See the discussion thread on the issue for the full alternatives analysis (server-echo / client-generate / server-generate-only) and the gateway-regeneration failure mode plus a falsification check.

2. **Mode-gated column emission.** `ExportTraceV2` only emits `x_request_id` when `header.Mode == "real"` AND at least one record has a non-empty UUID. Picked option 3 from the vet-issue review (mode gate at export, not at load) for two reasons: it mirrors the established `vllm_priority` precedent, and it keeps `LoadTraceV2` lossless so analysis tooling can still read populated UUIDs out of a re-loaded real-mode trace. Tested explicitly: `replayed`-mode trace with `XRequestID` populated → column omitted.

3. **Trailing column placement + header-position lookup on load.** Appending at the end avoids shifting any positional indices in `parseTraceRecord` (which already juggles offsets for `vllm_priority` and `slo_target_us`). The load path looks up the column by absolute index from the header row, decoupling it from the existing offset math.

## Run / replay parity (INV-13)

- **`run`** — no HTTP, never sets `XRequestID`, column omitted in export. Output byte-identical to before.
- **`replay`** — loads the column harmlessly into `TraceRecord.XRequestID`; the mode gate (`real` only) means replay re-export drops the column even if records carry UUIDs.
- **`observe`** — the change.

## Backward compatibility

Older traces (no `x_request_id` column) load unchanged — `csv.Reader.FieldsPerRecord = -1` was already permitting trailing optional columns.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests:
  - `TestRealClient_SetsXRequestIDHeader` — captures inbound header, verifies match with `record.XRequestID`
  - `TestRealClient_XRequestID_IsUnique` — 5 sends, all distinct UUIDs
  - `TestRealClient_XRequestID_RetainedOnServerError` — 500 response, UUID still recorded
  - `TestRecorder_PropagatesXRequestID` — verifies `RequestRecord` → `TraceRecord` propagation
  - `TestExportTraceV2_XRequestID_RoundTrip` — 4 subtests covering real/no-UUID/replayed/synthetic modes
  - `TestLoadTraceV2_BackwardCompat_NoXRequestIDColumn` — older trace loads unchanged
  - `TestExportTraceV2_XRequestID_CoexistsWithOtherOptionalColumns` — vllm_priority + slo_target_us + x_request_id all together

## Acceptance criteria from #1428

- [x] Every outgoing request from `blis observe` carries `x-request-id` with a fresh UUID
- [x] `trace_data.csv` includes `x_request_id` column iff at least one record has a UUID
- [x] Header value and CSV row's `x_request_id` match exactly
- [x] Older traces (no column) load unchanged
- [x] `replay --trace-output` of a real-mode trace **with** the column produces a `mode: replayed` trace **without** the column

## Out of scope (per issue)

- Analysis-side join code in sim2real / downstream tooling.
- Defensive response-side capture of `x-request-id` (will become a follow-up if the join-rate diagnostic in the issue's comment thread shows gateway regeneration).
- v3 schema bump.