### PR TITLE
feat(sim): ExpertPlacement interface + BalancedPlacement (#1418)

### DIFF
--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -45,6 +45,7 @@ inference-sim/
 │   ├── metrics_utils.go       # Percentile/mean calculation, MetricsOutput JSON struct, NewRequestMetrics canonical constructor
 │   ├── rng.go                 # PartitionedRNG for deterministic multi-subsystem simulation
 │   ├── model_hardware_config.go # ModelConfig, HardwareCalib structs (config types stay in sim/); HardwareCalib includes MemoryGiB (used by KV capacity auto-calculation in roofline and trained-physics modes). ModelConfig.WeightBytesPerParam (0=fallback to BytesPerParam) with EffectiveWeightBytesPerParam() accessor decouples weight storage precision from compute/KV dtype. Note: MaxModelLen is int64 (aligned with ProgressIndex, TotalKVBlocks, BlockSizeTokens).
+│   ├── expert_placement.go    # ExpertPlacement interface (single-method pure query) + BalancedPlacement default: maps a step's routed-token population onto busiest-GPU MoE cost (ExpertLoad: per-GPU compute tokens, expert count, dispatch/combine comm). Lives in sim core so future consumers reach it without importing latency/; consumed by trained-physics StepTime (#1419).
 │   └── internal/              # Shared internal packages
 │       ├── hash/              # Block-level hashing for prefix cache
 │       ├── testutil/          # Shared test infrastructure (golden dataset loading)

--- a/sim/expert_placement.go
+++ b/sim/expert_placement.go
@@ -1,0 +1,75 @@
+package sim
+
+// ExpertPlacement maps a step's routed-token population onto per-GPU MoE cost,
+// returning the load of the BUSIEST GPU in the flattened MoE group. A collective
+// runs at its slowest participant, so step time is "max over GPUs" — returning
+// the busiest GPU lets that physics emerge automatically once a future strategy
+// (imbalanceFactor >= 1: EPLB, skewed routing, redundant experts) introduces
+// load skew. It is a single-method, pure-query contract (R13/R14): it observes
+// the routed-token population and parallelism degrees and computes a cost; it
+// owns no state and mutates nothing.
+//
+// Lives in sim core, not sim/latency/: expert placement is a model-deployment
+// concept (same domain as ModelConfig and the parallelism degrees) that future
+// consumers — scheduler, KV-capacity — must reach without importing latency/,
+// which would invert the dependency direction cmd/ -> sim/cluster/ -> sim/. The
+// latency model already imports sim, so it consumes sim.ExpertPlacement for free.
+//
+// Parameters:
+//   - globalTokens: routed tokens summed over the whole step (all DP ranks).
+//   - kEff:         effective experts activated per token (top_k, possibly fractional).
+//   - numExperts:   total routed experts in the layer.
+//   - moeGroupSize: the flattened MoE group the experts are sharded over (TP·DP
+//     for MoE, mirroring vLLM's flattened dp·pcp·tp group; 1 = single-GPU MoE).
+//   - dp:           data-parallel degree. Each DP rank owns a disjoint ~globalTokens/dp
+//     slice of the sequence tokens, so per-rank communication volume scales by 1/dp.
+type ExpertPlacement interface {
+	Resolve(globalTokens, kEff float64, numExperts, moeGroupSize, dp int) ExpertLoad
+}
+
+// ExpertLoad is the per-GPU MoE cost of the busiest GPU for one step, in the
+// raw units the latency model's basis functions expect (coefficients are applied
+// by the consumer, not here).
+type ExpertLoad struct {
+	// PerGPUComputeTokens is the token·activation count the max-loaded GPU computes
+	// in the MoE FFN (drives compute-bound FLOPs).
+	PerGPUComputeTokens float64
+	// PerGPUExpertCount is the full-expert-equivalent count resident on the GPU,
+	// driving routed-expert weight bytes. EP-mode-agnostic: numExperts/moeGroupSize
+	// equals both EP-off tensor-sharded full-expert-equivalent bytes and EP-on whole
+	// experts owned per GPU (see issue #1418 / design §4 vLLM proofs).
+	PerGPUExpertCount float64
+	// PerGPUCommTokens is the dispatch+combine all-to-all volume (token·top_k) the
+	// busiest source GPU moves. Zero when moeGroupSize == 1 (nothing to exchange).
+	PerGPUCommTokens float64
+}
+
+// BalancedPlacement is the default ExpertPlacement: it assumes routed tokens and
+// experts are spread perfectly evenly across the MoE group (imbalanceFactor == 1).
+// At the saturation operating point this latency model targets, the balanced-load
+// assumption is exact, so the busiest GPU carries exactly the average share.
+//
+//	PerGPUComputeTokens = globalTokens · kEff / moeGroupSize
+//	PerGPUExpertCount   = numExperts / moeGroupSize
+//	PerGPUCommTokens    = (globalTokens / dp) · kEff · (moeGroupSize-1)/moeGroupSize · 2
+//
+// PerGPUCommTokens is divided by dp because the term is a per-rank latency paid by
+// the busiest source GPU, and each DP rank owns only ~globalTokens/dp sequence
+// tokens — not an aggregate cluster byte count. The (moeGroupSize-1)/moeGroupSize·2
+// factor is the standard dispatch+combine all-to-all volume over the flattened
+// group: a GPU sends to the other moeGroupSize-1 members on dispatch and receives
+// back on combine.
+type BalancedPlacement struct{}
+
+// Resolve computes the balanced per-GPU MoE load. moeGroupSize and dp are assumed
+// >= 1 (guaranteed by ModelHardwareConfig.EffectiveMoEGroupSize / EffectiveDP,
+// which clamp to a minimum of 1); the formulas are well-defined and the comm term
+// is exactly 0 at the degenerate moeGroupSize == 1.
+func (BalancedPlacement) Resolve(globalTokens, kEff float64, numExperts, moeGroupSize, dp int) ExpertLoad {
+	group := float64(moeGroupSize)
+	return ExpertLoad{
+		PerGPUComputeTokens: globalTokens * kEff / group,
+		PerGPUExpertCount:   float64(numExperts) / group,
+		PerGPUCommTokens:    (globalTokens / float64(dp)) * kEff * (group - 1) / group * 2,
+	}
+}

--- a/sim/expert_placement.go
+++ b/sim/expert_placement.go
@@ -59,6 +59,14 @@ type ExpertLoad struct {
 // factor is the standard dispatch+combine all-to-all volume over the flattened
 // group: a GPU sends to the other moeGroupSize-1 members on dispatch and receives
 // back on combine.
+//
+// This single expression is a unified comm model across vLLM's two MoE-FFN comm
+// regimes, not just the DP>1 dispatch/combine path: at dp == 1 it reduces to
+// (moeGroupSize-1)/moeGroupSize · 2 · globalTokens · kEff, which is exactly the
+// ring all-reduce volume vLLM pays over the TP group when DP==1 (the two
+// expressions are numerically identical). So PerGPUCommTokens is physically
+// accurate for all dp, and #C can charge it unconditionally without branching on
+// the comm regime.
 type BalancedPlacement struct{}
 
 // Resolve computes the balanced per-GPU MoE load. moeGroupSize and dp are assumed

--- a/sim/expert_placement.go
+++ b/sim/expert_placement.go
@@ -1,11 +1,13 @@
 package sim
 
+import "fmt"
+
 // ExpertPlacement maps a step's routed-token population onto per-GPU MoE cost,
 // returning the load of the BUSIEST GPU in the flattened MoE group. A collective
 // runs at its slowest participant, so step time is "max over GPUs" — returning
-// the busiest GPU lets that physics emerge automatically once a future strategy
-// (imbalanceFactor >= 1: EPLB, skewed routing, redundant experts) introduces
-// load skew. It is a single-method, pure-query contract (R13/R14): it observes
+// the busiest GPU lets that physics emerge automatically once a future load-skew
+// strategy (EPLB, skewed routing, redundant experts) replaces BalancedPlacement.
+// It is a single-method, pure-query contract (R13/R14): it observes
 // the routed-token population and parallelism degrees and computes a cost; it
 // owns no state and mutates nothing.
 //
@@ -19,8 +21,9 @@ package sim
 //   - globalTokens: routed tokens summed over the whole step (all DP ranks).
 //   - kEff:         effective experts activated per token (top_k, possibly fractional).
 //   - numExperts:   total routed experts in the layer.
-//   - moeGroupSize: the flattened MoE group the experts are sharded over (TP·DP
-//     for MoE, mirroring vLLM's flattened dp·pcp·tp group; 1 = single-GPU MoE).
+//   - moeGroupSize: the flattened MoE group the experts are sharded over. BLIS
+//     assumes PCP=1, so this is TP·DP for MoE (vLLM's flattened group is dp·pcp·tp;
+//     see ModelHardwareConfig.EffectiveMoEGroupSize); 1 = single-GPU MoE.
 //   - dp:           data-parallel degree. Each DP rank owns a disjoint ~globalTokens/dp
 //     slice of the sequence tokens, so per-rank communication volume scales by 1/dp.
 type ExpertPlacement interface {
@@ -45,8 +48,8 @@ type ExpertLoad struct {
 }
 
 // BalancedPlacement is the default ExpertPlacement: it assumes routed tokens and
-// experts are spread perfectly evenly across the MoE group (imbalanceFactor == 1).
-// At the saturation operating point this latency model targets, the balanced-load
+// experts are spread perfectly evenly across the MoE group (no load skew). At the
+// saturation operating point this latency model targets, the balanced-load
 // assumption is exact, so the busiest GPU carries exactly the average share.
 //
 //	PerGPUComputeTokens = globalTokens · kEff / moeGroupSize
@@ -60,20 +63,30 @@ type ExpertLoad struct {
 // group: a GPU sends to the other moeGroupSize-1 members on dispatch and receives
 // back on combine.
 //
-// This single expression is a unified comm model across vLLM's two MoE-FFN comm
-// regimes, not just the DP>1 dispatch/combine path: at dp == 1 it reduces to
-// (moeGroupSize-1)/moeGroupSize · 2 · globalTokens · kEff, which is exactly the
-// ring all-reduce volume vLLM pays over the TP group when DP==1 (the two
-// expressions are numerically identical). So PerGPUCommTokens is physically
-// accurate for all dp, and #C can charge it unconditionally without branching on
-// the comm regime.
+// PerGPUCommTokens models the DP>1 dispatch/combine path only. It deliberately
+// carries a kEff factor (top-k routed-token volume per source rank) as the
+// balanced-load approximation of that all-to-all; the consumer scales it by
+// hidden·bytes-per-param and must NOT re-multiply by kEff (design §5). It is NOT
+// the DP=1 collective: at DP=1 vLLM runs a tensor-parallel all-reduce on the dense
+// output hidden states ([tokens, hidden], no top-k factor) — a different volume the
+// trained-physics model charges under a separate reduction term. The two are not
+// numerically equal and must not be conflated.
 type BalancedPlacement struct{}
 
-// Resolve computes the balanced per-GPU MoE load. moeGroupSize and dp are assumed
-// >= 1 (guaranteed by ModelHardwareConfig.EffectiveMoEGroupSize / EffectiveDP,
-// which clamp to a minimum of 1); the formulas are well-defined and the comm term
-// is exactly 0 at the degenerate moeGroupSize == 1.
+// Resolve computes the balanced per-GPU MoE load. moeGroupSize and dp must be
+// >= 1 — production callers get this for free from ModelHardwareConfig.
+// EffectiveMoEGroupSize / EffectiveDP, which clamp to a minimum of 1. A direct
+// caller that passes 0 (or negative) would otherwise silently emit +Inf/NaN loads
+// into downstream step-time math, so this panics at the library boundary instead
+// (R1: no silent bad output). With both >= 1 the formulas are well-defined and the
+// comm term is exactly 0 at the degenerate moeGroupSize == 1.
 func (BalancedPlacement) Resolve(globalTokens, kEff float64, numExperts, moeGroupSize, dp int) ExpertLoad {
+	if moeGroupSize < 1 {
+		panic(fmt.Sprintf("BalancedPlacement.Resolve: moeGroupSize must be >= 1, got %d", moeGroupSize))
+	}
+	if dp < 1 {
+		panic(fmt.Sprintf("BalancedPlacement.Resolve: dp must be >= 1, got %d", dp))
+	}
 	group := float64(moeGroupSize)
 	return ExpertLoad{
 		PerGPUComputeTokens: globalTokens * kEff / group,

--- a/sim/expert_placement_test.go
+++ b/sim/expert_placement_test.go
@@ -152,21 +152,30 @@ func TestBalancedPlacement_CommConservationLaw(t *testing.T) {
 	}
 }
 
-// TestBalancedPlacement_CommUnifiesAllReduceAtDP1 locks in the unified-comm-model
-// property documented on BalancedPlacement: at dp == 1, PerGPUCommTokens equals
-// the TP ring all-reduce volume (moeGroupSize-1)/moeGroupSize · 2 · globalTokens ·
-// kEff. This guards the doc claim that #C can charge a single comm term across
-// both vLLM regimes (DP=1 all-reduce vs DP>1 dispatch/combine) without branching.
-func TestBalancedPlacement_CommUnifiesAllReduceAtDP1(t *testing.T) {
+// TestBalancedPlacement_Resolve_FractionalKEff exercises a fractional kEff, which
+// the interface explicitly admits ("possibly fractional" — e.g. a shared+routed
+// mix or an averaged top-k). The loads must scale linearly in kEff with no
+// integer truncation.
+func TestBalancedPlacement_Resolve_FractionalKEff(t *testing.T) {
 	p := BalancedPlacement{}
-	for _, group := range []int{1, 2, 4, 8, 16} {
-		const gt, kEff = 2048.0, 2.0
-		got := p.Resolve(gt, kEff, 32, group, 1) // dp == 1
-		g := float64(group)
-		wantAllReduce := (g - 1) / g * 2 * gt * kEff
-		assert.InDelta(t, wantAllReduce, got.PerGPUCommTokens, 1e-6,
-			"at dp=1 comm must equal the TP all-reduce volume (group=%d)", group)
-	}
+	// globalTokens=1000, kEff=2.5, group=4, dp=2.
+	got := p.Resolve(1000, 2.5, 8, 4, 2)
+	assert.InDelta(t, 625, got.PerGPUComputeTokens, floatEqTol, "1000·2.5/4")
+	assert.InDelta(t, 2, got.PerGPUExpertCount, floatEqTol, "8/4 (kEff-independent)")
+	assert.InDelta(t, 1875, got.PerGPUCommTokens, floatEqTol, "(1000/2)·2.5·(3/4)·2")
+}
+
+// TestBalancedPlacement_Resolve_RejectsDegenerateDivisors verifies the library
+// boundary guard (R1): a divisor < 1 would otherwise silently emit +Inf/NaN loads
+// into downstream step-time math. Production callers never hit this (the config
+// EffectiveMoEGroupSize / EffectiveDP helpers clamp to >= 1), but a direct caller
+// passing 0 must fail loudly.
+func TestBalancedPlacement_Resolve_RejectsDegenerateDivisors(t *testing.T) {
+	p := BalancedPlacement{}
+	assert.Panics(t, func() { p.Resolve(1000, 2, 8, 0, 1) }, "moeGroupSize=0 must panic")
+	assert.Panics(t, func() { p.Resolve(1000, 2, 8, 4, 0) }, "dp=0 must panic")
+	assert.Panics(t, func() { p.Resolve(1000, 2, 8, -1, 1) }, "negative moeGroupSize must panic")
+	assert.NotPanics(t, func() { p.Resolve(1000, 2, 8, 1, 1) }, "minimal valid divisors must not panic")
 }
 
 // TestBalancedPlacement_NonNegativeAndFinite verifies that for any physically

--- a/sim/expert_placement_test.go
+++ b/sim/expert_placement_test.go
@@ -115,6 +115,60 @@ func TestBalancedPlacement_ComputeConservationLaw(t *testing.T) {
 	}
 }
 
+// TestBalancedPlacement_CommConservationLaw is the comm-term companion to the
+// compute conservation law (CLAUDE.md BDD/TDD rule 4): it validates the dp and
+// moeGroupSize scaling of PerGPUCommTokens from first principles rather than
+// re-encoding the golden-table arithmetic.
+//
+// Multiplying the busiest-GPU per-rank comm volume back up by the group size and
+// the dp degree must recover the dp/group-independent total dispatch+combine
+// volume:
+//
+//	PerGPUCommTokens · moeGroupSize · dp == globalTokens · kEff · (moeGroupSize-1) · 2
+//
+// The right-hand side has no dp or 1/moeGroupSize dependence, so this independently
+// pins both the /dp per-rank split and the (group-1)/group all-to-all factor.
+func TestBalancedPlacement_CommConservationLaw(t *testing.T) {
+	cases := []struct {
+		globalTokens float64
+		kEff         float64
+		numExperts   int
+		moeGroupSize int
+		dp           int
+	}{
+		{1000, 2, 8, 4, 2},
+		{512, 4, 16, 1, 1}, // degenerate: both sides collapse to 0
+		{2048, 1, 64, 8, 1},
+		{4000, 2, 128, 8, 4},
+		{333, 3, 7, 5, 5},
+	}
+
+	p := BalancedPlacement{}
+	for _, c := range cases {
+		got := p.Resolve(c.globalTokens, c.kEff, c.numExperts, c.moeGroupSize, c.dp)
+		want := c.globalTokens * c.kEff * float64(c.moeGroupSize-1) * 2
+		assert.InDelta(t, want, got.PerGPUCommTokens*float64(c.moeGroupSize)*float64(c.dp), 1e-6,
+			"dispatch+combine comm volume must be conserved across the MoE group and dp ranks")
+	}
+}
+
+// TestBalancedPlacement_CommUnifiesAllReduceAtDP1 locks in the unified-comm-model
+// property documented on BalancedPlacement: at dp == 1, PerGPUCommTokens equals
+// the TP ring all-reduce volume (moeGroupSize-1)/moeGroupSize · 2 · globalTokens ·
+// kEff. This guards the doc claim that #C can charge a single comm term across
+// both vLLM regimes (DP=1 all-reduce vs DP>1 dispatch/combine) without branching.
+func TestBalancedPlacement_CommUnifiesAllReduceAtDP1(t *testing.T) {
+	p := BalancedPlacement{}
+	for _, group := range []int{1, 2, 4, 8, 16} {
+		const gt, kEff = 2048.0, 2.0
+		got := p.Resolve(gt, kEff, 32, group, 1) // dp == 1
+		g := float64(group)
+		wantAllReduce := (g - 1) / g * 2 * gt * kEff
+		assert.InDelta(t, wantAllReduce, got.PerGPUCommTokens, 1e-6,
+			"at dp=1 comm must equal the TP all-reduce volume (group=%d)", group)
+	}
+}
+
 // TestBalancedPlacement_NonNegativeAndFinite verifies that for any physically
 // meaningful input (group >= 1, dp >= 1, tokens/kEff >= 0) every returned load
 // is non-negative and finite — guarding against a sign error or a divide-by-zero

--- a/sim/expert_placement_test.go
+++ b/sim/expert_placement_test.go
@@ -1,0 +1,145 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// floatEq compares two MoE-load floats with a tolerance loose enough to absorb
+// IEEE-754 rounding in the (moeGroupSize-1)/moeGroupSize factor but tight enough
+// to catch any genuine formula error.
+const floatEqTol = 1e-9
+
+// TestBalancedPlacement_Resolve verifies BalancedPlacement.Resolve against
+// hand-computed ExpertLoad for representative (globalTokens, kEff, numExperts,
+// moeGroupSize, dp) tuples — including the degenerate moeGroupSize == 1 — per
+// design §4 / issue #1418.
+//
+// The balanced (imbalanceFactor == 1) formulas under test:
+//
+//	PerGPUComputeTokens = globalTokens · kEff / moeGroupSize
+//	PerGPUExpertCount   = numExperts / moeGroupSize
+//	PerGPUCommTokens    = (globalTokens / dp) · kEff · (moeGroupSize-1)/moeGroupSize · 2
+func TestBalancedPlacement_Resolve(t *testing.T) {
+	tests := []struct {
+		name         string
+		globalTokens float64
+		kEff         float64
+		numExperts   int
+		moeGroupSize int
+		dp           int
+		wantCompute  float64
+		wantExperts  float64
+		wantComm     float64
+	}{
+		{
+			// EP-off-style: TP·DP = 4, dp = 2, top-2 routing.
+			name: "group4_dp2", globalTokens: 1000, kEff: 2, numExperts: 8, moeGroupSize: 4, dp: 2,
+			wantCompute: 500,  // 1000·2/4
+			wantExperts: 2,    // 8/4
+			wantComm:    1500, // (1000/2)·2·(3/4)·2
+		},
+		{
+			// Degenerate single-GPU MoE group: per-GPU == global, no all-to-all.
+			name: "group1_dp1_degenerate", globalTokens: 512, kEff: 4, numExperts: 16, moeGroupSize: 1, dp: 1,
+			wantCompute: 2048, // 512·4/1
+			wantExperts: 16,   // 16/1
+			wantComm:    0,    // (512/1)·4·(0/1)·2
+		},
+		{
+			// Pure TP MoE group (dp == 1), top-1 routing.
+			name: "group8_dp1", globalTokens: 2048, kEff: 1, numExperts: 64, moeGroupSize: 8, dp: 1,
+			wantCompute: 256,  // 2048·1/8
+			wantExperts: 8,    // 64/8
+			wantComm:    3584, // (2048/1)·1·(7/8)·2
+		},
+		{
+			// dp = 4 splits comm volume per source rank; compute/experts unaffected by dp.
+			name: "group8_dp4", globalTokens: 4000, kEff: 2, numExperts: 128, moeGroupSize: 8, dp: 4,
+			wantCompute: 1000, // 4000·2/8
+			wantExperts: 16,   // 128/8
+			wantComm:    3500, // (4000/4)·2·(7/8)·2
+		},
+		{
+			// Zero routed tokens (empty step) — all loads vanish.
+			name: "zero_tokens", globalTokens: 0, kEff: 2, numExperts: 8, moeGroupSize: 4, dp: 2,
+			wantCompute: 0,
+			wantExperts: 2, // expert weight residency is token-independent
+			wantComm:    0,
+		},
+	}
+
+	p := BalancedPlacement{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Resolve(tc.globalTokens, tc.kEff, tc.numExperts, tc.moeGroupSize, tc.dp)
+			assert.InDelta(t, tc.wantCompute, got.PerGPUComputeTokens, floatEqTol, "PerGPUComputeTokens")
+			assert.InDelta(t, tc.wantExperts, got.PerGPUExpertCount, floatEqTol, "PerGPUExpertCount")
+			assert.InDelta(t, tc.wantComm, got.PerGPUCommTokens, floatEqTol, "PerGPUCommTokens")
+		})
+	}
+}
+
+// TestBalancedPlacement_ComputeConservationLaw asserts the routed-compute
+// conservation law from issue #1418: summing the busiest-GPU compute over the
+// whole MoE group recovers the global routed-token·activation count. Under the
+// balanced strategy every GPU carries an equal share, so
+// PerGPUComputeTokens · moeGroupSize == globalTokens · kEff exactly.
+//
+// This is the companion invariant test to the golden table above (CLAUDE.md
+// BDD/TDD rule 4): it validates the formula from first principles rather than
+// re-encoding the same arithmetic.
+func TestBalancedPlacement_ComputeConservationLaw(t *testing.T) {
+	cases := []struct {
+		globalTokens float64
+		kEff         float64
+		numExperts   int
+		moeGroupSize int
+		dp           int
+	}{
+		{1000, 2, 8, 4, 2},
+		{512, 4, 16, 1, 1},
+		{2048, 1, 64, 8, 1},
+		{4000, 2, 128, 8, 4},
+		{333, 3, 7, 5, 5},
+	}
+
+	p := BalancedPlacement{}
+	for _, c := range cases {
+		got := p.Resolve(c.globalTokens, c.kEff, c.numExperts, c.moeGroupSize, c.dp)
+		want := c.globalTokens * c.kEff
+		assert.InDelta(t, want, got.PerGPUComputeTokens*float64(c.moeGroupSize), 1e-6,
+			"routed compute must be conserved across the MoE group")
+	}
+}
+
+// TestBalancedPlacement_NonNegativeAndFinite verifies that for any physically
+// meaningful input (group >= 1, dp >= 1, tokens/kEff >= 0) every returned load
+// is non-negative and finite — guarding against a sign error or a divide-by-zero
+// leaking NaN/Inf into downstream step-time math.
+func TestBalancedPlacement_NonNegativeAndFinite(t *testing.T) {
+	p := BalancedPlacement{}
+	for _, group := range []int{1, 2, 4, 8, 16} {
+		for _, dp := range []int{1, 2, 4} {
+			got := p.Resolve(1234.5, 2, 32, group, dp)
+			for name, v := range map[string]float64{
+				"PerGPUComputeTokens": got.PerGPUComputeTokens,
+				"PerGPUExpertCount":   got.PerGPUExpertCount,
+				"PerGPUCommTokens":    got.PerGPUCommTokens,
+			} {
+				assert.GreaterOrEqual(t, v, 0.0, "%s must be non-negative (group=%d dp=%d)", name, group, dp)
+				assert.False(t, math.IsNaN(v) || math.IsInf(v, 0), "%s must be finite (group=%d dp=%d)", name, group, dp)
+			}
+		}
+	}
+}
+
+// TestBalancedPlacement_SatisfiesInterface is a compile-time assertion that
+// BalancedPlacement implements the ExpertPlacement contract. It is a behavioral
+// guard, not a structural one: if the interface signature drifts, this fails to
+// compile, flagging the consumer-contract break (#C wires this field).
+func TestBalancedPlacement_SatisfiesInterface(t *testing.T) {
+	var _ ExpertPlacement = BalancedPlacement{}
+}


### PR DESCRIPTION
## Summary

- Adds `sim.ExpertPlacement` — a single-method, pure-query contract (R13/R14) that maps a step's routed-token population onto **busiest-GPU** MoE cost, plus the default `BalancedPlacement` (`imbalanceFactor = 1`). Returning the busiest GPU lets "step = max over GPUs" physics emerge automatically once a future strategy (EPLB / skewed routing / redundant experts) introduces load skew.
- Lives in **`sim` core** (`sim/expert_placement.go`), not `sim/latency/`: expert placement is a model-*deployment* concept (same domain as `ModelConfig` and the parallelism degrees). Future consumers (scheduler, KV-capacity) must reach it without importing `latency/`, which would invert `cmd/ → sim/cluster/ → sim/`. The latency model already imports `sim`, so it gets `sim.ExpertPlacement` for free.
- This is the seam #C (#1419) consumes; no consumer is wired in this PR.

### Formulas (`BalancedPlacement`)

```
PerGPUComputeTokens = globalTokens · kEff / moeGroupSize
PerGPUExpertCount   = numExperts / moeGroupSize
PerGPUCommTokens    = (globalTokens / dp) · kEff · (moeGroupSize-1)/moeGroupSize · 2
```

- `PerGPUExpertCount = numExperts/moeGroupSize` matches **both** vLLM EP modes (`moeGroup = TP·DP`): EP-off tensor-sharded full-expert-equivalent bytes, EP-on whole experts per GPU — the device count is invariant across EP modes, only the partition axis changes.
- `PerGPUCommTokens` is divided by `dp` because it is a **per-rank** latency paid by the busiest source GPU (each DP rank owns ~`globalTokens/dp` disjoint sequence tokens), not an aggregate cluster byte count. The `(moeGroup-1)/moeGroup · 2` factor is the standard dispatch+combine all-to-all volume.

## Issue

Closes #1418 · Tracker #1416 · Source of truth: `docs/plans/2026-06-10-dp-ep-latency-scoped-design.md` §4 · vLLM parity `vllm-project/vllm@f6ec81c7`

## Cross-Path Parity

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | N/A | N/A | Pure library type; no CLI/event surface. No consumer wired yet (#C wires it via the shared `NewLatencyModel` constructor, preserving INV-13 by construction). |
| `blis replay` | N/A | N/A | Same. |
| `blis observe` | N/A | N/A | Same. |

## Invariants Affected

- **None.** No event changes; no invariant touched (per issue's friction note). Pure, stateless computation — deterministic (INV-6) by construction.

## Test Plan

- [x] `go build ./...` — passes
- [x] `go test ./... -count=1` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] **Golden table** — hand-computed `ExpertLoad` for representative `(globalTokens, kEff, numExperts, moeGroupSize, dp)` tuples, **including the degenerate `moeGroupSize = 1`** (per-GPU = global, comm = 0) and zero-token edge case.
- [x] **Conservation law** (companion invariant test per CLAUDE.md BDD rule 4) — `PerGPUComputeTokens · moeGroupSize == globalTokens · kEff` validated from first principles, not by re-encoding the table arithmetic.
- [x] **Robustness** — non-negative & finite guard across the group/dp grid; compile-time interface-satisfaction assertion.

---

Generated with [Claude Code](https://claude.ai/claude-code)