### PR TITLE
fix(docker): bump builder base image to golang:1.24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # ── Build stage ────────────────────────────────────────────────────────────────
 # Keep base image Go version in sync with the 'go' directive in go.mod.
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # TARGETOS/TARGETARCH are injected by Buildx for each platform in a multi-arch
 # build (e.g. linux/amd64, linux/arm64). Declaring them as ARGs makes them


### PR DESCRIPTION
## Summary

The release **"Build and push image"** workflow fails at `go mod download`:

```
go: go.mod requires go >= 1.24.0 (running go 1.21.13; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

`go.mod` has declared `go 1.24.0` / `toolchain go1.24.4` since #1310 (2026-05-11), but the Dockerfile builder stage was still pinned to `golang:1.21-alpine`. This one-line bump to `golang:1.24-alpine` satisfies the `go.mod` requirement and honors the in-file comment *"Keep base image Go version in sync with the 'go' directive in go.mod."*

## Why it went unnoticed

The image-build workflow is triggered on **tag/release pushes**, not on PRs. The regular PR CI (`ci.yml` — build/lint/test) already runs on Go 1.24, so it stayed green throughout. The mismatch only surfaced on the `v0.7.14` release push ([run 27561187407](https://github.com/inference-sim/inference-sim/actions/runs/27561187407)).

## Scope

- **One line**, mechanical: `golang:1.21-alpine` → `golang:1.24-alpine`. No code change.
- Runtime stage (`alpine:3.19`) is unaffected.
- Verified no other stale `golang:1.x` references exist in any Dockerfile or workflow.

## Test plan

- [x] `go.mod` requires `go >= 1.24.0`; `golang:1.24-alpine` provides 1.24.x → requirement satisfied.
- [ ] The image-build workflow on this PR / next release tag completes `go mod download` + `go build` (authoritative confirmation; Docker daemon not available locally).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)