### PR TITLE
feat(observe): add --prewarm-duration flag for system priming (#1430)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,13 @@ go build -o blis main.go
   --think-time-dist "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" \
   --trace-header trace.yaml --trace-data trace.csv
 
+# Observe with system prewarm (recommended for cold systems, #1430)
+# Sends small fixed requests at low concurrency to warm CUDA/EPP/memory before measurement
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --prewarm-duration 60s \
+  --workload chatbot --rate 10 --num-requests 100 \
+  --trace-header trace.yaml --trace-data trace.csv
+
 # Observe with ITL (inter-token latency) recording for streaming requests
 # --record-itl forces streaming on non-streaming workloads to capture per-chunk timestamps
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,10 @@ go build -o blis main.go
   --trace-header trace.yaml --trace-data trace.csv
 
 # Observe with system prewarm (recommended for cold systems, #1430)
-# Sends small fixed requests at low concurrency to warm CUDA/EPP/memory before measurement
+# --prewarm-duration: warms infrastructure (EPP/gateway connections, TCP pools)
+#   before measurement. Use for cold systems. Shape-independent.
+# --warmup-requests: excludes first N real-workload requests from trace.
+#   Use for statistical trimming. Rarely needed if --prewarm-duration is set.
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
   --prewarm-duration 60s \
   --workload chatbot --rate 10 --num-requests 100 \

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -62,6 +62,7 @@ var (
 	observeRecordITL           bool
 	observeITLOutput           string
 	observeTimeout             int
+	observePrewarmDuration     time.Duration
 	// saturationReport is declared in root.go and shared across run, replay, observe
 )
 
@@ -128,6 +129,7 @@ func init() {
 	observeCmd.Flags().StringVar(&observeServerType, "server-type", "vllm", "Server type (vllm, tgi, etc.)")
 	observeCmd.Flags().IntVar(&observeMaxConcur, "max-concurrency", 256, "Maximum simultaneous in-flight requests")
 	observeCmd.Flags().IntVar(&observeWarmup, "warmup-requests", 0, "Number of initial requests to exclude from trace")
+	observeCmd.Flags().DurationVar(&observePrewarmDuration, "prewarm-duration", 0, "Duration of system priming phase before real workload (e.g., 60s). Sends small fixed requests at low concurrency to warm CUDA/EPP/memory. 0 = disabled.")
 	observeCmd.Flags().BoolVar(&observeNoStreaming, "no-streaming", false, "Disable streaming (use non-streaming HTTP)")
 	observeCmd.Flags().Int64Var(&observeSeed, "seed", 42, "RNG seed for workload generation")
 	observeCmd.Flags().Int64Var(&observeHorizon, "horizon", 0, "Observation horizon in microseconds (0 = from spec or unlimited)")
@@ -293,6 +295,9 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	}
 	if observeWarmup < 0 {
 		logrus.Fatalf("--warmup-requests must be >= 0, got %d", observeWarmup)
+	}
+	if observePrewarmDuration < 0 {
+		logrus.Fatalf("--prewarm-duration must be >= 0, got %v", observePrewarmDuration)
 	}
 	if cmd.Flags().Changed("rate") && (observeRate <= 0 || math.IsNaN(observeRate) || math.IsInf(observeRate, 0)) {
 		logrus.Fatalf("--rate must be a finite value > 0, got %v", observeRate)
@@ -469,6 +474,11 @@ func runObserve(cmd *cobra.Command, _ []string) {
 		logrus.Warn("Received interrupt signal, cancelling observation...")
 		cancel()
 	}()
+
+	// Prewarm if requested (#1430)
+	if observePrewarmDuration > 0 {
+		runPrewarm(ctx, client, observePrewarmDuration)
+	}
 
 	// Run orchestrator
 	startTime := time.Now()
@@ -781,6 +791,55 @@ func printObserveMetrics(w io.Writer, records []workload.TraceRecord, wallClockD
 
 	// Print with section header (BC-5)
 	_, _ = fmt.Fprintf(w, "=== Simulation Metrics ===\n%s\n", string(jsonBytes))
+}
+
+// runPrewarm sends small, fixed requests to warm the target system before the
+// real workload begins. Uses low concurrency and small token counts that cannot
+// overload the system regardless of the real workload's rate.
+func runPrewarm(ctx context.Context, client *RealClient, duration time.Duration) {
+	const (
+		concurrency     = 4
+		inputTokens     = 256
+		maxOutputTokens = 64
+	)
+
+	logrus.Infof("Prewarming system for %v (concurrency=%d, input=%d, output=%d tokens)...",
+		duration, concurrency, inputTokens, maxOutputTokens)
+
+	prompt := strings.Repeat("warm ", inputTokens)
+
+	// done channel is closed when duration elapses — all goroutines see the close.
+	done := make(chan struct{})
+	timer := time.AfterFunc(duration, func() { close(done) })
+	defer timer.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				req := &PendingRequest{
+					RequestID:       -1,
+					Streaming:       false,
+					MaxOutputTokens: maxOutputTokens,
+					Prompt:          prompt,
+				}
+				_, _ = client.Send(ctx, req)
+			}
+		}()
+	}
+
+	wg.Wait()
+	logrus.Infof("Prewarm complete")
 }
 
 // runObserveOrchestrator implements the dispatch loop with session support.

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -813,6 +813,8 @@ func runPrewarm(ctx context.Context, client *RealClient, duration time.Duration)
 	timer := time.AfterFunc(duration, func() { close(done) })
 	defer timer.Stop()
 
+	var totalRequests, totalErrors atomic.Int64
+
 	var wg sync.WaitGroup
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
@@ -833,13 +835,34 @@ func runPrewarm(ctx context.Context, client *RealClient, duration time.Duration)
 					MaxOutputTokens: maxOutputTokens,
 					Prompt:          prompt,
 				}
-				_, _ = client.Send(ctx, req)
+				rec, _ := client.Send(ctx, req)
+				totalRequests.Add(1)
+				if rec != nil && rec.Status != "ok" {
+					totalErrors.Add(1)
+					// Back off on errors to avoid CPU spin when server is unreachable.
+					select {
+					case <-done:
+						return
+					case <-ctx.Done():
+						return
+					case <-time.After(500 * time.Millisecond):
+					}
+				}
 			}
 		}()
 	}
 
 	wg.Wait()
-	logrus.Infof("Prewarm complete")
+
+	sent := totalRequests.Load()
+	errs := totalErrors.Load()
+	if sent == 0 || errs == sent {
+		logrus.Warnf("Prewarm: %d/%d requests failed (is the server reachable at %s?)", errs, sent, client.baseURL)
+	} else if errs > 0 {
+		logrus.Infof("Prewarm complete: %d requests sent, %d errors", sent, errs)
+	} else {
+		logrus.Infof("Prewarm complete: %d requests sent", sent)
+	}
 }
 
 // runObserveOrchestrator implements the dispatch loop with session support.

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -2330,3 +2330,59 @@ func TestRecorder_PropagatesXRequestID(t *testing.T) {
 		t.Errorf("TraceRecord.XRequestID: got %q, want %q", records[0].XRequestID, "uuid-test-value")
 	}
 }
+
+func TestRunPrewarm_SendsRequestsForDuration(t *testing.T) {
+	var mu sync.Mutex
+	var count int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
+	}))
+	defer srv.Close()
+
+	client := NewRealClient(srv.URL, "", "qwen/qwen3-14b", "completions")
+
+	start := time.Now()
+	runPrewarm(context.Background(), client, 2*time.Second)
+	elapsed := time.Since(start)
+
+	mu.Lock()
+	finalCount := count
+	mu.Unlock()
+
+	if finalCount < 1 {
+		t.Errorf("Expected at least 1 prewarm request, got %d", finalCount)
+	}
+	if elapsed < 1900*time.Millisecond || elapsed > 4*time.Second {
+		t.Errorf("Expected ~2s duration, got %v", elapsed)
+	}
+}
+
+func TestRunPrewarm_RespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
+	}))
+	defer srv.Close()
+
+	client := NewRealClient(srv.URL, "", "qwen/qwen3-14b", "completions")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	runPrewarm(ctx, client, 30*time.Second)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("Expected prewarm to stop within ~500ms of cancel, took %v", elapsed)
+	}
+}

--- a/cmd/observe_test.go
+++ b/cmd/observe_test.go
@@ -2340,7 +2340,7 @@ func TestRunPrewarm_SendsRequestsForDuration(t *testing.T) {
 		count++
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
+		_, _ = fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
 	}))
 	defer srv.Close()
 
@@ -2366,7 +2366,7 @@ func TestRunPrewarm_RespectsContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
+		_, _ = fmt.Fprintf(w, `{"choices":[{"text":"ok","finish_reason":"stop"}],"usage":{"prompt_tokens":256,"completion_tokens":10}}`)
 	}))
 	defer srv.Close()
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -95,6 +95,7 @@ Four input modes are available. At least one must be provided per invocation:
 | `--server-type` | `string` | `"vllm"` | Server type (vllm, tgi, etc.) |
 | `--max-concurrency` | `int` | `256` | Maximum simultaneous in-flight requests |
 | `--warmup-requests` | `int` | `0` | Number of initial requests to exclude from trace |
+| `--prewarm-duration` | `duration` | `0` | System priming phase before real workload (e.g., `60s`). Sends small fixed requests at low concurrency to warm CUDA/EPP/memory. 0 = disabled |
 | `--no-streaming` | `bool` | `false` | Disable streaming (use non-streaming HTTP) |
 | `--seed` | `int64` | `42` | RNG seed for workload generation |
 | `--horizon` | `int64` | `0` | Observation horizon in microseconds (0 = from spec or unlimited) |
@@ -184,6 +185,23 @@ Used when `--rate` or `--concurrency` mode is active (ignored when `--workload-s
 
 !!! info "Session support"
     If the workload spec contains session clients, observe runs in closed-loop mode: each completed request may trigger follow-up requests from the session manager, interleaved with pre-generated arrivals by arrival time.
+
+### System Prewarming
+
+When targeting a cold system (fresh vLLM restart, new EPP connections), the first 30-60s of requests typically see 20-25x worse latency due to CUDA kernel compilation, memory allocator priming, and connection establishment. At high target rates, this cold-start transient can even trigger queue collapse.
+
+The `--prewarm-duration` flag addresses this by running a fixed priming phase before measurement begins:
+
+```bash
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --prewarm-duration 60s \
+  --workload chatbot --rate 20 --num-requests 500 \
+  --trace-header trace.yaml --trace-data trace.csv
+```
+
+The prewarm phase sends small, fixed requests (256 input tokens, 64 output tokens) at low concurrency (4 simultaneous requests). This exercises the full request path without risking overload, regardless of the real workload's rate or token sizes. Prewarm requests never appear in `trace_data.csv`.
+
+The `--prewarm-duration` flag is independent of `--warmup-requests` — both can be used together. Use `--prewarm-duration` for system-level warming (CUDA, connections) and `--warmup-requests` for workload-level exclusion (initial ramp-up).
 
 ---
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -201,7 +201,7 @@ The `--prewarm-duration` flag addresses this by running a fixed priming phase be
 
 The prewarm phase sends small, fixed requests (256 input tokens, 64 output tokens) at low concurrency (4 simultaneous requests). This exercises the full request path without risking overload, regardless of the real workload's rate or token sizes. Prewarm requests never appear in `trace_data.csv`.
 
-The `--prewarm-duration` flag is independent of `--warmup-requests` — both can be used together. Use `--prewarm-duration` for system-level warming (CUDA, connections) and `--warmup-requests` for workload-level exclusion (initial ramp-up).
+**Which warmup flag?** Use `--prewarm-duration` when targeting a cold system (fresh restart, new connections). Use `--warmup-requests` only if you need to exclude initial requests for other reasons (e.g., rate ramp-up). You typically don't need both.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #1430.

Adds `--prewarm-duration` to `blis observe` that runs a fixed, conservative priming phase before the real workload begins. This warms CUDA kernels, EPP connections, and memory allocators without risking queue collapse — regardless of the real workload's rate or token sizes.

**Usage:**
```bash
blis observe --server-url http://localhost:8000 --model Qwen/Qwen3-14B \
  --prewarm-duration 60s \
  --workload chatbot --rate 20 --num-requests 500 \
  --trace-header trace.yaml --trace-data trace.csv
```

**Prewarm behavior (hardcoded, not tied to workload):**
- Concurrency: 4 simultaneous requests
- Input tokens: 256 (small, fast prefill)
- Output tokens: 64 (short decode)
- Arrival: constant (no spikes)
- Drain: all prewarm requests complete before real workload starts
- No output: prewarm requests never appear in trace_data.csv

## Behavioral Contracts

- **BC-1:** Requests sent continuously for the specified duration
- **BC-2:** Prewarm requests never appear in trace output
- **BC-3:** All in-flight prewarm requests drain before real workload starts
- **BC-4:** Fixed parameters independent of workload config
- **BC-5:** Disabled by default (0 = no prewarm, backward compatible)
- **BC-6:** Respects context cancellation (Ctrl+C stops immediately)

## Files Changed

| File | What |
|------|------|
| `cmd/observe_cmd.go` | Flag registration, validation, `runPrewarm()` function, wiring |
| `cmd/observe_test.go` | Two behavioral tests (duration, cancellation) |
| `docs/guide/observe-replay-calibrate.md` | Flag table + "System Prewarming" section |
| `CLAUDE.md` | Usage example |

## Design choices

1. **Hardcoded parameters** — no `--prewarm-concurrency` or `--prewarm-tokens`. The point is a single flag that's safe for any workload. Configurability would be overengineering.
2. **Independent of `--warmup-requests`** — both can coexist. `--prewarm-duration` warms the system; `--warmup-requests` excludes initial real-workload requests from trace.
3. **`time.AfterFunc` + `close(done)`** — broadcasts stop signal to all goroutines (unlike `time.After` channel which only fires once to one receiver).

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `TestRunPrewarm_SendsRequestsForDuration` — verifies requests are sent for ~2s
- [x] `TestRunPrewarm_RespectsContextCancellation` — verifies early stop on cancel

## Invariants

No invariants affected:
- **INV-1 (request conservation):** prewarm requests never enter the recording pipeline
- **INV-6 (determinism):** observe is non-deterministic by nature
- **INV-13 (run/replay parity):** prewarm is observe-only; run/replay unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)