### PR TITLE
refactor(cluster): RequestSource interface + eager adapter (#1439)

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -530,7 +530,7 @@ Example:
 				return followUps
 			}
 		}
-		cs := cluster.NewClusterSimulator(config, requests, onRequestDone)
+		cs := cluster.NewClusterSimulator(config, cluster.NewSliceRequestSource(requests), onRequestDone)
 		if err := cs.Run(); err != nil {
 			logrus.Fatalf("Replay simulation failed: %v", err)
 		}

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -1934,7 +1934,7 @@ func TestINV13_RunReplayParity_PD(t *testing.T) {
 	}
 
 	// WHEN: direct run.
-	cs1 := cluster.NewClusterSimulator(cfg, requests, nil)
+	cs1 := cluster.NewClusterSimulator(cfg, cluster.NewSliceRequestSource(requests), nil)
 	if err := cs1.Run(); err != nil {
 		t.Fatalf("direct run failed: %v", err)
 	}
@@ -1962,7 +1962,7 @@ func TestINV13_RunReplayParity_PD(t *testing.T) {
 		t.Fatalf("LoadTraceV2Requests: %v", err)
 	}
 
-	cs2 := cluster.NewClusterSimulator(cfg, replayReqs, nil)
+	cs2 := cluster.NewClusterSimulator(cfg, cluster.NewSliceRequestSource(replayReqs), nil)
 	if err := cs2.Run(); err != nil {
 		t.Fatalf("replay run failed: %v", err)
 	}
@@ -2070,7 +2070,7 @@ func TestINV13_RunReplayParity_PD_CLI(t *testing.T) {
 		PDTransferBandwidthGBps: 25.0,
 		PDTransferBaseLatencyMs: 0.05,
 	}
-	cs1 := cluster.NewClusterSimulator(cfg, requests, nil)
+	cs1 := cluster.NewClusterSimulator(cfg, cluster.NewSliceRequestSource(requests), nil)
 	if err := cs1.Run(); err != nil {
 		t.Fatalf("direct run failed: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1770,7 +1770,7 @@ var runCmd = &cobra.Command{
 				return followUps
 			}
 		}
-		cs := cluster.NewClusterSimulator(config, preGeneratedRequests, onRequestDone)
+		cs := cluster.NewClusterSimulator(config, cluster.NewSliceRequestSource(preGeneratedRequests), onRequestDone)
 		if err := cs.Run(); err != nil {
 			logrus.Fatalf("Simulation failed: %v", err)
 		}

--- a/sim/cluster/actuator_test.go
+++ b/sim/cluster/actuator_test.go
@@ -24,7 +24,7 @@ func TestDirectActuatorApply(t *testing.T) {
 	t.Run("scale_down_transitions_to_draining", func(t *testing.T) {
 		// Two active instances for model "m1" with variant A100/TP=1.
 		// Scale-down should drain the lexicographically first (oldest) instance.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		inst1 := newActiveInst("inst-b", "m1", "A100", 1)
 		inst2 := newActiveInst("inst-a", "m1", "A100", 1)
 		cs.instances = []*InstanceSimulator{inst1, inst2}
@@ -48,7 +48,7 @@ func TestDirectActuatorApply(t *testing.T) {
 
 	t.Run("scale_down_no_match_returns_error", func(t *testing.T) {
 		// No active instances matching the variant — should return error.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		inst := newActiveInst("inst-1", "m1", "H100", 2) // wrong variant
 		cs.instances = []*InstanceSimulator{inst}
 
@@ -63,7 +63,7 @@ func TestDirectActuatorApply(t *testing.T) {
 
 	t.Run("scale_down_skips_non_active_instances", func(t *testing.T) {
 		// One Draining instance, one Active — should only drain the Active one.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		draining := newActiveInst("inst-a", "m1", "A100", 1)
 		draining.State = sim.InstanceStateDraining
 		active := newActiveInst("inst-b", "m1", "A100", 1)
@@ -83,7 +83,7 @@ func TestDirectActuatorApply(t *testing.T) {
 
 	t.Run("scale_up_nil_placement_returns_error", func(t *testing.T) {
 		// No PlacementManager — scale-up should return error.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		cs.placement = nil
 
 		actuator := NewDirectActuator(cs)
@@ -98,7 +98,7 @@ func TestDirectActuatorApply(t *testing.T) {
 	t.Run("scale_down_continue_not_return", func(t *testing.T) {
 		// Delta=-2 but only 1 matching active instance.
 		// First iteration drains it, second finds no match → error, but first drain still applied.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		inst := newActiveInst("inst-a", "m1", "A100", 1)
 		cs.instances = []*InstanceSimulator{inst}
 
@@ -127,7 +127,7 @@ func TestDirectActuatorApply(t *testing.T) {
 	t.Run("id_format_is_zero_padded", func(t *testing.T) {
 		// Verify that instance IDs use zero-padded format (%06d) so lexicographic
 		// sort matches creation order even past single digits.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		actuator := NewDirectActuator(cs)
 
 		// Manually increment seq and check ID format
@@ -148,7 +148,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		base.NodePools = []NodePoolConfig{
 			{Name: "a100-pool", GPUType: "A100-80", GPUsPerNode: 2, InitialNodes: 1, MaxNodes: 2, GPUMemoryGiB: 80},
 		}
-		cs := NewClusterSimulator(base, nil, nil)
+		cs := NewClusterSimulator(base, NewSliceRequestSource(nil), nil)
 		cs.instances = []*InstanceSimulator{} // Clear initial instances to simulate scale-up from empty
 
 		// WHEN: scaleUp is called for 1 instance.
@@ -200,7 +200,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		base.NodePools = []NodePoolConfig{
 			{Name: "a100-pool", GPUType: "A100-80", GPUsPerNode: 4, InitialNodes: 1, MaxNodes: 2, GPUMemoryGiB: 80},
 		}
-		cs := NewClusterSimulator(base, nil, nil)
+		cs := NewClusterSimulator(base, NewSliceRequestSource(nil), nil)
 		cs.instances = []*InstanceSimulator{} // Clear initial instances to simulate scale-up from empty
 
 		actuator := NewDirectActuator(cs)
@@ -230,7 +230,7 @@ func TestDirectActuatorApply(t *testing.T) {
 		base.NodePools = []NodePoolConfig{
 			{Name: "tiny-pool", GPUType: "A100-80", GPUsPerNode: 2, InitialNodes: 1, MaxNodes: 1, GPUMemoryGiB: 80},
 		}
-		cs := NewClusterSimulator(base, nil, nil)
+		cs := NewClusterSimulator(base, NewSliceRequestSource(nil), nil)
 		cs.instances = []*InstanceSimulator{} // Clear initial instances; placement already consumed 1 slot
 
 		actuator := NewDirectActuator(cs)

--- a/sim/cluster/autoscaler_test.go
+++ b/sim/cluster/autoscaler_test.go
@@ -113,7 +113,7 @@ func wireAutoscaler(cs *ClusterSimulator) *countingCollector {
 func TestScalingTickScheduling(t *testing.T) {
 	t.Run("a_zero_interval_no_tick", func(t *testing.T) {
 		cfg := newAutoscalerTestConfig(0)
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		collector := wireAutoscaler(cs)
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -126,7 +126,7 @@ func TestScalingTickScheduling(t *testing.T) {
 	t.Run("b_60s_interval_200s_horizon_fires_4_ticks", func(t *testing.T) {
 		const intervalUs = 60_000_000.0 // 60s
 		cfg := newAutoscalerTestConfig(intervalUs)
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		collector := wireAutoscaler(cs)
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -146,7 +146,7 @@ func TestScalingTickScheduling(t *testing.T) {
 		cfg := newAutoscalerTestConfig(intervalUs)
 		cfg.Horizon = 1 // 1µs horizon: only first tick at t=0 fires
 		cfg.HPAScrapeDelay = DelaySpec{Mean: 0, Stddev: 0}
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 		actuator := newRecordingActuator()
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, &onceEngine{delta: 1}, actuator)
@@ -169,7 +169,7 @@ func TestScalingTickScheduling(t *testing.T) {
 		cfg := newAutoscalerTestConfig(intervalUs)
 		cfg.Horizon = horizonUs
 		cfg.HPAScrapeDelay = DelaySpec{Mean: 30, Stddev: 0} // 30s deterministic delay
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 		actuator := newRecordingActuator()
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, &onceEngine{delta: 1}, actuator)
@@ -204,7 +204,7 @@ func TestNoOpPipelineDeterminism(t *testing.T) {
 		cfg := newTestDeploymentConfig(1)
 		cfg.ModelAutoscalerIntervalUs = intervalUs
 		cfg.Horizon = horizonUs
-		cs := NewClusterSimulator(cfg, newTestRequests(20), nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(newTestRequests(20)), nil)
 		wireAutoscaler(cs)
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run %s: %v", label, err)
@@ -266,7 +266,7 @@ func TestNilComponentGuard(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			const intervalUs = 60_000_000.0
 			cfg := newAutoscalerTestConfig(intervalUs)
-			cs := NewClusterSimulator(cfg, nil, nil)
+			cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 			var col Collector = tc.wiredCollector
 			if tc.nilCollector {
@@ -315,7 +315,7 @@ func TestStabilizationWindowFilter(t *testing.T) {
 		cfg.ScaleUpStabilizationWindowUs = 0 // zero window: immediate
 
 		applied := 0
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, &alwaysScaleUpEngine{}, &countingApplyActuator{count: &applied})
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -332,7 +332,7 @@ func TestStabilizationWindowFilter(t *testing.T) {
 		cfg.ScaleUpStabilizationWindowUs = windowUs
 
 		applied := 0
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, &alwaysScaleUpEngine{}, &countingApplyActuator{count: &applied})
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -353,7 +353,7 @@ func TestStabilizationWindowFilter(t *testing.T) {
 		cfg.ScaleDownStabilizationWindowUs = windowUs
 
 		applied := 0
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, &alwaysScaleDownEngine{}, &countingApplyActuator{count: &applied})
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -373,7 +373,7 @@ func TestStabilizationWindowFilter(t *testing.T) {
 		engine := &interruptAtTickEngine{skipTick: 1, delta: 1} // skip second tick (t=60s)
 
 		applied := 0
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		cs.autoscaler = newTestPipeline(&countingCollector{}, &nopAnalyzer{}, engine, &countingApplyActuator{count: &applied})
 		if err := cs.Run(); err != nil {
 			t.Fatalf("Run: %v", err)
@@ -398,7 +398,7 @@ func TestStabilizationWindowFilter(t *testing.T) {
 		engine := &directionFlipEngine{flipAtTick: 2}
 
 		scaleUpApplied, scaleDownApplied := 0, 0
-		cs := NewClusterSimulator(cfg, nil, nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 		cs.autoscaler = newTestPipeline(
 			&countingCollector{}, &nopAnalyzer{}, engine,
 			&splitCountingActuator{scaleUp: &scaleUpApplied, scaleDown: &scaleDownApplied},
@@ -529,7 +529,7 @@ func TestGPUInventory(t *testing.T) {
 
 	t.Run("no_placement_returns_empty", func(t *testing.T) {
 		// Without NodePools, gpuInventory returns an empty inventory.
-		cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+		cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 		if got := cs.gpuInventory().Variants(); len(got) != 0 {
 			t.Errorf("no placement: expected empty inventory, got %v", got)
 		}
@@ -538,7 +538,7 @@ func TestGPUInventory(t *testing.T) {
 	t.Run("zero_instances_seeds_from_ready_nodes", func(t *testing.T) {
 		// Pool has 1 Ready node with 8 GPUs; no active instances.
 		// Inventory must include the variant so scale-from-zero is possible.
-		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
+		cs := NewClusterSimulator(newPoolCfg(1), NewSliceRequestSource(nil), nil)
 		cs.instances = nil // clear the 1 placed instance
 		v := NewVariantSpec("A100", 1)
 		if got := cs.gpuInventory().FreeSlots(v); got != 8 {
@@ -548,7 +548,7 @@ func TestGPUInventory(t *testing.T) {
 
 	t.Run("active_instances_subtract_gpus", func(t *testing.T) {
 		// 1 Active instance with TPDegree=2 uses 2 of 8 GPUs → 6 free.
-		cs := NewClusterSimulator(newPoolCfg(2), nil, nil)
+		cs := NewClusterSimulator(newPoolCfg(2), NewSliceRequestSource(nil), nil)
 		cs.instances = []*InstanceSimulator{newA100Inst("inst-a", 2, sim.InstanceStateActive)}
 		v := NewVariantSpec("A100", 2)
 		if got := cs.gpuInventory().FreeSlots(v); got != 6 {
@@ -560,7 +560,7 @@ func TestGPUInventory(t *testing.T) {
 		// Loading, WarmingUp, Active, Draining each use 1 GPU (4 total).
 		// Scheduling and Terminated do NOT subtract.
 		// Pool: 8 GPUs → 8 - 4 = 4 free.
-		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
+		cs := NewClusterSimulator(newPoolCfg(1), NewSliceRequestSource(nil), nil)
 		cs.instances = []*InstanceSimulator{
 			newA100Inst("loading", 1, sim.InstanceStateLoading),
 			newA100Inst("warmup", 1, sim.InstanceStateWarmingUp),
@@ -578,7 +578,7 @@ func TestGPUInventory(t *testing.T) {
 	t.Run("tp_fallback_when_config_tp_zero", func(t *testing.T) {
 		// config.TP=0 triggers clusterTPDegree=1 fallback; variant A100/TP=1 must appear.
 		// Construct with TP=1 (roofline requires TP > 0), then override to test fallback.
-		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
+		cs := NewClusterSimulator(newPoolCfg(1), NewSliceRequestSource(nil), nil)
 		cs.config.TP = 0
 		cs.instances = nil // clear placed instance so all 8 GPUs are free
 		v := NewVariantSpec("A100", 1)
@@ -590,7 +590,7 @@ func TestGPUInventory(t *testing.T) {
 	t.Run("negative_free_slots_clamped_to_zero", func(t *testing.T) {
 		// 10 active instances × 1 GPU, but pool only has 8 → over-subscription.
 		// gpuInventory must clamp to 0, not return negative.
-		cs := NewClusterSimulator(newPoolCfg(1), nil, nil)
+		cs := NewClusterSimulator(newPoolCfg(1), NewSliceRequestSource(nil), nil)
 		cs.instances = nil
 		for i := 0; i < 10; i++ {
 			cs.instances = append(cs.instances, newA100Inst("over-"+string(rune('a'+i)), 1, sim.InstanceStateActive))

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -151,10 +151,13 @@ func effectiveAnalyzerConfig(cfg V2SaturationAnalyzerConfig) V2SaturationAnalyze
 // requests which are routed through the cluster pipeline (not injected locally).
 // Pass nil for non-session workloads.
 //
-// Panics if config.NumInstances < 1.
+// Panics if config.NumInstances < 1 or if requestSource is nil.
 func NewClusterSimulator(config DeploymentConfig, requestSource RequestSource, onRequestDone func(*sim.Request, int64) []*sim.Request) *ClusterSimulator {
 	if config.NumInstances < 1 {
 		panic("ClusterSimulator: NumInstances must be >= 1")
+	}
+	if requestSource == nil {
+		panic("ClusterSimulator: requestSource must not be nil (use NewSliceRequestSource(nil) for an empty workload)")
 	}
 
 	// Validate pool topology and overrides early (before instance construction).
@@ -636,8 +639,9 @@ func (c *ClusterSimulator) Run() error {
 	}
 
 	// 2. Drain the request source to schedule arrival events. The source is
-	// guaranteed to yield in non-decreasing ArrivalTime order (RequestSource
-	// contract); we count emissions to preserve today's "no requests" warning.
+	// required to yield in non-decreasing ArrivalTime order (RequestSource
+	// contract — caller obligation, not verified here); we count emissions to
+	// preserve today's "no requests" warning.
 	arrivalCount := 0
 	for {
 		req, ok := c.requestSource.Next()

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -648,6 +648,9 @@ func (c *ClusterSimulator) Run() error {
 		if !ok {
 			break
 		}
+		if req == nil {
+			panic("ClusterSimulator: RequestSource.Next() returned (nil, true) — implementation contract violation (Next must never return ok=true with a nil request)")
+		}
 		c.pushArrival(req, req.ArrivalTime)
 		arrivalCount++
 	}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -40,7 +40,7 @@ type ClusterSimulator struct {
 	// before any drop/route/admission decision. Goodput denominator (issue #1409, BC-5).
 	injectedByClass map[string]int64
 	trace                 *trace.SimulationTrace    // nil when trace-level is "none" (BC-1: zero overhead)
-	preGeneratedRequests  []*sim.Request            // Pre-generated requests (all workload paths unified)
+	requestSource         RequestSource             // Source of requests to inject as arrival events. Drained once by Run().
 	inFlightRequests      map[string]int            // instance ID → dispatched-but-not-completed count (#463)
 	evictionTracker       *EvictionTracker          // tracks routed sheddable requests for in-flight eviction (nil unless --in-flight-eviction set)
 	gatewayEvicted        int                       // count of requests evicted in-flight from instances (INV-1: gw_evicted)
@@ -143,13 +143,16 @@ func effectiveAnalyzerConfig(cfg V2SaturationAnalyzerConfig) V2SaturationAnalyze
 }
 
 // NewClusterSimulator creates a ClusterSimulator with N instances.
-// All workload generation now happens externally — requests are passed in directly.
+// Requests are pulled from requestSource (which yields in non-decreasing
+// ArrivalTime order, exactly once each) at the start of Run().
+//
 // onRequestDone is an optional callback invoked when a request reaches a terminal state
 // (completed, length-capped, timed out, or dropped). The callback returns follow-up
 // requests which are routed through the cluster pipeline (not injected locally).
 // Pass nil for non-session workloads.
+//
 // Panics if config.NumInstances < 1.
-func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onRequestDone func(*sim.Request, int64) []*sim.Request) *ClusterSimulator {
+func NewClusterSimulator(config DeploymentConfig, requestSource RequestSource, onRequestDone func(*sim.Request, int64) []*sim.Request) *ClusterSimulator {
 	if config.NumInstances < 1 {
 		panic("ClusterSimulator: NumInstances must be >= 1")
 	}
@@ -242,7 +245,7 @@ func NewClusterSimulator(config DeploymentConfig, requests []*sim.Request, onReq
 		config:               config,
 		instances:            make([]*InstanceSimulator, 0, config.NumInstances),
 		rng:                  rng,
-		preGeneratedRequests: requests,
+		requestSource:        requestSource,
 		clusterEvents:        make(ClusterEventQueue, 0),
 		admissionLatency:     config.AdmissionLatency,
 		routingLatency:       config.RoutingLatency,
@@ -609,9 +612,9 @@ func (cs *ClusterSimulator) pushArrival(req *sim.Request, timeUs int64) {
 	cs.pendingArrivals++
 }
 
-// Run executes the cluster simulation using online routing pipeline:
-// generates requests centrally, schedules ClusterArrivalEvents, runs a shared-clock
-// event loop processing cluster events before instance events, then finalizes.
+// Run executes the cluster simulation using online routing pipeline: drains the
+// configured RequestSource into ClusterArrivalEvents, runs a shared-clock event
+// loop processing cluster events before instance events, then finalizes.
 // Panics if called more than once.
 func (c *ClusterSimulator) Run() error {
 	if c.hasRun {
@@ -619,13 +622,7 @@ func (c *ClusterSimulator) Run() error {
 	}
 	c.hasRun = true
 
-	// 1. Use pre-generated requests (all workload paths now pre-generate)
-	requests := c.preGeneratedRequests
-	if len(requests) == 0 {
-		logrus.Warn("[cluster] no requests provided — simulation will produce zero results")
-	}
-
-	// 2. Schedule ClusterArrivalEvents (NC-1: no pre-dispatch before event loop)
+	// 1. Schedule ClusterArrivalEvents (NC-1: no pre-dispatch before event loop)
 	heap.Init(&c.clusterEvents)
 
 	// Phase 1C: schedule the first ScalingTickEvent when the autoscaler is enabled (T015).
@@ -638,8 +635,20 @@ func (c *ClusterSimulator) Run() error {
 		})
 	}
 
-	for _, req := range requests {
+	// 2. Drain the request source to schedule arrival events. The source is
+	// guaranteed to yield in non-decreasing ArrivalTime order (RequestSource
+	// contract); we count emissions to preserve today's "no requests" warning.
+	arrivalCount := 0
+	for {
+		req, ok := c.requestSource.Next()
+		if !ok {
+			break
+		}
 		c.pushArrival(req, req.ArrivalTime)
+		arrivalCount++
+	}
+	if arrivalCount == 0 {
+		logrus.Warn("[cluster] no requests provided — simulation will produce zero results")
 	}
 
 	// 3. Shared-clock event loop (BC-4: cluster events before instance events)

--- a/sim/cluster/cluster_event_test.go
+++ b/sim/cluster/cluster_event_test.go
@@ -157,7 +157,7 @@ func TestClusterEventPriorities(t *testing.T) {
 // buildRouterState must produce a RouterState with one snapshot per instance and the current clock.
 func TestBuildRouterState_PopulatesSnapshots(t *testing.T) {
 	config := newTestDeploymentConfig(3)
-	cs := NewClusterSimulator(config, newTestRequests(1), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(1)), nil)
 
 	state := buildRouterState(cs, nil)
 
@@ -182,7 +182,7 @@ func TestBuildRouterState_PopulatesSnapshots(t *testing.T) {
 func TestBuildRouterState_LoadingSnapshot_PopulatedNotInSnapshots(t *testing.T) {
 	// newTestDeploymentConfig(1) creates one instance that starts Active (no NodePools).
 	// We manually force it to Loading state to simulate an in-flight scale-up.
-	cs := NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
 	for _, inst := range cs.instances {
 		inst.State = sim.InstanceStateLoading
 	}
@@ -235,7 +235,7 @@ func TestBuildRouterState_LoadingSnapshot_PopulatedNotInSnapshots(t *testing.T) 
 // has both Active and Loading instances, they appear in the correct slices.
 func TestBuildRouterState_ActiveAndLoadingMixed_SeparateBuckets(t *testing.T) {
 	// Start with 2 instances, force one to Loading and leave the other Active.
-	cs := NewClusterSimulator(newTestDeploymentConfig(2), nil, nil)
+	cs := NewClusterSimulator(newTestDeploymentConfig(2), NewSliceRequestSource(nil), nil)
 	cs.instances[0].State = sim.InstanceStateActive
 	cs.instances[1].State = sim.InstanceStateLoading
 

--- a/sim/cluster/cluster_tenant_test.go
+++ b/sim/cluster/cluster_tenant_test.go
@@ -63,7 +63,7 @@ func TestTenantAdmission_OverBudgetSheddableShed(t *testing.T) {
 	// Run A: alice=0.1 (1 slot), bob=0.9 (9 slots) — alice is over-budget, sheds sheddable.
 	cfgA := newTenantConfig(2, map[string]float64{"alice": 0.1, "bob": 0.9})
 	cfgA.BatchConfig = sim.NewBatchConfig(5, 2048, 0) // totalCapacity=10; alice limit=1 slot
-	csA := NewClusterSimulator(cfgA, makeRequests(), nil)
+	csA := NewClusterSimulator(cfgA, NewSliceRequestSource(makeRequests()), nil)
 	mustRun(t, csA)
 
 	shedA := csA.ShedByTier()["sheddable"]
@@ -75,7 +75,7 @@ func TestTenantAdmission_OverBudgetSheddableShed(t *testing.T) {
 	// Now bob is over-budget; shed count should be non-zero regardless of which tenant is constrained.
 	cfgB := newTenantConfig(2, map[string]float64{"alice": 0.9, "bob": 0.1})
 	cfgB.BatchConfig = sim.NewBatchConfig(5, 2048, 0) // totalCapacity=10; bob limit=1 slot
-	csB := NewClusterSimulator(cfgB, makeRequests(), nil)
+	csB := NewClusterSimulator(cfgB, NewSliceRequestSource(makeRequests()), nil)
 	mustRun(t, csB)
 
 	shedB := csB.ShedByTier()["sheddable"]
@@ -103,7 +103,7 @@ func TestTenantAdmission_CriticalAndStandardProtectedFromBudgetShed(t *testing.T
 	cfg := newTenantConfig(2, map[string]float64{
 		"alice": 0.05, // only ~0.5 slots allowed
 	})
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// No critical requests should be shed by tenant budget enforcement
@@ -126,13 +126,13 @@ func TestTenantAdmission_NilBudgets_ZeroValueSafety(t *testing.T) {
 
 	// Run 1: no tenant budgets
 	cfg1 := newTestDeploymentConfig(2)
-	cs1 := NewClusterSimulator(cfg1, requests1, nil)
+	cs1 := NewClusterSimulator(cfg1, NewSliceRequestSource(requests1), nil)
 	mustRun(t, cs1)
 
 	// Run 2: explicit nil TenantBudgets (zero-value safe)
 	cfg2 := newTestDeploymentConfig(2)
 	cfg2.TenantBudgets = nil
-	cs2 := NewClusterSimulator(cfg2, requests2, nil)
+	cs2 := NewClusterSimulator(cfg2, NewSliceRequestSource(requests2), nil)
 	mustRun(t, cs2)
 
 	m1, _ := json.Marshal(cs1.AggregatedMetrics())
@@ -167,12 +167,12 @@ func TestTenantAdmission_INV6_Determinism(t *testing.T) {
 	cfg.BatchConfig = sim.NewBatchConfig(5, 2048, 0)
 
 	// Run 1
-	cs1 := NewClusterSimulator(cfg, makeReqs(), nil)
+	cs1 := NewClusterSimulator(cfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, cs1)
 	m1, _ := json.Marshal(cs1.AggregatedMetrics())
 
 	// Run 2 — identical config and seed
-	cs2 := NewClusterSimulator(cfg, makeReqs(), nil)
+	cs2 := NewClusterSimulator(cfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, cs2)
 	m2, _ := json.Marshal(cs2.AggregatedMetrics())
 
@@ -202,7 +202,7 @@ func TestTenantAdmission_INV1_BudgetShedConservation(t *testing.T) {
 	// alice budget=0.1 with totalCapacity=10 → 1 slot; dense arrivals guarantee budget enforcement fires.
 	cfg := newTenantConfig(2, map[string]float64{"alice": 0.1})
 	cfg.BatchConfig = sim.NewBatchConfig(5, 2048, 0) // totalCapacity=10; alice limit=1 slot
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// Verify budget enforcement actually fired (test setup check).
@@ -252,12 +252,12 @@ func TestTenantAdmission_INV9_DoesNotReadOutputTokens(t *testing.T) {
 	// Dense arrivals ensure the budget enforcement code path actually executes.
 	cfg1 := newTenantConfig(2, map[string]float64{"alice": 0.1})
 	cfg1.BatchConfig = sim.NewBatchConfig(5, 2048, 0)
-	cs1 := NewClusterSimulator(cfg1, makeReqs(true), nil)
+	cs1 := NewClusterSimulator(cfg1, NewSliceRequestSource(makeReqs(true)), nil)
 	mustRun(t, cs1)
 
 	cfg2 := newTenantConfig(2, map[string]float64{"alice": 0.1})
 	cfg2.BatchConfig = sim.NewBatchConfig(5, 2048, 0)
-	cs2 := NewClusterSimulator(cfg2, makeReqs(false), nil)
+	cs2 := NewClusterSimulator(cfg2, NewSliceRequestSource(makeReqs(false)), nil)
 	mustRun(t, cs2)
 
 	shed1 := cs1.ShedByTier()["sheddable"]
@@ -297,7 +297,7 @@ func TestTenantAdmission_PDMode_BudgetEnforced(t *testing.T) {
 	cfg.TenantBudgets = map[string]float64{"alice": 0.1}
 	cfg.BatchConfig = sim.NewBatchConfig(10, 2048, 0) // totalCapacity=40; alice limit=4 slots
 
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	shed := cs.ShedByTier()["sheddable"]

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -50,7 +50,7 @@ func TestPerInstanceMetrics_BeforeRun_Panics(t *testing.T) {
 		}
 	}()
 	config := newTestDeploymentConfig(1)
-	cs := NewClusterSimulator(config, newTestRequests(5), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(5)), nil)
 	cs.PerInstanceMetrics() // should panic
 }
 
@@ -152,7 +152,7 @@ func TestClusterSimulator_SingleInstance_GoldenEquivalence(t *testing.T) {
 				tc.PromptTokens, tc.PromptTokensStdev, tc.PromptTokensMin, tc.PromptTokensMax,
 				tc.OutputTokens, tc.OutputTokensStdev, tc.OutputTokensMin, tc.OutputTokensMax)
 
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			m := cs.AggregatedMetrics()
@@ -202,7 +202,7 @@ func TestClusterSimulator_SingleInstance_GoldenInvariants(t *testing.T) {
 				tc.PromptTokens, tc.PromptTokensStdev, tc.PromptTokensMin, tc.PromptTokensMax,
 				tc.OutputTokens, tc.OutputTokensStdev, tc.OutputTokensMin, tc.OutputTokensMax)
 
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 			m := cs.AggregatedMetrics()
 
@@ -236,10 +236,10 @@ func TestClusterSimulator_SingleInstance_GoldenInvariants(t *testing.T) {
 func TestClusterSimulator_MultiInstance_Determinism(t *testing.T) {
 	config := newTestDeploymentConfig(4)
 
-	cs1 := NewClusterSimulator(config, newTestRequests(100), nil)
+	cs1 := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(100)), nil)
 	mustRun(t, cs1)
 
-	cs2 := NewClusterSimulator(config, newTestRequests(100), nil)
+	cs2 := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(100)), nil)
 	mustRun(t, cs2)
 
 	// Check aggregated
@@ -292,7 +292,7 @@ func TestClusterSimulator_MultiInstance_AllComplete(t *testing.T) {
 	config := newTestDeploymentConfig(4)
 	requests := newTestRequests(100)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -315,7 +315,7 @@ func TestClusterSimulator_RoundRobin_EvenDistribution(t *testing.T) {
 	config := newTestDeploymentConfig(3)
 	requests := newTestRequests(9)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	for i, inst := range cs.Instances() {
@@ -334,7 +334,7 @@ func TestClusterSimulator_RoundRobin_UnevenDistribution(t *testing.T) {
 	config := newTestDeploymentConfig(3)
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	expected := []int{4, 3, 3}
@@ -354,7 +354,7 @@ func TestClusterSimulator_ZeroRequestInstances(t *testing.T) {
 	config := newTestDeploymentConfig(4)
 	requests := newTestRequests(2)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	expected := []int{1, 1, 0, 0}
@@ -379,7 +379,7 @@ func TestClusterSimulator_AggregatedMetrics_Correctness(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	requests := newTestRequests(50)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	var sumCompleted, sumInput, sumOutput int
@@ -460,7 +460,7 @@ func TestClusterSimulator_SharedClock_MonotonicGlobal(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	requests := newTestRequests(50)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	for i, inst := range cs.Instances() {
@@ -479,7 +479,7 @@ func TestClusterSimulator_RunOnce_Panics(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	defer func() {
@@ -512,7 +512,7 @@ func TestNewClusterSimulator_ZeroInstances_Panics(t *testing.T) {
 	}()
 
 	config := newTestDeploymentConfig(0)
-	NewClusterSimulator(config, newTestRequests(10), nil)
+	NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(10)), nil)
 }
 
 // TestInstanceSimulator_InjectAfterRun_Panics verifies C.3:
@@ -548,7 +548,7 @@ func TestClusterSimulator_GloballyUniqueRequestIDs(t *testing.T) {
 	config := newTestDeploymentConfig(4)
 	requests := newTestRequests(20)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -578,7 +578,7 @@ func TestClusterSimulator_HorizonEnforcement(t *testing.T) {
 	config.Horizon = 500000 // finite horizon
 	requests := newTestRequests(100)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -601,7 +601,7 @@ func TestClusterSimulator_NilRequests_NoPanic(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 
 	// nil requests: should not panic
-	cs := NewClusterSimulator(config, nil, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 	mustRun(t, cs)
 
 	if cs.AggregatedMetrics().CompletedRequests != 0 {
@@ -610,7 +610,7 @@ func TestClusterSimulator_NilRequests_NoPanic(t *testing.T) {
 	}
 
 	// empty requests: should not panic
-	cs2 := NewClusterSimulator(config, []*sim.Request{}, nil)
+	cs2 := NewClusterSimulator(config, NewSliceRequestSource([]*sim.Request{}), nil)
 	mustRun(t, cs2)
 
 	if cs2.AggregatedMetrics().CompletedRequests != 0 {
@@ -633,7 +633,7 @@ func TestClusterSimulator_AggregatedMetrics_BeforeRun_Panics(t *testing.T) {
 	}()
 
 	config := newTestDeploymentConfig(2)
-	cs := NewClusterSimulator(config, newTestRequests(10), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(10)), nil)
 	cs.AggregatedMetrics()
 }
 
@@ -648,7 +648,7 @@ func TestClusterSimulator_HandledBy_PopulatedInMetrics(t *testing.T) {
 	config.RoutingPolicy = "round-robin"
 	requests := newTestRequests(15)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -694,7 +694,7 @@ func TestClusterSimulator_HandledBy_PopulatedInMetrics(t *testing.T) {
 func TestClusterSimulator_HandledBy_SingleInstance(t *testing.T) {
 	config := newTestDeploymentConfig(1)
 	requests := newTestRequests(5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -716,7 +716,7 @@ func TestClusterSimulator_RoutingPolicy_RoundRobinDefault(t *testing.T) {
 	config.RoutingPolicy = "round-robin"
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// Requests distributed evenly: 4, 3, 3 (or variant)
@@ -743,7 +743,7 @@ func TestClusterSimulator_RoutingPolicy_LeastLoaded(t *testing.T) {
 	config.RoutingPolicy = "least-loaded"
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.AggregatedMetrics().CompletedRequests == 0 {
@@ -762,7 +762,7 @@ func TestClusterSimulator_AllRoutingPolicies_Smoke(t *testing.T) {
 			config.RoutingScorerConfigs = sim.DefaultScorerConfigs()
 			requests := newTestRequests(5)
 
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			if cs.AggregatedMetrics().CompletedRequests == 0 {
@@ -778,7 +778,7 @@ func BenchmarkClusterSimulator_1K_1Instance(b *testing.B) {
 	config := newTestDeploymentConfig(1)
 	for i := 0; i < b.N; i++ {
 		requests := newTestRequests(1000)
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		if err := cs.Run(); err != nil {
 			b.Fatalf("cs.Run: %v", err)
 		}
@@ -789,7 +789,7 @@ func BenchmarkClusterSimulator_10K_4Instances(b *testing.B) {
 	config := newTestDeploymentConfig(4)
 	for i := 0; i < b.N; i++ {
 		requests := newTestRequests(10000)
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		if err := cs.Run(); err != nil {
 			b.Fatalf("cs.Run: %v", err)
 		}
@@ -800,7 +800,7 @@ func BenchmarkClusterSimulator_1K_10Instances(b *testing.B) {
 	config := newTestDeploymentConfig(10)
 	for i := 0; i < b.N; i++ {
 		requests := newTestRequests(1000)
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		if err := cs.Run(); err != nil {
 			b.Fatalf("cs.Run: %v", err)
 		}
@@ -810,7 +810,7 @@ func BenchmarkClusterSimulator_1K_10Instances(b *testing.B) {
 func TestAggregateMetrics_IncludesKVCacheFields(t *testing.T) {
 	// GIVEN a cluster simulation with 2 instances
 	cfg := newTestDeploymentConfig(2)
-	cs := NewClusterSimulator(cfg, newTestRequests(10), nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(newTestRequests(10)), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -858,7 +858,7 @@ func TestAggregateMetrics_IncludesKVCacheFields(t *testing.T) {
 func TestAggregateMetrics_SingleInstance_AverageEqualsSelf(t *testing.T) {
 	// GIVEN a cluster with exactly 1 instance (edge case: average = self)
 	cfg := newTestDeploymentConfig(1)
-	cs := NewClusterSimulator(cfg, newTestRequests(5), nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(newTestRequests(5)), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -888,7 +888,7 @@ func TestClusterSimulator_RequestConservation_SumAcrossInstances(t *testing.T) {
 	config := newTestDeploymentConfig(4)
 	requests := newTestRequests(100)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	sumCompleted := 0
@@ -919,7 +919,7 @@ func TestClusterSimulator_Causality_PerInstance(t *testing.T) {
 	config := newTestDeploymentConfig(3)
 	requests := newTestRequests(50)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	totalChecked := 0
@@ -962,7 +962,7 @@ func TestClusterSimulator_ClockMonotonicity_ClusterDominatesInstances(t *testing
 	config := newTestDeploymentConfig(4)
 	requests := newTestRequests(100)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	for i, inst := range cs.Instances() {
@@ -981,7 +981,7 @@ func TestClusterSimulator_Determinism_ByteIdenticalAggregation(t *testing.T) {
 	run := func() *sim.Metrics {
 		config := newTestDeploymentConfig(3)
 		requests := newTestRequests(50)
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		return cs.AggregatedMetrics()
 	}
@@ -1087,7 +1087,7 @@ func TestClusterSimulator_Conservation_PolicyMatrix(t *testing.T) {
 			}
 
 			requests := newTestRequests(numRequests)
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			agg := cs.AggregatedMetrics()
@@ -1148,7 +1148,7 @@ func TestClusterSimulator_Determinism_WeightedPrefixScorer_ByteIdentical(t *test
 				// Use prefix tokens to exercise the prefix cache index
 				requests := testGenerateRequests(42, math.MaxInt64, 10.0/1e6, 30,
 					32, 100, 20, 10, 200, 50, 10, 10, 100)
-				cs := NewClusterSimulator(config, requests, nil)
+				cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 				mustRun(t, cs)
 				return cs
 			}
@@ -1235,7 +1235,7 @@ func TestClusterSimulator_OverloadConservation(t *testing.T) {
 			requests := testGenerateRequests(42, math.MaxInt64, rateReqPerS/1e6, numRequests,
 				0, 100, 20, 10, 200, 50, 10, 10, 100)
 
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			agg := cs.AggregatedMetrics()
@@ -1316,7 +1316,7 @@ func TestClusterSimulator_SchedulerLiveness(t *testing.T) {
 			requests := testGenerateRequests(42, math.MaxInt64, rateReqPerS/1e6, numRequests,
 				0, 200, 100, 32, 512, 128, 64, 16, 256)
 
-			cs := NewClusterSimulator(config, requests, nil)
+			cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			agg := cs.AggregatedMetrics()
@@ -1365,7 +1365,7 @@ func TestClusterSimulator_AdmissionLatency_ExactOffset(t *testing.T) {
 		config := newTestDeploymentConfig(numInstances)
 		config.RoutingPolicy = "least-loaded"
 		config.AdmissionLatency = latencyUS
-		cs := NewClusterSimulator(config, mkRequests(), nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(mkRequests()), nil)
 		mustRun(t, cs)
 		return cs.AggregatedMetrics()
 	}
@@ -1461,7 +1461,7 @@ func TestClusterSimulator_FullStackConservation(t *testing.T) {
 	t.Run("always-admit/ample-kv", func(t *testing.T) {
 		// BC-3: Happy path — all modules active, ample resources
 		config := mkFullStackConfig()
-		cs := NewClusterSimulator(config, mkRequests(), nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(mkRequests()), nil)
 		mustRun(t, cs)
 
 		agg := cs.AggregatedMetrics()
@@ -1498,7 +1498,7 @@ func TestClusterSimulator_FullStackConservation(t *testing.T) {
 		config.Horizon = 500000 // 0.5 seconds — many requests still in-flight at end
 		constRequests := testGenerateRequests(42, math.MaxInt64, 2000.0/1e6, numRequests,
 			32, 128, 0, 128, 128, 64, 0, 64, 64)
-		cs := NewClusterSimulator(config, constRequests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(constRequests), nil)
 		mustRun(t, cs)
 
 		agg := cs.AggregatedMetrics()
@@ -1528,7 +1528,7 @@ func TestClusterSimulator_FullStackConservation(t *testing.T) {
 		config.AdmissionPolicy = "token-bucket"
 		config.TokenBucketCapacity = 500
 		config.TokenBucketRefillRate = 300
-		cs := NewClusterSimulator(config, mkRequests(), nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(mkRequests()), nil)
 		mustRun(t, cs)
 
 		agg := cs.AggregatedMetrics()
@@ -1623,7 +1623,7 @@ func TestClusterSimulator_MaxModelLen_DroppedUnservable(t *testing.T) {
 	totalInjected := numFit + numGuard1a + numGuard1b
 	expectedDropped := numGuard1a + numGuard1b
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -1691,8 +1691,8 @@ func TestClusterSimulator_FlowControl_NeverSaturated_PassThrough(t *testing.T) {
 		requestsCopy[i] = &cp
 	}
 
-	csNoFC := NewClusterSimulator(configNoFC, requests, nil)
-	csWithFC := NewClusterSimulator(configWithFC, requestsCopy, nil)
+	csNoFC := NewClusterSimulator(configNoFC, NewSliceRequestSource(requests), nil)
+	csWithFC := NewClusterSimulator(configWithFC, NewSliceRequestSource(requestsCopy), nil)
 	mustRun(t, csNoFC)
 	mustRun(t, csWithFC)
 
@@ -1739,7 +1739,7 @@ func TestClusterSimulator_FlowControl_GatewayQueueDelay(t *testing.T) {
 	for i, req := range requests {
 		req.ArrivalTime = int64(i) * 100 // 100 ticks apart
 	}
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	agg := cs.AggregatedMetrics()
@@ -1779,7 +1779,7 @@ func TestClusterSimulator_FlowControl_Conservation(t *testing.T) {
 	config.FlowControlKVCacheUtilThreshold = 0.5
 
 	requests := newTestRequests(20)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1812,7 +1812,7 @@ func TestClusterSimulator_FlowControl_Conservation(t *testing.T) {
 func TestClusterSimulator_FlowControl_Accessors_Disabled(t *testing.T) {
 	config := newTestDeploymentConfig(1)
 	// flow control NOT enabled
-	cs := NewClusterSimulator(config, newTestRequests(3), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(3)), nil)
 	mustRun(t, cs)
 
 	if cs.GatewayQueueDepth() != 0 {
@@ -1855,7 +1855,7 @@ func TestNewClusterSimulator_UsesPoolGPUType(t *testing.T) {
 		},
 		InstanceLifecycle: InstanceLifecycleConfig{},
 	}
-	cs := NewClusterSimulator(withPools, nil, nil)
+	cs := NewClusterSimulator(withPools, NewSliceRequestSource(nil), nil)
 	if len(cs.instances) != 2 {
 		t.Fatalf("expected 2 placed instances, got %d", len(cs.instances))
 	}
@@ -1873,7 +1873,7 @@ func TestNewClusterSimulator_UsesPoolGPUType(t *testing.T) {
 		NumInstances:      2,
 		InstanceLifecycle: InstanceLifecycleConfig{},
 	}
-	cs2 := NewClusterSimulator(withoutPools, nil, nil)
+	cs2 := NewClusterSimulator(withoutPools, NewSliceRequestSource(nil), nil)
 	if len(cs2.instances) != 2 {
 		t.Fatalf("counter-assertion: expected 2 instances, got %d", len(cs2.instances))
 	}
@@ -1890,10 +1890,10 @@ func TestNewClusterSimulator_NoNodePools_DeterminismPreserved(t *testing.T) {
 	// NodePools intentionally empty (not set in newTestDeploymentConfig)
 	config := newTestDeploymentConfig(2)
 
-	cs1 := NewClusterSimulator(config, newTestRequests(100), nil)
+	cs1 := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(100)), nil)
 	mustRun(t, cs1)
 
-	cs2 := NewClusterSimulator(config, newTestRequests(100), nil)
+	cs2 := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(100)), nil)
 	mustRun(t, cs2)
 
 	m1 := cs1.AggregatedMetrics()
@@ -2003,7 +2003,7 @@ func TestNewClusterSimulator_RooflineUsesPoolHWConfig(t *testing.T) {
 			"H100": fastH100,
 		},
 	}
-	csPool := NewClusterSimulator(poolCfg, makeReqs(), nil)
+	csPool := NewClusterSimulator(poolCfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, csPool)
 	completedPool := csPool.AggregatedMetrics().CompletedRequests
 
@@ -2012,7 +2012,7 @@ func TestNewClusterSimulator_RooflineUsesPoolHWConfig(t *testing.T) {
 		SimConfig:    baseSimCfg,
 		NumInstances: 1,
 	}
-	csNoPool := NewClusterSimulator(noPoolCfg, makeReqs(), nil)
+	csNoPool := NewClusterSimulator(noPoolCfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, csNoPool)
 	completedNoPool := csNoPool.AggregatedMetrics().CompletedRequests
 
@@ -2071,7 +2071,7 @@ func TestNodeReadyEvent_RooflineUsesPoolHWConfig(t *testing.T) {
 			"H100": fastH100,
 		},
 	}
-	csDeferred := NewClusterSimulator(deferredCfg, makeReqs(), nil)
+	csDeferred := NewClusterSimulator(deferredCfg, NewSliceRequestSource(makeReqs()), nil)
 	if len(csDeferred.instances) != 0 {
 		t.Fatalf("precondition: expected 0 instances before NodeReadyEvent (InitialNodes=0), got %d", len(csDeferred.instances))
 	}
@@ -2090,7 +2090,7 @@ func TestNodeReadyEvent_RooflineUsesPoolHWConfig(t *testing.T) {
 		SimConfig:    baseSimCfg,
 		NumInstances: 1,
 	}
-	csNoPool := NewClusterSimulator(noPoolCfg, makeReqs(), nil)
+	csNoPool := NewClusterSimulator(noPoolCfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, csNoPool)
 	completedNoPool := csNoPool.AggregatedMetrics().CompletedRequests
 
@@ -2155,13 +2155,13 @@ func TestClusterRun_E2E_NodePoolsHWConfig_TTFTReflectsPoolHardware(t *testing.T)
 			"fast-gpu": fastGPU,
 		},
 	}
-	csPool := NewClusterSimulator(poolCfg, makeReqs(), nil)
+	csPool := NewClusterSimulator(poolCfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, csPool)
 	metricsPool := csPool.AggregatedMetrics()
 
 	// No-pool cluster: uses CLI fast-gpu calibration directly (no NodePools, no HWConfigByGPU).
 	noPoolCfg := DeploymentConfig{SimConfig: baseSimCfg, NumInstances: 1}
-	csNoPool := NewClusterSimulator(noPoolCfg, makeReqs(), nil)
+	csNoPool := NewClusterSimulator(noPoolCfg, NewSliceRequestSource(makeReqs()), nil)
 	mustRun(t, csNoPool)
 	metricsNoPool := csNoPool.AggregatedMetrics()
 
@@ -2214,7 +2214,7 @@ func TestNodeReadyEvent_DeferredConstruction_UsesPoolGPUType(t *testing.T) {
 		},
 	}
 
-	cs := NewClusterSimulator(cfg, nil, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 	// Precondition: all instances are pending (no capacity at startup).
 	if len(cs.instances) != 0 {
@@ -2335,7 +2335,7 @@ func TestClusterSimulator_SessionTerminalStateCompleteness(t *testing.T) {
 
 	config := newTestDeploymentConfig(1)
 	config.Horizon = horizon
-	cs := NewClusterSimulator(config, seeds, onDone)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(seeds), onDone)
 	mustRun(t, cs)
 
 	// INV-11: every session reached exactly one terminal state
@@ -2422,7 +2422,7 @@ func TestClusterSimulator_SessionFollowUpCausality(t *testing.T) {
 	}
 
 	config := newTestDeploymentConfig(1)
-	cs := NewClusterSimulator(config, seeds, onDone)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(seeds), onDone)
 	mustRun(t, cs)
 
 	// Verify INV-10 for every consecutive round pair.
@@ -2530,7 +2530,7 @@ func TestClusterSimulator_MultiTurnSession_EndToEnd(t *testing.T) {
 	}
 
 	config := newTestDeploymentConfig(1)
-	cs := NewClusterSimulator(config, seeds, onDone)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(seeds), onDone)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -2575,7 +2575,7 @@ func TestNewClusterSimulator_AutoscalerWiredWhenEnabled(t *testing.T) {
 	cfg := newTestDeploymentConfig(2)
 	cfg.ModelAutoscalerIntervalUs = 30_000_000
 	// AutoscalerAnalyzerConfig zero values → defaults applied inside constructor.
-	cs := NewClusterSimulator(cfg, nil, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 	if cs.autoscaler == nil {
 		t.Fatal("autoscaler must not be nil when ModelAutoscalerIntervalUs > 0")
 	}
@@ -2596,7 +2596,7 @@ func TestNewClusterSimulator_AutoscalerWiredWhenEnabled(t *testing.T) {
 func TestNewClusterSimulator_AutoscalerNilWhenDisabled(t *testing.T) {
 	cfg := newTestDeploymentConfig(2)
 	// ModelAutoscalerIntervalUs == 0 (default) → autoscaler stays nil.
-	cs := NewClusterSimulator(cfg, nil, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 	if cs.autoscaler != nil {
 		t.Error("autoscaler must be nil when ModelAutoscalerIntervalUs == 0")
 	}
@@ -2611,7 +2611,7 @@ func TestAutoscaler_RequestBoundedRun_Terminates(t *testing.T) {
 	cfg.ModelAutoscalerIntervalUs = 100_000 // 100 ms ticks — fires many times during test
 	reqs := newTestRequests(10)
 
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 
 	done := make(chan error, 1)
 	go func() { done <- cs.Run() }()
@@ -2666,7 +2666,7 @@ func TestPushArrival_CoInvariant_SessionFollowUpsProcessed(t *testing.T) {
 		}}
 	}
 
-	cs := NewClusterSimulator(cfg, reqs, onDone)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), onDone)
 
 	done := make(chan error, 1)
 	go func() { done <- cs.Run() }()
@@ -2712,7 +2712,7 @@ func TestBatchRequestsNotSerialized(t *testing.T) {
 		t.Run(sloClass, func(t *testing.T) {
 			requests := newBatchTestRequests(10, sloClass)
 			cfg := newTestDeploymentConfig(1)
-			cs := NewClusterSimulator(cfg, requests, nil)
+			cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 			mustRun(t, cs)
 
 			// Always-admit must not reject batch/background requests.
@@ -2776,7 +2776,7 @@ func TestClusterSimulator_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.
 		}
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -2850,7 +2850,7 @@ func TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics(t *testi
 		},
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -2911,7 +2911,7 @@ func TestClusterSimulator_PD_OrphanedTimeout_TimingNotInflated(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -2977,7 +2977,7 @@ func TestClusterSimulator_FlowControl_RoundRobinWiring(t *testing.T) {
 		r.MaxOutputLen = len(r.OutputTokens)
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -3035,7 +3035,7 @@ func TestClusterSimulator_FlowControl_Eviction_Conservation(t *testing.T) {
 		requests = append(requests, r)
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -3121,7 +3121,7 @@ func TestClusterSimulator_FlowControl_NoEviction_Default(t *testing.T) {
 		})
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	gwEvicted := cs.GatewayEvicted()
@@ -3188,7 +3188,7 @@ func TestClusterSimulator_FlowControl_Eviction_PD(t *testing.T) {
 		})
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()

--- a/sim/cluster/cluster_tier_test.go
+++ b/sim/cluster/cluster_tier_test.go
@@ -59,7 +59,7 @@ func TestTierShed_MonotonicSheddingOrder(t *testing.T) {
 
 	// tier-shed: MinAdmitPriority=3 → Standard and above pass, Sheddable shed.
 	cfg := newTierShedConfig(0, 3)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	shedCounts := cs.ShedByTier()
@@ -97,12 +97,12 @@ func TestTierShed_NoRegressionWithDefaultPolicy(t *testing.T) {
 
 	// Run 1: default admission (always-admit)
 	cfg1 := newTestDeploymentConfig(2)
-	cs1 := NewClusterSimulator(cfg1, requests1, nil)
+	cs1 := NewClusterSimulator(cfg1, NewSliceRequestSource(requests1), nil)
 	mustRun(t, cs1)
 
 	// Run 2: same config, same seed, same requests — must be byte-identical
 	cfg2 := newTestDeploymentConfig(2)
-	cs2 := NewClusterSimulator(cfg2, requests2, nil)
+	cs2 := NewClusterSimulator(cfg2, NewSliceRequestSource(requests2), nil)
 	mustRun(t, cs2)
 
 	m1, err1 := json.Marshal(cs1.AggregatedMetrics())
@@ -133,7 +133,7 @@ func TestTierShed_BatchBackgroundShedUnderOverload(t *testing.T) {
 	}
 
 	cfg := newTierShedConfig(0, 3) // MinAdmitPriority=3 rejects batch(-1) and background(-3)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// With MinAdmitPriority=3, batch(priority=-1) and background(priority=-3) should be rejected
@@ -146,7 +146,7 @@ func TestTierShed_BatchBackgroundShedUnderOverload(t *testing.T) {
 func TestTierShed_HighThresholdNeverSheds(t *testing.T) {
 	requests := newTierTestRequests(20, "sheddable")
 	cfg := newTierShedConfig(math.MaxInt32, 3)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if shed := cs.ShedByTier()["sheddable"]; shed > 0 {
@@ -186,7 +186,7 @@ func TestGAIELegacy_INV1_Conservation(t *testing.T) {
 
 	// Use low QD threshold (1) so saturation triggers easily under queue buildup.
 	cfg := newGAIELegacyConfig(2, 1)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// Full-pipeline INV-1 conservation: num_requests == injected_requests + rejected_requests,
@@ -233,7 +233,7 @@ func TestGAIELegacy_INV1_Conservation(t *testing.T) {
 func TestGAIELegacy_LightLoadAdmitsAll(t *testing.T) {
 	requests := newTierTestRequests(5, "sheddable")
 	cfg := newGAIELegacyConfig(2, 5)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if rejected := cs.RejectedRequests(); rejected > 0 {
@@ -251,7 +251,7 @@ func TestShedByTier_RejectAll_PopulatesTierCounts(t *testing.T) {
 	}
 	cfg := newTestDeploymentConfig(2)
 	cfg.AdmissionPolicy = "reject-all"
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.RejectedRequests() != 3 {

--- a/sim/cluster/cluster_trace_test.go
+++ b/sim/cluster/cluster_trace_test.go
@@ -23,7 +23,7 @@ func TestClusterSimulator_TraceLevelNone_NilTrace(t *testing.T) {
 	}
 	requests := testGenerateRequests(42, 1000000, 1.0/1e6, 3,
 		0, 10, 0, 10, 10, 5, 0, 5, 5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -51,7 +51,7 @@ func TestClusterSimulator_TraceLevelDecisions_RecordsAllEvents(t *testing.T) {
 	}
 	requests := testGenerateRequests(42, 10000000, 1.0/1e6, 5,
 		0, 10, 0, 10, 10, 5, 0, 5, 5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -95,7 +95,7 @@ func TestClusterSimulator_TraceLevelDecisions_WithCounterfactual(t *testing.T) {
 	}
 	requests := testGenerateRequests(42, 10000000, 1.0/1e6, 3,
 		0, 10, 0, 10, 10, 5, 0, 5, 5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -134,7 +134,7 @@ func TestClusterSimulator_TraceWithTokenBucket_RecordsRejections(t *testing.T) {
 	}
 	requests := testGenerateRequests(42, 5000000, 5.0/1e6, 10,
 		0, 10, 0, 10, 10, 5, 0, 5, 5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)

--- a/sim/cluster/cluster_warnings_test.go
+++ b/sim/cluster/cluster_warnings_test.go
@@ -38,7 +38,7 @@ func TestClusterSimulator_HorizonTooSmall_WarnsAtStartup(t *testing.T) {
 
 	// WHEN the cluster simulator is constructed
 	output := captureLogOutput(func() {
-		NewClusterSimulator(config, workload, nil)
+		NewClusterSimulator(config, NewSliceRequestSource(workload), nil)
 	})
 
 	// THEN a warning about horizon being too small MUST be logged
@@ -57,7 +57,7 @@ func TestClusterSimulator_HorizonSufficient_NoWarning(t *testing.T) {
 
 	// WHEN the cluster simulator is constructed
 	output := captureLogOutput(func() {
-		NewClusterSimulator(config, workload, nil)
+		NewClusterSimulator(config, NewSliceRequestSource(workload), nil)
 	})
 
 	// THEN no horizon warning MUST be logged
@@ -73,7 +73,7 @@ func TestClusterSimulator_AllRejected_WarnsAfterRun(t *testing.T) {
 	config.AdmissionPolicy = "reject-all"
 	workload := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, workload, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(workload), nil)
 
 	// WHEN the simulation runs to completion
 	output := captureLogOutput(func() {
@@ -94,7 +94,7 @@ func TestClusterSimulator_ZeroCompletions_WarnsAfterRun(t *testing.T) {
 	config.Horizon = 1 // 1 tick — admits but can't finish
 	workload := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, workload, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(workload), nil)
 
 	// WHEN the simulation runs to completion
 	output := captureLogOutput(func() {
@@ -115,7 +115,7 @@ func TestClusterSimulator_NormalOperation_NoPostSimWarning(t *testing.T) {
 	config.Horizon = 1000000
 	workload := newTestRequests(2)
 
-	cs := NewClusterSimulator(config, workload, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(workload), nil)
 
 	// WHEN the simulation runs to completion
 	output := captureLogOutput(func() {

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -135,14 +135,14 @@ func TestNewClusterSimulator_PDEnabled_InvalidModelConfig_Panics(t *testing.T) {
 			t.Error("expected panic for PD with zero ModelConfig, got none")
 		}
 	}()
-	NewClusterSimulator(cfg, nil, nil)
+	NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 }
 
 func TestDisaggregation_PrefillRoutedToPrefillPool(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// BC-PD-7: Prefill sub-requests must be routed to prefill instances
@@ -165,7 +165,7 @@ func TestDisaggregation_DecodeRoutedToDecodePool(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// BC-PD-7: Decode sub-requests must be routed to decode instances
@@ -190,7 +190,7 @@ func TestDisaggregation_RequestCompletesFullPath(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -215,7 +215,7 @@ func TestDisaggregation_TransferConservation(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.transfersInitiated != cs.transfersCompleted {
@@ -251,7 +251,7 @@ func TestDisaggregation_INV1Conservation(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -271,7 +271,7 @@ func TestDisaggregation_INV1Conservation_BoundedHorizon(t *testing.T) {
 	config.Horizon = 5000000 // 5 seconds — all requests arrive, most but maybe not all complete
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -294,7 +294,7 @@ func TestDisaggregation_DecodeOnlyBatchKVPressure(t *testing.T) {
 	config.KVCacheConfig = sim.NewKVCacheConfig(50, 16, 0, 0, 0, 0) // small KV cache
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -332,7 +332,7 @@ func TestDisaggregation_DroppedAtDecodeKV(t *testing.T) {
 	config.KVCacheConfig = sim.NewKVCacheConfig(3, 16, 0, 0, 0, 0) // 3 blocks = 48 tokens
 
 	requests := newShortRequests(4)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.droppedAtDecodeKV == 0 {
@@ -349,7 +349,7 @@ func TestDisaggregation_PhaseCausality(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	for _, parent := range cs.parentRequests {
@@ -383,7 +383,7 @@ func TestDisaggregation_PoolStability(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	membershipBefore := cs.PoolMembership()
 
 	mustRun(t, cs)
@@ -410,7 +410,7 @@ func TestDisaggregation_Determinism(t *testing.T) {
 
 	run := func() *sim.Metrics {
 		requests := newTestRequests(10)
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		return cs.AggregatedMetrics()
 	}
@@ -445,7 +445,7 @@ func TestDisaggregation_BackwardCompatibility(t *testing.T) {
 	}
 
 	requests := newTestRequests(10)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// No parent requests when pools not configured
@@ -470,7 +470,7 @@ func TestDisaggregation_PerPoolScorerConfigs(t *testing.T) {
 	config.DecodeScorerConfigs = []sim.ScorerConfig{{Name: "kv-utilization", Weight: 1.0}}
 
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	if cs.prefillRoutingPolicy == nil {
 		t.Error("prefillRoutingPolicy is nil when PrefillScorerConfigs specified")
@@ -567,7 +567,7 @@ func TestPDDisagg_OneOutputToken_CompletesWith1Token(t *testing.T) {
 		},
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("ClusterSimulator.Run: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestPrefixThreshold_BelowThresholdNotDisaggregated(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if len(cs.parentRequests) != 0 {
@@ -650,7 +650,7 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if len(cs.parentRequests) != 3 {
@@ -724,7 +724,7 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	}
 	_ = blockSize // documents the block arithmetic above
 
-	cs := NewClusterSimulator(config, []*sim.Request{req1, req2}, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource([]*sim.Request{req1, req2}), nil)
 	mustRun(t, cs)
 
 	// req1 must be disaggregated (400 non-cached tokens > 300 threshold).
@@ -769,7 +769,7 @@ func TestDisaggregation_MetricProjection_NoOp(t *testing.T) {
 	config := newTestDeploymentConfig(2) // standard cluster, no PD roles
 	requests := newTestRequests(3)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if len(cs.parentRequests) != 0 {
@@ -813,7 +813,7 @@ func TestDisaggregation_MetricProjection_NoSubRequestKeys(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -841,7 +841,7 @@ func TestDisaggregation_MetricProjection_E2ECount(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -859,7 +859,7 @@ func TestDisaggregation_MetricProjection_E2ECorrectness(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -896,7 +896,7 @@ func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -989,7 +989,7 @@ func TestDisaggregation_TTFT_NoSilentDrops(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1105,7 +1105,7 @@ func TestDisaggregation_MetricProjection_SchedulingDelay(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1134,7 +1134,7 @@ func TestDisaggregation_MetricProjection_CompletionTimes(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1162,7 +1162,7 @@ func TestDisaggregation_MetricProjection_RequestsMap(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1200,7 +1200,7 @@ func TestDisaggregation_MetricProjection_DroppedParent_NoSubRequestKeys(t *testi
 	config.KVCacheConfig = sim.NewKVCacheConfig(3, 16, 0, 0, 0, 0)
 
 	requests := newShortRequests(4)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.droppedAtDecodeKV == 0 {
@@ -1236,7 +1236,7 @@ func TestDisaggregation_MetricProjection_ITL(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(10)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1307,12 +1307,12 @@ func TestDisaggregation_CompletionTime_IncludesNonZeroOverhead(t *testing.T) {
 
 	requests := newTestRequests(3)
 	// Run 1: overhead = 0 (baseline)
-	cs0 := NewClusterSimulator(newTestDisaggDeploymentConfigWithOverhead(0), requests, nil)
+	cs0 := NewClusterSimulator(newTestDisaggDeploymentConfigWithOverhead(0), NewSliceRequestSource(requests), nil)
 	mustRun(t, cs0)
 	m0 := cs0.AggregatedMetrics()
 
 	// Run 2: overhead = wantOverheadUs
-	cs1 := NewClusterSimulator(newTestDisaggDeploymentConfigWithOverhead(float64(wantOverheadUs)), requests, nil)
+	cs1 := NewClusterSimulator(newTestDisaggDeploymentConfigWithOverhead(float64(wantOverheadUs)), NewSliceRequestSource(requests), nil)
 	mustRun(t, cs1)
 	m1 := cs1.AggregatedMetrics()
 
@@ -1347,7 +1347,7 @@ func TestDisaggregation_CompletionTime_IncludesNonZeroOverhead(t *testing.T) {
 func TestDisaggregation_CompletionTime_GeqAllPriorPhaseTimestamps(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	for _, parent := range cs.parentRequests {
@@ -1370,7 +1370,7 @@ func TestDisaggregation_CompletionTime_GeqAllPriorPhaseTimestamps(t *testing.T) 
 func TestDisaggregation_E2E_IncludesOverhead_ZeroOverheadRegression(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	m := cs.AggregatedMetrics()
@@ -1439,7 +1439,7 @@ func TestDisaggregation_SessionFollowUp_CallsOnRequestDone(t *testing.T) {
 		return nil // no follow-ups — just capture
 	}
 
-	cs := NewClusterSimulator(config, reqs, callback)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), callback)
 	mustRun(t, cs)
 
 	// Filter calls with non-empty SessionID (sub-request callbacks have empty SessionID)
@@ -1509,7 +1509,7 @@ func TestDisaggregation_SessionFollowUp_InjectsFollowUp(t *testing.T) {
 		}}
 	}
 
-	cs := NewClusterSimulator(config, reqs, callback)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), callback)
 	mustRun(t, cs)
 
 	// Follow-ups should have been disaggregated too — more parentRequests than initial
@@ -1550,7 +1550,7 @@ func TestDisaggregation_AggregateMode_Unaffected(t *testing.T) {
 		return nil
 	}
 
-	cs := NewClusterSimulator(config, reqs, callback)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), callback)
 	mustRun(t, cs)
 
 	// In aggregate mode, ALL completed requests should trigger callback with SessionID
@@ -1640,7 +1640,7 @@ func TestDisaggregation_PD_SessionManager_GeneratesFollowUps(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(config, reqs, callback)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), callback)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -1725,7 +1725,7 @@ func TestDisaggregation_PD_SessionManager_ContextAccumulation(t *testing.T) {
 		},
 	}
 
-	cs := NewClusterSimulator(config, reqs, callback)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), callback)
 	mustRun(t, cs)
 
 	metrics := cs.AggregatedMetrics()
@@ -1791,7 +1791,7 @@ func TestDisaggregation_NonDisaggRoutedToDecodePoolOnly(t *testing.T) {
 	config.PDDecider = "never"
 	const numRequests = 8
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN: simulation runs
 	mustRun(t, cs)
@@ -1824,7 +1824,7 @@ func TestDisaggregation_DecodeInstancePreSelected(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	const numRequests = 5
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN: simulation runs
 	mustRun(t, cs)
@@ -1862,7 +1862,7 @@ func TestDisaggregation_NoDecodeRoutingEvent(t *testing.T) {
 	config.TraceLevel = "decisions"
 	const numRequests = 4
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN: simulation runs
 	mustRun(t, cs)
@@ -1914,7 +1914,7 @@ func TestPDRouting_InjectionTimingPreserved(t *testing.T) {
 		r.ArrivalTime = int64(i) * 200_000 // 200ms apart
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	parents := cs.ParentRequests()
@@ -1982,7 +1982,7 @@ func TestDisaggregation_DeciderReceivesDecodePoolState(t *testing.T) {
 	const numRequests = 3
 	requests := newTestRequests(numRequests)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	rec := &recordingDecider{inner: &sim.AlwaysDisaggregate{}}
 	cs.disaggregationDecider = rec
 
@@ -2040,7 +2040,7 @@ func TestDisaggregation_DecodePodOverrideReroutes(t *testing.T) {
 	const numRequests = 5
 	requests := newTestRequests(numRequests)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// Pick a specific decode-pool instance as the override target. Use the
 	// lexicographically-last decode ID so the override differs from the

--- a/sim/cluster/epd_test.go
+++ b/sim/cluster/epd_test.go
@@ -58,7 +58,7 @@ func allTextRequests(n int) []*sim.Request {
 // no EncodeRoutingRecords are emitted regardless of request modality.
 func TestEPD_EncodeNever_IsPDUnchanged(t *testing.T) {
 	cfg := newTestEPDDeploymentConfig(2, 2, 1, "never")
-	cs := NewClusterSimulator(cfg, multimodalRequests(6), nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(multimodalRequests(6)), nil)
 	mustRun(t, cs)
 
 	if cs.trace == nil {
@@ -80,7 +80,7 @@ func TestEPD_EncodeFires_WithDisagg(t *testing.T) {
 	cfg := newTestEPDDeploymentConfig(2, 2, 1, "always")
 	cfg.PDDecider = "always" // force disaggregation
 	reqs := newTestRequests(3)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.trace == nil {
@@ -132,7 +132,7 @@ func TestEPD_EncodeFires_WithoutDisagg(t *testing.T) {
 	cfg := newTestEPDDeploymentConfig(2, 2, 1, "always")
 	cfg.PDDecider = "never" // disagg decider says "don't disaggregate"
 	reqs := newTestRequests(3)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.trace == nil {
@@ -165,7 +165,7 @@ func TestEPD_EmptyEncodePool_RoutingRejection(t *testing.T) {
 	cfg := newTestEPDDeploymentConfig(1, 1, 1, "always")
 	cfg.PDDecider = "never"
 	reqs := newTestRequests(3)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 
 	// Take the only encode instance offline before Run so the encode pool is empty.
 	// Draining state makes IsRoutable() return false.
@@ -204,7 +204,7 @@ func TestEPD_DeciderReadsDecodeInstanceID(t *testing.T) {
 	spy := &spyEncodeDecider{}
 	cfg := newTestEPDDeploymentConfig(2, 2, 1, "always")
 	cfg.PDDecider = "always"
-	cs := NewClusterSimulator(cfg, newTestRequests(4), nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(newTestRequests(4)), nil)
 	// Inject the spy after construction (the factory can't return the spy).
 	cs.encodeDecider = spy
 
@@ -233,7 +233,7 @@ func TestEPD_TextOnly_MultimodalDecider_Skips(t *testing.T) {
 	cfg := newTestEPDDeploymentConfig(2, 2, 1, "multimodal")
 	cfg.PDDecider = "always"
 	reqs := allTextRequests(4)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if got := len(cs.trace.EncodeRoutings); got != 0 {
@@ -254,7 +254,7 @@ func TestEPD_MultimodalSubsetEncoded(t *testing.T) {
 			wantMM++
 		}
 	}
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if got := len(cs.trace.EncodeRoutings); got != wantMM {
@@ -270,7 +270,7 @@ func TestEPD_Determinism(t *testing.T) {
 		cfg.PDDecider = "always"
 		// Build a stable request list from the same seed (multimodalRequests
 		// is deterministic given newTestRequests' seed=42).
-		cs := NewClusterSimulator(cfg, multimodalRequests(5), nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(multimodalRequests(5)), nil)
 		mustRun(t, cs)
 		return cs.trace.EncodeRoutings
 	}
@@ -312,7 +312,7 @@ func TestEPDDisabled_ZeroInstances_NoEncodeActivity(t *testing.T) {
 	cfg.TraceLevel = "decisions"
 	// EncodeInstances defaulted to 0 by newTestDisaggDeploymentConfig.
 	reqs := multimodalRequests(6) // half multimodal, half text — worst case
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.encodeDecider != nil {

--- a/sim/cluster/evaluation_test.go
+++ b/sim/cluster/evaluation_test.go
@@ -25,7 +25,7 @@ func TestNewEvaluationResult_WithTraceAndSummary_SummaryAccessible(t *testing.T)
 	}
 	requests := testGenerateRequests(42, 5000000, 1.0/1e6, 3,
 		0, 10, 0, 10, 10, 5, 0, 5, 5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("cs.Run: %v", err)
 	}

--- a/sim/cluster/flow_control_admission_test.go
+++ b/sim/cluster/flow_control_admission_test.go
@@ -200,7 +200,7 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 			}
 		}
 
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		verifyINV1Conservation(t, cs, requests)
 	})
@@ -231,7 +231,7 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 			}
 		}
 
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		verifyINV1Conservation(t, cs, requests)
 	})
@@ -260,7 +260,7 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 			}
 		}
 
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		verifyINV1Conservation(t, cs, requests)
 	})

--- a/sim/cluster/gateway_queue_ttl_test.go
+++ b/sim/cluster/gateway_queue_ttl_test.go
@@ -28,7 +28,7 @@ func TestGatewayQueueTTL_ExpiresQueuedRequest(t *testing.T) {
 		{ID: "r2", ArrivalTime: 100, SLOClass: "batch",
 			InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
 	}
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.GatewayExpired() != 1 {
@@ -44,7 +44,7 @@ func TestGatewayQueueTTL_NoOpWhenDispatched(t *testing.T) {
 	cfg := newFlowControlTTLConfig(1, 5000, "never")
 	cfg.Horizon = 100_000
 	reqs := newTestRequests(3)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.GatewayExpired() != 0 {
@@ -56,7 +56,7 @@ func TestGatewayQueueTTL_DisabledByDefault(t *testing.T) {
 	cfg := newFlowControlTTLConfig(1, 0, "never")
 	cfg.Horizon = 100_000
 	reqs := newTestRequests(5)
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	if cs.GatewayExpired() != 0 {

--- a/sim/cluster/inflight_requests_test.go
+++ b/sim/cluster/inflight_requests_test.go
@@ -48,7 +48,7 @@ func TestClusterSimulator_InFlightRequests_VisibleInRoutingState(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	mustRun(t, cs)
 
@@ -116,7 +116,7 @@ func TestClusterSimulator_InFlightRequests_CounterfactualIncludesInFlight(t *tes
 		}
 	}
 
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	mustRun(t, cs)
 
@@ -166,7 +166,7 @@ func TestClusterSimulator_InFlightRequests_DrainsToZeroAfterCompletion(t *testin
 	}
 	requests := testGenerateRequests(42, 10000000, 2.0/1e6, 6,
 		0, 16, 0, 16, 16, 8, 0, 8, 8)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	mustRun(t, cs)
 
@@ -209,7 +209,7 @@ func TestClusterSimulator_InFlightRequests_DroppedUnservable_Decrements(t *testi
 			State:        sim.StateQueued,
 		}
 	}
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	// All requests should be dropped as unservable
@@ -261,7 +261,7 @@ func TestClusterSimulator_InFlightRequests_CompletionBasedDecrement(t *testing.T
 			State:        sim.StateQueued,
 		}
 	}
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)
 
 	// Key assertion: at least one routing decision sees InFlightRequests > QueueDepth + BatchSize

--- a/sim/cluster/instance_lifecycle_test.go
+++ b/sim/cluster/instance_lifecycle_test.go
@@ -38,7 +38,7 @@ func TestInstanceLifecycle_WarmUpTTFTPenalty(t *testing.T) {
 		},
 	}
 
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run() failed: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestInstanceLifecycle_RedirectDrainPreservesConservation(t *testing.T) {
 	const numSeeded = 3
 	seeded := newTestRequests(numSeeded)
 
-	cs := NewClusterSimulator(cfg, []*sim.Request{}, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource([]*sim.Request{}), nil)
 	inst0 := cs.instances[0]
 
 	// Seed requests directly into inst0's WaitQ (bypassing admission/routing),

--- a/sim/cluster/metrics_substrate_test.go
+++ b/sim/cluster/metrics_substrate_test.go
@@ -42,7 +42,7 @@ func msClusterConfig(numInstances int) DeploymentConfig {
 func TestClusterMetrics_E2E_Identity_AcrossInstances(t *testing.T) {
 	cfg := msClusterConfig(4)
 	requests := newTestRequests(20)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestClusterMetrics_E2E_Identity_AcrossInstances(t *testing.T) {
 func TestClusterMetrics_AllITLs_Sum_Consistency(t *testing.T) {
 	cfg := msClusterConfig(2)
 	requests := newTestRequests(15)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestClusterMetrics_AllITLs_Sum_Consistency(t *testing.T) {
 func TestClusterMetrics_CacheHitRate_Bounded(t *testing.T) {
 	cfg := msClusterConfig(2)
 	requests := newTestRequests(10)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestClusterMetrics_ZeroOutput_NoPollution(t *testing.T) {
 		{ID: "n4", InputTokens: makeTokens(32), OutputTokens: makeTokens(5), ArrivalTime: 400000, State: sim.StateQueued},
 		{ID: "z5", InputTokens: makeTokens(16), OutputTokens: []int{}, ArrivalTime: 500000, State: sim.StateQueued},
 	}
-	cs := NewClusterSimulator(cfg, reqs, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run: %v", err)

--- a/sim/cluster/metrics_test.go
+++ b/sim/cluster/metrics_test.go
@@ -568,7 +568,7 @@ func TestPathological_RejectAll_AllRejected(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	config.AdmissionPolicy = "reject-all"
 
-	cs := NewClusterSimulator(config, newTestRequests(20), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(20)), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("cs.Run: %v", err)
 	}
@@ -590,7 +590,7 @@ func TestPathological_AlwaysBusiest_CausesImbalance(t *testing.T) {
 	config := newTestDeploymentConfig(3)
 	config.RoutingPolicy = "always-busiest"
 
-	cs := NewClusterSimulator(config, newTestRequests(20), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(20)), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("cs.Run: %v", err)
 	}

--- a/sim/cluster/multi_model_test.go
+++ b/sim/cluster/multi_model_test.go
@@ -41,7 +41,7 @@ func TestMultiModel_BuildRouterState_FiltersbyModel(t *testing.T) {
 	// Create cluster with 2 "llama" instances and 2 "qwen" instances by
 	// creating a cluster where instances have Model set.
 	llamaCfg := newTestDeploymentConfigWithModel(2, "llama")
-	cs := NewClusterSimulator(llamaCfg, nil, nil)
+	cs := NewClusterSimulator(llamaCfg, NewSliceRequestSource(nil), nil)
 
 	// Manually set model on instances to simulate multi-model setup
 	for _, inst := range cs.instances {
@@ -49,7 +49,7 @@ func TestMultiModel_BuildRouterState_FiltersbyModel(t *testing.T) {
 	}
 	// Add 2 "qwen" instances
 	qwenCfg := newTestDeploymentConfigWithModel(2, "qwen")
-	cs2 := NewClusterSimulator(qwenCfg, nil, nil)
+	cs2 := NewClusterSimulator(qwenCfg, NewSliceRequestSource(nil), nil)
 	for _, inst := range cs2.instances {
 		inst.Model = "qwen"
 	}
@@ -78,7 +78,7 @@ func TestMultiModel_BuildRouterState_FiltersbyModel(t *testing.T) {
 // T046: All instances of model M non-Active → empty RouterState.
 func TestMultiModel_BuildRouterState_EmptyWhenNonActive(t *testing.T) {
 	cfg := newTestDeploymentConfigWithModel(2, "model-m")
-	cs := NewClusterSimulator(cfg, nil, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 	// Mark all instances as Draining (not routable)
 	for _, inst := range cs.instances {
@@ -99,7 +99,7 @@ func TestMultiModel_BuildRouterState_EmptyWhenNonActive(t *testing.T) {
 // T046b: Request with empty Model includes all routable instances (backward-compat).
 func TestMultiModel_BuildRouterState_EmptyModelIncludesAll(t *testing.T) {
 	cfg := newTestDeploymentConfig(3)
-	cs := NewClusterSimulator(cfg, nil, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(nil), nil)
 
 	// No model set — all instances treated as routable (backward-compat)
 	noModelReq := newModelRequest("req-nomodel", "", 0)
@@ -199,7 +199,7 @@ func TestWarmUpTTFTFactor_AppliedInAggregateMetrics(t *testing.T) {
 		WarmUpTTFTFactor:   2.0,
 	}
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 
 	// Manually set instance to WarmingUp and record two warm-up requests
 	inst := cs.instances[0]

--- a/sim/cluster/pd_traces_test.go
+++ b/sim/cluster/pd_traces_test.go
@@ -24,7 +24,7 @@ func TestPDTrace_NonDisaggMode_NoDisaggRecords(t *testing.T) {
 		TraceLevel:   "decisions",
 	}
 	requests := newTestRequests(5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -62,7 +62,7 @@ func TestPDTrace_DisaggMode_AllRecordTypesPresent(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	config.TraceLevel = "decisions"
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	mustRun(t, cs)
 
@@ -143,7 +143,7 @@ func TestPDTrace_DisaggMode_Counterfactual(t *testing.T) {
 	config.RoutingPolicy = "weighted"
 	config.RoutingScorerConfigs = sim.DefaultScorerConfigs()
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	mustRun(t, cs)
 
@@ -181,7 +181,7 @@ func TestPDTrace_DisaggMode_Cardinality(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	config.TraceLevel = "decisions"
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -219,7 +219,7 @@ func TestPDTrace_DisaggMode_DisaggDecisionRecorded(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	config.TraceLevel = "decisions"
 	requests := newTestRequests(3)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -262,7 +262,7 @@ func TestPDTrace_DroppedAtDecodeKV_NoOrphanRecords(t *testing.T) {
 	config.KVCacheConfig = sim.NewKVCacheConfig(3, 16, 0, 0, 0, 0)
 	config.TraceLevel = "decisions"
 	requests := newShortRequests(4)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -305,7 +305,7 @@ func TestPDTrace_NeverDecider_WithPools_OnlyDisaggRecords(t *testing.T) {
 	config.TraceLevel = "decisions"
 	const numRequests = 4
 	requests := newTestRequests(numRequests)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)
@@ -352,7 +352,7 @@ func TestPDTrace_NormalMode_NoDroppedUnservable(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
 	config.TraceLevel = "decisions"
 	requests := newTestRequests(5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// WHEN run
 	mustRun(t, cs)

--- a/sim/cluster/pipeline_integration_test.go
+++ b/sim/cluster/pipeline_integration_test.go
@@ -40,7 +40,7 @@ func TestFullPipelineEndToEnd(t *testing.T) {
 		}
 	}
 
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 
 	// Wire the real pipeline
 	collector := &DefaultCollector{}

--- a/sim/cluster/prefix_routing_test.go
+++ b/sim/cluster/prefix_routing_test.go
@@ -101,7 +101,7 @@ func TestPrefixAffinityRouting_LongPrefix_ConcentratesVsLoadOnly(t *testing.T) {
 		{Name: "prefix-affinity", Weight: 5.0},
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	affinityCS := NewClusterSimulator(affinityConfig, copyRequests(requests), nil)
+	affinityCS := NewClusterSimulator(affinityConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, affinityCS.Run())
 	affinityDist := getRoutingDistribution(affinityCS)
 
@@ -111,14 +111,14 @@ func TestPrefixAffinityRouting_LongPrefix_ConcentratesVsLoadOnly(t *testing.T) {
 	loadConfig.RoutingScorerConfigs = []sim.ScorerConfig{
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	loadCS := NewClusterSimulator(loadConfig, copyRequests(requests), nil)
+	loadCS := NewClusterSimulator(loadConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, loadCS.Run())
 	loadDist := getRoutingDistribution(loadCS)
 
 	// Experiment C: round-robin baseline
 	rrConfig := config
 	rrConfig.RoutingPolicy = "round-robin"
-	rrCS := NewClusterSimulator(rrConfig, copyRequests(requests), nil)
+	rrCS := NewClusterSimulator(rrConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, rrCS.Run())
 	rrDist := getRoutingDistribution(rrCS)
 
@@ -161,7 +161,7 @@ func TestPrefixAffinityRouting_ShortPrefix_NoAdvantage(t *testing.T) {
 		{Name: "prefix-affinity", Weight: 5.0},
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	affinityCS := NewClusterSimulator(affinityConfig, copyRequests(requests), nil)
+	affinityCS := NewClusterSimulator(affinityConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, affinityCS.Run())
 	affinityDist := getRoutingDistribution(affinityCS)
 
@@ -171,7 +171,7 @@ func TestPrefixAffinityRouting_ShortPrefix_NoAdvantage(t *testing.T) {
 	loadConfig.RoutingScorerConfigs = []sim.ScorerConfig{
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	loadCS := NewClusterSimulator(loadConfig, copyRequests(requests), nil)
+	loadCS := NewClusterSimulator(loadConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, loadCS.Run())
 	loadDist := getRoutingDistribution(loadCS)
 
@@ -296,7 +296,7 @@ func TestPrefixAffinityRouting_MultiTurn_SessionAffinity(t *testing.T) {
 		{Name: "prefix-affinity", Weight: 5.0},
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	affinityCS := NewClusterSimulator(affinityConfig, copyRequests(requests), nil)
+	affinityCS := NewClusterSimulator(affinityConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, affinityCS.Run())
 	affinityAffinity := countSessionAffinity(affinityCS)
 
@@ -306,7 +306,7 @@ func TestPrefixAffinityRouting_MultiTurn_SessionAffinity(t *testing.T) {
 	loadConfig.RoutingScorerConfigs = []sim.ScorerConfig{
 		{Name: "queue-depth", Weight: 1.0},
 	}
-	loadCS := NewClusterSimulator(loadConfig, copyRequests(requests), nil)
+	loadCS := NewClusterSimulator(loadConfig, NewSliceRequestSource(copyRequests(requests)), nil)
 	require.NoError(t, loadCS.Run())
 	loadAffinity := countSessionAffinity(loadCS)
 

--- a/sim/cluster/progress_hook_test.go
+++ b/sim/cluster/progress_hook_test.go
@@ -21,7 +21,7 @@ var _ sim.ProgressHook = (*clusterCollectingHook)(nil)
 func TestClusterSimulator_ProgressHook_FiresWithInstances(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	reqs := newTestRequests(10)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 500_000)
@@ -55,7 +55,7 @@ func TestClusterSimulator_ProgressHook_FiresWithInstances(t *testing.T) {
 func TestClusterSimulator_ProgressHook_NilHookNoImpact(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	reqs := newTestRequests(10)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	mustRun(t, cs)
 
@@ -68,7 +68,7 @@ func TestClusterSimulator_ProgressHook_NilHookNoImpact(t *testing.T) {
 func TestClusterSimulator_ProgressHook_ZeroIntervalOnlyFinal(t *testing.T) {
 	config := newTestDeploymentConfig(1)
 	reqs := newTestRequests(5)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 0)
@@ -86,7 +86,7 @@ func TestClusterSimulator_ProgressHook_ZeroIntervalOnlyFinal(t *testing.T) {
 func TestClusterSimulator_ProgressHook_SnapshotClockMonotonicity(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	reqs := newTestRequests(20)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 100_000)
@@ -105,7 +105,7 @@ func TestClusterSimulator_ProgressHook_FinalSnapshotOnHorizon(t *testing.T) {
 	config := newTestDeploymentConfig(1)
 	config.Horizon = 1_000_000
 	reqs := newTestRequests(100)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 100_000)
@@ -138,7 +138,7 @@ func TestClusterSimulator_ProgressHook_ShedByTier(t *testing.T) {
 	}
 
 	cfg := newTierShedConfig(0, 3) // MinAdmitPriority=3 → sheddable is rejected
-	cs := NewClusterSimulator(cfg, requests, nil)
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(requests), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 500_000)
@@ -214,7 +214,7 @@ func TestClusterSimulator_ProgressHook_ShedByTierNilWhenNoShedding(t *testing.T)
 	// BC-2: always-admit produces nil ShedByTier in all snapshots.
 	config := newTestDeploymentConfig(2)
 	reqs := newTestRequests(10)
-	cs := NewClusterSimulator(config, reqs, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 
 	var snapshots []sim.ProgressSnapshot
 	cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 100_000)
@@ -247,7 +247,7 @@ func TestClusterSimulator_ProgressHook_ShedByTierDeterminism(t *testing.T) {
 
 	run := func(withHook bool) map[string]int {
 		cfg := newTierShedConfig(0, 3)
-		cs := NewClusterSimulator(cfg, makeRequests(), nil)
+		cs := NewClusterSimulator(cfg, NewSliceRequestSource(makeRequests()), nil)
 		if withHook {
 			var snapshots []sim.ProgressSnapshot
 			cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 500_000)
@@ -276,7 +276,7 @@ func TestClusterSimulator_ProgressHook_Determinism(t *testing.T) {
 		config := newTestDeploymentConfig(2)
 		config.Horizon = math.MaxInt64
 		reqs := newTestRequests(10)
-		cs := NewClusterSimulator(config, reqs, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(reqs), nil)
 		if withHook {
 			var snapshots []sim.ProgressSnapshot
 			cs.SetProgressHook(&clusterCollectingHook{snapshots: &snapshots}, 100_000)

--- a/sim/cluster/request_source.go
+++ b/sim/cluster/request_source.go
@@ -2,9 +2,16 @@ package cluster
 
 import "github.com/inference-sim/inference-sim/sim"
 
-// RequestSource yields requests in non-decreasing ArrivalTime order, exactly
-// once each. Next returns (nil, false) when the source is exhausted; subsequent
-// calls also return (nil, false).
+// RequestSource is a pull-style stream of *sim.Request values for the cluster
+// arrival pump.
+//
+// Implementations MUST:
+//   - Yield each request exactly once, in non-decreasing ArrivalTime order.
+//     Run() relies on this and does not verify or re-sort it.
+//   - Return (nil, false) when exhausted. Subsequent calls MUST also return
+//     (nil, false) — exhaustion is sticky.
+//   - Never return (nil, true). Run() dereferences the returned request and
+//     would panic on a nil with ok=true.
 //
 // Implementations are not expected to be safe for concurrent use. The cluster's
 // Run() loop consumes a source from a single goroutine.

--- a/sim/cluster/request_source.go
+++ b/sim/cluster/request_source.go
@@ -1,0 +1,43 @@
+package cluster
+
+import "github.com/inference-sim/inference-sim/sim"
+
+// RequestSource yields requests in non-decreasing ArrivalTime order, exactly
+// once each. Next returns (nil, false) when the source is exhausted; subsequent
+// calls also return (nil, false).
+//
+// Implementations are not expected to be safe for concurrent use. The cluster's
+// Run() loop consumes a source from a single goroutine.
+//
+// The streaming generator (issue #1438 Change A3) will add a second
+// implementation that yields requests on demand without ever materializing the
+// full slice. This PR introduces only the eager SliceRequestSource adapter.
+type RequestSource interface {
+	Next() (*sim.Request, bool)
+}
+
+// SliceRequestSource is the trivial eager adapter that wraps a pre-materialized
+// []*sim.Request and serves it through the RequestSource interface. It is
+// value-identity over the input slice: same elements, same order, no
+// transformation, no copy.
+type SliceRequestSource struct {
+	reqs []*sim.Request
+	i    int
+}
+
+// NewSliceRequestSource wraps reqs as a RequestSource. The caller retains
+// ownership of the slice; the adapter does not copy it. A nil or empty reqs is
+// valid and exhausts immediately.
+func NewSliceRequestSource(reqs []*sim.Request) *SliceRequestSource {
+	return &SliceRequestSource{reqs: reqs}
+}
+
+// Next returns the next request and true, or (nil, false) when exhausted.
+func (s *SliceRequestSource) Next() (*sim.Request, bool) {
+	if s.i >= len(s.reqs) {
+		return nil, false
+	}
+	req := s.reqs[s.i]
+	s.i++
+	return req, true
+}

--- a/sim/cluster/request_source_test.go
+++ b/sim/cluster/request_source_test.go
@@ -1,0 +1,108 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// Compile-time check that *SliceRequestSource satisfies RequestSource.
+var _ RequestSource = (*SliceRequestSource)(nil)
+
+func TestSliceRequestSource_YieldsRequestsInOrder(t *testing.T) {
+	reqs := []*sim.Request{
+		{ID: "r0", ArrivalTime: 0},
+		{ID: "r1", ArrivalTime: 100},
+		{ID: "r2", ArrivalTime: 200},
+	}
+	src := NewSliceRequestSource(reqs)
+
+	for i, want := range reqs {
+		got, ok := src.Next()
+		if !ok {
+			t.Fatalf("Next() at i=%d: expected ok=true, got false", i)
+		}
+		if got != want {
+			t.Errorf("Next() at i=%d: got %p, want %p (pointer-equal expected)", i, got, want)
+		}
+	}
+}
+
+func TestSliceRequestSource_ExhaustionReturnsFalse(t *testing.T) {
+	reqs := []*sim.Request{{ID: "r0", ArrivalTime: 0}}
+	src := NewSliceRequestSource(reqs)
+
+	if _, ok := src.Next(); !ok {
+		t.Fatalf("first Next(): expected ok=true")
+	}
+	for i := 0; i < 3; i++ {
+		got, ok := src.Next()
+		if ok {
+			t.Errorf("post-exhaustion Next() #%d: expected ok=false, got %v", i, got)
+		}
+		if got != nil {
+			t.Errorf("post-exhaustion Next() #%d: expected nil request, got %v", i, got)
+		}
+	}
+}
+
+func TestSliceRequestSource_EmptyAndNilExhaustImmediately(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []*sim.Request
+	}{
+		{"nil", nil},
+		{"empty", []*sim.Request{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := NewSliceRequestSource(tc.in)
+			got, ok := src.Next()
+			if ok {
+				t.Errorf("Next() on %s: expected ok=false, got true (req=%v)", tc.name, got)
+			}
+			if got != nil {
+				t.Errorf("Next() on %s: expected nil request, got %v", tc.name, got)
+			}
+		})
+	}
+}
+
+// fakeCountingSource wraps a SliceRequestSource and counts emissions vs
+// terminating false calls. Provided as a helper for any future test that wants
+// to assert drain-to-exhaustion semantics directly.
+type fakeCountingSource struct {
+	inner   *SliceRequestSource
+	yielded int
+	exhaust int
+}
+
+func (f *fakeCountingSource) Next() (*sim.Request, bool) {
+	r, ok := f.inner.Next()
+	if ok {
+		f.yielded++
+	} else {
+		f.exhaust++
+	}
+	return r, ok
+}
+
+func TestSliceRequestSource_CountingWrapperIntegrates(t *testing.T) {
+	reqs := []*sim.Request{
+		{ID: "r0", ArrivalTime: 0},
+		{ID: "r1", ArrivalTime: 100},
+	}
+	src := &fakeCountingSource{inner: NewSliceRequestSource(reqs)}
+	for {
+		_, ok := src.Next()
+		if !ok {
+			break
+		}
+	}
+	if src.yielded != 2 {
+		t.Errorf("yielded=%d, want 2", src.yielded)
+	}
+	if src.exhaust != 1 {
+		t.Errorf("exhaust=%d, want 1 (one terminating false call)", src.exhaust)
+	}
+}

--- a/sim/cluster/request_source_test.go
+++ b/sim/cluster/request_source_test.go
@@ -87,6 +87,24 @@ func (f *fakeCountingSource) Next() (*sim.Request, bool) {
 	return r, ok
 }
 
+func TestNewClusterSimulator_PanicsOnNilRequestSource(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on nil RequestSource, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic value, got %T: %v", r, r)
+		}
+		// Caller-friendly hint matters: we want the message to point at the fix.
+		if msg == "" {
+			t.Errorf("panic message is empty")
+		}
+	}()
+	NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+}
+
 func TestSliceRequestSource_CountingWrapperIntegrates(t *testing.T) {
 	reqs := []*sim.Request{
 		{ID: "r0", ArrivalTime: 0},

--- a/sim/cluster/request_source_test.go
+++ b/sim/cluster/request_source_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -103,6 +104,44 @@ func TestNewClusterSimulator_PanicsOnNilRequestSource(t *testing.T) {
 		}
 	}()
 	NewClusterSimulator(newTestDeploymentConfig(1), nil, nil)
+}
+
+// nilTrueRequestSource violates the RequestSource contract by returning
+// (nil, true) on the first call, then exhausting. Used to verify Run() fails
+// fast with an actionable message rather than producing an opaque nil-deref.
+type nilTrueRequestSource struct {
+	fired bool
+}
+
+func (n *nilTrueRequestSource) Next() (*sim.Request, bool) {
+	if n.fired {
+		return nil, false
+	}
+	n.fired = true
+	return nil, true
+}
+
+func TestClusterSimulator_PanicsOnNilTrueFromSource(t *testing.T) {
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), &nilTrueRequestSource{}, nil)
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on (nil, true) from RequestSource, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic value, got %T: %v", r, r)
+		}
+		// The message should name the contract violation so future implementers
+		// can debug it without spelunking through Run().
+		if !strings.Contains(msg, "nil") {
+			t.Errorf("panic message should mention nil, got: %q", msg)
+		}
+		if !strings.Contains(msg, "contract") {
+			t.Errorf("panic message should mention contract violation, got: %q", msg)
+		}
+	}()
+	_ = cs.Run()
 }
 
 func TestSliceRequestSource_CountingWrapperIntegrates(t *testing.T) {

--- a/sim/cluster/resolve_test.go
+++ b/sim/cluster/resolve_test.go
@@ -250,7 +250,7 @@ func TestNewClusterSimulator_PerPoolConfig_HeterogeneousTP(t *testing.T) {
 		DecodeOverrides:         PoolOverrides{TP: &decodeTP},
 	}
 
-	cs := NewClusterSimulator(config, nil, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 
 	if len(cs.Instances()) != 4 {
 		t.Errorf("instance count = %d, want 4", len(cs.Instances()))
@@ -301,7 +301,7 @@ func TestNewClusterSimulator_NoOverrides_BackwardCompat(t *testing.T) {
 		// No PrefillOverrides or DecodeOverrides — zero valued
 	}
 
-	cs := NewClusterSimulator(config, nil, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 	if len(cs.Instances()) != 4 {
 		t.Errorf("instance count = %d, want 4", len(cs.Instances()))
 	}
@@ -345,7 +345,7 @@ func TestINV_P2_1_PoolConfigConsistency(t *testing.T) {
 	}
 
 	requests := newTestRequests(5)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// INV-P2-1 pre-check: verify per-pool KV capacity via observable FreeKVBlocks().
 	// Before simulation, FreeKVBlocks() == TotalCapacity (no requests allocated yet).
@@ -781,7 +781,7 @@ func TestNewClusterSimulator_PanicsOnInvalidPrefillOverrides(t *testing.T) {
 		}
 	}()
 
-	NewClusterSimulator(config, nil, nil)
+	NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 }
 
 // TestNewClusterSimulator_PureSharedCluster verifies issue #1276: a pure-shared
@@ -805,7 +805,7 @@ func TestNewClusterSimulator_PureSharedCluster(t *testing.T) {
 	}
 
 	// Must construct without panicking — the extended guard accepts pure-shared.
-	cs := NewClusterSimulator(config, nil, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 	if cs == nil {
 		t.Fatal("NewClusterSimulator returned nil for a valid pure-shared cluster")
 	}
@@ -841,7 +841,7 @@ func TestNewClusterSimulator_PureSharedWithTransferContention(t *testing.T) {
 		RoutingPolicy:        "round-robin",
 	}
 
-	cs := NewClusterSimulator(config, nil, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 	if cs == nil {
 		t.Fatal("NewClusterSimulator returned nil for pure-shared + PDTransferContention")
 	}
@@ -882,7 +882,7 @@ func TestNewClusterSimulator_PanicsOnInvalidDecodeOverrides(t *testing.T) {
 		}
 	}()
 
-	NewClusterSimulator(config, nil, nil)
+	NewClusterSimulator(config, NewSliceRequestSource(nil), nil)
 }
 
 // TestINV_P2_1_RequestConservation verifies INV-1 holds for a heterogeneous PD cluster:
@@ -919,7 +919,7 @@ func TestINV_P2_1_RequestConservation(t *testing.T) {
 		DecodeOverrides:         PoolOverrides{TotalKVBlocks: &decodeKV},
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	if err := cs.Run(); err != nil {
 		t.Fatalf("Run() failed: %v", err)
 	}

--- a/sim/cluster/roofline_golden_test.go
+++ b/sim/cluster/roofline_golden_test.go
@@ -191,7 +191,7 @@ func TestRoofline_GoldenDataset(t *testing.T) {
 				},
 				NumInstances: 1,
 			}
-			cs := NewClusterSimulator(cfg, wl.Requests, onDone)
+			cs := NewClusterSimulator(cfg, NewSliceRequestSource(wl.Requests), onDone)
 			if err := cs.Run(); err != nil {
 				t.Fatalf("ClusterSimulator.Run: %v", err)
 			}

--- a/sim/cluster/snapshot_test.go
+++ b/sim/cluster/snapshot_test.go
@@ -715,12 +715,12 @@ func TestCluster_CacheSignalDelay_StaleRouting(t *testing.T) {
 	}
 
 	// Oracle mode: delay=0
-	csOracle := NewClusterSimulator(makeConfig(0), makeRequests(), nil)
+	csOracle := NewClusterSimulator(makeConfig(0), NewSliceRequestSource(makeRequests()), nil)
 	require.NoError(t, csOracle.Run())
 	oraclePerInst := csOracle.PerInstanceMetrics()
 
 	// Stale mode: delay=50s (much larger than total workload span)
-	csStale := NewClusterSimulator(makeConfig(50_000_000), makeRequests(), nil)
+	csStale := NewClusterSimulator(makeConfig(50_000_000), NewSliceRequestSource(makeRequests()), nil)
 	require.NoError(t, csStale.Run())
 	stalePerInst := csStale.PerInstanceMetrics()
 
@@ -776,7 +776,7 @@ func TestCluster_CacheSignalDelay_Zero_OracleBehavior(t *testing.T) {
 		{ID: "r2", ArrivalTime: 100_000, InputTokens: tokens, OutputTokens: []int{1}, State: sim.StateQueued},
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	err := cs.Run()
 	require.NoError(t, err)
 

--- a/sim/cluster/trained_physics_golden_test.go
+++ b/sim/cluster/trained_physics_golden_test.go
@@ -194,7 +194,7 @@ func TestTrainedPhysics_GoldenDataset(t *testing.T) {
 				},
 				NumInstances: 1,
 			}
-			cs := NewClusterSimulator(cfg, wl.Requests, onDone)
+			cs := NewClusterSimulator(cfg, NewSliceRequestSource(wl.Requests), onDone)
 			if err := cs.Run(); err != nil {
 				t.Fatalf("ClusterSimulator.Run: %v", err)
 			}

--- a/sim/cluster/transfer_contention_test.go
+++ b/sim/cluster/transfer_contention_test.go
@@ -46,7 +46,7 @@ func TestTransferContention_INVP22_FairShareBandwidth(t *testing.T) {
 		r.ArrivalTime = 0
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	parents := cs.ParentRequests()
@@ -95,9 +95,9 @@ func TestTransferContention_BCP25_SingleTransferIdentical(t *testing.T) {
 		requests2[i] = &cp
 	}
 
-	cs1 := NewClusterSimulator(configNoContention, requests1, nil)
+	cs1 := NewClusterSimulator(configNoContention, NewSliceRequestSource(requests1), nil)
 	mustRun(t, cs1)
-	cs2 := NewClusterSimulator(configContention, requests2, nil)
+	cs2 := NewClusterSimulator(configContention, NewSliceRequestSource(requests2), nil)
 	mustRun(t, cs2)
 
 	parents1 := cs1.ParentRequests()
@@ -130,7 +130,7 @@ func TestTransferContention_BCP26_FairShareDivision(t *testing.T) {
 		r.ArrivalTime = 0
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	parents := cs.ParentRequests()
@@ -155,7 +155,7 @@ func TestTransferContention_BCP26_FairShareDivision(t *testing.T) {
 		r.ArrivalTime = 0
 	}
 
-	csNoContention := NewClusterSimulator(configNoContention, requestsCopy, nil)
+	csNoContention := NewClusterSimulator(configNoContention, NewSliceRequestSource(requestsCopy), nil)
 	mustRun(t, csNoContention)
 
 	parentsNC := csNoContention.ParentRequests()
@@ -201,7 +201,7 @@ func TestTransferContention_BCP27_INVPD3_Holds(t *testing.T) {
 		r.ArrivalTime = 0
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	// Run() returns non-nil only if contention bookkeeping was corrupted; err == nil
 	// rules out that failure path but does not by itself prove INV-PD-3.
 	if err := cs.Run(); err != nil {
@@ -225,7 +225,7 @@ func TestTransferContention_BCP28_MetricsAvailable(t *testing.T) {
 		r.ArrivalTime = 0
 	}
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	pd := CollectPDMetrics(
@@ -257,7 +257,7 @@ func TestTransferContention_DisabledByDefault(t *testing.T) {
 	// PDTransferContention defaults to false
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.PeakConcurrentTransfers() != 0 {
@@ -276,7 +276,7 @@ func TestTransferContention_ActiveTransfersZeroAtEnd(t *testing.T) {
 	config := newContentionConfig(4, 2, 2, 25.0)
 	requests := newTestRequests(5)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	// After simulation completes, activeTransfers should be back to 0
@@ -299,7 +299,7 @@ func TestTransferContention_HorizonCutoff_RunReturnsNil(t *testing.T) {
 	config := newContentionConfig(4, 2, 2, 25.0)
 	// Empty request set: simulation finishes immediately without any events,
 	// leaving activeTransfers untouched at whatever we set before Run().
-	cs := NewClusterSimulator(config, newTestRequests(0), nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(0)), nil)
 	// Pre-set to simulate a horizon that cut off one in-flight transfer.
 	cs.activeTransfers = 1
 
@@ -341,7 +341,7 @@ func TestTransferContention_INVP22_EffectiveBandwidthFormula(t *testing.T) {
 	}
 
 	config := newContentionConfig(4, 2, 2, 10.0) // 10 GB/s, zero base latency
-	cs := NewClusterSimulator(config, []*sim.Request{req}, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource([]*sim.Request{req}), nil)
 	mustRun(t, cs)
 
 	parents := cs.ParentRequests()
@@ -387,7 +387,7 @@ func TestTransferContention_MeanQueueDepthCalculation(t *testing.T) {
 // so no transfers are ever started.
 func TestTransferContention_MeanQueueDepthZeroTransfers(t *testing.T) {
 	config := newContentionConfig(4, 2, 2, 25.0)
-	cs := NewClusterSimulator(config, []*sim.Request{}, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource([]*sim.Request{}), nil)
 	mustRun(t, cs)
 	got := cs.MeanTransferQueueDepth()
 	if got != 0 {
@@ -511,7 +511,7 @@ func TestTransferContention_CorruptionFlagCausesRunError(t *testing.T) {
 	// Use 1 request so the simulation completes quickly and INV-PD-3 holds.
 	requests := newTestRequests(1)
 
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	// Inject corruption flag before Run(). The event loop will execute normally,
 	// but the post-loop check should detect the corruption and return an error.
 	cs.contentionBookkeepingCorrupted = true
@@ -588,7 +588,7 @@ func TestTransferContention_F1_RequiresPDEnabled(t *testing.T) {
 	config := newTestDeploymentConfig(2)
 	config.PDTransferContention = true
 	// This must panic because PD is not active.
-	NewClusterSimulator(config, []*sim.Request{}, nil)
+	NewClusterSimulator(config, NewSliceRequestSource([]*sim.Request{}), nil)
 }
 
 // TestTransferContention_NegativeGuard_SetsCorruptionFlag verifies that when
@@ -870,7 +870,7 @@ func TestTransferContention_INV6_Determinism(t *testing.T) {
 		for _, r := range requests {
 			r.ArrivalTime = 0
 		}
-		cs := NewClusterSimulator(config, requests, nil)
+		cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 		mustRun(t, cs)
 		return cs.PeakConcurrentTransfers(), cs.MeanTransferQueueDepth(),
 			cs.transfersInitiated, cs.transfersCompleted

--- a/sim/cluster/waiting_for_remote_kvs_test.go
+++ b/sim/cluster/waiting_for_remote_kvs_test.go
@@ -30,7 +30,7 @@ func TestWaitingForRemoteKVs_ReservationHoldsBlocksDuringTransfer(t *testing.T) 
 	// immediately after the started event (before the completed event fires).
 	config := newTestDisaggDeploymentConfig(3, 1, 2)
 	requests := newShortRequests(1) // single request → deterministic pod choice
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// Before the simulation starts, no blocks are used anywhere.
 	for _, inst := range cs.instances {
@@ -58,7 +58,7 @@ func TestWaitingForRemoteKVs_ReservationHoldsBlocksDuringTransfer(t *testing.T) 
 func TestWaitingForRemoteKVs_StateDuringTransfer(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(3, 1, 2)
 	requests := newShortRequests(1)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 
 	// Drive the event loop manually until a KVTransferStartedEvent fires,
 	// then stop and check the sub-request state.
@@ -102,7 +102,7 @@ func TestWaitingForRemoteKVs_ReservationFailure_DropsAtTransferStart(t *testing.
 	config.KVCacheConfig = sim.NewKVCacheConfig(3, 16, 0, 0, 0, 0)
 
 	requests := newShortRequests(4)
-	cs := NewClusterSimulator(config, requests, nil)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
 	mustRun(t, cs)
 
 	if cs.droppedAtDecodeKV == 0 {


### PR DESCRIPTION
## Summary

Foundation PR for #1438 Change A (lazy streaming workload generation). This PR is **deliberately behavior-preserving** — no memory win lands here. It exists to decouple the workload generator from the cluster's arrival-event handler so that a streaming generator can be dropped in later (A3) without touching cluster code or tests again.

- Adds a single-method `RequestSource` interface in `sim/cluster/`: `Next() (*sim.Request, bool)`.
- Adds the trivial eager adapter `SliceRequestSource` wrapping `[]*sim.Request`. Value-identity over the input slice — same elements, same order, no copy, no transformation.
- Migrates `cluster.NewClusterSimulator` signature from `[]*sim.Request` to `RequestSource` (in place — no parallel constructor, per R4).
- Updates all ~270 call sites (`blis run`, `blis replay`, 28 cluster test files, `cmd/replay_test.go`) to wrap via `cluster.NewSliceRequestSource(...)`. Mechanical edits.
- Replaces `Run()`'s slice-range arrival-injection with a `Next()`-driven drain. The empty-source warning is preserved via a local `arrivalCount` counter (since the streaming source can't cheaply expose `Len()`).

## Review-response fixes (commit `c273803`)

Applied the should-fix and important findings from the multi-agent review on the first push:

- **Nil `RequestSource` guard in `NewClusterSimulator`** — matches the existing `NumInstances < 1` panic style; fails fast at the construction site instead of an opaque nil-deref inside `Run()` when A3's second implementation lands.
- **Caller-obligation wording** — the interface's order requirement is now phrased as "Implementations MUST yield..." (caller obligation, not verified) instead of "guaranteed to yield..." which read as an enforcer claim.
- **`(nil, true)` prohibition documented** — `Run()` dereferences the returned request; one doc line covers what the prior slice-range code also assumed implicitly.
- **`TestNewClusterSimulator_PanicsOnNilRequestSource`** — covers the new guard.

The minor items (cluster-level drain spy, aliasing-hazard wording, "future test" comment) the reviewer marked low-priority/acceptable — left for a follow-up.

## Behavioral Contracts

- **BC-1 / BC-2 / BC-3 (adapter):** Order + identity, sticky exhaustion, empty/nil exhausts immediately. Covered by `request_source_test.go`.
- **BC-4 (cluster drains source):** Every existing cluster test (~263 of them) now exercises this path; a counting helper test asserts drain semantics directly.
- **BC-5 / BC-6 (INV-6 / INV-13):** Byte-identical stdout verified across `blis run` and `blis replay --trace-output ... → blis replay` against d059008 with `meta-llama/llama-3.1-8b-instruct --seed 1234`. Empty diffs. INV-6 re-verified after the review-response commit.
- **BC-7 (no internal slice copy):** Cluster's `preGeneratedRequests` field replaced with `requestSource RequestSource`. No `[]*sim.Request` field remains on `ClusterSimulator`.
- **BC-8 (no new behavior):** No new flag, metric, event type, or error path beyond the nil-guard panic. Single new file is the interface + adapter.

## What's NOT in this PR (deferred to subsequent issues in the #1438 family)

- Streaming generator (A3) — localized to `sim/workload/generator.go` after this PR.
- Trace export hook (A2) — moves the arrival-time-sorted slice off the eager `allRequests` accumulator.
- `blis observe` migration — unaffected; it doesn't construct `ClusterSimulator`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all packages green; cluster tests took ~73s)
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] **INV-6 byte-identity:** `diff <(blis-d059008 run --seed 1234 ...) <(blis-pr run --seed 1234 ...)` empty
- [x] **INV-13 byte-identity:** `diff <(blis-d059008 replay <trace> ...) <(blis-pr replay <trace> ...)` empty
- [x] Spot-check 4 representative test files post-rewrite — all use `NewSliceRequestSource(...)`
- [x] Verify no orphan `NewClusterSimulator(...)` call site without the wrap: `grep -nE "NewClusterSimulator\(" sim/cluster/*_test.go cmd/*_test.go cmd/root.go cmd/replay.go | grep -v NewSliceRequestSource` returns only one comment hit (a code reference inside a test docstring)

Closes #1439
