### PR TITLE
refactor(cluster): per-arrival trace hook (#1440)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1812,7 +1812,10 @@ var runCmd = &cobra.Command{
 
 		// Assemble allRequests for saturation analysis (BC-12, issue #1298).
 		// Trace export is now driven by the arrival hook above and no longer
-		// shares this slice (issue #1440).
+		// shares this slice (issue #1440). NOTE: allRequests is nil when
+		// --saturation-report is not set — any new downstream consumer must
+		// either trigger this assembly path or source its data elsewhere
+		// (the hook buffer for trace, or aggregateMetrics for per-instance).
 		var allRequests []*sim.Request
 		if saturationReport != "" {
 			allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1812,10 +1812,8 @@ var runCmd = &cobra.Command{
 
 		// Assemble allRequests for saturation analysis (BC-12, issue #1298).
 		// Trace export is now driven by the arrival hook above and no longer
-		// shares this slice (issue #1440). NOTE: allRequests is nil when
-		// --saturation-report is not set — any new downstream consumer must
-		// either trigger this assembly path or source its data elsewhere
-		// (the hook buffer for trace, or aggregateMetrics for per-instance).
+		// shares this slice (issue #1440). allRequests is nil when
+		// --saturation-report is not set.
 		var allRequests []*sim.Request
 		if saturationReport != "" {
 			allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1784,8 +1784,15 @@ var runCmd = &cobra.Command{
 		// trace is disabled). Saturation analysis continues to use the
 		// preGeneratedRequests + followUpRequests path below — those slices
 		// remain populated for that purpose only.
+		//
+		// Install/export coupling: traceArrivals is declared nil here and
+		// assigned a non-nil empty slice ONLY inside the install branch.
+		// A nil traceArrivals at the export site below with traceOutput
+		// non-empty means the install branch was dropped — we fail loudly
+		// rather than write a silent empty trace (R1).
 		var traceArrivals []*sim.Request
 		if traceOutput != "" {
+			traceArrivals = make([]*sim.Request, 0)
 			cs.SetArrivalHook(func(req *sim.Request) {
 				traceArrivals = append(traceArrivals, req)
 			})
@@ -1829,6 +1836,13 @@ var runCmd = &cobra.Command{
 		// the arrival hook (issue #1440) — already in clock-monotonic order
 		// per INV-3, so no sort is required.
 		if traceOutput != "" {
+			// Install/export coupling guard (R1): traceArrivals is a non-nil
+			// empty slice when SetArrivalHook ran above. A nil here means
+			// the install branch was dropped or moved without updating this
+			// site — refuse to write a silent empty trace.
+			if traceArrivals == nil {
+				logrus.Fatalf("Trace export: arrival hook was not installed but --trace-output=%q is set — install/export branches diverged (issue #1440)", traceOutput)
+			}
 			records := workload.RequestsToTraceRecords(traceArrivals)
 			header := &workload.TraceHeader{
 				Version:           3,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1771,6 +1771,25 @@ var runCmd = &cobra.Command{
 			}
 		}
 		cs := cluster.NewClusterSimulator(config, cluster.NewSliceRequestSource(preGeneratedRequests), onRequestDone)
+
+		// Arrival hook: capture trace-emission references at the cluster's
+		// single arrival boundary so the trace exporter no longer relies on
+		// the eager preGeneratedRequests + followUpRequests list assembly
+		// (issue #1440). The hook fires once per fresh arrival in
+		// clock-monotonic order — see ClusterArrivalEvent.Execute. We hold
+		// pointers (not copies) so the request's final state (set by the
+		// event loop) is visible at export time.
+		//
+		// Only install when --trace-output is set (BC-1: zero overhead when
+		// trace is disabled). Saturation analysis continues to use the
+		// preGeneratedRequests + followUpRequests path below — those slices
+		// remain populated for that purpose only.
+		var traceArrivals []*sim.Request
+		if traceOutput != "" {
+			cs.SetArrivalHook(func(req *sim.Request) {
+				traceArrivals = append(traceArrivals, req)
+			})
+		}
 		if err := cs.Run(); err != nil {
 			logrus.Fatalf("Simulation failed: %v", err)
 		}
@@ -1791,9 +1810,11 @@ var runCmd = &cobra.Command{
 		}
 		goodputTargets := mergeGoodputTargets(cliTTFT, cliITL, cliE2E, nil, specTargets)
 
-		// Assemble allRequests if trace export or saturation analysis requested (BC-12, issue #1298)
+		// Assemble allRequests for saturation analysis (BC-12, issue #1298).
+		// Trace export is now driven by the arrival hook above and no longer
+		// shares this slice (issue #1440).
 		var allRequests []*sim.Request
-		if traceOutput != "" || saturationReport != "" {
+		if saturationReport != "" {
 			allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))
 			allRequests = append(allRequests, preGeneratedRequests...)
 			allRequests = append(allRequests, followUpRequests...)
@@ -1803,9 +1824,11 @@ var runCmd = &cobra.Command{
 			})
 		}
 
-		// Export trace if requested (BC-1, BC-7)
+		// Export trace if requested (BC-1, BC-7). Records are sourced from
+		// the arrival hook (issue #1440) — already in clock-monotonic order
+		// per INV-3, so no sort is required.
 		if traceOutput != "" {
-			records := workload.RequestsToTraceRecords(allRequests)
+			records := workload.RequestsToTraceRecords(traceArrivals)
 			header := &workload.TraceHeader{
 				Version:           3,
 				TimeUnit:          "microseconds",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1144,6 +1144,188 @@ func TestRunCmd_MetricsPath_WritesMetricsOutput(t *testing.T) {
 	}
 }
 
+// TestRunCmd_TraceOutput_RecordCountMatchesRequests verifies the issue
+// #1440 end-to-end contract: when `blis run --trace-output X` is used,
+// the exported `X.csv` contains exactly one TraceV2 record per request
+// produced by the workload generator. The hook installed in cmd/root.go
+// replaced the eager `preGeneratedRequests + followUpRequests + sort +
+// RequestsToTraceRecords` path; this test guards the substitution against
+// silent record-count drift (would corrupt INV-13 replay parity).
+// NOTE: Do NOT use t.Parallel() — mutates package-level vars.
+func TestRunCmd_TraceOutput_RecordCountMatchesRequests(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePrefix := filepath.Join(tmpDir, "trace")
+
+	mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+
+	// Save and restore the package-level flag vars runCmd.Run mutates.
+	// Same list as TestRunCmd_MetricsPath_WritesMetricsOutput, with
+	// traceOutput added.
+	origMetrics := metricsPath
+	origModel := model
+	origBackend := latencyModelBackend
+	origBeta := betaCoeffs
+	origAlpha := alphaCoeffs
+	origTotalKV := totalKVBlocks
+	origBlockSize := blockSizeTokens
+	origMaxRunning := maxRunningReqs
+	origMaxSched := maxScheduledTokens
+	origInstances := numInstances
+	origSeed := seed
+	origResults := resultsPath
+	origThreshold := longPrefillTokenThreshold
+	origKVCPU := kvCPUBlocks
+	origOffload := kvOffloadThreshold
+	origBandwidth := kvTransferBandwidth
+	origBaseLatency := kvTransferBaseLatency
+	origSnapRefresh := snapshotRefreshInterval
+	origAdmission := admissionPolicy
+	origRouting := routingPolicy
+	origScheduler := scheduler
+	origPolicyConfig := policyConfigPath
+	origMaxModelLen := maxModelLen
+	origTraceLevel := traceLevel
+	origCounterfactualK := counterfactualK
+	origSimHorizon := simulationHorizon
+	origWorkloadType := workloadType
+	origRate := rate
+	origNumReqs := numRequests
+	origConcurrency := concurrency
+	origThinkTime := thinkTimeMs
+	origPrefix := prefixTokens
+	origPromptMean := promptTokensMean
+	origPromptStdev := promptTokensStdev
+	origPromptMin := promptTokensMin
+	origPromptMax := promptTokensMax
+	origOutputMean := outputTokensMean
+	origOutputStdev := outputTokensStdev
+	origOutputMin := outputTokensMin
+	origOutputMax := outputTokensMax
+	origWorkloadSpec := workloadSpecPath
+	origRequestTimeout := requestTimeoutSecs
+	origTraceOut := traceOutput
+	origLogLevel := logLevel
+	origModelConfigFolder := modelConfigFolder
+	origHwConfigPath := hwConfigPath
+	origGPU := gpu
+	origTP := tensorParallelism
+	defer func() {
+		metricsPath = origMetrics
+		model = origModel
+		latencyModelBackend = origBackend
+		betaCoeffs = origBeta
+		alphaCoeffs = origAlpha
+		totalKVBlocks = origTotalKV
+		blockSizeTokens = origBlockSize
+		maxRunningReqs = origMaxRunning
+		maxScheduledTokens = origMaxSched
+		numInstances = origInstances
+		seed = origSeed
+		resultsPath = origResults
+		longPrefillTokenThreshold = origThreshold
+		kvCPUBlocks = origKVCPU
+		kvOffloadThreshold = origOffload
+		kvTransferBandwidth = origBandwidth
+		kvTransferBaseLatency = origBaseLatency
+		snapshotRefreshInterval = origSnapRefresh
+		admissionPolicy = origAdmission
+		routingPolicy = origRouting
+		scheduler = origScheduler
+		policyConfigPath = origPolicyConfig
+		maxModelLen = origMaxModelLen
+		traceLevel = origTraceLevel
+		counterfactualK = origCounterfactualK
+		simulationHorizon = origSimHorizon
+		workloadType = origWorkloadType
+		rate = origRate
+		numRequests = origNumReqs
+		concurrency = origConcurrency
+		thinkTimeMs = origThinkTime
+		prefixTokens = origPrefix
+		promptTokensMean = origPromptMean
+		promptTokensStdev = origPromptStdev
+		promptTokensMin = origPromptMin
+		promptTokensMax = origPromptMax
+		outputTokensMean = origOutputMean
+		outputTokensStdev = origOutputStdev
+		outputTokensMin = origOutputMin
+		outputTokensMax = origOutputMax
+		workloadSpecPath = origWorkloadSpec
+		requestTimeoutSecs = origRequestTimeout
+		traceOutput = origTraceOut
+		logLevel = origLogLevel
+		modelConfigFolder = origModelConfigFolder
+		hwConfigPath = origHwConfigPath
+		gpu = origGPU
+		tensorParallelism = origTP
+	}()
+
+	// 5 distribution-mode requests — non-session workload, so each
+	// initial request emits exactly one trace record.
+	const wantRecords = 5
+	traceOutput = tracePrefix
+	workloadType = "distribution"
+	rate = 1.0
+	numRequests = wantRecords
+	promptTokensMean = 512
+	promptTokensStdev = 256
+	promptTokensMin = 2
+	promptTokensMax = 7000
+	outputTokensMean = 512
+	outputTokensStdev = 256
+	outputTokensMin = 2
+	outputTokensMax = 7000
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	testCmd.Flags().IntVar(&numRequests, "num-requests", 0, "")
+	testCmd.Flags().Float64Var(&rate, "rate", 0, "")
+	testCmd.Flags().StringVar(&workloadType, "workload", "", "")
+	testCmd.Flags().StringVar(&traceOutput, "trace-output", "", "")
+	if err := testCmd.ParseFlags([]string{
+		"--model", "qwen/qwen3-14b",
+		"--latency-model", "trained-physics",
+		"--defaults-filepath", defaultsPath,
+		"--model-config-folder", mcFolder,
+		"--hardware-config", hwPath,
+		"--hardware", "H100",
+		"--tp", "1",
+		"--total-kv-blocks", "1000",
+		"--num-requests", strconv.Itoa(wantRecords),
+		"--seed", "42",
+		"--rate", "1.0",
+		"--workload", "distribution",
+		"--trace-output", tracePrefix,
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	runCmd.Run(testCmd, nil)
+
+	// Read back the exported trace and assert exactly one record per
+	// generated request — the key INV-13 contract guarded by the hook
+	// substitution.
+	trace, err := workload.LoadTraceV2(tracePrefix+".yaml", tracePrefix+".csv")
+	if err != nil {
+		t.Fatalf("LoadTraceV2: %v", err)
+	}
+	if got := len(trace.Records); got != wantRecords {
+		t.Fatalf("trace contains %d records, want %d (one per generated request); hook may have dropped or duplicated arrivals", got, wantRecords)
+	}
+
+	// Records are written in arrival-hook fire order, which is
+	// clock-monotonic per INV-3. Assert ArrivalTimeUs is non-decreasing
+	// (a defensive check that the hook stream did not get reordered).
+	var prev int64
+	for i, rec := range trace.Records {
+		if rec.ArrivalTimeUs < prev {
+			t.Fatalf("trace record[%d] ArrivalTimeUs=%d regressed from %d — INV-3/INV-13 violation",
+				i, rec.ArrivalTimeUs, prev)
+		}
+		prev = rec.ArrivalTimeUs
+	}
+}
+
 func TestRunCmd_ModelAutoscalerIntervalUs_FlagRegistered(t *testing.T) {
 	flag := runCmd.Flags().Lookup("model-autoscaler-interval-us")
 	assert.NotNil(t, flag, "model-autoscaler-interval-us flag must be registered")

--- a/sim/cluster/arrival_hook_test.go
+++ b/sim/cluster/arrival_hook_test.go
@@ -149,10 +149,89 @@ func TestArrivalHook_FiresForSessionFollowUps(t *testing.T) {
 	})
 	mustRun(t, cs)
 
-	wantMin := len(initial)                                                 // every initial fires
-	wantMax := len(initial) + 3                                              // plus the follow-up budget
-	if calls < wantMin || calls > wantMax {
-		t.Fatalf("arrival hook fired %d times, want in [%d, %d]: initial=%d, follow-up budget=3",
-			calls, wantMin, wantMax, len(initial))
+	// The follow-up budget is fully consumed (each of the 3 initial
+	// requests yields one follow-up before remaining hits 0), so the
+	// exact expected count is initial + budget.
+	const followUpBudget = 3
+	if want := len(initial) + followUpBudget; calls != want {
+		t.Fatalf("arrival hook fired %d times, want %d (initial=%d, follow-up budget=%d consumed)",
+			calls, want, len(initial), followUpBudget)
+	}
+}
+
+// TestArrivalHook_BeyondHorizonFollowUpsExcluded asserts the documented
+// behavior shift introduced by issue #1440: a closed-loop follow-up whose
+// scheduled ArrivalTime exceeds config.Horizon never executes in the DES
+// event loop, so the hook does not see it. This is intentional — the
+// old eager `preGeneratedRequests + followUpRequests` assembly emitted
+// trace records for these never-arrived requests; the hook does not.
+// Excluding them strengthens INV-13 (replay reads the same trace the
+// run produced).
+func TestArrivalHook_BeyondHorizonFollowUpsExcluded(t *testing.T) {
+	cfg := newTestDeploymentConfig(1)
+	cfg.Horizon = 100_000 // 100ms — small enough that follow-ups can land past it
+	initial := newTestRequests(2)
+
+	// Always emit a follow-up at clock+1 hour. With Horizon=100ms the
+	// resulting ClusterArrivalEvent never executes and the hook never
+	// sees this request.
+	const beyondHorizonOffsetUs = int64(60 * 60 * 1_000_000) // 1 hour
+	beyondHorizonID := "fu-beyond-horizon"
+	emitted := false
+	onRequestDone := func(req *sim.Request, clock int64) []*sim.Request {
+		if emitted {
+			return nil
+		}
+		emitted = true
+		return []*sim.Request{{
+			ID:           beyondHorizonID,
+			ArrivalTime:  clock + beyondHorizonOffsetUs,
+			InputTokens:  []int{1, 2, 3},
+			OutputTokens: []int{4, 5},
+			Model:        req.Model,
+		}}
+	}
+
+	cs := NewClusterSimulator(cfg, NewSliceRequestSource(initial), onRequestDone)
+
+	seenIDs := make(map[string]int)
+	cs.SetArrivalHook(func(req *sim.Request) {
+		seenIDs[req.ID]++
+	})
+	mustRun(t, cs)
+
+	if got := seenIDs[beyondHorizonID]; got != 0 {
+		t.Fatalf("beyond-horizon follow-up %q must not reach the arrival hook; got %d fire(s)", beyondHorizonID, got)
+	}
+	// Sanity: at least the initial requests still fire.
+	for _, req := range initial {
+		if seenIDs[req.ID] != 1 {
+			t.Fatalf("initial request %q: hook fired %d times, want 1", req.ID, seenIDs[req.ID])
+		}
+	}
+}
+
+// TestSetArrivalHook_NilClearResetsMonotonicityFloor verifies the reset
+// behavior of SetArrivalHook(nil): a subsequently installed hook must
+// not inherit the previous hook's last-seen ArrivalTime, otherwise
+// callers re-using a ClusterSimulator instance to set up scenarios
+// would see spurious panics from the monotonicity guard.
+func TestSetArrivalHook_NilClearResetsMonotonicityFloor(t *testing.T) {
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
+
+	// First hook sees a high timestamp, then is cleared.
+	cs.SetArrivalHook(func(req *sim.Request) {})
+	cs.fireArrivalHook(&sim.Request{ID: "r1", ArrivalTime: 1_000_000}, 1_000_000)
+	cs.SetArrivalHook(nil)
+
+	// Install a new hook and fire an EARLIER timestamp. Without the
+	// reset, this would panic — the prior watermark of 1_000_000 would
+	// still be in place.
+	calls := 0
+	cs.SetArrivalHook(func(req *sim.Request) { calls++ })
+	cs.fireArrivalHook(&sim.Request{ID: "r2", ArrivalTime: 10}, 10)
+
+	if calls != 1 {
+		t.Fatalf("after nil-clear + reinstall, hook fired %d times, want 1 (monotonicity floor was not reset)", calls)
 	}
 }

--- a/sim/cluster/arrival_hook_test.go
+++ b/sim/cluster/arrival_hook_test.go
@@ -1,9 +1,11 @@
 package cluster
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
 )
 
 // TestArrivalHook_FiresOncePerInitialRequest verifies the hook is invoked
@@ -207,6 +209,87 @@ func TestArrivalHook_BeyondHorizonFollowUpsExcluded(t *testing.T) {
 	for _, req := range initial {
 		if seenIDs[req.ID] != 1 {
 			t.Fatalf("initial request %q: hook fired %d times, want 1", req.ID, seenIDs[req.ID])
+		}
+	}
+}
+
+// TestINV13_ArrivalHookRunReplayParity asserts the central INV-13 claim of
+// issue #1440: trace records captured via the arrival hook on a run, when
+// exported and replayed through a fresh ClusterSimulator with the same
+// config, produce identical per-request TTFT and E2E metrics. This closes
+// the gap noted in the round-3 review — previously only record count +
+// ArrivalTimeUs monotonicity were checked, not the full run→replay loop
+// for the hook-driven path.
+func TestINV13_ArrivalHookRunReplayParity(t *testing.T) {
+	const fixedSeed int64 = 1234
+	initial := newTestRequests(20)
+
+	cfg := newTestDeploymentConfig(1)
+	cfg.Seed = fixedSeed
+
+	// WHEN: direct run captures records via the arrival hook (the new path).
+	csRun := NewClusterSimulator(cfg, NewSliceRequestSource(initial), nil)
+	var traceArrivals []*sim.Request
+	csRun.SetArrivalHook(func(req *sim.Request) {
+		traceArrivals = append(traceArrivals, req)
+	})
+	mustRun(t, csRun)
+	runTTFTs := csRun.AggregatedMetrics().RequestTTFTs
+	runE2Es := csRun.AggregatedMetrics().RequestE2Es
+
+	if len(runTTFTs) == 0 {
+		t.Fatal("INV-13: direct run produced no completed requests — cannot verify parity")
+	}
+	if len(traceArrivals) != len(initial) {
+		t.Fatalf("hook captured %d requests, want %d (one per initial)", len(traceArrivals), len(initial))
+	}
+
+	// AND: export the hook-captured trace and reload it as replay would.
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "trace.yaml")
+	dataPath := filepath.Join(dir, "trace.csv")
+	records := workload.RequestsToTraceRecords(traceArrivals)
+	hdr := &workload.TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+	if err := workload.ExportTraceV2(hdr, records, headerPath, dataPath); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+	loaded, err := workload.LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatalf("LoadTraceV2: %v", err)
+	}
+	replayReqs, err := workload.LoadTraceV2Requests(loaded, fixedSeed)
+	if err != nil {
+		t.Fatalf("LoadTraceV2Requests: %v", err)
+	}
+
+	// WHEN: replay the trace through a fresh ClusterSimulator with the same config.
+	csReplay := NewClusterSimulator(cfg, NewSliceRequestSource(replayReqs), nil)
+	mustRun(t, csReplay)
+	replayTTFTs := csReplay.AggregatedMetrics().RequestTTFTs
+	replayE2Es := csReplay.AggregatedMetrics().RequestE2Es
+
+	// THEN: per-request TTFT and E2E are identical (INV-13).
+	if len(runTTFTs) != len(replayTTFTs) {
+		t.Fatalf("INV-13: completed-request count diverged: run=%d replay=%d", len(runTTFTs), len(replayTTFTs))
+	}
+	for id, ttft := range runTTFTs {
+		got, ok := replayTTFTs[id]
+		if !ok {
+			t.Errorf("INV-13: request %q present in run, missing from replay TTFTs", id)
+			continue
+		}
+		if got != ttft {
+			t.Errorf("INV-13: request %q TTFT mismatch: run=%v replay=%v", id, ttft, got)
+		}
+	}
+	for id, e2e := range runE2Es {
+		got, ok := replayE2Es[id]
+		if !ok {
+			t.Errorf("INV-13: request %q present in run, missing from replay E2Es", id)
+			continue
+		}
+		if got != e2e {
+			t.Errorf("INV-13: request %q E2E mismatch: run=%v replay=%v", id, e2e, got)
 		}
 	}
 }

--- a/sim/cluster/arrival_hook_test.go
+++ b/sim/cluster/arrival_hook_test.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// TestArrivalHook_FiresOncePerInitialRequest verifies the hook is invoked
+// exactly once per request supplied through the RequestSource, in arrival
+// order (issue #1440 — trace-export hook contract).
+func TestArrivalHook_FiresOncePerInitialRequest(t *testing.T) {
+	requests := newTestRequests(20)
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(requests), nil)
+
+	seen := make([]*sim.Request, 0, len(requests))
+	cs.SetArrivalHook(func(req *sim.Request) {
+		seen = append(seen, req)
+	})
+	mustRun(t, cs)
+
+	if got, want := len(seen), len(requests); got != want {
+		t.Fatalf("arrival hook fired %d times, want %d (one per request)", got, want)
+	}
+
+	// Hook must observe the SAME pointers the cluster received — the trace
+	// exporter relies on this identity to read final per-request state at
+	// export time.
+	for i, req := range seen {
+		if req != requests[i] {
+			t.Errorf("arrival hook[%d]: got request %q (ptr %p), want %q (ptr %p)",
+				i, req.ID, req, requests[i].ID, requests[i])
+		}
+	}
+
+	// Arrival-order invariant (INV-3): timestamps must be non-decreasing.
+	var prev int64
+	for i, req := range seen {
+		if req.ArrivalTime < prev {
+			t.Fatalf("arrival hook[%d] saw out-of-order ArrivalTime %d (prev=%d)", i, req.ArrivalTime, prev)
+		}
+		prev = req.ArrivalTime
+	}
+}
+
+// TestArrivalHook_NoDuplicateFiresForRedirectedRequests verifies that
+// REDIRECT re-injections (drain policy) do NOT fire the hook a second
+// time — a redirected request is the same logical request already
+// recorded on its original arrival.
+func TestArrivalHook_NoDuplicateFiresForRedirectedRequests(t *testing.T) {
+	requests := newTestRequests(5)
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(requests), nil)
+
+	calls := 0
+	cs.SetArrivalHook(func(req *sim.Request) {
+		calls++
+	})
+
+	// Simulate a REDIRECT re-injection by pushing the same logical
+	// request a second time with Redirected=true. The hook must NOT fire.
+	cs.fireArrivalHook(requests[0], requests[0].ArrivalTime)
+	if calls != 1 {
+		t.Fatalf("after one fresh fireArrivalHook, want calls=1, got %d", calls)
+	}
+	redirected := *requests[0]
+	redirected.Redirected = true
+	cs.fireArrivalHook(&redirected, requests[0].ArrivalTime)
+	if calls != 1 {
+		t.Fatalf("hook must not fire for redirected request, got calls=%d", calls)
+	}
+}
+
+// TestArrivalHook_DisabledWhenNotSet verifies zero overhead path (BC-1):
+// when no hook is installed, fireArrivalHook is a no-op and the cluster
+// completes normally.
+func TestArrivalHook_DisabledWhenNotSet(t *testing.T) {
+	requests := newTestRequests(10)
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(requests), nil)
+	mustRun(t, cs) // no hook installed; should not panic, should not record anything
+}
+
+// TestArrivalHook_PanicsOnNonMonotonicArrival verifies the INV-3/INV-6
+// guard: if the cluster ever fires the hook with a timestamp behind the
+// previous one, we fail loudly rather than silently sort. The hook is
+// the sole trace-emission point, so order regressions would corrupt the
+// downstream parity contract.
+func TestArrivalHook_PanicsOnNonMonotonicArrival(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on non-monotonic arrival, got none")
+		}
+	}()
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
+	cs.SetArrivalHook(func(req *sim.Request) {})
+
+	req1 := &sim.Request{ID: "r1", ArrivalTime: 100}
+	req2 := &sim.Request{ID: "r2", ArrivalTime: 50} // earlier than req1
+	cs.fireArrivalHook(req1, req1.ArrivalTime)
+	cs.fireArrivalHook(req2, req2.ArrivalTime) // expected: panic
+}
+
+// TestSetArrivalHook_AfterRun_Panics verifies the hook cannot be installed
+// after Run() has executed (avoids silent contract violations where a
+// trace exporter is wired up post-hoc and sees zero records).
+func TestSetArrivalHook_AfterRun_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when SetArrivalHook is called after Run")
+		}
+	}()
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(nil), nil)
+	mustRun(t, cs)
+	cs.SetArrivalHook(func(req *sim.Request) {})
+}
+
+// TestArrivalHook_FiresForSessionFollowUps verifies that requests injected
+// via the onRequestDone callback (closed-loop session follow-ups) reach
+// the hook through the same path as initial arrivals. This is the
+// contract the trace exporter depends on: every request — initial or
+// follow-up — emits a single arrival-hook event.
+func TestArrivalHook_FiresForSessionFollowUps(t *testing.T) {
+	initial := newTestRequests(3)
+
+	// onRequestDone emits one follow-up for each terminal completion, up
+	// to a small budget — small enough not to slow the test, large enough
+	// to exercise the follow-up code path. ArrivalTime is monotonically
+	// later than the completion clock so the INV-3 guard inside the hook
+	// stays happy.
+	remaining := 3
+	onRequestDone := func(req *sim.Request, clock int64) []*sim.Request {
+		if remaining == 0 {
+			return nil
+		}
+		remaining--
+		return []*sim.Request{{
+			ID:           req.ID + "-followup",
+			ArrivalTime:  clock,
+			InputTokens:  []int{1, 2, 3},
+			OutputTokens: []int{4, 5},
+			Model:        req.Model,
+		}}
+	}
+
+	cs := NewClusterSimulator(newTestDeploymentConfig(1), NewSliceRequestSource(initial), onRequestDone)
+
+	calls := 0
+	cs.SetArrivalHook(func(req *sim.Request) {
+		calls++
+	})
+	mustRun(t, cs)
+
+	wantMin := len(initial)                                                 // every initial fires
+	wantMax := len(initial) + 3                                              // plus the follow-up budget
+	if calls < wantMin || calls > wantMax {
+		t.Fatalf("arrival hook fired %d times, want in [%d, %d]: initial=%d, follow-up budget=3",
+			calls, wantMin, wantMax, len(initial))
+	}
+}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -124,8 +124,9 @@ type ClusterSimulator struct {
 
 	// arrivalHook fires once per fresh arrival (initial workload and
 	// follow-ups from closed-loop sessions). It does NOT fire for requests
-	// re-injected by the REDIRECT drain policy — those are the same logical
-	// request already observed. Nil unless SetArrivalHook was called.
+	// re-injected by the REDIRECT drain policy — whether or not a prior
+	// ClusterArrivalEvent fired, emitting here would duplicate or create
+	// a spurious record. Nil unless SetArrivalHook was called.
 	//
 	// Contract:
 	//   - Fires at most once per (logical) request.

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -640,8 +640,11 @@ func (cs *ClusterSimulator) pushArrival(req *sim.Request, timeUs int64) {
 // traverse at their effective arrival time. Firing here — rather than at
 // pushArrival — gives the hook a clock-monotonic stream (INV-3), so trace
 // records emerge already in arrival order without a downstream sort.
-// REDIRECT re-injections are skipped: the same logical request was observed
-// on its original arrival, and its trace identity must not duplicate.
+// REDIRECT re-injections are skipped: req.Redirected=true marks requests
+// the drain policy is rerouting internally. Whether or not a prior
+// ClusterArrivalEvent fired for this request, emitting a trace record
+// here would either duplicate an existing record or create a spurious
+// one for internally-rerouted work.
 //
 // Horizon semantics: ClusterArrivalEvents whose timestamp exceeds
 // config.Horizon never execute (cluster.go event loop short-circuits past

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -642,6 +642,13 @@ func (cs *ClusterSimulator) pushArrival(req *sim.Request, timeUs int64) {
 // records emerge already in arrival order without a downstream sort.
 // REDIRECT re-injections are skipped: the same logical request was observed
 // on its original arrival, and its trace identity must not duplicate.
+//
+// Horizon semantics: ClusterArrivalEvents whose timestamp exceeds
+// config.Horizon never execute (cluster.go event loop short-circuits past
+// Horizon), so the hook does NOT see beyond-horizon follow-ups. This is
+// intentional — a request that never arrived to the cluster has no place
+// in the exported trace, and excluding it strengthens INV-13 (replay reads
+// the same trace the run produced).
 func (cs *ClusterSimulator) fireArrivalHook(req *sim.Request, timeUs int64) {
 	if cs.arrivalHook == nil || req.Redirected {
 		return
@@ -658,7 +665,9 @@ func (cs *ClusterSimulator) fireArrivalHook(req *sim.Request, timeUs int64) {
 // (initial workload + closed-loop session follow-ups). The hook does NOT
 // fire for requests re-injected by the REDIRECT drain policy.
 //
-// Must be called before Run(); panics otherwise. Pass nil to clear.
+// Must be called before Run(); panics otherwise. Pass nil to clear; the
+// monotonicity guard (lastArrivalHookTime) is reset to zero on clear so
+// a subsequently installed hook starts from a clean baseline.
 //
 // Used by `blis run` to capture TraceV2 records at the arrival boundary
 // (issue #1440), replacing the eager post-run RequestsToTraceRecords pass.
@@ -667,6 +676,11 @@ func (cs *ClusterSimulator) SetArrivalHook(hook func(*sim.Request)) {
 		panic("ClusterSimulator: SetArrivalHook must be called before Run()")
 	}
 	cs.arrivalHook = hook
+	if hook == nil {
+		// Reset the monotonicity floor so a future hook installation does
+		// not inherit the previous hook's timestamp watermark.
+		cs.lastArrivalHookTime = 0
+	}
 }
 
 // Run executes the cluster simulation using online routing pipeline: drains the

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -137,8 +137,8 @@ type ClusterSimulator struct {
 	//     must not mutate the request — it is shared with the cluster pipeline.
 	//
 	// Determinism (INV-6): the hook sees requests in the same monotonic
-	// non-decreasing ArrivalTime order the cluster enqueues them. Run() panics
-	// on a regression.
+	// non-decreasing ArrivalTime order the cluster enqueues them.
+	// fireArrivalHook() panics on a regression.
 	arrivalHook         func(*sim.Request)
 	lastArrivalHookTime int64 // monotonicity guard for arrivalHook (us)
 }

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -121,6 +121,25 @@ type ClusterSimulator struct {
 	progressHook               sim.ProgressHook
 	simClockProgressIntervalUs int64
 	nextSnapshotClockUs        int64
+
+	// arrivalHook fires once per fresh arrival (initial workload and
+	// follow-ups from closed-loop sessions). It does NOT fire for requests
+	// re-injected by the REDIRECT drain policy — those are the same logical
+	// request already observed. Nil unless SetArrivalHook was called.
+	//
+	// Contract:
+	//   - Fires at most once per (logical) request.
+	//   - Called from pushArrival on the cluster's single Run() goroutine
+	//     (no concurrency).
+	//   - Must be cheap (recording-only). Heavy work belongs in Run finalization.
+	//   - Receives the *sim.Request pointer the cluster will inject. The hook
+	//     must not mutate the request — it is shared with the cluster pipeline.
+	//
+	// Determinism (INV-6): the hook sees requests in the same monotonic
+	// non-decreasing ArrivalTime order the cluster enqueues them. Run() panics
+	// on a regression.
+	arrivalHook         func(*sim.Request)
+	lastArrivalHookTime int64 // monotonicity guard for arrivalHook (us)
 }
 
 // effectiveAnalyzerConfig applies WVA reference defaults to zero-valued fields.
@@ -613,6 +632,40 @@ func (cs *ClusterSimulator) pushArrival(req *sim.Request, timeUs int64) {
 		seqID: cs.nextSeqID(),
 	})
 	cs.pendingArrivals++
+}
+
+// fireArrivalHook is called from ClusterArrivalEvent.Execute on the single
+// path that all fresh arrivals (initial workload and closed-loop follow-ups)
+// traverse at their effective arrival time. Firing here — rather than at
+// pushArrival — gives the hook a clock-monotonic stream (INV-3), so trace
+// records emerge already in arrival order without a downstream sort.
+// REDIRECT re-injections are skipped: the same logical request was observed
+// on its original arrival, and its trace identity must not duplicate.
+func (cs *ClusterSimulator) fireArrivalHook(req *sim.Request, timeUs int64) {
+	if cs.arrivalHook == nil || req.Redirected {
+		return
+	}
+	if timeUs < cs.lastArrivalHookTime {
+		panic(fmt.Sprintf("ClusterSimulator: arrival hook received out-of-order request %q (timeUs=%d < last=%d) — INV-3/INV-6 violation: arrivals must be non-decreasing in ArrivalTime",
+			req.ID, timeUs, cs.lastArrivalHookTime))
+	}
+	cs.lastArrivalHookTime = timeUs
+	cs.arrivalHook(req)
+}
+
+// SetArrivalHook installs a callback fired once per fresh request arrival
+// (initial workload + closed-loop session follow-ups). The hook does NOT
+// fire for requests re-injected by the REDIRECT drain policy.
+//
+// Must be called before Run(); panics otherwise. Pass nil to clear.
+//
+// Used by `blis run` to capture TraceV2 records at the arrival boundary
+// (issue #1440), replacing the eager post-run RequestsToTraceRecords pass.
+func (cs *ClusterSimulator) SetArrivalHook(hook func(*sim.Request)) {
+	if cs.hasRun {
+		panic("ClusterSimulator: SetArrivalHook must be called before Run()")
+	}
+	cs.arrivalHook = hook
 }
 
 // Run executes the cluster simulation using online routing pipeline: drains the

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -129,8 +129,9 @@ type ClusterSimulator struct {
 	//
 	// Contract:
 	//   - Fires at most once per (logical) request.
-	//   - Called from pushArrival on the cluster's single Run() goroutine
-	//     (no concurrency).
+	//   - Called from ClusterArrivalEvent.Execute on the cluster's single
+	//     Run() goroutine (no concurrency). Firing at execute time — not
+	//     push time — is what makes the hook clock-monotonic per INV-3.
 	//   - Must be cheap (recording-only). Heavy work belongs in Run finalization.
 	//   - Receives the *sim.Request pointer the cluster will inject. The hook
 	//     must not mutate the request — it is shared with the cluster pipeline.

--- a/sim/cluster/cluster_event.go
+++ b/sim/cluster/cluster_event.go
@@ -132,6 +132,10 @@ func (e *ClusterArrivalEvent) Execute(cs *ClusterSimulator) {
 	cs.pendingArrivals--
 	cs.injectedByClass[e.request.SLOClass]++
 	logrus.Debugf("[cluster] req %s arrived at tick %d", e.request.ID, e.time)
+	// Fire the arrival hook (issue #1440): trace exporters see each fresh
+	// arrival exactly once, in clock-monotonic order (INV-3). REDIRECT
+	// re-injections are filtered inside fireArrivalHook.
+	cs.fireArrivalHook(e.request, e.time)
 	heap.Push(&cs.clusterEvents, clusterEventEntry{
 		event: &AdmissionDecisionEvent{
 			time:    e.time + cs.admissionLatency,

--- a/sim/cluster/instance_lifecycle_test.go
+++ b/sim/cluster/instance_lifecycle_test.go
@@ -151,6 +151,19 @@ func TestInstanceLifecycle_RedirectDrainPreservesConservation(t *testing.T) {
 	cs := NewClusterSimulator(cfg, NewSliceRequestSource([]*sim.Request{}), nil)
 	inst0 := cs.instances[0]
 
+	// Issue #1440 integration check: install an arrival hook and assert
+	// REDIRECT re-injections do NOT fire it. Seeded requests bypass
+	// admission/routing (no original ClusterArrivalEvent), so the only
+	// way the hook could fire is from the redirect path — which is
+	// suppressed by the req.Redirected flag set in
+	// infra_lifecycle_event.go. A non-zero count would indicate a
+	// regression in REDIRECT marking that would corrupt trace identity
+	// (the same logical request would emit two trace records).
+	hookCalls := 0
+	cs.SetArrivalHook(func(req *sim.Request) {
+		hookCalls++
+	})
+
 	// Seed requests directly into inst0's WaitQ (bypassing admission/routing),
 	// mirroring what RoutingDecisionEvent does, so they are present at drain time.
 	// EnqueueRequest puts the request in WaitQ immediately (unlike InjectArrivalAt
@@ -195,6 +208,14 @@ func TestInstanceLifecycle_RedirectDrainPreservesConservation(t *testing.T) {
 	}
 	if m.CompletedRequests != injected {
 		t.Errorf("expected all %d redirected requests to complete, got %d", injected, m.CompletedRequests)
+	}
+
+	// Issue #1440: REDIRECT re-injections must not fire the arrival hook.
+	// These requests bypassed the original arrival event (seeded directly
+	// into WaitQ), so the only candidate fire site is the redirect path —
+	// which is suppressed by req.Redirected. Zero is the expected count.
+	if hookCalls != 0 {
+		t.Errorf("arrival hook fired %d times for REDIRECT re-injections, want 0 (issue #1440: redirected requests must not duplicate trace records)", hookCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `ClusterSimulator.SetArrivalHook(func(*sim.Request))`, fired exactly once per fresh arrival from `ClusterArrivalEvent.Execute` so trace records emerge in clock-monotonic order (INV-3).
- Replaces the eager `preGeneratedRequests + followUpRequests` append+sort+`RequestsToTraceRecords` block in `cmd/root.go` with a hook-driven buffer that captures `*sim.Request` pointers at the cluster's single arrival boundary.
- `REDIRECT` re-injections are filtered inside the hook so a request never emits two trace records; a non-monotonic timestamp regression panics rather than silently sorting (INV-6 guard).

## Issue

Closes #1440 (Tracker: #1438 · Change A — PR 2 of 4 · depends on A1).

## Why this PR

The hook must work in **both eager and lazy generation modes**. A3 (the next PR in this series) introduces lazy generation as an alpha behind `--lazy-generation` (default false); when the flag is on there is no finished list to iterate. The arrival hook lives at the cluster's single `ClusterArrivalEvent.Execute` boundary, which is independent of how requests are sourced (eager `SliceRequestSource` today, a streaming generator tomorrow) — so it is the only emission point that works uniformly across both modes.

Today the trace exporter also relies on the same eager list feeding both the cluster and the trace, which is what makes INV-13 (run/replay parity) "structural by construction." Under lazy mode that goes away; capturing trace records at the arrival hook (the same boundary the cluster sees) keeps the invariant test-enforced rather than implicit.

This PR is behavior-preserving — the on-disk TraceV2 format does not change, the eager generator from `main` still runs, and the memory win still doesn't land here. The memory win lands in A3.

## Cross-Path Parity

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | yes | yes | Hook installed in `cmd/root.go` when `--trace-output` is set; eager list dropped from the trace path. Mode-agnostic: ready for A3's `--lazy-generation`. |
| `blis replay` | no | n/a | Reads requests from disk; no generator-side trace assembly to migrate. |
| `blis observe` | no | n/a | Already streaming-shaped; separate migration per issue notes. |

## Invariants Preserved

- **INV-3 (Clock monotonicity)**: Hook fires from `ClusterArrivalEvent.Execute`, which runs in cluster-clock order. A regression panics in `fireArrivalHook` (loud failure per issue guidance).
- **INV-6 (Determinism)**: Trace YAML+CSV are byte-identical to `main` at d059008 for chatbot and code-gen workloads under `--seed 1234` (verified locally; see Test plan).
- **INV-13 (Run/replay parity)**: A trace produced by the hook replays cleanly through `blis replay` — verified locally on the chatbot trace.

## Behavioral change documented

Beyond-horizon closed-loop follow-ups (scheduled at `clock + think_time` past `config.Horizon`) are now **excluded** from the exported trace. The old eager path emitted records for these requests even though they never executed; the hook fires only when `ClusterArrivalEvent.Execute` runs, which the event loop short-circuits past Horizon. This strengthens INV-13 (replay sees the same arrivals the run executed) and is covered by `TestArrivalHook_BeyondHorizonFollowUpsExcluded`.

## Out of scope

- Streaming generator + `--lazy-generation` flag (A3).
- Removing `preGeneratedRequests` from the cluster (stays until A3).
- `cmd/observe.go` migration (separate PR).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Per-arrival hook unit tests (`sim/cluster/arrival_hook_test.go`): fires exactly once per initial request; preserves pointer identity; non-decreasing arrival order; **no duplicate fires for REDIRECT re-injections**; disabled when not set (zero overhead); panics on non-monotonic arrival; panics if `SetArrivalHook` called after `Run`; fires for session follow-ups (exact count); beyond-horizon follow-ups excluded; `SetArrivalHook(nil)` resets the monotonicity floor.
- [x] **End-to-end** `cmd/root_test.go` test (`TestRunCmd_TraceOutput_RecordCountMatchesRequests`) runs `runCmd.Run` with `--trace-output` and asserts trace record count + non-decreasing `ArrivalTimeUs`.
- [x] **REDIRECT integration** (`TestInstanceLifecycle_RedirectDrainPreservesConservation`) installs the hook and asserts `hookCalls == 0` through the live drain path.
- [x] **Byte-identical determinism** (`diff` exit 0 on YAML + CSV) for `blis run --seed 1234 --trace-output … --num-requests 50` vs `main` at d059008:
  - default workload
  - `--workload chatbot` (session follow-ups exercised)
- [x] Replay round-trip: `blis replay --trace-header … --trace-data …` succeeds against the hook-produced chatbot trace.

## Files changed

- `sim/cluster/cluster.go` — `arrivalHook`+`lastArrivalHookTime` fields, `SetArrivalHook`, `fireArrivalHook`.
- `sim/cluster/cluster_event.go` — `ClusterArrivalEvent.Execute` fires the hook before scheduling admission.
- `cmd/root.go` — install hook when `--trace-output` is set; trace-export path consumes `traceArrivals` directly; saturation path keeps its own `allRequests` assembly.
- `sim/cluster/arrival_hook_test.go` — new unit tests.
- `sim/cluster/instance_lifecycle_test.go` — REDIRECT-drain test now installs the hook and asserts no duplicate fires.
- `cmd/root_test.go` — new end-to-end record-count test.

---

Generated with [Claude Code](https://claude.ai/claude-code)