### PR TITLE
feat(workload): lazy --lazy-generation streaming source (alpha, #1441)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,17 @@ go build -o blis main.go
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
   --slo-ttft "critical=100ms" --slo-e2e "critical=5s" --report calibration.json
 
+# Run with lazy request generation (alpha, #1441). Streams requests from the
+# workload generator into the cluster instead of pre-generating the full
+# slice — reduces peak memory from O(total_requests) to O(in_flight_requests).
+# Falls back to the eager generator with a one-line warning for:
+#   - workloads with per-window parameters (time-varying)
+#   - concurrency clients (Concurrency > 0)
+#   - reasoning clients with SingleSession=false (multi-session)
+# Supported: single-shot, single-session reasoning, prefix-group sharing,
+# multi-client / cohort workloads. Behavior with the flag off is unchanged.
+./blis run --model qwen/qwen3-14b --lazy-generation
+
 # Convert workload formats
 ./blis convert preset --name chatbot --rate 10 --num-requests 100
 ./blis convert servegen --path data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,11 @@ go build -o blis main.go
 
 # Run with lazy request generation (alpha, #1441). Streams requests from the
 # workload generator into the cluster instead of pre-generating the full
-# slice — reduces peak memory from O(total_requests) to O(in_flight_requests).
+# slice — reduces peak generator memory from O(total_requests) to
+# O(num_clients + max_session_rounds): the heap holds one entry per client,
+# and per-client reasoning state holds at most one session's pending rounds.
+# (Cluster-side memory still scales with in-flight cluster requests, which
+# this PR does not change.)
 # Falls back to the eager generator with a one-line warning for:
 #   - workloads with per-window parameters (time-varying)
 #   - concurrency clients (Concurrency > 0)

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -784,6 +784,12 @@ func init() {
 	replayCmd.Flags().StringVar(&goodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header > workload spec.")
 	replayCmd.Flags().StringVar(&goodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds (e.g. \"critical=50ms,standard=150ms\").")
 	replayCmd.Flags().StringVar(&goodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
+	// --lazy-generation: accepted for CLI symmetry with `blis run` (#1441),
+	// but ignored — replay reads requests from a captured trace and never
+	// invokes the workload generator. The flag binds to a throwaway local
+	// so no global state is mutated. BC-9.
+	var replayLazyGenerationIgnored bool
+	replayCmd.Flags().BoolVar(&replayLazyGenerationIgnored, "lazy-generation", false, "Accepted for symmetry with `blis run` (#1441); has no effect on replay.")
 	rootCmd.AddCommand(replayCmd)
 }
 

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -387,6 +387,26 @@ func TestReplayCmd_TraceOutputFlag_Registered(t *testing.T) {
 	}
 }
 
+// TestReplayCmd_LazyGenerationFlag_AcceptedAsNoOp pins BC-9 of #1441:
+// --lazy-generation is registered on replay for CLI symmetry with
+// `blis run` but has no effect (replay reads requests from a captured
+// trace and never invokes the workload generator).
+func TestReplayCmd_LazyGenerationFlag_AcceptedAsNoOp(t *testing.T) {
+	f := replayCmd.Flags().Lookup("lazy-generation")
+	if f == nil {
+		t.Fatal("replayCmd missing --lazy-generation flag (BC-9, #1441)")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--lazy-generation default = %q, want %q", f.DefValue, "false")
+	}
+	// Flag value must parse without error.
+	if err := replayCmd.Flags().Set("lazy-generation", "true"); err != nil {
+		t.Errorf("flag parse failed: %v", err)
+	}
+	// Reset for other tests.
+	_ = replayCmd.Flags().Set("lazy-generation", "false")
+}
+
 func TestReplayCmd_TraceHeaderFlag_Registered(t *testing.T) {
 	// GIVEN the replay command
 	// WHEN checking for --trace-header flag

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1447,6 +1447,13 @@ var runCmd = &cobra.Command{
 		// (because expansion inside GenerateWorkloadLazy happens AFTER
 		// applyTimeoutToSpec runs), producing the default 300 s deadline
 		// instead of the user-requested value (PR #1453 self-review).
+		//
+		// REMOVING THIS CALL re-introduces that bug silently. The
+		// regression is covered by
+		// TestGenerateWorkloadLazy_InferencePerf_TimeoutAppliedAfterPreExpand
+		// at the library layer; the cmd-level smoke is covered by the
+		// inference-perf byte-identity check verified during PR review.
+		//
 		// ExpandClientsAndCohorts is idempotent — the generators'
 		// validateAndExpandSpec runs it again with no effect since both
 		// branches guard on len(spec.Clients) == 0. (#1441)
@@ -1899,6 +1906,13 @@ var runCmd = &cobra.Command{
 				// clock-monotonic order — no separate followUpRequests merge
 				// or post-sort required (the cluster delivers them in arrival
 				// order via the hook).
+				//
+				// SAFETY: allRequests aliases the same backing array as
+				// traceArrivals. Both downstream consumers (trace export
+				// below + saturation analysis) MUST be read-only of this
+				// slice — neither appends, reorders, nor mutates element
+				// contents. If a future consumer needs to mutate, copy
+				// first: `allRequests = append([]*sim.Request(nil), traceArrivals...)`.
 				allRequests = traceArrivals
 			} else {
 				allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1439,6 +1439,20 @@ var runCmd = &cobra.Command{
 		if requestTimeoutSecs == 0 {
 			logrus.Fatalf("--timeout must be positive (seconds) or negative to disable; got 0")
 		}
+		// Pre-expand inference-perf / ServeGen specs so the timeout-
+		// application step below sees every client — including those
+		// populated by expansion. Without this, --lazy-generation +
+		// --workload-spec=inference_perf.yaml + an explicit --timeout
+		// would build streaming states from clients whose Timeout is nil
+		// (because expansion inside GenerateWorkloadLazy happens AFTER
+		// applyTimeoutToSpec runs), producing the default 300 s deadline
+		// instead of the user-requested value (PR #1453 self-review).
+		// ExpandClientsAndCohorts is idempotent — the generators'
+		// validateAndExpandSpec runs it again with no effect since both
+		// branches guard on len(spec.Clients) == 0. (#1441)
+		if err := workload.ExpandClientsAndCohorts(spec); err != nil {
+			logrus.Fatalf("Failed to expand workload spec: %v", err)
+		}
 		if workloadSpecPath == "" || cmd.Flags().Changed("timeout") {
 			applyTimeoutToSpec(spec, requestTimeoutSecs)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -127,6 +128,7 @@ var (
 
 	// Workload spec config (PR10)
 	workloadSpecPath string // Path to YAML workload specification file
+	lazyGeneration   bool   // --lazy-generation: stream requests from generator (alpha, #1441)
 
 	// Tiered KV cache config (PR12)
 	kvCPUBlocks             int64
@@ -1452,13 +1454,41 @@ var runCmd = &cobra.Command{
 			logrus.Fatalf("Workload requires either num_requests or --horizon to bound generation")
 		}
 
-		wl, err := workload.GenerateWorkload(spec, simulationHorizon, maxRequests)
-		if err != nil {
-			logrus.Fatalf("Failed to generate workload: %v", err)
+		// Lazy generation path (#1441, alpha). Default off. When set, build
+		// a streaming workload source instead of materializing the full
+		// request slice. Falls back to eager (with a warning) for specs
+		// the streaming source cannot handle yet (time-varying parameters,
+		// concurrency clients, multi-session reasoning).
+		var wl *workload.GeneratedWorkload
+		var lazyRequestSource interface{ Next() (*sim.Request, bool) }
+		if lazyGeneration {
+			src, sessions, followUpBudget, lazyErr := workload.GenerateWorkloadLazy(spec, simulationHorizon, maxRequests)
+			switch {
+			case errors.Is(lazyErr, workload.ErrLazyUnsupportedTimeVarying):
+				logrus.Warnf("[workload] --lazy-generation ignored: workload has per-window parameters; using eager generator (issue #1441)")
+			case errors.Is(lazyErr, workload.ErrLazyUnsupportedConcurrency):
+				logrus.Warnf("[workload] --lazy-generation ignored: workload has concurrency clients; using eager generator (issue #1441)")
+			case errors.Is(lazyErr, workload.ErrLazyUnsupportedMultiSession):
+				logrus.Warnf("[workload] --lazy-generation ignored: workload has multi-session reasoning (SingleSession=false); using eager generator (issue #1441)")
+			case lazyErr != nil:
+				logrus.Fatalf("Failed to build lazy workload: %v", lazyErr)
+			default:
+				lazyRequestSource = src
+				wl = &workload.GeneratedWorkload{Sessions: sessions, FollowUpBudget: followUpBudget}
+			}
+		}
+		if wl == nil {
+			var err error
+			wl, err = workload.GenerateWorkload(spec, simulationHorizon, maxRequests)
+			if err != nil {
+				logrus.Fatalf("Failed to generate workload: %v", err)
+			}
 		}
 		// Re-apply timeout to generated requests and session blueprints.
 		// For inference_perf specs, spec.Clients was empty at applyTimeoutToSpec time
 		// and populated inside GenerateWorkload — deadlines need correction here.
+		// In lazy mode wl.Requests is nil (no-op for the request loop); session
+		// blueprint Timeout pointers still need refresh.
 		if workloadSpecPath == "" || cmd.Flags().Changed("timeout") {
 			applyTimeoutToRequests(wl, requestTimeoutSecs)
 		}
@@ -1468,7 +1498,13 @@ var runCmd = &cobra.Command{
 			if wl.FollowUpBudget >= 0 {
 				sessionMgr.SetFollowUpBudget(wl.FollowUpBudget)
 			}
-			logrus.Infof("Generated %d requests + %d session blueprints (closed-loop)", len(wl.Requests), len(wl.Sessions))
+			if lazyRequestSource != nil {
+				logrus.Infof("Generated streaming source + %d session blueprints (closed-loop, lazy)", len(wl.Sessions))
+			} else {
+				logrus.Infof("Generated %d requests + %d session blueprints (closed-loop)", len(wl.Requests), len(wl.Sessions))
+			}
+		} else if lazyRequestSource != nil {
+			logrus.Infof("Generated streaming workload source (lazy, #1441)")
 		} else {
 			logrus.Infof("Generated %d requests via unified workload pipeline", len(wl.Requests))
 		}
@@ -1770,7 +1806,16 @@ var runCmd = &cobra.Command{
 				return followUps
 			}
 		}
-		cs := cluster.NewClusterSimulator(config, cluster.NewSliceRequestSource(preGeneratedRequests), onRequestDone)
+		// RequestSource: streaming in lazy mode, eager-slice otherwise.
+		// The workload package's lazy source satisfies cluster.RequestSource
+		// via structural typing — both define the same Next() method.
+		var clusterRequestSource cluster.RequestSource
+		if lazyRequestSource != nil {
+			clusterRequestSource = lazyRequestSource
+		} else {
+			clusterRequestSource = cluster.NewSliceRequestSource(preGeneratedRequests)
+		}
+		cs := cluster.NewClusterSimulator(config, clusterRequestSource, onRequestDone)
 
 		// Arrival hook: capture trace-emission references at the cluster's
 		// single arrival boundary so the trace exporter no longer relies on
@@ -1790,8 +1835,15 @@ var runCmd = &cobra.Command{
 		// A nil traceArrivals at the export site below with traceOutput
 		// non-empty means the install branch was dropped — we fail loudly
 		// rather than write a silent empty trace (R1).
+		// The arrival hook captures fresh-arrival references at the single
+		// cluster boundary. It powers trace export (#1440) and, in lazy mode
+		// where preGeneratedRequests is nil, also feeds saturation analysis.
+		// In eager mode without --trace-output, the hook stays uninstalled
+		// (BC-1 zero overhead) and saturation falls back to the
+		// preGeneratedRequests + followUpRequests path.
 		var traceArrivals []*sim.Request
-		if traceOutput != "" {
+		arrivalHookNeeded := traceOutput != "" || (lazyRequestSource != nil && saturationReport != "")
+		if arrivalHookNeeded {
 			traceArrivals = make([]*sim.Request, 0)
 			cs.SetArrivalHook(func(req *sim.Request) {
 				traceArrivals = append(traceArrivals, req)
@@ -1821,15 +1873,28 @@ var runCmd = &cobra.Command{
 		// Trace export is now driven by the arrival hook above and no longer
 		// shares this slice (issue #1440). allRequests is nil when
 		// --saturation-report is not set.
+		//
+		// In lazy mode (#1441), preGeneratedRequests is nil — the arrival hook
+		// captures every fresh arrival in clock-monotonic order (already sorted
+		// by INV-3), so we use traceArrivals directly. In eager mode we keep
+		// the existing append+sort path for backward compatibility.
 		var allRequests []*sim.Request
 		if saturationReport != "" {
-			allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))
-			allRequests = append(allRequests, preGeneratedRequests...)
-			allRequests = append(allRequests, followUpRequests...)
-			// Sort by arrival time so RequestIDs (array indices) are arrival-ordered
-			sort.SliceStable(allRequests, func(i, j int) bool {
-				return allRequests[i].ArrivalTime < allRequests[j].ArrivalTime
-			})
+			if lazyRequestSource != nil {
+				// traceArrivals already contains every fresh arrival in
+				// clock-monotonic order — no separate followUpRequests merge
+				// or post-sort required (the cluster delivers them in arrival
+				// order via the hook).
+				allRequests = traceArrivals
+			} else {
+				allRequests = make([]*sim.Request, 0, len(preGeneratedRequests)+len(followUpRequests))
+				allRequests = append(allRequests, preGeneratedRequests...)
+				allRequests = append(allRequests, followUpRequests...)
+				// Sort by arrival time so RequestIDs (array indices) are arrival-ordered
+				sort.SliceStable(allRequests, func(i, j int) bool {
+					return allRequests[i].ArrivalTime < allRequests[j].ArrivalTime
+				})
+			}
 		}
 
 		// Export trace if requested (BC-1, BC-7). Records are sourced from
@@ -2233,6 +2298,7 @@ func init() {
 	runCmd.Flags().IntVar(&outputTokensMin, "output-tokens-min", defaultOutputMin, "Min Output Token Count")
 	runCmd.Flags().IntVar(&outputTokensMax, "output-tokens-max", defaultOutputMax, "Max Output Token Count")
 	runCmd.Flags().StringVar(&workloadSpecPath, "workload-spec", "", "Path to YAML workload specification file (overrides --workload)")
+	runCmd.Flags().BoolVar(&lazyGeneration, "lazy-generation", false, "Alpha (#1441): stream requests from the workload generator instead of pre-generating the full slice. Default off. Falls back to eager mode (with a warning) for time-varying workloads, concurrency clients, and multi-session reasoning (SingleSession=false).")
 	runCmd.Flags().IntVar(&requestTimeoutSecs, "timeout", 300, "Per-request deadline in seconds (default 300s matches the session-client default in computeDeadline). Negative = disabled; 0 is rejected. Consistent with blis observe: both commands reject 0.")
 	runCmd.Flags().StringVar(&goodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header > workload spec.")
 	runCmd.Flags().StringVar(&goodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds (e.g. \"critical=50ms,standard=150ms\").")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1439,17 +1439,28 @@ var runCmd = &cobra.Command{
 		if requestTimeoutSecs == 0 {
 			logrus.Fatalf("--timeout must be positive (seconds) or negative to disable; got 0")
 		}
-		// Pre-expand inference-perf / ServeGen specs so the timeout-
-		// application step below sees every client — including those
-		// populated by expansion. Without this, --lazy-generation +
+		// Pre-expand inference-perf / ServeGen specs (LAZY MODE ONLY) so
+		// the timeout-application step below sees every client — including
+		// those populated by expansion. Without this, --lazy-generation +
 		// --workload-spec=inference_perf.yaml + an explicit --timeout
 		// would build streaming states from clients whose Timeout is nil
 		// (because expansion inside GenerateWorkloadLazy happens AFTER
 		// applyTimeoutToSpec runs), producing the default 300 s deadline
 		// instead of the user-requested value (PR #1453 self-review).
 		//
-		// REMOVING THIS CALL re-introduces that bug silently. The
-		// regression is covered by
+		// Scoped to `lazyGeneration` so it does not run for eager-only
+		// invocations. Running it unconditionally would clear the
+		// spec.InferencePerf marker before GenerateWorkload's Validate,
+		// which suppresses the mixed-slo_class check via
+		// `s.InferencePerf == nil && s.ServeGenData == nil` in spec.go.
+		// Today all inference-perf-expanded clients carry SLOClass="standard"
+		// (uniform → check can't fire), so eager was accidentally safe.
+		// But scoping here defends against a future ExpandInferencePerfSpec
+		// change that emits mixed/empty slo_class from silently failing
+		// eager runs that previously validated (PR #1453 review round 3).
+		//
+		// REMOVING THIS CALL re-introduces the lazy timeout bug silently.
+		// The regression is covered by
 		// TestGenerateWorkloadLazy_InferencePerf_TimeoutAppliedAfterPreExpand
 		// at the library layer; the cmd-level smoke is covered by the
 		// inference-perf byte-identity check verified during PR review.
@@ -1457,8 +1468,10 @@ var runCmd = &cobra.Command{
 		// ExpandClientsAndCohorts is idempotent — the generators'
 		// validateAndExpandSpec runs it again with no effect since both
 		// branches guard on len(spec.Clients) == 0. (#1441)
-		if err := workload.ExpandClientsAndCohorts(spec); err != nil {
-			logrus.Fatalf("Failed to expand workload spec: %v", err)
+		if lazyGeneration {
+			if err := workload.ExpandClientsAndCohorts(spec); err != nil {
+				logrus.Fatalf("Failed to expand workload spec: %v", err)
+			}
 		}
 		if workloadSpecPath == "" || cmd.Flags().Changed("timeout") {
 			applyTimeoutToSpec(spec, requestTimeoutSecs)
@@ -1481,7 +1494,16 @@ var runCmd = &cobra.Command{
 		// the streaming source cannot handle yet (time-varying parameters,
 		// concurrency clients, multi-session reasoning).
 		var wl *workload.GeneratedWorkload
-		var lazyRequestSource interface{ Next() (*sim.Request, bool) }
+		// lazyRequestSource is typed as the interface satisfied by
+		// *workload.lazyRequestSource: Next() delivers requests to the
+		// cluster; Err() surfaces any terminal sampler/generator error
+		// recorded on a per-client state after the run completes, so
+		// cmd can Fatalf and match the eager path's abort-on-invalid-spec
+		// behavior (PR #1453 review round 3).
+		var lazyRequestSource interface {
+			Next() (*sim.Request, bool)
+			Err() error
+		}
 		if lazyGeneration {
 			src, sessions, followUpBudget, lazyErr := workload.GenerateWorkloadLazy(spec, simulationHorizon, maxRequests)
 			switch {
@@ -1872,6 +1894,17 @@ var runCmd = &cobra.Command{
 		}
 		if err := cs.Run(); err != nil {
 			logrus.Fatalf("Simulation failed: %v", err)
+		}
+
+		// Surface any terminal sampler / generator error the lazy source
+		// recorded on a per-client state during the run. Eager mode would
+		// have hit logrus.Fatalf inside cmd on the same invalid spec;
+		// without this check, lazy mode would exit 0 with reduced traffic
+		// and misleading capacity numbers (PR #1453 review round 3).
+		if lazyRequestSource != nil {
+			if err := lazyRequestSource.Err(); err != nil {
+				logrus.Fatalf("Lazy workload sampler failure: %v", err)
+			}
 		}
 
 		// Wall-clock timing on stderr (BC-6); stdout remains deterministic (BC-7)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1351,3 +1351,222 @@ func buildTestCohort() workload.CohortSpec {
 	return workload.CohortSpec{ID: "cohort-0"}
 }
 
+// runRunCmdAndCaptureTraces invokes runCmd.Run with a distribution-mode
+// workload at the given seed and lazyGeneration flag, capturing both the
+// exported TraceV2 header bytes and data bytes. It restores every package-
+// level CLI variable it touches on return — using the existing helper
+// captured by TestRunCmd_TraceOutput_RecordCountMatchesRequests's pattern.
+//
+// Used by the byte-identity tests below (BC-2 / BC-4 / #1441) to compare
+// eager vs lazy mode output without running the binary subprocess.
+func runRunCmdAndCaptureTraces(t *testing.T, seedVal int64, numReq int, lazyFlag bool) (headerBytes, dataBytes []byte) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	tracePrefix := filepath.Join(tmpDir, "trace")
+	mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+
+	// Save and restore package-level flag vars touched by runCmd.Run.
+	orig := captureCmdLevelVars()
+	defer orig.restore()
+
+	// Set inputs for this run.
+	traceOutput = tracePrefix
+	workloadType = "distribution"
+	rate = 1.0
+	numRequests = numReq
+	seed = seedVal
+	lazyGeneration = lazyFlag
+	promptTokensMean = 64
+	promptTokensStdev = 8
+	promptTokensMin = 2
+	promptTokensMax = 256
+	outputTokensMean = 32
+	outputTokensStdev = 8
+	outputTokensMin = 2
+	outputTokensMax = 256
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	testCmd.Flags().IntVar(&numRequests, "num-requests", 0, "")
+	testCmd.Flags().Float64Var(&rate, "rate", 0, "")
+	testCmd.Flags().StringVar(&workloadType, "workload", "", "")
+	testCmd.Flags().StringVar(&traceOutput, "trace-output", "", "")
+	testCmd.Flags().BoolVar(&lazyGeneration, "lazy-generation", false, "")
+	args := []string{
+		"--model", "qwen/qwen3-14b",
+		"--latency-model", "trained-physics",
+		"--defaults-filepath", defaultsPath,
+		"--model-config-folder", mcFolder,
+		"--hardware-config", hwPath,
+		"--hardware", "H100",
+		"--tp", "1",
+		"--total-kv-blocks", "1000",
+		"--num-requests", strconv.Itoa(numReq),
+		"--seed", strconv.FormatInt(seedVal, 10),
+		"--rate", "1.0",
+		"--workload", "distribution",
+		"--trace-output", tracePrefix,
+	}
+	if lazyFlag {
+		args = append(args, "--lazy-generation=true")
+	}
+	if err := testCmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	runCmd.Run(testCmd, nil)
+
+	hdr, err := os.ReadFile(tracePrefix + ".yaml")
+	if err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	data, err := os.ReadFile(tracePrefix + ".csv")
+	if err != nil {
+		t.Fatalf("read data: %v", err)
+	}
+	return hdr, data
+}
+
+// origCmdLevelVars captures the subset of package-level CLI variables
+// runRunCmdAndCaptureTraces mutates. It mirrors the explicit save/restore
+// dance in TestRunCmd_TraceOutput_RecordCountMatchesRequests but as a
+// helper to keep the lazy-generation tests short.
+type origCmdLevelVars struct {
+	metrics, model, backend, results, policyConfig, traceOut, logLvl, mcFolder, hwCfg, gpuVal string
+	beta, alpha                                                                                []float64
+	totalKV, blockSize, maxRunning, maxSched, simHorizon, snapRefresh, kvCPU, baseLatency      int64
+	threshold, maxModelLen                                                                     int64
+	offload, bandwidth                                                                          float64
+	instances, tp, counterfactualK, numReqs, concurrencyV, thinkTime, prefix                    int
+	rateV                                                                                       float64
+	seedV                                                                                       int64
+	traceLvl, workloadT, admission, routing, sched, workloadSpec                                string
+	promptMean, promptStdev, promptMin, promptMax                                              int
+	outputMean, outputStdev, outputMin, outputMax                                              int
+	requestTimeout                                                                              int
+	lazy                                                                                        bool
+}
+
+func captureCmdLevelVars() origCmdLevelVars {
+	return origCmdLevelVars{
+		metrics: metricsPath, model: model, backend: latencyModelBackend,
+		beta: betaCoeffs, alpha: alphaCoeffs,
+		totalKV: totalKVBlocks, blockSize: blockSizeTokens, maxRunning: maxRunningReqs,
+		maxSched: maxScheduledTokens, instances: numInstances, seedV: seed, results: resultsPath,
+		threshold: longPrefillTokenThreshold, kvCPU: kvCPUBlocks, offload: kvOffloadThreshold,
+		bandwidth: kvTransferBandwidth, baseLatency: kvTransferBaseLatency,
+		snapRefresh: snapshotRefreshInterval, admission: admissionPolicy,
+		routing: routingPolicy, sched: scheduler, policyConfig: policyConfigPath,
+		maxModelLen: maxModelLen, traceLvl: traceLevel, counterfactualK: counterfactualK,
+		simHorizon: simulationHorizon, workloadT: workloadType, rateV: rate,
+		numReqs: numRequests, concurrencyV: concurrency, thinkTime: thinkTimeMs,
+		prefix: prefixTokens, promptMean: promptTokensMean, promptStdev: promptTokensStdev,
+		promptMin: promptTokensMin, promptMax: promptTokensMax,
+		outputMean: outputTokensMean, outputStdev: outputTokensStdev,
+		outputMin: outputTokensMin, outputMax: outputTokensMax,
+		workloadSpec: workloadSpecPath, requestTimeout: requestTimeoutSecs,
+		traceOut: traceOutput, logLvl: logLevel, mcFolder: modelConfigFolder,
+		hwCfg: hwConfigPath, gpuVal: gpu, tp: tensorParallelism,
+		lazy: lazyGeneration,
+	}
+}
+
+func (o origCmdLevelVars) restore() {
+	metricsPath = o.metrics
+	model = o.model
+	latencyModelBackend = o.backend
+	betaCoeffs = o.beta
+	alphaCoeffs = o.alpha
+	totalKVBlocks = o.totalKV
+	blockSizeTokens = o.blockSize
+	maxRunningReqs = o.maxRunning
+	maxScheduledTokens = o.maxSched
+	numInstances = o.instances
+	seed = o.seedV
+	resultsPath = o.results
+	longPrefillTokenThreshold = o.threshold
+	kvCPUBlocks = o.kvCPU
+	kvOffloadThreshold = o.offload
+	kvTransferBandwidth = o.bandwidth
+	kvTransferBaseLatency = o.baseLatency
+	snapshotRefreshInterval = o.snapRefresh
+	admissionPolicy = o.admission
+	routingPolicy = o.routing
+	scheduler = o.sched
+	policyConfigPath = o.policyConfig
+	maxModelLen = o.maxModelLen
+	traceLevel = o.traceLvl
+	counterfactualK = o.counterfactualK
+	simulationHorizon = o.simHorizon
+	workloadType = o.workloadT
+	rate = o.rateV
+	numRequests = o.numReqs
+	concurrency = o.concurrencyV
+	thinkTimeMs = o.thinkTime
+	prefixTokens = o.prefix
+	promptTokensMean = o.promptMean
+	promptTokensStdev = o.promptStdev
+	promptTokensMin = o.promptMin
+	promptTokensMax = o.promptMax
+	outputTokensMean = o.outputMean
+	outputTokensStdev = o.outputStdev
+	outputTokensMin = o.outputMin
+	outputTokensMax = o.outputMax
+	workloadSpecPath = o.workloadSpec
+	requestTimeoutSecs = o.requestTimeout
+	traceOutput = o.traceOut
+	logLevel = o.logLvl
+	modelConfigFolder = o.mcFolder
+	hwConfigPath = o.hwCfg
+	gpu = o.gpuVal
+	tensorParallelism = o.tp
+	lazyGeneration = o.lazy
+}
+
+// TestRunCmd_LazyGeneration_FlagRegistered verifies the --lazy-generation
+// flag is registered on `blis run` and defaults to false. BC-1, #1441.
+func TestRunCmd_LazyGeneration_FlagRegistered(t *testing.T) {
+	flag := runCmd.Flags().Lookup("lazy-generation")
+	if flag == nil {
+		t.Fatal("--lazy-generation flag must be registered on runCmd")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--lazy-generation default = %q, want %q", flag.DefValue, "false")
+	}
+}
+
+// TestRunCmd_LazyVsEager_Distribution_ByteIdentical pins BC-4: under the
+// same seed, model, and workload, `blis run --lazy-generation` produces
+// TraceV2 output (YAML header + CSV data) byte-identical to `blis run`
+// without the flag.
+//
+// NOTE: Do NOT use t.Parallel() — mutates package-level vars.
+func TestRunCmd_LazyVsEager_Distribution_ByteIdentical(t *testing.T) {
+	hdrEager, dataEager := runRunCmdAndCaptureTraces(t, /*seed=*/1234, /*numReq=*/8, /*lazy=*/false)
+	hdrLazy, dataLazy := runRunCmdAndCaptureTraces(t, 1234, 8, true)
+	if !bytes.Equal(hdrEager, hdrLazy) {
+		t.Fatalf("trace header diverged between eager and lazy modes\nEAGER:\n%s\nLAZY:\n%s", hdrEager, hdrLazy)
+	}
+	if !bytes.Equal(dataEager, dataLazy) {
+		t.Fatalf("trace data diverged between eager and lazy modes\nEAGER:\n%s\nLAZY:\n%s", dataEager, dataLazy)
+	}
+	if len(dataEager) == 0 {
+		t.Fatal("trace data is empty; tests must produce non-zero output to be meaningful")
+	}
+}
+
+// TestRunCmd_LazyGeneration_SameSeed_Deterministic pins BC-5 (INV-6):
+// `blis run --lazy-generation --seed S` invoked twice produces
+// byte-identical trace output across the two runs.
+//
+// NOTE: Do NOT use t.Parallel() — mutates package-level vars.
+func TestRunCmd_LazyGeneration_SameSeed_Deterministic(t *testing.T) {
+	hdrA, dataA := runRunCmdAndCaptureTraces(t, /*seed=*/2026, /*numReq=*/6, /*lazy=*/true)
+	hdrB, dataB := runRunCmdAndCaptureTraces(t, 2026, 6, true)
+	if !bytes.Equal(hdrA, hdrB) {
+		t.Fatalf("lazy trace header non-deterministic across runs with seed 2026")
+	}
+	if !bytes.Equal(dataA, dataB) {
+		t.Fatalf("lazy trace data non-deterministic across runs with seed 2026")
+	}
+}
+

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1570,3 +1570,87 @@ func TestRunCmd_LazyGeneration_SameSeed_Deterministic(t *testing.T) {
 	}
 }
 
+// TestRunCmd_LazyGeneration_ConcurrencyFallback_DoesNotFatal pins BC-8 at
+// the CLI seam (PR #1453 self-review minor #5): when --lazy-generation is
+// combined with a workload-spec containing a concurrency client (an
+// unsupported lazy shape), cmd/root.go MUST log a warning and fall back
+// to the eager GenerateWorkload rather than Fatalf-ing. The eager run
+// completes normally and produces a trace file. Regression coverage
+// against accidentally promoting the fallback warning to a fatal error.
+//
+// We use --workload-spec rather than --concurrency for control of the
+// per-flag interactions on the run command; the spec-based path is the
+// closest production path that exercises the concurrency-fallback.
+//
+// NOTE: Do NOT use t.Parallel() — mutates package-level vars.
+func TestRunCmd_LazyGeneration_ConcurrencyFallback_DoesNotFatal(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePrefix := filepath.Join(tmpDir, "trace")
+	mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+
+	// Write a minimal concurrency-mode workload spec.
+	specPath := filepath.Join(tmpDir, "concurrency.yaml")
+	specYAML := `version: "2"
+seed: 7
+category: language
+clients:
+  - id: c1
+    tenant_id: t1
+    slo_class: batch
+    concurrency: 3
+    think_time_us: 100000
+    arrival:
+      process: constant
+    input_distribution:
+      type: constant
+      params: { value: 32 }
+    output_distribution:
+      type: constant
+      params: { value: 16 }
+`
+	if err := os.WriteFile(specPath, []byte(specYAML), 0644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	orig := captureCmdLevelVars()
+	defer orig.restore()
+
+	traceOutput = tracePrefix
+	workloadSpecPath = specPath
+	simulationHorizon = 2_000_000
+	seed = 2031
+	lazyGeneration = true
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	testCmd.Flags().StringVar(&workloadSpecPath, "workload-spec", "", "")
+	testCmd.Flags().StringVar(&traceOutput, "trace-output", "", "")
+	testCmd.Flags().BoolVar(&lazyGeneration, "lazy-generation", false, "")
+	args := []string{
+		"--model", "qwen/qwen3-14b",
+		"--latency-model", "trained-physics",
+		"--defaults-filepath", defaultsPath,
+		"--model-config-folder", mcFolder,
+		"--hardware-config", hwPath,
+		"--hardware", "H100",
+		"--tp", "1",
+		"--total-kv-blocks", "1000",
+		"--seed", strconv.FormatInt(seed, 10),
+		"--workload-spec", specPath,
+		"--horizon", "2000000",
+		"--trace-output", tracePrefix,
+		"--lazy-generation=true",
+	}
+	if err := testCmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	// If the fallback path were promoted to logrus.Fatalf, the test
+	// process would exit here. A normal return = warning + eager fallback
+	// completed without aborting.
+	runCmd.Run(testCmd, nil)
+
+	if _, err := os.Stat(tracePrefix + ".csv"); err != nil {
+		t.Fatalf("expected trace CSV to be written by eager fallback, got: %v", err)
+	}
+}
+

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -676,7 +676,51 @@ func validateAndExpandSpec(spec *WorkloadSpec) error {
 	if len(sourceNames) > 1 {
 		return fmt.Errorf("workload sources {%s} are mutually exclusive; specify exactly one of: clients, servegen_data, inference_perf", strings.Join(sourceNames, ", "))
 	}
-	// Expand inference-perf spec if specified (populates spec.Clients)
+	if err := expandClientsAndCohorts(spec); err != nil {
+		return err
+	}
+	UpgradeV1ToV2(spec)
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("invalid workload spec: %w", err)
+	}
+	return nil
+}
+
+// ExpandClientsAndCohorts performs only the spec-populating expansion
+// step shared by GenerateRequests and GenerateWorkloadLazy: inference-perf
+// expansion into spec.Clients and ServeGen data load into spec.Cohorts.
+//
+// Mutates spec in place. Idempotent: callers may invoke it before the
+// generators run (e.g., cmd/root.go pre-populates spec.Clients so that
+// applyTimeoutToSpec covers every client even when the original spec
+// only set InferencePerf — fixes the --lazy-generation + inference-perf
+// timeout divergence found in PR #1453 review).
+//
+// After expansion, the consumed marker (spec.InferencePerf or
+// spec.ServeGenData) is cleared so the generators' subsequent
+// validateAndExpandSpec call does not flag the (Clients > 0 + marker)
+// state as a mutual-exclusion violation. This is the canonical form:
+// after expansion, the workload is fully expressed through spec.Clients
+// and spec.Cohorts. Note: this clearing means downstream
+// spec.Validate() loses the inference-perf "slo_class skip" marker;
+// callers that need that semantic should not pre-expand.
+//
+// Does NOT run mutual-exclusion checks or spec.Validate(). The
+// generators run those themselves.
+func ExpandClientsAndCohorts(spec *WorkloadSpec) error {
+	if err := expandClientsAndCohorts(spec); err != nil {
+		return err
+	}
+	// Clear consumed markers — see godoc for rationale.
+	spec.InferencePerf = nil
+	spec.ServeGenData = nil
+	return nil
+}
+
+func expandClientsAndCohorts(spec *WorkloadSpec) error {
+	// Expand inference-perf spec if specified (populates spec.Clients).
+	// Idempotent: the len(spec.Clients) == 0 guard prevents re-expansion
+	// if a prior call already ran.
 	if spec.InferencePerf != nil && len(spec.Clients) == 0 {
 		expanded, err := ExpandInferencePerfSpec(spec.InferencePerf, spec.Seed)
 		if err != nil {
@@ -695,15 +739,12 @@ func validateAndExpandSpec(spec *WorkloadSpec) error {
 		}
 		spec.AggregateRate = expanded.AggregateRate
 	}
-	// Load ServeGen data if specified (populates spec.Cohorts)
+	// Load ServeGen data if specified (populates spec.Cohorts).
+	// Idempotent for the same reason as above.
 	if spec.ServeGenData != nil && len(spec.Clients) == 0 && len(spec.Cohorts) == 0 {
 		if err := loadServeGenData(spec); err != nil {
 			return fmt.Errorf("loading ServeGen data: %w", err)
 		}
-	}
-	UpgradeV1ToV2(spec)
-	if err := spec.Validate(); err != nil {
-		return fmt.Errorf("invalid workload spec: %w", err)
 	}
 	return nil
 }

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -22,53 +22,8 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 	if maxRequests < 0 {
 		return nil, fmt.Errorf("maxRequests must be non-negative, got %d", maxRequests)
 	}
-	// Mutual exclusion: at most one primary workload source allowed (R1).
-	// Clients+Cohorts compose (cohorts expand into clients), but
-	// InferencePerf and ServeGenData are exclusive alternatives.
-	var sourceNames []string
-	if len(spec.Clients) > 0 {
-		sourceNames = append(sourceNames, "clients")
-	}
-	if spec.ServeGenData != nil {
-		sourceNames = append(sourceNames, "servegen_data")
-	}
-	if spec.InferencePerf != nil {
-		sourceNames = append(sourceNames, "inference_perf")
-	}
-	if len(sourceNames) > 1 {
-		return nil, fmt.Errorf("workload sources {%s} are mutually exclusive; specify exactly one of: clients, servegen_data, inference_perf", strings.Join(sourceNames, ", "))
-	}
-	// Expand inference-perf spec if specified (populates spec.Clients)
-	if spec.InferencePerf != nil && len(spec.Clients) == 0 {
-		expanded, err := ExpandInferencePerfSpec(spec.InferencePerf, spec.Seed)
-		if err != nil {
-			return nil, fmt.Errorf("expanding inference-perf spec: %w", err)
-		}
-		spec.Clients = expanded.Clients
-		if spec.Category == "" {
-			spec.Category = expanded.Category
-		}
-		// Always use the expanded aggregate rate — per-stage rates define the
-		// ground truth. A user-specified aggregate_rate would silently scale
-		// all per-stage rates by the wrong factor.
-		if spec.AggregateRate > 0 && spec.AggregateRate != expanded.AggregateRate {
-			logrus.Warnf("overriding aggregate_rate %.2f with sum of stage rates %.2f",
-				spec.AggregateRate, expanded.AggregateRate)
-		}
-		spec.AggregateRate = expanded.AggregateRate
-	}
-
-	// Load ServeGen data if specified (populates spec.Cohorts)
-	if spec.ServeGenData != nil && len(spec.Clients) == 0 && len(spec.Cohorts) == 0 {
-		if err := loadServeGenData(spec); err != nil {
-			return nil, fmt.Errorf("loading ServeGen data: %w", err)
-		}
-	}
-
-	UpgradeV1ToV2(spec)
-
-	if err := spec.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid workload spec: %w", err)
+	if err := validateAndExpandSpec(spec); err != nil {
+		return nil, err
 	}
 
 	// Build working client list without mutating spec.Clients (idempotency, INV-6).
@@ -694,6 +649,63 @@ func lastWindowEndUs(lifecycle *LifecycleSpec) int64 {
 // newRandFromSeed creates a new *rand.Rand from a seed (avoids importing math/rand in callers).
 func newRandFromSeed(seed int64) *rand.Rand {
 	return rand.New(rand.NewSource(seed))
+}
+
+// validateAndExpandSpec performs the spec-mutating prelude shared by
+// GenerateRequests and GenerateWorkloadLazy: mutual-exclusion check across
+// primary workload sources, inference-perf expansion, ServeGen data load,
+// v1→v2 upgrade, and final Validate.
+//
+// Mutates spec in place: spec.Clients may be populated by InferencePerf /
+// ServeGen expansion; spec.AggregateRate may be overridden by the
+// inference-perf expanded value.
+func validateAndExpandSpec(spec *WorkloadSpec) error {
+	// Mutual exclusion: at most one primary workload source allowed (R1).
+	// Clients+Cohorts compose (cohorts expand into clients), but
+	// InferencePerf and ServeGenData are exclusive alternatives.
+	var sourceNames []string
+	if len(spec.Clients) > 0 {
+		sourceNames = append(sourceNames, "clients")
+	}
+	if spec.ServeGenData != nil {
+		sourceNames = append(sourceNames, "servegen_data")
+	}
+	if spec.InferencePerf != nil {
+		sourceNames = append(sourceNames, "inference_perf")
+	}
+	if len(sourceNames) > 1 {
+		return fmt.Errorf("workload sources {%s} are mutually exclusive; specify exactly one of: clients, servegen_data, inference_perf", strings.Join(sourceNames, ", "))
+	}
+	// Expand inference-perf spec if specified (populates spec.Clients)
+	if spec.InferencePerf != nil && len(spec.Clients) == 0 {
+		expanded, err := ExpandInferencePerfSpec(spec.InferencePerf, spec.Seed)
+		if err != nil {
+			return fmt.Errorf("expanding inference-perf spec: %w", err)
+		}
+		spec.Clients = expanded.Clients
+		if spec.Category == "" {
+			spec.Category = expanded.Category
+		}
+		// Always use the expanded aggregate rate — per-stage rates define the
+		// ground truth. A user-specified aggregate_rate would silently scale
+		// all per-stage rates by the wrong factor.
+		if spec.AggregateRate > 0 && spec.AggregateRate != expanded.AggregateRate {
+			logrus.Warnf("overriding aggregate_rate %.2f with sum of stage rates %.2f",
+				spec.AggregateRate, expanded.AggregateRate)
+		}
+		spec.AggregateRate = expanded.AggregateRate
+	}
+	// Load ServeGen data if specified (populates spec.Cohorts)
+	if spec.ServeGenData != nil && len(spec.Clients) == 0 && len(spec.Cohorts) == 0 {
+		if err := loadServeGenData(spec); err != nil {
+			return fmt.Errorf("loading ServeGen data: %w", err)
+		}
+	}
+	UpgradeV1ToV2(spec)
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("invalid workload spec: %w", err)
+	}
+	return nil
 }
 
 // DefaultTimeoutUs is the default per-request timeout (300s = 5 minutes).

--- a/sim/workload/stream.go
+++ b/sim/workload/stream.go
@@ -42,13 +42,13 @@ var ErrLazyUnsupportedMultiSession = errors.New("lazy generation: reasoning clie
 // it is the priority-queue tie-break for identical arrival times, and it
 // determines blueprint enumeration order — see GenerateWorkloadLazy).
 type clientStreamState struct {
-	clientIdx       int          // position in original allClients slice
-	client          *ClientSpec  // pointer for field access; never mutated
+	clientIdx       int         // position in original allClients slice
+	client          *ClientSpec // pointer for field access; never mutated
 	arrivalSampler  ArrivalSampler
 	inputSampler    LengthSampler
 	outputSampler   LengthSampler
 	clientRNG       *rand.Rand
-	prefix          []int
+	prefix          []sim.TokenID
 	horizon         int64
 	isReasoning     bool
 	isSingleSession bool
@@ -76,6 +76,23 @@ type clientStreamState struct {
 	// exhausted is sticky — once true, produceNext returns (nil, 0, false)
 	// forever. Matches the cluster's RequestSource exhaustion contract.
 	exhausted bool
+
+	// lastErr captures the terminal error from a failed sampler /
+	// generator call (multimodal token generation, reasoning session
+	// generation). Set alongside `exhausted = true` on the failure
+	// path. Surfaced up via lazyRequestSource.Err() so cmd/root.go
+	// can Fatalf and match the eager path's abort-on-invalid-spec
+	// behavior — instead of silently reducing traffic and exiting 0
+	// with misleading capacity numbers (#1453 self-review round 3).
+	lastErr error
+
+	// dryRun disables user-facing logs on sampler errors — set true by
+	// the blueprint pre-pass in enumerateSurvivingSessionsPerClient so
+	// the same error is not double-logged (once in the pre-pass, once
+	// in Phase 3 streaming). The Phase 3 pass is authoritative for
+	// user feedback; the pre-pass's copy-of-the-state runs the same
+	// samplers and would surface the same error immediately after.
+	dryRun bool
 }
 
 // produceNext returns the next request this client would emit (if any),
@@ -127,7 +144,7 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 		// path exactly, including the RNG-draw order for multimodal vs
 		// standard paths (multimodal: tokens → outputLen → outputTokens;
 		// standard: inputLen → outputLen → input → output).
-		var inputTokens, outputTokens []int
+		var inputTokens, outputTokens []sim.TokenID
 		var textCount, imageCount, audioCount, videoCount int
 		if s.client.Multimodal != nil {
 			var err error
@@ -135,13 +152,12 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 			if err != nil {
 				// spec.Validate() does NOT validate MultimodalSpec distribution
 				// fields, so this path IS reachable for invalid multimodal specs.
-				// R1: don't drop silently — log the failure (with client ID so
-				// the user can locate the bad spec) before exhausting the
-				// stream. Eager mode surfaces this via logrus.Fatalf in cmd;
-				// in lazy library code we log + sticky-exhaust so the
-				// simulation does not silently continue with reduced traffic.
-				logrus.Errorf("[workload] client %q: multimodal token generation failed (exhausting stream): %v", s.client.ID, err)
-				s.exhausted = true
+				// Record the error on the state and sticky-exhaust; the
+				// user-facing log happens on the Phase 3 pass only (skipped
+				// during the blueprint pre-pass to avoid double-logging).
+				// lazyRequestSource.Err() surfaces this to cmd/root.go so it
+				// can Fatalf and match the eager path's abort-on-invalid-spec.
+				s.recordError(fmt.Errorf("multimodal token generation: %w", err))
 				return nil, 0, false
 			}
 			outputLen := s.outputSampler.Sample(s.clientRNG)
@@ -154,7 +170,7 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 		}
 		var prefixLength int
 		if len(s.prefix) > 0 {
-			inputTokens = append(append([]int{}, s.prefix...), inputTokens...)
+			inputTokens = append(append([]sim.TokenID{}, s.prefix...), inputTokens...)
 			prefixLength = len(s.prefix)
 		}
 		req := &sim.Request{
@@ -261,31 +277,26 @@ func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
 			}
 		}
 
-		// Build this session.
+		// Build this session. GenerateReasoningRequests takes the prefix
+		// and seeds it into the shared session buffer / prepends per-round
+		// as needed (#1445); we no longer prepend ourselves.
 		reasoningReqs, err := GenerateReasoningRequests(
 			s.clientRNG, s.client.Reasoning,
 			s.inputSampler, s.outputSampler,
 			startTime,
 			s.client.ID, s.client.TenantID, s.client.SLOClass, s.client.Model,
+			s.prefix,
 		)
 		if err != nil {
 			// spec.Validate() does NOT validate ReasoningSpec's distribution
-			// fields (e.g. ReasonRatioDist), so this path IS reachable. R1:
-			// log the failure with client ID before sticky-exhausting so the
-			// simulation does not silently continue with reduced traffic.
-			// Eager mode surfaces this via logrus.Fatalf in cmd.
-			logrus.Errorf("[workload] client %q: reasoning session generation failed at t=%d (exhausting stream): %v", s.client.ID, startTime, err)
-			s.exhausted = true
+			// fields (e.g. ReasonRatioDist), so this path IS reachable.
+			// Record the error on the state and sticky-exhaust; the
+			// user-facing log happens on the Phase 3 pass only (skipped
+			// during the blueprint pre-pass to avoid double-logging).
+			// lazyRequestSource.Err() surfaces this to cmd/root.go so it
+			// can Fatalf and match the eager path's abort-on-invalid-spec.
+			s.recordError(fmt.Errorf("reasoning session generation at t=%d: %w", startTime, err))
 			return nil, 0, false
-		}
-		// Prepend shared prefix (mirrors the prefix-prepend loop applied
-		// to every reasoningReqs entry in GenerateRequests' reasoning
-		// path, single-session and multi-session branches).
-		if len(s.prefix) > 0 {
-			for _, req := range reasoningReqs {
-				req.InputTokens = append(append([]int{}, s.prefix...), req.InputTokens...)
-				req.PrefixLength = len(s.prefix)
-			}
 		}
 		// Set Deadline + SLOTargetUs on every round (mirrors the
 		// per-round Deadline/SLOTargetUs assignment in GenerateRequests'
@@ -297,6 +308,20 @@ func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
 		s.pendingSession = reasoningReqs
 		s.pendingSessionIdx = 0
 		// Loop back to yield the first round.
+	}
+}
+
+// recordError marks the state as exhausted with a terminal error,
+// logging it at the Errorf level (client-scoped) unless the state is
+// running in dryRun mode — the blueprint pre-pass runs the same
+// samplers as Phase 3 and would double-log the same error otherwise.
+// lazyRequestSource.Err() aggregates these errors across states so
+// cmd/root.go can Fatalf on invalid-spec failures (matching eager).
+func (s *clientStreamState) recordError(err error) {
+	s.exhausted = true
+	s.lastErr = err
+	if !s.dryRun {
+		logrus.Errorf("[workload] client %q: %v (stream exhausted)", s.client.ID, err)
 	}
 }
 
@@ -347,6 +372,31 @@ type lazyRequestSource struct {
 	popped      int64 // total heap pops (counts toward maxRequests cap, including suppressed intermediate closed-loop rounds)
 	yielded     int64 // requests actually returned from Next; used for sequential ID assignment
 	maxRequests int64
+	// states retains a reference to every per-client streaming state
+	// (populated at construction) so Err() can surface a sampler failure
+	// that terminated a state after it stopped being on the heap. Without
+	// this, once a state exhausted its heap entry got dropped and the
+	// error would be unreachable from cmd.
+	states []*clientStreamState
+}
+
+// Err returns the first terminal sampler / generator error recorded on any
+// per-client state after the cluster has finished draining the source
+// (i.e. after cluster.Run returns). Callers MUST invoke Err() post-Run
+// and Fatalf on a non-nil value to match the eager path's
+// abort-on-invalid-spec behavior (issue #1441, PR #1453 review round 3).
+// Returns nil when every state exhausted cleanly.
+//
+// Scan order is per-client-index so the surfaced error is deterministic
+// across runs (any parallel drainers would still see the first client's
+// error first).
+func (l *lazyRequestSource) Err() error {
+	for _, s := range l.states {
+		if s.lastErr != nil {
+			return fmt.Errorf("client %q: %w", s.client.ID, s.lastErr)
+		}
+	}
+	return nil
 }
 
 // Next returns the next request and true, or (nil, false) when exhausted.
@@ -423,7 +473,7 @@ type clientPrep struct {
 	client     *ClientSpec
 	clientSeed int64
 	rate       float64
-	prefix     []int
+	prefix     []sim.TokenID
 }
 
 // GenerateWorkloadLazy mirrors GenerateWorkload's setup but returns a
@@ -555,7 +605,7 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 		// but the value is exactly prefixes[client.PrefixGroup] (eager prepends
 		// it in the same way before populating req.InputTokens). We use it
 		// directly to avoid materializing requests just to read them back.
-		var prefixTokens []int
+		var prefixTokens []sim.TokenID
 		if p.client.PrefixGroup != "" {
 			prefixTokens = prefixes[p.client.PrefixGroup]
 		}
@@ -590,11 +640,13 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 	// emissions to what the pre-pass simulated.
 	h := &heapByArrival{}
 	heap.Init(h)
+	states := make([]*clientStreamState, 0, len(preps))
 	for _, p := range preps {
 		state, err := buildClientStreamState(p, horizon)
 		if err != nil {
 			return nil, nil, 0, err
 		}
+		states = append(states, state)
 		if firstReq, t, ok := state.produceNext(); ok {
 			heap.Push(h, heapEntry{
 				arrivalUs:    t,
@@ -610,7 +662,7 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 	// eager codepath's "totalConcurrencyUsers > 0" condition is always
 	// false — budget stays at -1 (no cap), matching the
 	// `followUpBudget := int64(-1)` initialization in GenerateWorkload.
-	return &lazyRequestSource{h: h, maxRequests: maxRequests}, sessions, int64(-1), nil
+	return &lazyRequestSource{h: h, maxRequests: maxRequests, states: states}, sessions, int64(-1), nil
 }
 
 // buildClientStreamState constructs one client's streaming state. The
@@ -674,11 +726,13 @@ func buildClientStreamState(p clientPrep, horizon int64) (*clientStreamState, er
 // state (one session at a time, MaxRounds entries).
 func enumerateSurvivingSessionsPerClient(
 	preps []clientPrep,
-	prefixes map[string][]int,
+	prefixes map[string][]sim.TokenID,
 	horizon int64,
 	maxRequests int64,
 ) (map[int][]string, error) {
 	// Clone per-client states (fresh RNGs from the same clientSeed).
+	// dryRun=true so sampler-error paths don't user-log twice (the Phase 3
+	// pass runs the same samplers and is authoritative for user feedback).
 	cloneStates := make([]*clientStreamState, 0, len(preps))
 	for _, p := range preps {
 		// Mirror the prefix-binding rule of Phase 3 so the clone consumes
@@ -688,6 +742,7 @@ func enumerateSurvivingSessionsPerClient(
 		if err != nil {
 			return nil, fmt.Errorf("client %q: %w", p.client.ID, err)
 		}
+		state.dryRun = true
 		cloneStates = append(cloneStates, state)
 	}
 	// Build the clone heap with each state's first candidate, matching

--- a/sim/workload/stream.go
+++ b/sim/workload/stream.go
@@ -1,0 +1,642 @@
+package workload
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// ErrLazyUnsupportedTimeVarying signals that lazy generation cannot handle
+// a spec with per-window parameter overrides. The caller (cmd/root.go) is
+// expected to log a warning and fall back to GenerateWorkload. The error
+// path is intentionally a value, not a Fatalf — library code does not
+// terminate the process (R6, #1441).
+var ErrLazyUnsupportedTimeVarying = errors.New("lazy generation: time-varying workloads (per-window parameters) not supported in alpha")
+
+// ErrLazyUnsupportedConcurrency signals fallback for specs containing
+// concurrency clients (Concurrency > 0). Concurrency-driven workloads
+// generate their seed requests through a separate path in GenerateWorkload
+// (concurrencyRNG); lazy mode in this PR's alpha scope does not replicate
+// that path. Caller should fall back to GenerateWorkload.
+var ErrLazyUnsupportedConcurrency = errors.New("lazy generation: concurrency clients not supported in alpha")
+
+// ErrLazyUnsupportedMultiSession signals fallback for specs containing
+// reasoning multi-turn clients with SingleSession=false. In multi-session
+// mode the eager generator interleaves sessions of a single client by
+// arrival time across the merge-sort, and reproducing that interleaving
+// in a single-entry-per-client streaming source would require pushing
+// every session's anchor onto the heap up front — defeating the memory
+// savings. SingleSession=true clients (the inference-perf shape and the
+// issue's reproducer) ARE supported. Caller falls back to GenerateWorkload
+// for multi-session specs.
+var ErrLazyUnsupportedMultiSession = errors.New("lazy generation: reasoning clients with SingleSession=false not supported in alpha")
+
+// clientStreamState holds per-client streaming production state.
+// One per "live" client in the original allClients order (the order matters:
+// it is the priority-queue tie-break for identical arrival times, and it
+// determines blueprint enumeration order — see GenerateWorkloadLazy).
+type clientStreamState struct {
+	clientIdx       int          // position in original allClients slice
+	client          *ClientSpec  // pointer for field access; never mutated
+	arrivalSampler  ArrivalSampler
+	inputSampler    LengthSampler
+	outputSampler   LengthSampler
+	clientRNG       *rand.Rand
+	prefix          []int
+	horizon         int64
+	isReasoning     bool
+	isSingleSession bool
+	isClosedLoop    bool
+
+	// Single-shot mode: monotonic IAT accumulator (matches generator.go:281).
+	currentTime int64
+
+	// Reasoning mode: pendingSession holds one session's pre-computed rounds.
+	// Yielded one at a time via pendingSessionIdx, then drained by drawing the
+	// next IAT and calling GenerateReasoningRequests again.
+	pendingSession    []*sim.Request
+	pendingSessionIdx int
+	// singleSessionDone short-circuits SingleSession=true reasoning clients
+	// after they emit their only session.
+	singleSessionDone bool
+
+	// perClientSeq increments on every successful produceNext yield. Used as
+	// the tertiary heap tie-breaker so that even when two queue entries from
+	// the same client (theoretically impossible) would collide, the heap is
+	// deterministic.
+	perClientSeq int64
+
+	// exhausted is sticky — once true, produceNext returns (nil, 0, false)
+	// forever. Matches the cluster's RequestSource exhaustion contract.
+	exhausted bool
+}
+
+// produceNext returns the next request this client would emit (if any),
+// advancing the client's RNG and perClientSeq. Returns (nil, 0, false)
+// when exhausted.
+//
+// CRITICAL: This method must consume RNG draws in the same order as the
+// eager loop in GenerateRequests for the corresponding client kind.
+// Any reordering breaks INV-6 (byte-identical stdout across modes).
+func (s *clientStreamState) produceNext() (*sim.Request, int64, bool) {
+	if s.exhausted {
+		return nil, 0, false
+	}
+	if s.isReasoning {
+		return s.produceNextReasoning()
+	}
+	return s.produceNextSingleShot()
+}
+
+func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) {
+	for {
+		if s.currentTime >= s.horizon {
+			s.exhausted = true
+			return nil, 0, false
+		}
+		iat := s.arrivalSampler.SampleIAT(s.clientRNG)
+		if iat == 0 {
+			// Stateful sampler exhausted (matches eager generator.go:288).
+			s.exhausted = true
+			return nil, 0, false
+		}
+		s.currentTime += iat
+		if s.currentTime >= s.horizon {
+			s.exhausted = true
+			return nil, 0, false
+		}
+		// Lifecycle window filtering (matches generator.go:299-304).
+		if s.client.Lifecycle != nil && !isInActiveWindow(s.currentTime, s.client.Lifecycle) {
+			if s.currentTime >= lastWindowEndUs(s.client.Lifecycle) {
+				s.exhausted = true
+				return nil, 0, false
+			}
+			continue
+		}
+
+		// Token generation — must match generator.go:306-325 exactly,
+		// including the RNG-draw order for multimodal vs standard paths.
+		var inputTokens, outputTokens []int
+		var textCount, imageCount, audioCount, videoCount int
+		if s.client.Multimodal != nil {
+			var err error
+			inputTokens, textCount, imageCount, audioCount, videoCount, err = GenerateMultimodalTokens(s.clientRNG, s.client.Multimodal)
+			if err != nil {
+				// Multimodal validation runs at GenerateWorkloadLazy time, so this
+				// shouldn't happen for valid specs. Treat as terminal failure rather
+				// than panicking inside library code (R6); the resulting empty
+				// stream surfaces the issue via downstream "no requests" warning.
+				s.exhausted = true
+				return nil, 0, false
+			}
+			outputLen := s.outputSampler.Sample(s.clientRNG)
+			outputTokens = sim.GenerateRandomTokenIDs(s.clientRNG, outputLen)
+		} else {
+			inputLen := s.inputSampler.Sample(s.clientRNG)
+			outputLen := s.outputSampler.Sample(s.clientRNG)
+			inputTokens = sim.GenerateRandomTokenIDs(s.clientRNG, inputLen)
+			outputTokens = sim.GenerateRandomTokenIDs(s.clientRNG, outputLen)
+		}
+		var prefixLength int
+		if len(s.prefix) > 0 {
+			inputTokens = append(append([]int{}, s.prefix...), inputTokens...)
+			prefixLength = len(s.prefix)
+		}
+		req := &sim.Request{
+			ID:               "", // assigned at heap-pop by lazyRequestSource.Next
+			ArrivalTime:      s.currentTime,
+			InputTokens:      inputTokens,
+			OutputTokens:     outputTokens,
+			MaxOutputLen:     len(outputTokens),
+			State:            sim.StateQueued,
+			ScheduledStepIdx: 0,
+			FinishedStepIdx:  0,
+			TenantID:         s.client.TenantID,
+			SLOClass:         s.client.SLOClass,
+			Model:            s.client.Model,
+			TextTokenCount:   textCount,
+			ImageTokenCount:  imageCount,
+			AudioTokenCount:  audioCount,
+			VideoTokenCount:  videoCount,
+			Deadline:         computeDeadline(s.currentTime, s.client.Timeout, isClosedLoop(s.client)),
+			SLOTargetUs:      derefInt64(s.client.SLOTargetUs),
+			ClientID:         s.client.ID,
+			PrefixGroup:      s.client.PrefixGroup,
+			PrefixLength:     prefixLength,
+			Streaming:        s.client.Streaming,
+		}
+		s.perClientSeq++
+		return req, s.currentTime, true
+	}
+}
+
+func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
+	for {
+		// First, drain any pending session rounds. We yield ALL rounds here,
+		// including non-round-0 rounds of closed-loop sessions, so that each
+		// counts toward maxRequests at the lazyRequestSource level — matching
+		// eager mode's "produce all rounds, sort+truncate, then filter round-0"
+		// sequencing in GenerateWorkload. The round-0-only filter for
+		// closed-loop sessions is applied at lazyRequestSource.Next, AFTER
+		// the cap-counting heap pop.
+		for s.pendingSessionIdx < len(s.pendingSession) {
+			req := s.pendingSession[s.pendingSessionIdx]
+			s.pendingSessionIdx++
+			if req.ArrivalTime >= s.horizon {
+				// Rounds are chronological; remaining are past horizon too.
+				// Matches generator.go:264 / generator.go:203 break.
+				s.pendingSession = nil
+				s.pendingSessionIdx = 0
+				break
+			}
+			if s.client.Lifecycle != nil && !isInActiveWindow(req.ArrivalTime, s.client.Lifecycle) {
+				// Skip rounds outside lifecycle windows (matches generator.go:268).
+				continue
+			}
+			s.perClientSeq++
+			return req, req.ArrivalTime, true
+		}
+		// No more pending rounds — release the session slice.
+		s.pendingSession = nil
+		s.pendingSessionIdx = 0
+
+		// Single-session reasoning client: only one session per client.
+		if s.isSingleSession && s.singleSessionDone {
+			s.exhausted = true
+			return nil, 0, false
+		}
+
+		// Draw the next session's start time.
+		iat := s.arrivalSampler.SampleIAT(s.clientRNG)
+		if iat == 0 {
+			s.exhausted = true
+			return nil, 0, false
+		}
+		var startTime int64
+		if s.isSingleSession {
+			startTime = iat
+			if s.client.Lifecycle != nil && len(s.client.Lifecycle.Windows) > 0 {
+				startTime = s.client.Lifecycle.Windows[0].StartUs + iat
+			}
+			s.singleSessionDone = true
+			if startTime >= s.horizon {
+				s.exhausted = true
+				return nil, 0, false
+			}
+			if s.client.Lifecycle != nil && !isInActiveWindow(startTime, s.client.Lifecycle) {
+				s.exhausted = true
+				return nil, 0, false
+			}
+		} else {
+			s.currentTime += iat
+			startTime = s.currentTime
+			if startTime >= s.horizon {
+				s.exhausted = true
+				return nil, 0, false
+			}
+			if s.client.Lifecycle != nil && !isInActiveWindow(startTime, s.client.Lifecycle) {
+				if startTime >= lastWindowEndUs(s.client.Lifecycle) {
+					s.exhausted = true
+					return nil, 0, false
+				}
+				continue // try next IAT (matches generator.go:233-238)
+			}
+		}
+
+		// Build this session.
+		reasoningReqs, err := GenerateReasoningRequests(
+			s.clientRNG, s.client.Reasoning,
+			s.inputSampler, s.outputSampler,
+			startTime,
+			s.client.ID, s.client.TenantID, s.client.SLOClass, s.client.Model,
+		)
+		if err != nil {
+			s.exhausted = true
+			return nil, 0, false
+		}
+		// Prepend shared prefix (matches generator.go:191-196 / 248-254).
+		if len(s.prefix) > 0 {
+			for _, req := range reasoningReqs {
+				req.InputTokens = append(append([]int{}, s.prefix...), req.InputTokens...)
+				req.PrefixLength = len(s.prefix)
+			}
+		}
+		// Set Deadline + SLOTargetUs on every round (matches generator.go:198-201 / 256-259).
+		for _, req := range reasoningReqs {
+			req.Deadline = computeDeadline(req.ArrivalTime, s.client.Timeout, true)
+			req.SLOTargetUs = derefInt64(s.client.SLOTargetUs)
+		}
+		s.pendingSession = reasoningReqs
+		s.pendingSessionIdx = 0
+		// Loop back to yield the first round.
+	}
+}
+
+// heapEntry is one priority-queue entry. The ordering key is
+// (arrivalUs, clientIdx, perClientSeq) — the second component matches
+// sort.SliceStable's tie-break behavior in the eager path (lower
+// allClients index emitted first on identical arrivals), and the third
+// breaks any residual ties deterministically.
+type heapEntry struct {
+	arrivalUs    int64
+	clientIdx    int
+	perClientSeq int64
+	req          *sim.Request
+	state        *clientStreamState
+}
+
+type heapByArrival []heapEntry
+
+func (h heapByArrival) Len() int { return len(h) }
+func (h heapByArrival) Less(i, j int) bool {
+	a, b := h[i], h[j]
+	if a.arrivalUs != b.arrivalUs {
+		return a.arrivalUs < b.arrivalUs
+	}
+	if a.clientIdx != b.clientIdx {
+		return a.clientIdx < b.clientIdx
+	}
+	return a.perClientSeq < b.perClientSeq
+}
+func (h heapByArrival) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *heapByArrival) Push(x interface{}) { *h = append(*h, x.(heapEntry)) }
+func (h *heapByArrival) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+// lazyRequestSource is the streaming RequestSource implementation. It
+// satisfies cluster.RequestSource via structural typing (Go duck-typing);
+// sim/workload does not import sim/cluster. The cluster's Run() loop
+// pulls requests one at a time via Next() until exhausted.
+//
+// Concurrency: not safe for concurrent use. Single-goroutine consumer.
+type lazyRequestSource struct {
+	h           *heapByArrival
+	popped      int64 // total heap pops (counts toward maxRequests cap, including suppressed intermediate closed-loop rounds)
+	yielded     int64 // requests actually returned from Next; used for sequential ID assignment
+	maxRequests int64
+}
+
+// Next returns the next request and true, or (nil, false) when exhausted.
+// Exhaustion is sticky — once the source returns (nil, false) once, it
+// must continue to do so on subsequent calls.
+//
+// Each pop:
+//  1. Pop the lowest-(arrival, clientIdx, perClientSeq) entry.
+//  2. Ask that entry's state to produce its next candidate; if it does,
+//     push the new entry back onto the heap.
+//  3. If the popped request belongs to a closed-loop session AND its
+//     RoundIndex > 0, it is a non-emitted intermediate round (matches
+//     GenerateWorkload's round-0-only filter at generator.go:531-542).
+//     Such rounds DO count toward maxRequests (so the eager/lazy total
+//     budget matches) but are NOT yielded to the cluster — we loop and
+//     pop the next entry instead.
+//  4. Assign req.ID = "request_<emitted>" in pop order, then increment
+//     the emit counter.
+//
+// Stopping conditions: heap empty, or emitted >= maxRequests (when > 0).
+func (l *lazyRequestSource) Next() (*sim.Request, bool) {
+	if l.h == nil {
+		return nil, false
+	}
+	for {
+		if l.maxRequests > 0 && l.popped >= l.maxRequests {
+			return nil, false
+		}
+		if l.h.Len() == 0 {
+			return nil, false
+		}
+		e := heap.Pop(l.h).(heapEntry)
+		// Re-push the state with its next candidate, if any. Always push
+		// regardless of whether THIS entry will be yielded to the cluster
+		// (intermediate closed-loop rounds advance state but don't emit).
+		if nextReq, t, ok := e.state.produceNext(); ok {
+			heap.Push(l.h, heapEntry{
+				arrivalUs:    t,
+				clientIdx:    e.state.clientIdx,
+				perClientSeq: e.state.perClientSeq,
+				req:          nextReq,
+				state:        e.state,
+			})
+		}
+		// Count this pop against the global maxRequests budget regardless
+		// of whether it surfaces to the cluster — this preserves eager/lazy
+		// parity, where GenerateWorkload produces all rounds, truncates to
+		// maxRequests, then filters round-0 for closed-loop sessions.
+		l.popped++
+		// Intermediate closed-loop rounds are suppressed; loop to pop the
+		// next candidate. The cluster only ever sees round-0 of closed-loop
+		// sessions (the SessionManager generates the follow-up rounds).
+		if e.state.isClosedLoop && e.req.RoundIndex != 0 {
+			continue
+		}
+		// Sequential IDs are assigned in yield order, matching
+		// GenerateWorkload's post-filter renumbering at generator.go:619-621.
+		e.req.ID = fmt.Sprintf("request_%d", l.yielded)
+		l.yielded++
+		return e.req, true
+	}
+}
+
+// clientPrep captures the per-client information collected during the
+// construction prelude of GenerateWorkloadLazy. clientSeed is drawn
+// from workloadRNG in allClients order before any client begins
+// producing requests — matching the eager generator (generator.go:119).
+type clientPrep struct {
+	idx        int
+	client     *ClientSpec
+	clientSeed int64
+	rate       float64
+	prefix     []int
+}
+
+// GenerateWorkloadLazy mirrors GenerateWorkload's setup but returns a
+// streaming RequestSource instead of materializing the request slice.
+// Memory consumption while the cluster drains the source is
+// O(num_clients + max_session_rounds), independent of total request count.
+//
+// Returns:
+//   - source: implements cluster.RequestSource via structural typing.
+//   - sessions: deterministic session blueprints for closed-loop clients,
+//     in the same (client-order, sorted-session-IDs) as GenerateWorkload.
+//   - followUpBudget: -1 in lazy mode (concurrency clients force eager fallback).
+//   - err: ErrLazyUnsupported* signals the caller to fall back; other errors
+//     are real spec/validation failures.
+//
+// Determinism: same seed produces the same source byte-identically to
+// GenerateWorkload's request stream (BC-3).
+func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) (
+	*lazyRequestSource, []SessionBlueprint, int64, error) {
+
+	if horizon <= 0 {
+		// Empty workload: return an immediately-exhausted source.
+		return &lazyRequestSource{h: &heapByArrival{}, maxRequests: maxRequests}, nil, -1, nil
+	}
+	if maxRequests < 0 {
+		return nil, nil, 0, fmt.Errorf("maxRequests must be non-negative, got %d", maxRequests)
+	}
+
+	// Shared spec prelude (mutual-exclusion, inference-perf expansion,
+	// servegen load, v1→v2 upgrade, Validate). Mutates spec.Clients in place.
+	if err := validateAndExpandSpec(spec); err != nil {
+		return nil, nil, 0, err
+	}
+
+	// Build working client list (matches generator.go:74-79).
+	allClients := append([]ClientSpec{}, spec.Clients...)
+	if len(spec.Cohorts) > 0 {
+		allClients = append(allClients, ExpandCohorts(spec.Cohorts, spec.Seed)...)
+	}
+
+	// Fallback gates. The caller (cmd/root.go) catches these sentinel errors
+	// and switches to the eager generator with a one-line warning.
+	if hasPerWindowParameters(allClients) {
+		return nil, nil, 0, ErrLazyUnsupportedTimeVarying
+	}
+	for i := range allClients {
+		if allClients[i].Concurrency > 0 {
+			return nil, nil, 0, ErrLazyUnsupportedConcurrency
+		}
+		if allClients[i].Reasoning != nil && allClients[i].Reasoning.MultiTurn != nil &&
+			!allClients[i].Reasoning.MultiTurn.SingleSession {
+			return nil, nil, 0, ErrLazyUnsupportedMultiSession
+		}
+	}
+
+	rng := sim.NewPartitionedRNG(sim.NewSimulationKey(spec.Seed))
+	workloadRNG := rng.ForSubsystem(sim.SubsystemWorkloadGen)
+	clientRates := normalizeRateFractions(allClients, spec.AggregateRate)
+	prefixes := generatePrefixTokens(allClients, workloadRNG)
+
+	// Phase 1: prelude — draw clientSeeds in allClients order, mirroring the
+	// eager loop's draw order (generator.go:114-120). Zero-rate clients are
+	// skipped BEFORE the draw, matching generator.go:114-116.
+	preps := make([]clientPrep, 0, len(allClients))
+	for i := range allClients {
+		if clientRates[i] <= 0 {
+			continue
+		}
+		clientSeed := workloadRNG.Int63()
+		preps = append(preps, clientPrep{
+			idx:        i,
+			client:     &allClients[i],
+			clientSeed: clientSeed,
+			rate:       clientRates[i],
+			prefix:     prefixes[allClients[i].PrefixGroup],
+		})
+	}
+
+	// Phase 2: blueprint pre-pass (closed-loop reasoning clients only).
+	// We replay each closed-loop client's RNG to enumerate session IDs
+	// without retaining any request slices (each session's slice is
+	// generated and discarded). This advances a temporary clientRNG; the
+	// real streaming pass below uses a *fresh* clientRNG seeded from the
+	// same clientSeed, so both passes see identical RNG streams.
+	blueprintRNG := rand.New(rand.NewSource(spec.Seed + 7919))
+	var sessions []SessionBlueprint
+	for _, p := range preps {
+		if !isClosedLoop(p.client) || p.client.Reasoning == nil || p.client.Reasoning.MultiTurn == nil {
+			continue
+		}
+		sessIDs, err := enumerateReasoningSessionIDs(p, horizon)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("client %q: %w", p.client.ID, err)
+		}
+		// Sort session IDs to match GenerateWorkload's deterministic
+		// blueprint-construction order (generator.go:504-508).
+		sort.Strings(sessIDs)
+		// Build samplers once per client (mirrors generator.go:447-455).
+		inputSampler, err := NewLengthSampler(p.client.InputDist)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("client %q input distribution for blueprint: %w", p.client.ID, err)
+		}
+		outputSampler, err := NewLengthSampler(p.client.OutputDist)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("client %q output distribution for blueprint: %w", p.client.ID, err)
+		}
+		// Per-session prefix: GenerateWorkload extracts from req.InputTokens,
+		// but the value is exactly prefixes[client.PrefixGroup] (eager prepends
+		// it in the same way before populating req.InputTokens). We use it
+		// directly to avoid materializing requests just to read them back.
+		var prefixTokens []int
+		if p.client.PrefixGroup != "" {
+			prefixTokens = prefixes[p.client.PrefixGroup]
+		}
+		mt := p.client.Reasoning.MultiTurn
+		for _, sessID := range sessIDs {
+			sessSeed := blueprintRNG.Int63()
+			sessions = append(sessions, SessionBlueprint{
+				SessionID:     sessID,
+				ClientID:      p.client.ID,
+				MaxRounds:     mt.MaxRounds,
+				ContextGrowth: mt.ContextGrowth,
+				ThinkTimeUs:   mt.ThinkTimeUs,
+				Timeout:       p.client.Timeout,
+				Horizon:       horizon,
+				InputSampler:  inputSampler,
+				OutputSampler: outputSampler,
+				RNG:           rand.New(rand.NewSource(sessSeed)),
+				Prefix:        prefixTokens,
+				TenantID:      p.client.TenantID,
+				SLOClass:      p.client.SLOClass,
+				Model:         p.client.Model,
+				SLOTargetUs:   derefInt64(p.client.SLOTargetUs),
+			})
+		}
+	}
+
+	// Phase 3: build the streaming states with fresh RNGs seeded from the
+	// same clientSeeds. Seeded from scratch — `rand.New(rand.NewSource(s))`
+	// is deterministic, so the streaming RNG produces the same sequence as
+	// the pre-pass RNG that enumerated session IDs.
+	h := &heapByArrival{}
+	heap.Init(h)
+	for _, p := range preps {
+		state, err := buildClientStreamState(p, horizon)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		if firstReq, t, ok := state.produceNext(); ok {
+			heap.Push(h, heapEntry{
+				arrivalUs:    t,
+				clientIdx:    state.clientIdx,
+				perClientSeq: state.perClientSeq,
+				req:          firstReq,
+				state:        state,
+			})
+		}
+	}
+
+	// FollowUpBudget: lazy mode rejects concurrency specs above, so the
+	// eager codepath's "totalConcurrencyUsers > 0" condition is always
+	// false — budget stays at -1 (no cap), matching GenerateWorkload:671.
+	return &lazyRequestSource{h: h, maxRequests: maxRequests}, sessions, int64(-1), nil
+}
+
+// buildClientStreamState constructs one client's streaming state. The
+// RNG is seeded from p.clientSeed; sampler construction mirrors the
+// eager generator (generator.go:122-143) including the CustomSamplerFactory
+// sub-RNG draw.
+func buildClientStreamState(p clientPrep, horizon int64) (*clientStreamState, error) {
+	clientRNG := newRandFromSeed(p.clientSeed)
+	var arrivalSampler ArrivalSampler
+	if p.client.CustomSamplerFactory != nil {
+		subSeed := clientRNG.Int63()
+		subRNG := newRandFromSeed(subSeed)
+		arrivalSampler = p.client.CustomSamplerFactory(subRNG)
+	} else {
+		arrivalSampler = NewArrivalSampler(p.client.Arrival, p.rate)
+	}
+	inputSampler, err := NewLengthSampler(p.client.InputDist)
+	if err != nil {
+		return nil, fmt.Errorf("client %q input distribution: %w", p.client.ID, err)
+	}
+	outputSampler, err := NewLengthSampler(p.client.OutputDist)
+	if err != nil {
+		return nil, fmt.Errorf("client %q output distribution: %w", p.client.ID, err)
+	}
+	state := &clientStreamState{
+		clientIdx:      p.idx,
+		client:         p.client,
+		arrivalSampler: arrivalSampler,
+		inputSampler:   inputSampler,
+		outputSampler:  outputSampler,
+		clientRNG:      clientRNG,
+		prefix:         p.prefix,
+		horizon:        horizon,
+	}
+	if p.client.Reasoning != nil && p.client.Reasoning.MultiTurn != nil {
+		state.isReasoning = true
+		state.isSingleSession = p.client.Reasoning.MultiTurn.SingleSession
+		state.isClosedLoop = isClosedLoop(p.client)
+	}
+	return state, nil
+}
+
+// enumerateReasoningSessionIDs replays a closed-loop reasoning client's
+// RNG to discover the SessionIDs it would produce, without retaining
+// session slices. Used by the blueprint pre-pass in GenerateWorkloadLazy.
+//
+// Implementation strategy: build a temporary clientStreamState (with a
+// fresh RNG seeded from p.clientSeed) and call produceNext repeatedly,
+// discarding requests but recording the SessionID of each new session.
+// We detect "new session" by tracking SessionID transitions.
+//
+// Memory: bounded by the per-session slice held inside the state's
+// pendingSession field (one session at a time, ~MaxRounds requests).
+func enumerateReasoningSessionIDs(p clientPrep, horizon int64) ([]string, error) {
+	state, err := buildClientStreamState(p, horizon)
+	if err != nil {
+		return nil, err
+	}
+	// Force closed-loop filtering OFF for the enumeration pass — we want to
+	// see ALL rounds (to record their SessionID) and not skip the very
+	// session-bearing round-0 either, but disabling the closed-loop filter
+	// makes the loop yield rounds uniformly so we can just read the first
+	// round's SessionID per pending-session refill. Either approach works;
+	// we go with the simpler one: leave the filter on (so only round-0 is
+	// yielded per closed-loop session) and read SessionID from each yield.
+	state.isClosedLoop = true
+
+	var ids []string
+	seen := make(map[string]bool)
+	for {
+		req, _, ok := state.produceNext()
+		if !ok {
+			break
+		}
+		if req.SessionID != "" && !seen[req.SessionID] {
+			seen[req.SessionID] = true
+			ids = append(ids, req.SessionID)
+		}
+	}
+	return ids, nil
+}

--- a/sim/workload/stream.go
+++ b/sim/workload/stream.go
@@ -7,6 +7,8 @@ import (
 	"math/rand"
 	"sort"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/inference-sim/inference-sim/sim"
 )
 
@@ -52,7 +54,8 @@ type clientStreamState struct {
 	isSingleSession bool
 	isClosedLoop    bool
 
-	// Single-shot mode: monotonic IAT accumulator (matches generator.go:281).
+	// Single-shot mode: monotonic IAT accumulator (matches the
+	// `currentTime` accumulator in GenerateRequests' non-reasoning loop).
 	currentTime int64
 
 	// Reasoning mode: pendingSession holds one session's pre-computed rounds.
@@ -100,7 +103,8 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 		}
 		iat := s.arrivalSampler.SampleIAT(s.clientRNG)
 		if iat == 0 {
-			// Stateful sampler exhausted (matches eager generator.go:288).
+			// Stateful sampler exhausted (mirrors the `iat == 0 → break`
+			// guard in GenerateRequests' non-reasoning per-client loop).
 			s.exhausted = true
 			return nil, 0, false
 		}
@@ -109,7 +113,8 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 			s.exhausted = true
 			return nil, 0, false
 		}
-		// Lifecycle window filtering (matches generator.go:299-304).
+		// Lifecycle window filtering (mirrors the lifecycle/lastWindowEnd
+		// check in GenerateRequests' non-reasoning loop).
 		if s.client.Lifecycle != nil && !isInActiveWindow(s.currentTime, s.client.Lifecycle) {
 			if s.currentTime >= lastWindowEndUs(s.client.Lifecycle) {
 				s.exhausted = true
@@ -118,18 +123,24 @@ func (s *clientStreamState) produceNextSingleShot() (*sim.Request, int64, bool) 
 			continue
 		}
 
-		// Token generation — must match generator.go:306-325 exactly,
-		// including the RNG-draw order for multimodal vs standard paths.
+		// Token generation — must match GenerateRequests' single-shot
+		// path exactly, including the RNG-draw order for multimodal vs
+		// standard paths (multimodal: tokens → outputLen → outputTokens;
+		// standard: inputLen → outputLen → input → output).
 		var inputTokens, outputTokens []int
 		var textCount, imageCount, audioCount, videoCount int
 		if s.client.Multimodal != nil {
 			var err error
 			inputTokens, textCount, imageCount, audioCount, videoCount, err = GenerateMultimodalTokens(s.clientRNG, s.client.Multimodal)
 			if err != nil {
-				// Multimodal validation runs at GenerateWorkloadLazy time, so this
-				// shouldn't happen for valid specs. Treat as terminal failure rather
-				// than panicking inside library code (R6); the resulting empty
-				// stream surfaces the issue via downstream "no requests" warning.
+				// spec.Validate() does NOT validate MultimodalSpec distribution
+				// fields, so this path IS reachable for invalid multimodal specs.
+				// R1: don't drop silently — log the failure (with client ID so
+				// the user can locate the bad spec) before exhausting the
+				// stream. Eager mode surfaces this via logrus.Fatalf in cmd;
+				// in lazy library code we log + sticky-exhaust so the
+				// simulation does not silently continue with reduced traffic.
+				logrus.Errorf("[workload] client %q: multimodal token generation failed (exhausting stream): %v", s.client.ID, err)
 				s.exhausted = true
 				return nil, 0, false
 			}
@@ -188,13 +199,15 @@ func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
 			s.pendingSessionIdx++
 			if req.ArrivalTime >= s.horizon {
 				// Rounds are chronological; remaining are past horizon too.
-				// Matches generator.go:264 / generator.go:203 break.
+				// Mirrors the `break` in GenerateRequests' reasoning round
+				// loop on the first round that exceeds horizon.
 				s.pendingSession = nil
 				s.pendingSessionIdx = 0
 				break
 			}
 			if s.client.Lifecycle != nil && !isInActiveWindow(req.ArrivalTime, s.client.Lifecycle) {
-				// Skip rounds outside lifecycle windows (matches generator.go:268).
+				// Skip rounds outside lifecycle windows (mirrors the
+				// per-round `continue` in GenerateRequests' reasoning loop).
 				continue
 			}
 			s.perClientSeq++
@@ -243,7 +256,8 @@ func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
 					s.exhausted = true
 					return nil, 0, false
 				}
-				continue // try next IAT (matches generator.go:233-238)
+				continue // try next IAT (mirrors the lifecycle-skip
+				// branch in GenerateRequests' multi-session reasoning loop)
 			}
 		}
 
@@ -255,17 +269,27 @@ func (s *clientStreamState) produceNextReasoning() (*sim.Request, int64, bool) {
 			s.client.ID, s.client.TenantID, s.client.SLOClass, s.client.Model,
 		)
 		if err != nil {
+			// spec.Validate() does NOT validate ReasoningSpec's distribution
+			// fields (e.g. ReasonRatioDist), so this path IS reachable. R1:
+			// log the failure with client ID before sticky-exhausting so the
+			// simulation does not silently continue with reduced traffic.
+			// Eager mode surfaces this via logrus.Fatalf in cmd.
+			logrus.Errorf("[workload] client %q: reasoning session generation failed at t=%d (exhausting stream): %v", s.client.ID, startTime, err)
 			s.exhausted = true
 			return nil, 0, false
 		}
-		// Prepend shared prefix (matches generator.go:191-196 / 248-254).
+		// Prepend shared prefix (mirrors the prefix-prepend loop applied
+		// to every reasoningReqs entry in GenerateRequests' reasoning
+		// path, single-session and multi-session branches).
 		if len(s.prefix) > 0 {
 			for _, req := range reasoningReqs {
 				req.InputTokens = append(append([]int{}, s.prefix...), req.InputTokens...)
 				req.PrefixLength = len(s.prefix)
 			}
 		}
-		// Set Deadline + SLOTargetUs on every round (matches generator.go:198-201 / 256-259).
+		// Set Deadline + SLOTargetUs on every round (mirrors the
+		// per-round Deadline/SLOTargetUs assignment in GenerateRequests'
+		// reasoning path).
 		for _, req := range reasoningReqs {
 			req.Deadline = computeDeadline(req.ArrivalTime, s.client.Timeout, true)
 			req.SLOTargetUs = derefInt64(s.client.SLOTargetUs)
@@ -335,7 +359,7 @@ type lazyRequestSource struct {
 //     push the new entry back onto the heap.
 //  3. If the popped request belongs to a closed-loop session AND its
 //     RoundIndex > 0, it is a non-emitted intermediate round (matches
-//     GenerateWorkload's round-0-only filter at generator.go:531-542).
+//     GenerateWorkload's round-0-only filter for closed-loop sessions).
 //     Such rounds DO count toward maxRequests (so the eager/lazy total
 //     budget matches) but are NOT yielded to the cluster — we loop and
 //     pop the next entry instead.
@@ -379,7 +403,9 @@ func (l *lazyRequestSource) Next() (*sim.Request, bool) {
 			continue
 		}
 		// Sequential IDs are assigned in yield order, matching
-		// GenerateWorkload's post-filter renumbering at generator.go:619-621.
+		// GenerateWorkload's post-filter sequential-ID renumbering pass
+		// (where it reassigns `req.ID = fmt.Sprintf("request_%d", i)`
+		// over the filtered + sorted slice).
 		e.req.ID = fmt.Sprintf("request_%d", l.yielded)
 		l.yielded++
 		return e.req, true
@@ -389,7 +415,9 @@ func (l *lazyRequestSource) Next() (*sim.Request, bool) {
 // clientPrep captures the per-client information collected during the
 // construction prelude of GenerateWorkloadLazy. clientSeed is drawn
 // from workloadRNG in allClients order before any client begins
-// producing requests — matching the eager generator (generator.go:119).
+// producing requests — matching the eager generator's
+// `clientSeed := workloadRNG.Int63()` draw at the top of its per-client
+// loop in GenerateRequests.
 type clientPrep struct {
 	idx        int
 	client     *ClientSpec
@@ -430,7 +458,9 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 		return nil, nil, 0, err
 	}
 
-	// Build working client list (matches generator.go:74-79).
+	// Build working client list (mirrors the same allClients assembly
+	// in GenerateRequests: copy spec.Clients, then append cohort-
+	// expanded clients).
 	allClients := append([]ClientSpec{}, spec.Clients...)
 	if len(spec.Cohorts) > 0 {
 		allClients = append(allClients, ExpandCohorts(spec.Cohorts, spec.Seed)...)
@@ -457,8 +487,9 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 	prefixes := generatePrefixTokens(allClients, workloadRNG)
 
 	// Phase 1: prelude — draw clientSeeds in allClients order, mirroring the
-	// eager loop's draw order (generator.go:114-120). Zero-rate clients are
-	// skipped BEFORE the draw, matching generator.go:114-116.
+	// eager loop's draw order in GenerateRequests' per-client loop.
+	// Zero-rate clients are skipped BEFORE the workloadRNG.Int63() draw,
+	// matching the eager loop's `if clientRate <= 0 { continue }` guard.
 	preps := make([]clientPrep, 0, len(allClients))
 	for i := range allClients {
 		if clientRates[i] <= 0 {
@@ -475,25 +506,43 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 	}
 
 	// Phase 2: blueprint pre-pass (closed-loop reasoning clients only).
-	// We replay each closed-loop client's RNG to enumerate session IDs
-	// without retaining any request slices (each session's slice is
-	// generated and discarded). This advances a temporary clientRNG; the
-	// real streaming pass below uses a *fresh* clientRNG seeded from the
-	// same clientSeed, so both passes see identical RNG streams.
+	//
+	// Mirrors GenerateWorkload's blueprint construction at
+	// GenerateWorkload's closed-loop blueprint construction loop — which scans the truncated `reqs` slice for
+	// round-0 SessionIDs per closed-loop client, sorts them, and draws
+	// one `blueprintRNG.Int63()` per surviving session.
+	//
+	// To match this RNG-draw budget exactly, the lazy pre-pass simulates
+	// the full streaming `Next()` loop with separate cloned per-client
+	// states (RNGs re-seeded from the same clientSeeds — same sequence)
+	// up to the same `maxRequests` cap that Phase 3 will impose. This
+	// way we discover the EXACT set of round-0 emissions that survive
+	// the cap, and only draw `blueprintRNG` for those sessions.
+	//
+	// Without `maxRequests` awareness, a binding cap that drops a later
+	// session's round-0 would still see that session enumerated here,
+	// consume an extra `blueprintRNG.Int63()`, and shift every
+	// subsequent blueprint RNG seed — breaking INV-6 byte-identity and
+	// INV-13 run/replay parity for closed-loop reasoning under a tight
+	// cap. (Bug found in PR #1453 self-review.)
+	survivingPerClient, err := enumerateSurvivingSessionsPerClient(preps, prefixes, horizon, maxRequests)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 	blueprintRNG := rand.New(rand.NewSource(spec.Seed + 7919))
 	var sessions []SessionBlueprint
 	for _, p := range preps {
 		if !isClosedLoop(p.client) || p.client.Reasoning == nil || p.client.Reasoning.MultiTurn == nil {
 			continue
 		}
-		sessIDs, err := enumerateReasoningSessionIDs(p, horizon)
-		if err != nil {
-			return nil, nil, 0, fmt.Errorf("client %q: %w", p.client.ID, err)
+		sessIDs := survivingPerClient[p.idx]
+		if len(sessIDs) == 0 {
+			continue // no round-0 of this client's sessions survived the cap
 		}
 		// Sort session IDs to match GenerateWorkload's deterministic
-		// blueprint-construction order (generator.go:504-508).
+		// blueprint-construction order (sort.Strings on the map of seen IDs).
 		sort.Strings(sessIDs)
-		// Build samplers once per client (mirrors generator.go:447-455).
+		// Build samplers once per client (mirrors the eager blueprint loop).
 		inputSampler, err := NewLengthSampler(p.client.InputDist)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("client %q input distribution for blueprint: %w", p.client.ID, err)
@@ -534,9 +583,11 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 	}
 
 	// Phase 3: build the streaming states with fresh RNGs seeded from the
-	// same clientSeeds. Seeded from scratch — `rand.New(rand.NewSource(s))`
-	// is deterministic, so the streaming RNG produces the same sequence as
-	// the pre-pass RNG that enumerated session IDs.
+	// same clientSeeds. The pre-pass RNGs ran to completion and are
+	// discarded; Phase 3's RNGs start anew but, because
+	// `rand.New(rand.NewSource(s))` is deterministic, both produce the
+	// SAME starting sequence — giving the streaming pass byte-identical
+	// emissions to what the pre-pass simulated.
 	h := &heapByArrival{}
 	heap.Init(h)
 	for _, p := range preps {
@@ -557,13 +608,16 @@ func GenerateWorkloadLazy(spec *WorkloadSpec, horizon int64, maxRequests int64) 
 
 	// FollowUpBudget: lazy mode rejects concurrency specs above, so the
 	// eager codepath's "totalConcurrencyUsers > 0" condition is always
-	// false — budget stays at -1 (no cap), matching GenerateWorkload:671.
+	// false — budget stays at -1 (no cap), matching the
+	// `followUpBudget := int64(-1)` initialization in GenerateWorkload.
 	return &lazyRequestSource{h: h, maxRequests: maxRequests}, sessions, int64(-1), nil
 }
 
 // buildClientStreamState constructs one client's streaming state. The
 // RNG is seeded from p.clientSeed; sampler construction mirrors the
-// eager generator (generator.go:122-143) including the CustomSamplerFactory
+// eager generator's per-client sampler construction (the block
+// immediately after `clientRNG := newRandFromSeed(clientSeed)` in
+// GenerateRequests), including the CustomSamplerFactory
 // sub-RNG draw.
 func buildClientStreamState(p clientPrep, horizon int64) (*clientStreamState, error) {
 	clientRNG := newRandFromSeed(p.clientSeed)
@@ -601,39 +655,93 @@ func buildClientStreamState(p clientPrep, horizon int64) (*clientStreamState, er
 	return state, nil
 }
 
-// enumerateReasoningSessionIDs replays a closed-loop reasoning client's
-// RNG to discover the SessionIDs it would produce, without retaining
-// session slices. Used by the blueprint pre-pass in GenerateWorkloadLazy.
+// enumerateSurvivingSessionsPerClient simulates the streaming source's
+// global heap-pop order up to maxRequests pops and returns, for each
+// closed-loop reasoning client (keyed by allClients index), the set of
+// SessionIDs whose round-0 emission survived the cap. This mirrors the
+// eager flow's "produce all rounds, sort+truncate to maxRequests, then
+// scan the truncated slice for SessionIDs per closed-loop client"
+// sequence (GenerateWorkload's closed-loop blueprint construction loop).
 //
-// Implementation strategy: build a temporary clientStreamState (with a
-// fresh RNG seeded from p.clientSeed) and call produceNext repeatedly,
-// discarding requests but recording the SessionID of each new session.
-// We detect "new session" by tracking SessionID transitions.
+// Uses CLONED per-client states with RNGs re-seeded from the same
+// clientSeeds, so the simulation does not advance the Phase 3
+// streaming-pass RNGs. The dry-run yields rounds and counts toward
+// the cap exactly as `lazyRequestSource.Next` will — including
+// intermediate closed-loop rounds (`RoundIndex > 0`), which pop and
+// count but do not yield to the cluster (and are not recorded here).
 //
-// Memory: bounded by the per-session slice held inside the state's
-// pendingSession field (one session at a time, ~MaxRounds requests).
-func enumerateReasoningSessionIDs(p clientPrep, horizon int64) ([]string, error) {
-	state, err := buildClientStreamState(p, horizon)
-	if err != nil {
-		return nil, err
+// Memory: bounded by the per-session pending slice inside each cloned
+// state (one session at a time, MaxRounds entries).
+func enumerateSurvivingSessionsPerClient(
+	preps []clientPrep,
+	prefixes map[string][]int,
+	horizon int64,
+	maxRequests int64,
+) (map[int][]string, error) {
+	// Clone per-client states (fresh RNGs from the same clientSeed).
+	cloneStates := make([]*clientStreamState, 0, len(preps))
+	for _, p := range preps {
+		// Mirror the prefix-binding rule of Phase 3 so the clone consumes
+		// identical RNG draws for prefix-prepending; p.prefix is already
+		// the per-prefix-group slice resolved in Phase 1.
+		state, err := buildClientStreamState(p, horizon)
+		if err != nil {
+			return nil, fmt.Errorf("client %q: %w", p.client.ID, err)
+		}
+		cloneStates = append(cloneStates, state)
 	}
-	// Keep isClosedLoop = true so only round 0 of each session is yielded
-	// (one per session). We read SessionID from each yielded round-0 to
-	// enumerate every session without retaining the full per-session
-	// request slice — pendingSession is overwritten on each refill.
-	state.isClosedLoop = true
-
-	var ids []string
-	seen := make(map[string]bool)
-	for {
-		req, _, ok := state.produceNext()
-		if !ok {
+	// Build the clone heap with each state's first candidate, matching
+	// Phase 3's heap construction.
+	h := &heapByArrival{}
+	heap.Init(h)
+	for _, state := range cloneStates {
+		if first, t, ok := state.produceNext(); ok {
+			heap.Push(h, heapEntry{
+				arrivalUs:    t,
+				clientIdx:    state.clientIdx,
+				perClientSeq: state.perClientSeq,
+				req:          first,
+				state:        state,
+			})
+		}
+	}
+	// Dry-run the streaming pop loop with the SAME stopping rule as
+	// lazyRequestSource.Next: stop at popped >= maxRequests (when > 0)
+	// or when the heap is empty.
+	surviving := make(map[int][]string)
+	seen := make(map[int]map[string]bool)
+	var popped int64
+	for h.Len() > 0 {
+		if maxRequests > 0 && popped >= maxRequests {
 			break
 		}
-		if req.SessionID != "" && !seen[req.SessionID] {
-			seen[req.SessionID] = true
-			ids = append(ids, req.SessionID)
+		e := heap.Pop(h).(heapEntry)
+		// Re-push state's next candidate, matching Next().
+		if nextReq, t, ok := e.state.produceNext(); ok {
+			heap.Push(h, heapEntry{
+				arrivalUs:    t,
+				clientIdx:    e.state.clientIdx,
+				perClientSeq: e.state.perClientSeq,
+				req:          nextReq,
+				state:        e.state,
+			})
+		}
+		popped++
+		// Only round-0 entries are observed by GenerateWorkload's
+		// blueprint-building loop (it filters round-0 only when keying
+		// the SessionID lookup). Intermediate rounds advance state and
+		// count toward the cap but produce no blueprint.
+		if e.req.RoundIndex != 0 || e.req.SessionID == "" {
+			continue
+		}
+		idx := e.state.clientIdx
+		if seen[idx] == nil {
+			seen[idx] = make(map[string]bool)
+		}
+		if !seen[idx][e.req.SessionID] {
+			seen[idx][e.req.SessionID] = true
+			surviving[idx] = append(surviving[idx], e.req.SessionID)
 		}
 	}
-	return ids, nil
+	return surviving, nil
 }

--- a/sim/workload/stream.go
+++ b/sim/workload/stream.go
@@ -617,13 +617,10 @@ func enumerateReasoningSessionIDs(p clientPrep, horizon int64) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	// Force closed-loop filtering OFF for the enumeration pass — we want to
-	// see ALL rounds (to record their SessionID) and not skip the very
-	// session-bearing round-0 either, but disabling the closed-loop filter
-	// makes the loop yield rounds uniformly so we can just read the first
-	// round's SessionID per pending-session refill. Either approach works;
-	// we go with the simpler one: leave the filter on (so only round-0 is
-	// yielded per closed-loop session) and read SessionID from each yield.
+	// Keep isClosedLoop = true so only round 0 of each session is yielded
+	// (one per session). We read SessionID from each yielded round-0 to
+	// enumerate every session without retaining the full per-session
+	// request slice — pendingSession is overwritten on each refill.
 	state.isClosedLoop = true
 
 	var ids []string

--- a/sim/workload/stream_test.go
+++ b/sim/workload/stream_test.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -446,6 +447,60 @@ func TestLazyRequestSource_Reasoning_SingleSession_MatchesEager(t *testing.T) {
 	}
 }
 
+// TestLazyRequestSource_SamplerError_SurfacedViaErr pins the fix for
+// PR #1453 review round 3 (IMPORTANT): a sampler failure inside the
+// streaming source MUST be surfaced via lazyRequestSource.Err() so
+// cmd/root.go can Fatalf after cluster.Run — matching eager mode's
+// abort-on-invalid-spec behavior. Regressions that swallow the error
+// (or return nil after logging) would silently reduce traffic and
+// yield misleading capacity numbers.
+//
+// spec.Validate() does NOT validate MultimodalSpec's sub-distribution
+// types, so an unknown TextDist type passes construction but fails
+// deterministically inside GenerateMultimodalTokens. Drain the source
+// once; assert Err() returns a wrapped error that names the client
+// and includes the "unknown distribution type" phrase.
+func TestLazyRequestSource_SamplerError_SurfacedViaErr(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "1", Seed: 42, Category: "language", AggregateRate: 5.0,
+		Clients: []ClientSpec{{
+			ID: "mm-bad", TenantID: "t1", SLOClass: "batch", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 50, "std_dev": 5, "min": 10, "max": 200}},
+			OutputDist: DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+			Multimodal: &MultimodalSpec{
+				// TextDist.Type is not a valid distribution; NewLengthSampler
+				// will error. spec.Validate() does NOT catch this because
+				// Multimodal sub-fields are not validated in advance.
+				TextDist: DistSpec{Type: "not-a-real-dist", Params: map[string]float64{"mean": 10}},
+			},
+		}},
+	}
+	src, _, _, err := GenerateWorkloadLazy(spec, 5_000_000, 5)
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+	// Drain — first Next() should trigger GenerateMultimodalTokens and
+	// record the error on the state, which will then exhaust.
+	for {
+		if _, ok := src.Next(); !ok {
+			break
+		}
+	}
+	got := src.Err()
+	if got == nil {
+		t.Fatal("Err() returned nil after sampler failure; must surface the error so cmd can Fatalf")
+	}
+	// Sanity-check the error mentions the offending client + the underlying cause.
+	msg := got.Error()
+	if !strings.Contains(msg, "mm-bad") {
+		t.Errorf("Err() = %q; expected mention of client ID 'mm-bad'", msg)
+	}
+	if !strings.Contains(msg, "unknown distribution type") {
+		t.Errorf("Err() = %q; expected underlying 'unknown distribution type' wrapped in message", msg)
+	}
+}
+
 // TestLazyRequestSource_Multimodal_MatchesEager pins BC-3 for the
 // multimodal branch of produceNextSingleShot: TextTokenCount,
 // ImageTokenCount, AudioTokenCount, and VideoTokenCount must be
@@ -503,11 +558,14 @@ func TestLazyRequestSource_Multimodal_MatchesEager(t *testing.T) {
 // to `l.yielded >= l.maxRequests` would yield extra round-0 requests
 // past the eager truncation point and break parity.
 //
-// Construction: 2 closed-loop reasoning clients (NOT SingleSession), so
-// each session has rounds 0, 1, 2 — all popped, only round-0 yielded.
-// With maxRequests = 6, eager truncates to first 6 in arrival order
-// (a mix of round-0 and intermediate rounds). Lazy must stop at popped
-// = 6 and yield strictly fewer than 6 requests to the cluster.
+// Construction: 2 closed-loop SingleSession=true reasoning clients
+// (SingleSession is a lazy-supported shape; multi-session would trip
+// ErrLazyUnsupportedMultiSession before reaching the streaming path).
+// Each client's one session has rounds 0, 1, 2 — all popped, only
+// round-0 yielded. With maxRequests = 4, eager truncates to first 4 in
+// arrival order (a mix of round-0 and intermediate rounds). Lazy must
+// stop at popped = 4 and yield strictly fewer than 4 requests to the
+// cluster.
 func TestLazyRequestSource_PoppedNotYielded_StopsAtPoppedCap(t *testing.T) {
 	mk := func() *WorkloadSpec {
 		mkClient := func(id string) ClientSpec {

--- a/sim/workload/stream_test.go
+++ b/sim/workload/stream_test.go
@@ -94,6 +94,20 @@ func assertRequestStreamsEqual(t *testing.T, eager, lazy []*sim.Request) {
 		if e.Streaming != l.Streaming {
 			t.Fatalf("request %d: Streaming eager=%v lazy=%v", i, e.Streaming, l.Streaming)
 		}
+		// Multimodal token counts (populated by produceNextSingleShot's
+		// multimodal branch; mirrored from the eager path).
+		if e.TextTokenCount != l.TextTokenCount {
+			t.Fatalf("request %d: TextTokenCount eager=%d lazy=%d", i, e.TextTokenCount, l.TextTokenCount)
+		}
+		if e.ImageTokenCount != l.ImageTokenCount {
+			t.Fatalf("request %d: ImageTokenCount eager=%d lazy=%d", i, e.ImageTokenCount, l.ImageTokenCount)
+		}
+		if e.AudioTokenCount != l.AudioTokenCount {
+			t.Fatalf("request %d: AudioTokenCount eager=%d lazy=%d", i, e.AudioTokenCount, l.AudioTokenCount)
+		}
+		if e.VideoTokenCount != l.VideoTokenCount {
+			t.Fatalf("request %d: VideoTokenCount eager=%d lazy=%d", i, e.VideoTokenCount, l.VideoTokenCount)
+		}
 	}
 }
 
@@ -248,15 +262,21 @@ func TestLazyRequestSource_IDsSequentialInArrivalOrder(t *testing.T) {
 // TestGenerateWorkloadLazy_StopsAtMaxRequests pins BC-6: lazy mode counts
 // emitted requests as it goes and stops at maxRequests (no per-client
 // 2*maxRequests safety cap applied — that exists only in eager mode).
+// The assertion is exact (== 7) so a regression that produces zero
+// requests (e.g., the horizon being misinterpreted) would also fail.
 func TestGenerateWorkloadLazy_StopsAtMaxRequests(t *testing.T) {
+	// 60s horizon × ~10 req/s mean rate → ~600 candidate IATs; with
+	// maxRequests=7 the source MUST stop exactly at 7. If the test ever
+	// emits fewer, the horizon is wrong, the cap is being applied at the
+	// wrong layer, or stream.go's Next() loop terminates early.
 	spec := singleClientChatbotSpec(13)
 	src, _, _, err := GenerateWorkloadLazy(spec, 60_000_000, 7)
 	if err != nil {
 		t.Fatalf("lazy: %v", err)
 	}
 	lazy := drainLazy(t, src)
-	if int64(len(lazy)) > 7 {
-		t.Fatalf("emitted %d requests; want <= 7", len(lazy))
+	if int64(len(lazy)) != 7 {
+		t.Fatalf("emitted %d requests; want exactly 7 (maxRequests cap should bind and horizon should not exhaust the source first)", len(lazy))
 	}
 }
 
@@ -426,6 +446,56 @@ func TestLazyRequestSource_Reasoning_SingleSession_MatchesEager(t *testing.T) {
 	}
 }
 
+// TestLazyRequestSource_Multimodal_MatchesEager pins BC-3 for the
+// multimodal branch of produceNextSingleShot: TextTokenCount,
+// ImageTokenCount, AudioTokenCount, and VideoTokenCount must be
+// populated identically to the eager generator (which calls
+// GenerateMultimodalTokens with the same RNG state).
+func TestLazyRequestSource_Multimodal_MatchesEager(t *testing.T) {
+	mk := func() *WorkloadSpec {
+		return &WorkloadSpec{
+			Version: "1", Seed: 99, Category: "language", AggregateRate: 5.0,
+			Clients: []ClientSpec{{
+				ID: "mm1", TenantID: "t1", SLOClass: "batch", RateFraction: 1.0,
+				Arrival:    ArrivalSpec{Process: "poisson"},
+				InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 50, "std_dev": 5, "min": 10, "max": 200}},
+				OutputDist: DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+				Multimodal: &MultimodalSpec{
+					TextDist:       DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 40, "std_dev": 5, "min": 10, "max": 100}},
+					ImageDist:      DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 20, "std_dev": 4, "min": 5, "max": 50}},
+					ImageCountDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 2, "std_dev": 1, "min": 1, "max": 3}},
+					AudioDist:      DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 15, "std_dev": 3, "min": 5, "max": 40}},
+					AudioCountDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 1, "std_dev": 1, "min": 0, "max": 2}},
+					VideoDist:      DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 25, "std_dev": 5, "min": 10, "max": 50}},
+					VideoCountDist: DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 0, "std_dev": 1, "min": 0, "max": 1}},
+				},
+			}},
+		}
+	}
+	eager, err := GenerateRequests(mk(), 5_000_000, 12)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, _, _, err := GenerateWorkloadLazy(mk(), 5_000_000, 12)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	// At least one request must have a non-zero multimodal token count for
+	// the assertion-helper to actually exercise those fields.
+	var hasMM bool
+	for _, r := range lazy {
+		if r.TextTokenCount+r.ImageTokenCount+r.AudioTokenCount+r.VideoTokenCount > 0 {
+			hasMM = true
+			break
+		}
+	}
+	if !hasMM {
+		t.Fatal("multimodal spec produced zero counts across all token kinds — test would not exercise the new comparisons")
+	}
+	assertRequestStreamsEqual(t, eager, lazy)
+}
+
 // TestGenerateWorkloadLazy_FallsBackOnMultiSession pins the
 // SingleSession=false fallback: any reasoning client without
 // SingleSession=true forces the caller back to GenerateWorkload.
@@ -433,5 +503,106 @@ func TestGenerateWorkloadLazy_FallsBackOnMultiSession(t *testing.T) {
 	_, _, _, err := GenerateWorkloadLazy(reasoningMultiSessionSpec(7), 5_000_000, 20)
 	if !errors.Is(err, ErrLazyUnsupportedMultiSession) {
 		t.Fatalf("want ErrLazyUnsupportedMultiSession, got %v", err)
+	}
+}
+
+// TestExpandClientsAndCohorts_Idempotent_InferencePerf pins the contract
+// that lets cmd/root.go safely call ExpandClientsAndCohorts before the
+// generator runs (so applyTimeoutToSpec sees the expanded clients for
+// inference-perf specs under --lazy-generation, fixing the bug flagged
+// in PR #1453 self-review) — and have the generator's internal
+// validateAndExpandSpec call NOT re-expand. A second call MUST be a
+// no-op: spec.Clients must not be re-expanded, AggregateRate must not
+// be recomputed.
+func TestExpandClientsAndCohorts_Idempotent_InferencePerf(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 11, Category: "language",
+		InferencePerf: &InferencePerfSpec{
+			Stages: []StageSpec{{Rate: 4.0, Duration: 5}},
+			SharedPrefix: &SharedPrefixSpec{
+				NumUniqueSystemPrompts:  2,
+				NumUsersPerSystemPrompt: 2,
+				SystemPromptLen:         16,
+				QuestionLen:             32,
+				OutputLen:               16,
+			},
+		},
+	}
+	if err := ExpandClientsAndCohorts(spec); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	firstLen := len(spec.Clients)
+	firstAgg := spec.AggregateRate
+	if firstLen == 0 {
+		t.Fatal("first call did not expand inference-perf into clients")
+	}
+	if err := ExpandClientsAndCohorts(spec); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := len(spec.Clients); got != firstLen {
+		t.Errorf("second call re-expanded clients: %d → %d (must be idempotent)", firstLen, got)
+	}
+	if got := spec.AggregateRate; got != firstAgg {
+		t.Errorf("second call mutated AggregateRate: %v → %v (must be idempotent)", firstAgg, got)
+	}
+}
+
+// TestGenerateWorkloadLazy_InferencePerf_TimeoutAppliedAfterPreExpand
+// pins the cmd/root.go fix for the PR-review regression: when an
+// inference-perf spec is expanded by ExpandClientsAndCohorts BEFORE
+// applyTimeoutToSpec runs, the Timeout pointer is set on every
+// expanded client, so produceNextSingleShot's computeDeadline call
+// returns ArrivalTime + the user-requested timeout — not the
+// 300 s session-client default that would arise from a nil Timeout.
+//
+// We can't reach applyTimeoutToSpec from sim/workload (cyclic), so we
+// emulate it: pre-expand, then set every client's Timeout pointer to
+// a known non-default value, then build the lazy source and assert
+// the first request's Deadline matches our value.
+func TestGenerateWorkloadLazy_InferencePerf_TimeoutAppliedAfterPreExpand(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "2", Seed: 11, Category: "language",
+		InferencePerf: &InferencePerfSpec{
+			Stages: []StageSpec{{Rate: 4.0, Duration: 5}},
+			SharedPrefix: &SharedPrefixSpec{
+				NumUniqueSystemPrompts:  2,
+				NumUsersPerSystemPrompt: 2,
+				SystemPromptLen:         16,
+				QuestionLen:             32,
+				OutputLen:               16,
+			},
+		},
+	}
+	// Step 1: expand inference-perf so spec.Clients is populated.
+	if err := ExpandClientsAndCohorts(spec); err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	if len(spec.Clients) == 0 {
+		t.Fatal("inference-perf expansion produced 0 clients")
+	}
+	// Step 2: apply a non-default timeout (120 s = 120_000_000 µs) to every
+	// expanded client — mirroring what cmd/root.go's applyTimeoutToSpec does.
+	const wantTimeoutUs = int64(120_000_000)
+	t120 := wantTimeoutUs
+	for i := range spec.Clients {
+		spec.Clients[i].Timeout = &t120
+	}
+	// Step 3: build the lazy source (single-session inference-perf is supported).
+	src, _, _, err := GenerateWorkloadLazy(spec, 10_000_000, 1)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	r, ok := src.Next()
+	if !ok || r == nil {
+		t.Fatal("expected at least one request from inference-perf spec")
+	}
+	// The Deadline should be ArrivalTime + 120 s, NOT ArrivalTime + 300 s
+	// (the DefaultTimeoutUs fallback that would fire if Timeout were nil).
+	wantDeadline := r.ArrivalTime + wantTimeoutUs
+	if r.Deadline != wantDeadline {
+		t.Fatalf("Deadline=%d, want %d (arrival=%d + timeout=%d). "+
+			"A 300_000_000 timeout-µs value would indicate the inference-perf "+
+			"clients were built with nil Timeout — the bug fixed in PR #1453.",
+			r.Deadline, wantDeadline, r.ArrivalTime, wantTimeoutUs)
 	}
 }

--- a/sim/workload/stream_test.go
+++ b/sim/workload/stream_test.go
@@ -1,0 +1,437 @@
+package workload
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// drainLazy collects every request a lazyRequestSource emits, then verifies
+// exhaustion stickiness on a follow-up Next() call (BC-3 contract semantics).
+func drainLazy(t *testing.T, src *lazyRequestSource) []*sim.Request {
+	t.Helper()
+	var out []*sim.Request
+	for {
+		r, ok := src.Next()
+		if !ok {
+			break
+		}
+		out = append(out, r)
+	}
+	// Exhaustion must be sticky.
+	if r, ok := src.Next(); ok || r != nil {
+		t.Fatalf("Next after exhaustion returned (%v, %v); want (nil, false)", r, ok)
+	}
+	return out
+}
+
+// assertRequestStreamsEqual compares two request sequences field-by-field.
+// Used by all eager ≡ lazy byte-identity tests (BC-3 / BC-4).
+func assertRequestStreamsEqual(t *testing.T, eager, lazy []*sim.Request) {
+	t.Helper()
+	if len(eager) != len(lazy) {
+		t.Fatalf("length mismatch: eager=%d lazy=%d", len(eager), len(lazy))
+	}
+	for i := range eager {
+		e, l := eager[i], lazy[i]
+		if e.ID != l.ID {
+			t.Fatalf("request %d: ID eager=%q lazy=%q", i, e.ID, l.ID)
+		}
+		if e.ArrivalTime != l.ArrivalTime {
+			t.Fatalf("request %d (%s): ArrivalTime eager=%d lazy=%d", i, e.ID, e.ArrivalTime, l.ArrivalTime)
+		}
+		if len(e.InputTokens) != len(l.InputTokens) {
+			t.Fatalf("request %d (%s): InputTokens length eager=%d lazy=%d", i, e.ID, len(e.InputTokens), len(l.InputTokens))
+		}
+		for j := range e.InputTokens {
+			if e.InputTokens[j] != l.InputTokens[j] {
+				t.Fatalf("request %d (%s): InputTokens[%d] eager=%d lazy=%d", i, e.ID, j, e.InputTokens[j], l.InputTokens[j])
+			}
+		}
+		if len(e.OutputTokens) != len(l.OutputTokens) {
+			t.Fatalf("request %d (%s): OutputTokens length eager=%d lazy=%d", i, e.ID, len(e.OutputTokens), len(l.OutputTokens))
+		}
+		for j := range e.OutputTokens {
+			if e.OutputTokens[j] != l.OutputTokens[j] {
+				t.Fatalf("request %d (%s): OutputTokens[%d] eager=%d lazy=%d", i, e.ID, j, e.OutputTokens[j], l.OutputTokens[j])
+			}
+		}
+		if e.MaxOutputLen != l.MaxOutputLen {
+			t.Fatalf("request %d (%s): MaxOutputLen eager=%d lazy=%d", i, e.ID, e.MaxOutputLen, l.MaxOutputLen)
+		}
+		if e.TenantID != l.TenantID {
+			t.Fatalf("request %d: TenantID eager=%q lazy=%q", i, e.TenantID, l.TenantID)
+		}
+		if e.SLOClass != l.SLOClass {
+			t.Fatalf("request %d: SLOClass eager=%q lazy=%q", i, e.SLOClass, l.SLOClass)
+		}
+		if e.Model != l.Model {
+			t.Fatalf("request %d: Model eager=%q lazy=%q", i, e.Model, l.Model)
+		}
+		if e.ClientID != l.ClientID {
+			t.Fatalf("request %d: ClientID eager=%q lazy=%q", i, e.ClientID, l.ClientID)
+		}
+		if e.PrefixGroup != l.PrefixGroup {
+			t.Fatalf("request %d: PrefixGroup eager=%q lazy=%q", i, e.PrefixGroup, l.PrefixGroup)
+		}
+		if e.PrefixLength != l.PrefixLength {
+			t.Fatalf("request %d: PrefixLength eager=%d lazy=%d", i, e.PrefixLength, l.PrefixLength)
+		}
+		if e.Deadline != l.Deadline {
+			t.Fatalf("request %d: Deadline eager=%d lazy=%d", i, e.Deadline, l.Deadline)
+		}
+		if e.SLOTargetUs != l.SLOTargetUs {
+			t.Fatalf("request %d: SLOTargetUs eager=%d lazy=%d", i, e.SLOTargetUs, l.SLOTargetUs)
+		}
+		if e.SessionID != l.SessionID {
+			t.Fatalf("request %d: SessionID eager=%q lazy=%q", i, e.SessionID, l.SessionID)
+		}
+		if e.RoundIndex != l.RoundIndex {
+			t.Fatalf("request %d: RoundIndex eager=%d lazy=%d", i, e.RoundIndex, l.RoundIndex)
+		}
+		if e.Streaming != l.Streaming {
+			t.Fatalf("request %d: Streaming eager=%v lazy=%v", i, e.Streaming, l.Streaming)
+		}
+	}
+}
+
+// singleClientChatbotSpec builds a single-client open-loop spec — the
+// simplest case that exercises every step of the streaming path
+// (samplers, prefix, deadline) without reasoning complications.
+func singleClientChatbotSpec(seed int64) *WorkloadSpec {
+	return &WorkloadSpec{
+		Version: "1", Seed: seed, Category: "language", AggregateRate: 10.0,
+		Clients: []ClientSpec{{
+			ID: "c1", TenantID: "t1", SLOClass: "batch",
+			RateFraction: 1.0,
+			Arrival:      ArrivalSpec{Process: "poisson"},
+			InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 100, "std_dev": 20, "min": 10, "max": 500}},
+			OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 50}},
+		}},
+	}
+}
+
+// twoClientConstantArrivalSpec returns a spec with two clients producing
+// requests at identical (constant) arrival cadence — used to deliberately
+// generate arrival-time ties so the heap tie-breaker (clientIdx) is
+// exercised.
+func twoClientConstantArrivalSpec(seed int64) *WorkloadSpec {
+	mk := func(id string) ClientSpec {
+		return ClientSpec{
+			ID: id, TenantID: id + "-tenant", SLOClass: "batch",
+			RateFraction: 0.5,
+			Arrival:      ArrivalSpec{Process: "constant"},
+			InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 80, "std_dev": 10, "min": 10, "max": 500}},
+			OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 40}},
+		}
+	}
+	return &WorkloadSpec{
+		Version: "1", Seed: seed, Category: "language", AggregateRate: 10.0,
+		Clients: []ClientSpec{mk("c1"), mk("c2")},
+	}
+}
+
+// reasoningSingleSessionSpec returns a spec with two closed-loop multi-turn
+// reasoning clients in SingleSession=true mode — the inference-perf shape
+// and the issue's reproducer shape. Each client represents one persistent
+// session cycling through rounds.
+func reasoningSingleSessionSpec(seed int64) *WorkloadSpec {
+	mk := func(id string) ClientSpec {
+		return ClientSpec{
+			ID: id, TenantID: id + "-t", SLOClass: "batch",
+			RateFraction: 0.5,
+			Arrival:      ArrivalSpec{Process: "poisson"},
+			InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 60, "std_dev": 10, "min": 10, "max": 200}},
+			OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+			Reasoning: &ReasoningSpec{
+				MultiTurn: &MultiTurnSpec{
+					MaxRounds:     3,
+					ContextGrowth: "accumulate",
+					ThinkTimeUs:   100_000,
+					SingleSession: true,
+				},
+			},
+		}
+	}
+	return &WorkloadSpec{
+		Version: "1", Seed: seed, Category: "language", AggregateRate: 4.0,
+		Clients: []ClientSpec{mk("r1"), mk("r2")},
+	}
+}
+
+// reasoningMultiSessionSpec is for the fallback test (SingleSession=false
+// is NOT in this PR's lazy scope — caller falls back to GenerateWorkload).
+func reasoningMultiSessionSpec(seed int64) *WorkloadSpec {
+	return &WorkloadSpec{
+		Version: "1", Seed: seed, Category: "language", AggregateRate: 4.0,
+		Clients: []ClientSpec{{
+			ID: "r1", TenantID: "rt1", SLOClass: "batch",
+			RateFraction: 1.0,
+			Arrival:      ArrivalSpec{Process: "poisson"},
+			InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 60, "std_dev": 10, "min": 10, "max": 200}},
+			OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+			Reasoning: &ReasoningSpec{
+				MultiTurn: &MultiTurnSpec{
+					MaxRounds:     3,
+					ContextGrowth: "accumulate",
+					ThinkTimeUs:   100_000,
+					// SingleSession: false (default)
+				},
+			},
+		}},
+	}
+}
+
+// TestLazyRequestSource_SingleClient_NonReasoning_MatchesEager pins BC-3
+// for the simplest non-reasoning case: a single open-loop client. The eager
+// generator's slice and the lazy source's drain must be byte-identical.
+func TestLazyRequestSource_SingleClient_NonReasoning_MatchesEager(t *testing.T) {
+	spec := singleClientChatbotSpec(42)
+	specCopy := *spec
+	specCopy.Clients = append([]ClientSpec{}, spec.Clients...)
+
+	eager, err := GenerateRequests(spec, 10_000_000, 50)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, _, _, err := GenerateWorkloadLazy(&specCopy, 10_000_000, 50)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	assertRequestStreamsEqual(t, eager, lazy)
+}
+
+// TestLazyRequestSource_TieBreakerByClientIndex pins BC-7: when two clients
+// produce identical-arrival-time requests, the lower-index client wins
+// the heap pop — matching sort.SliceStable's behavior in eager mode.
+func TestLazyRequestSource_TieBreakerByClientIndex(t *testing.T) {
+	spec := twoClientConstantArrivalSpec(7)
+	specCopy := *spec
+	specCopy.Clients = append([]ClientSpec{}, spec.Clients...)
+
+	eager, err := GenerateRequests(spec, 5_000_000, 10)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, _, _, err := GenerateWorkloadLazy(&specCopy, 5_000_000, 10)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	assertRequestStreamsEqual(t, eager, lazy)
+}
+
+// TestLazyRequestSource_IDsSequentialInArrivalOrder pins BC-7's ID format:
+// IDs are "request_<i>" in heap-pop (arrival) order.
+func TestLazyRequestSource_IDsSequentialInArrivalOrder(t *testing.T) {
+	spec := singleClientChatbotSpec(99)
+	src, _, _, err := GenerateWorkloadLazy(spec, 5_000_000, 20)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	for i, r := range lazy {
+		want := fmt.Sprintf("request_%d", i)
+		if r.ID != want {
+			t.Fatalf("request %d: ID=%q want=%q", i, r.ID, want)
+		}
+		if i > 0 && r.ArrivalTime < lazy[i-1].ArrivalTime {
+			t.Fatalf("request %d: ArrivalTime=%d < prev=%d (out of arrival order)",
+				i, r.ArrivalTime, lazy[i-1].ArrivalTime)
+		}
+	}
+}
+
+// TestGenerateWorkloadLazy_StopsAtMaxRequests pins BC-6: lazy mode counts
+// emitted requests as it goes and stops at maxRequests (no per-client
+// 2*maxRequests safety cap applied — that exists only in eager mode).
+func TestGenerateWorkloadLazy_StopsAtMaxRequests(t *testing.T) {
+	spec := singleClientChatbotSpec(13)
+	src, _, _, err := GenerateWorkloadLazy(spec, 60_000_000, 7)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	if int64(len(lazy)) > 7 {
+		t.Fatalf("emitted %d requests; want <= 7", len(lazy))
+	}
+}
+
+// TestGenerateWorkloadLazy_FallsBackOnPerWindowParameters pins BC-8's
+// time-varying fallback signal: when any client has a per-window
+// parameter override, the factory returns ErrLazyUnsupportedTimeVarying
+// (caller falls back to GenerateWorkload).
+func TestGenerateWorkloadLazy_FallsBackOnPerWindowParameters(t *testing.T) {
+	traceRate := 2.0
+	spec := &WorkloadSpec{
+		Version: "1", Seed: 1, Category: "language", AggregateRate: 4.0,
+		Clients: []ClientSpec{{
+			ID: "c1", TenantID: "t1", SLOClass: "batch", RateFraction: 1.0,
+			Arrival:    ArrivalSpec{Process: "poisson"},
+			InputDist:  DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 100, "std_dev": 10, "min": 10, "max": 500}},
+			OutputDist: DistSpec{Type: "exponential", Params: map[string]float64{"mean": 50}},
+			Lifecycle: &LifecycleSpec{Windows: []ActiveWindow{
+				{StartUs: 0, EndUs: 5_000_000, TraceRate: &traceRate},
+			}},
+		}},
+	}
+	_, _, _, err := GenerateWorkloadLazy(spec, 10_000_000, 10)
+	if !errors.Is(err, ErrLazyUnsupportedTimeVarying) {
+		t.Fatalf("want ErrLazyUnsupportedTimeVarying, got %v", err)
+	}
+}
+
+// TestGenerateWorkloadLazy_FallsBackOnConcurrencyClient pins BC-8's
+// concurrency fallback: any client with Concurrency > 0 forces the
+// caller to fall back to GenerateWorkload.
+func TestGenerateWorkloadLazy_FallsBackOnConcurrencyClient(t *testing.T) {
+	spec := &WorkloadSpec{
+		Version: "1", Seed: 1, Category: "language",
+		Clients: []ClientSpec{{
+			ID: "c1", TenantID: "t1", SLOClass: "batch",
+			Concurrency: 4,
+			ThinkTimeUs: 100_000,
+			InputDist:   DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 100, "std_dev": 10, "min": 10, "max": 500}},
+			OutputDist:  DistSpec{Type: "exponential", Params: map[string]float64{"mean": 50}},
+		}},
+	}
+	_, _, _, err := GenerateWorkloadLazy(spec, 10_000_000, 10)
+	if !errors.Is(err, ErrLazyUnsupportedConcurrency) {
+		t.Fatalf("want ErrLazyUnsupportedConcurrency, got %v", err)
+	}
+}
+
+// TestGenerateWorkloadLazy_EmptyHorizon_ImmediatelyExhausted pins R20: a
+// zero/negative horizon must return an empty, immediately-exhausted source
+// rather than nil.
+func TestGenerateWorkloadLazy_EmptyHorizon_ImmediatelyExhausted(t *testing.T) {
+	spec := singleClientChatbotSpec(1)
+	src, sessions, budget, err := GenerateWorkloadLazy(spec, 0, 10)
+	if err != nil {
+		t.Fatalf("zero-horizon: unexpected err %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source even for zero horizon")
+	}
+	if r, ok := src.Next(); ok || r != nil {
+		t.Fatalf("zero-horizon Next() = (%v, %v); want (nil, false)", r, ok)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("zero-horizon should return 0 sessions, got %d", len(sessions))
+	}
+	if budget != -1 {
+		t.Errorf("zero-horizon followUpBudget = %d; want -1", budget)
+	}
+}
+
+// TestLazyRequestSource_NegativeMaxRequests_ReturnsError pins R3-style
+// validation: negative maxRequests is rejected with an error rather than
+// silently treated as "unlimited".
+func TestLazyRequestSource_NegativeMaxRequests_ReturnsError(t *testing.T) {
+	spec := singleClientChatbotSpec(1)
+	_, _, _, err := GenerateWorkloadLazy(spec, 1_000_000, -1)
+	if err == nil {
+		t.Fatal("expected error for negative maxRequests")
+	}
+}
+
+// TestLazyRequestSource_SameSeed_TwoRunsIdentical pins BC-5 (INV-6
+// determinism): running the lazy source twice with the same seed
+// produces byte-identical request sequences.
+func TestLazyRequestSource_SameSeed_TwoRunsIdentical(t *testing.T) {
+	spec1 := singleClientChatbotSpec(2026)
+	spec2 := singleClientChatbotSpec(2026)
+	a, _, _, err := GenerateWorkloadLazy(spec1, 5_000_000, 25)
+	if err != nil {
+		t.Fatalf("lazy a: %v", err)
+	}
+	b, _, _, err := GenerateWorkloadLazy(spec2, 5_000_000, 25)
+	if err != nil {
+		t.Fatalf("lazy b: %v", err)
+	}
+	first := drainLazy(t, a)
+	second := drainLazy(t, b)
+	assertRequestStreamsEqual(t, first, second)
+}
+
+// TestLazyRequestSource_PrefixGroup_MatchesEager pins BC-3 across a
+// non-trivial code path: shared prefix tokens prepended to each
+// request's InputTokens. The prefix slice contents must be identical
+// in both modes (drawn from workloadRNG in identical order).
+func TestLazyRequestSource_PrefixGroup_MatchesEager(t *testing.T) {
+	mk := func() *WorkloadSpec {
+		return &WorkloadSpec{
+			Version: "1", Seed: 314, Category: "language", AggregateRate: 5.0,
+			Clients: []ClientSpec{{
+				ID: "c1", TenantID: "t1", SLOClass: "batch", RateFraction: 1.0,
+				PrefixGroup:  "g1",
+				PrefixLength: 200,
+				Arrival:      ArrivalSpec{Process: "poisson"},
+				InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 50, "std_dev": 5, "min": 10, "max": 200}},
+				OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+			}},
+		}
+	}
+	eager, err := GenerateRequests(mk(), 5_000_000, 20)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, _, _, err := GenerateWorkloadLazy(mk(), 5_000_000, 20)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazy := drainLazy(t, src)
+	assertRequestStreamsEqual(t, eager, lazy)
+	if len(lazy) == 0 || lazy[0].PrefixLength != 200 {
+		t.Fatalf("expected PrefixLength=200, got %d", lazy[0].PrefixLength)
+	}
+}
+
+// TestLazyRequestSource_Reasoning_SingleSession_MatchesEager pins BC-3 for
+// SingleSession=true reasoning (the inference-perf shape and #1441's
+// reproducer). The streaming source must produce the same session IDs in
+// the same order (only round-0 emitted) and consume RNG draws identically.
+func TestLazyRequestSource_Reasoning_SingleSession_MatchesEager(t *testing.T) {
+	mk := func() *WorkloadSpec {
+		return reasoningSingleSessionSpec(2027)
+	}
+	// GenerateWorkload is the eager closed-loop baseline (filters round-0).
+	wlEager, err := GenerateWorkload(mk(), 3_000_000, 20)
+	if err != nil {
+		t.Fatalf("eager GenerateWorkload: %v", err)
+	}
+	src, lazySessions, _, err := GenerateWorkloadLazy(mk(), 3_000_000, 20)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazyReqs := drainLazy(t, src)
+	assertRequestStreamsEqual(t, wlEager.Requests, lazyReqs)
+
+	// Blueprints must match in count, order, and SessionID.
+	if len(wlEager.Sessions) != len(lazySessions) {
+		t.Fatalf("session count: eager=%d lazy=%d", len(wlEager.Sessions), len(lazySessions))
+	}
+	for i := range wlEager.Sessions {
+		if wlEager.Sessions[i].SessionID != lazySessions[i].SessionID {
+			t.Fatalf("session %d: SessionID eager=%q lazy=%q",
+				i, wlEager.Sessions[i].SessionID, lazySessions[i].SessionID)
+		}
+		if wlEager.Sessions[i].ClientID != lazySessions[i].ClientID {
+			t.Fatalf("session %d: ClientID eager=%q lazy=%q",
+				i, wlEager.Sessions[i].ClientID, lazySessions[i].ClientID)
+		}
+	}
+}
+
+// TestGenerateWorkloadLazy_FallsBackOnMultiSession pins the
+// SingleSession=false fallback: any reasoning client without
+// SingleSession=true forces the caller back to GenerateWorkload.
+func TestGenerateWorkloadLazy_FallsBackOnMultiSession(t *testing.T) {
+	_, _, _, err := GenerateWorkloadLazy(reasoningMultiSessionSpec(7), 5_000_000, 20)
+	if !errors.Is(err, ErrLazyUnsupportedMultiSession) {
+		t.Fatalf("want ErrLazyUnsupportedMultiSession, got %v", err)
+	}
+}

--- a/sim/workload/stream_test.go
+++ b/sim/workload/stream_test.go
@@ -496,6 +496,155 @@ func TestLazyRequestSource_Multimodal_MatchesEager(t *testing.T) {
 	assertRequestStreamsEqual(t, eager, lazy)
 }
 
+// TestLazyRequestSource_PoppedNotYielded_StopsAtPoppedCap pins the
+// stopping rule of lazyRequestSource.Next: the cap applies to `popped`
+// (total heap pops, including suppressed intermediate closed-loop
+// rounds), not to `yielded`. Regressions that change the stop condition
+// to `l.yielded >= l.maxRequests` would yield extra round-0 requests
+// past the eager truncation point and break parity.
+//
+// Construction: 2 closed-loop reasoning clients (NOT SingleSession), so
+// each session has rounds 0, 1, 2 — all popped, only round-0 yielded.
+// With maxRequests = 6, eager truncates to first 6 in arrival order
+// (a mix of round-0 and intermediate rounds). Lazy must stop at popped
+// = 6 and yield strictly fewer than 6 requests to the cluster.
+func TestLazyRequestSource_PoppedNotYielded_StopsAtPoppedCap(t *testing.T) {
+	mk := func() *WorkloadSpec {
+		mkClient := func(id string) ClientSpec {
+			return ClientSpec{
+				ID: id, TenantID: id + "-t", SLOClass: "batch",
+				RateFraction: 0.5,
+				Arrival:      ArrivalSpec{Process: "poisson"},
+				InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 60, "std_dev": 10, "min": 10, "max": 200}},
+				OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+				Reasoning: &ReasoningSpec{
+					MultiTurn: &MultiTurnSpec{
+						MaxRounds:     3,
+						ContextGrowth: "accumulate",
+						ThinkTimeUs:   100_000,
+						SingleSession: true, // need lazy-supported variant
+					},
+				},
+			}
+		}
+		return &WorkloadSpec{
+			Version: "1", Seed: 2027, Category: "language", AggregateRate: 4.0,
+			Clients: []ClientSpec{mkClient("r1"), mkClient("r2")},
+		}
+	}
+	const tightCap = int64(4)
+	wlEager, err := GenerateWorkload(mk(), 3_000_000, tightCap)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, _, _, err := GenerateWorkloadLazy(mk(), 3_000_000, tightCap)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazyReqs := drainLazy(t, src)
+	// Lazy and eager must yield the same set of round-0 requests to the
+	// cluster, including the SAME truncation effect (fewer than maxRequests
+	// if intermediate rounds consumed some of the cap).
+	assertRequestStreamsEqual(t, wlEager.Requests, lazyReqs)
+	// Sanity: the test must actually exercise the popped > yielded case.
+	// If lazy yields >= maxRequests round-0s, the cap was applied at the
+	// wrong layer.
+	if int64(len(lazyReqs)) >= tightCap {
+		t.Fatalf("yielded %d requests under cap=%d — expected fewer (intermediate rounds should consume part of the cap)", len(lazyReqs), tightCap)
+	}
+}
+
+// TestLazyRequestSource_Reasoning_TightMaxRequests_BlueprintParity pins
+// the fix for PR #1453 self-review (IMPORTANT issue #1): when
+// maxRequests is small enough to drop a later session's round-0, the
+// blueprint pre-pass must produce the SAME set of SessionBlueprints
+// as the eager path — same count, same SessionIDs, same order, same
+// per-session RNG seeds.
+//
+// Eager constructs blueprints by scanning the truncated request slice.
+// Lazy's blueprint pre-pass must mirror that exactly, including the
+// truncation effect. A pre-pass that enumerates all sessions across
+// the horizon would consume extra blueprintRNG.Int63() draws,
+// shifting all subsequent blueprint RNG seeds and breaking byte-
+// identity (INV-6) + run/replay parity (INV-13).
+//
+// Construction: 8 single-session reasoning clients × MaxRounds=2 → 16
+// round-emissions total. maxRequests=10 → eager truncates to first 10
+// in arrival order. Most clients' round-0 survives but some don't.
+// Lazy must match the surviving subset exactly.
+func TestLazyRequestSource_Reasoning_TightMaxRequests_BlueprintParity(t *testing.T) {
+	mk := func() *WorkloadSpec {
+		mkClient := func(id string) ClientSpec {
+			return ClientSpec{
+				ID: id, TenantID: id + "-t", SLOClass: "batch",
+				RateFraction: 0.125, // 8 clients × 0.125 = 1.0
+				Arrival:      ArrivalSpec{Process: "poisson"},
+				InputDist:    DistSpec{Type: "gaussian", Params: map[string]float64{"mean": 60, "std_dev": 10, "min": 10, "max": 200}},
+				OutputDist:   DistSpec{Type: "exponential", Params: map[string]float64{"mean": 30}},
+				Reasoning: &ReasoningSpec{
+					MultiTurn: &MultiTurnSpec{
+						MaxRounds:     2,
+						ContextGrowth: "accumulate",
+						ThinkTimeUs:   100_000,
+						SingleSession: true,
+					},
+				},
+			}
+		}
+		return &WorkloadSpec{
+			Version: "1", Seed: 2031, Category: "language", AggregateRate: 4.0,
+			Clients: []ClientSpec{
+				mkClient("r0"), mkClient("r1"), mkClient("r2"), mkClient("r3"),
+				mkClient("r4"), mkClient("r5"), mkClient("r6"), mkClient("r7"),
+			},
+		}
+	}
+	const tightCap = int64(10)
+	wlEager, err := GenerateWorkload(mk(), 5_000_000, tightCap)
+	if err != nil {
+		t.Fatalf("eager: %v", err)
+	}
+	src, lazySessions, _, err := GenerateWorkloadLazy(mk(), 5_000_000, tightCap)
+	if err != nil {
+		t.Fatalf("lazy: %v", err)
+	}
+	lazyReqs := drainLazy(t, src)
+	assertRequestStreamsEqual(t, wlEager.Requests, lazyReqs)
+
+	// The point of this test: blueprints must match in count AND order
+	// AND RNG-seed-derived state. If lazy enumerated all sessions across
+	// the horizon (ignoring the cap), it would have MORE blueprints than
+	// eager — and each surviving blueprint's RNG seed would be shifted.
+	if len(wlEager.Sessions) != len(lazySessions) {
+		t.Fatalf("session count under tight cap: eager=%d lazy=%d (the pre-pass must respect maxRequests)",
+			len(wlEager.Sessions), len(lazySessions))
+	}
+	for i := range wlEager.Sessions {
+		if wlEager.Sessions[i].SessionID != lazySessions[i].SessionID {
+			t.Fatalf("blueprint %d: SessionID eager=%q lazy=%q",
+				i, wlEager.Sessions[i].SessionID, lazySessions[i].SessionID)
+		}
+		if wlEager.Sessions[i].ClientID != lazySessions[i].ClientID {
+			t.Fatalf("blueprint %d: ClientID eager=%q lazy=%q",
+				i, wlEager.Sessions[i].ClientID, lazySessions[i].ClientID)
+		}
+		// RNG byte-identity: draw one Int63 from each and compare. If
+		// blueprint RNG seeds matched, these MUST match too.
+		eDraw := wlEager.Sessions[i].RNG.Int63()
+		lDraw := lazySessions[i].RNG.Int63()
+		if eDraw != lDraw {
+			t.Fatalf("blueprint %d (session %q): RNG draw diverged eager=%d lazy=%d — blueprintRNG seeds shifted",
+				i, wlEager.Sessions[i].SessionID, eDraw, lDraw)
+		}
+	}
+	// Sanity: confirm at least one client lost its session to the cap.
+	// Otherwise the test would pass even without the fix.
+	if len(wlEager.Sessions) >= 8 {
+		t.Fatalf("test setup ineffective: expected fewer than 8 sessions to survive cap=%d, got %d — adjust the setup so the cap actually binds",
+			tightCap, len(wlEager.Sessions))
+	}
+}
+
 // TestGenerateWorkloadLazy_FallsBackOnMultiSession pins the
 // SingleSession=false fallback: any reasoning client without
 // SingleSession=true forces the caller back to GenerateWorkload.


### PR DESCRIPTION
## Summary

- Adds `--lazy-generation` (alpha, default off) on `blis run` so the workload generator emits requests through a streaming `RequestSource` interleaved by a `(arrival, clientIdx, perClientSeq)` priority queue, instead of pre-generating the full `[]*sim.Request` slice. Memory drops from O(total_requests) to O(num_clients + max_session_rounds).
- New file `sim/workload/stream.go` plus a focused unit test file. The lazy source structurally satisfies `cluster.RequestSource` (no new import edge from `sim/workload` to `sim/cluster`). Eager paths (`GenerateRequests`, `GenerateWorkload`, time-varying generator) are untouched.
- Three fallback gates so the flag is safe: time-varying parameters, concurrency clients, and multi-session reasoning (`SingleSession=false`) cause a one-line warning and fall through to the eager `GenerateWorkload`. Single-shot, single-session reasoning, prefix-group sharing, and cohort-expanded workloads are in scope for the alpha.
- `blis replay` accepts `--lazy-generation` and ignores it for CLI symmetry (replay never invokes the generator).

## Issue

Closes #1441 (Tracker: #1438 · Change A — PR 3 of 5 · depends on A1 #1446 + A2 #1448).

## Why this PR

The eager generator builds `[]*sim.Request` with a `perClientCap = 2 * maxRequests` per client and merge-sorts the union before truncating. For multi-turn cohort workloads at the scale called out in #1438 (N=40 cohort members × R=15 max rounds × 30K-token prefix × num_requests=500), that pre-merge slice peaks in the tens of GB — well before the simulator's algorithmic limits. Lazy mode streams each request through the cluster the moment it is produced, releasing token-slice memory as soon as the cluster has it on its event heap.

A1 (#1446) put the `cluster.RequestSource` interface in place; A2 (#1448) moved trace export off the materialized slice onto the per-arrival hook. With both in place, no pre-`Run()` consumer re-materializes the request list when `--lazy-generation` is on, so the memory-savings claim is unconditional for the supported workload shapes.

## Memory measurement

Smoke-tested with a 2-client × 10K-prefix × 200-request workload spec under `--lazy-generation`:

| Mode  | Peak RSS |
|-------|----------|
| Eager | 152.94 MB |
| Lazy  |  63.40 MB |

~58% peak-RSS reduction on this modest workload. The savings ratio grows with cohort size and prefix length — the issue's reproducer (40 cohort members, 30K-token prefix, 500 requests) is where the tens-of-GB → tens-to-hundreds-of-MB claim from #1441 lands.

## Byte-identity verification

Verified byte-identical stdout + trace YAML + trace CSV between `blis run` and `blis run --lazy-generation` at fixed seeds across three workload shapes:

| Workload | Seed | Result |
|----------|------|--------|
| distribution mode (50 reqs, rate=5) | 42 | stdout identical, trace identical |
| chatbot preset (30 reqs, rate=3) | 1234 | stdout identical |
| 2-client + 10K prefix YAML spec (200 reqs) | 7 | stdout identical |

Verified via diff of captured outputs. The cmd/root_test.go end-to-end test `TestRunCmd_LazyVsEager_Distribution_ByteIdentical` covers this in CI.

## Behavioral contracts (BCs)

- **BC-1 / BC-9** — Flag wired through both commands. `blis run --lazy-generation` parses; `blis replay --lazy-generation` is a no-op.
- **BC-2** — Eager mode unchanged (flag off → byte-identical to `main` at upstream head).
- **BC-3 / BC-4** — Lazy stream is byte-identical to the eager stream for every supported workload (same length, IDs, arrival times, token slices, in the same order). Trace YAML + CSV identical.
- **BC-5** — Determinism (INV-6): two lazy runs at the same seed produce byte-identical stdout.
- **BC-6** — In-loop `maxRequests` truncation. Eager's per-client `2 * maxRequests` safety cap is intentionally not applied in lazy mode.
- **BC-7** — Sequential IDs `request_<i>` assigned in arrival-sorted order with `clientIdx` tie-break (matches eager's `sort.SliceStable`).
- **BC-8** — Time-varying / concurrency / multi-session-reasoning fallback: one warning line, eager generator runs.
- **BC-10** — No fields added to any existing exported struct; no changes to `cluster.RequestSource`.

## Determinism (INV-6, the central correctness concern)

1. `workloadRNG.Int63()` per-client seeds are drawn in `allClients` order at construction time, **before any client produces its first request** — matching eager `generator.go:119`.
2. `generatePrefixTokens(allClients, workloadRNG)` runs in the same RNG state as eager.
3. Priority queue ordering key is `(arrivalUs, clientIdx, perClientSeq)` — the `clientIdx` term preserves `sort.SliceStable`'s tie-break behavior.
4. SessionBlueprints are constructed in a pre-pass that replays each closed-loop client's RNG to enumerate session IDs, then drawn from `blueprintRNG` in sorted-session-IDs-per-client order — matching `generator.go:506`.
5. Sequential IDs are assigned in heap-pop yield order, matching `GenerateWorkload`'s post-filter renumbering at `generator.go:619-621`.
6. Intermediate closed-loop rounds (`RoundIndex > 0`) are popped from the heap and **count toward maxRequests**, but are NOT yielded to the cluster — matching eager's "produce all rounds, truncate to maxRequests, then filter round-0" sequencing.

## Scope deviations from #1441

Documented in the plan's deviation log:

1. **Multi-session reasoning (`SingleSession=false`) falls back to eager** with a warning. The eager path's per-client multi-session loop produces all sessions in series and then global-sorts them; a single-entry-per-client streaming source cannot reproduce that interleaving correctly without pre-drawing every session's anchor. Single-session reasoning (the inference-perf shape and the #1441 reproducer shape per its `GenerateReasoningRequests` reference) IS supported.
2. **Concurrency clients (`Concurrency > 0`) fall back to eager** with a warning. Concurrency clients generate seed requests via `concurrencyRNG` in `GenerateWorkload`'s separate path; adding their merge into the heap is out of the alpha scope.
3. **Time-varying parameters fall back to eager** with a warning, as called out in the issue itself.

Each fallback is enforced by a sentinel error (`ErrLazyUnsupportedMultiSession`, `ErrLazyUnsupportedConcurrency`, `ErrLazyUnsupportedTimeVarying`) so the gating cannot drift silently.

## Saturation analysis under lazy mode

In lazy mode `preGeneratedRequests` is nil, so the existing `preGeneratedRequests + followUpRequests + sort` assembly for `--saturation-report` is unavailable. Instead, the per-arrival hook (added by A2 #1448) is installed unconditionally when lazy mode + `--saturation-report` are both set; the hook delivers request pointers in clock-monotonic arrival order (INV-3), so saturation reads them directly with no post-sort. Eager + saturation is unchanged.

## Cross-Path Parity

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | yes | yes | Lazy source feeds the cluster via `cluster.RequestSource`; arrival hook handles both trace export (A2) and saturation. |
| `blis replay` | flag accepted (BC-9) | yes (no-op) | Replay reads from a captured trace; the flag is for CLI symmetry only. |
| `blis observe` | no | n/a | Explicitly out of scope for this PR (Change A part 3 of 5). `cmd/observe_cmd.go:386` calls `workload.GenerateWorkload(...)` eagerly and mutates each `wl.Requests[i]` (streaming flags, think-time) — the #1438 memory spike applies equally to `observe`. Migration tracked in follow-up issue #1455. |

## Invariants Preserved

- **INV-6 (Determinism):** central concern — see "Determinism" section. Tested by same-seed determinism test + property byte-identity tests.
- **INV-13 (Run/replay parity):** trace export is unchanged (still flows through the A2 arrival hook); the lazy source produces the same arrival stream eager does, so replay sees an identical trace.
- **INV-1 / INV-2 / INV-3:** preserved trivially — the cluster sees the same request stream, just produced lazily.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout 240s` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] **Streaming unit tests** (`sim/workload/stream_test.go`): per-client production matches eager; priority-queue tie-break by `clientIdx`; sequential IDs in arrival order; `maxRequests` truncation; same-seed determinism; prefix-group sharing; single-session reasoning byte-identity; blueprint pre-pass matches eager; all three fallback paths; zero-horizon and negative-`maxRequests` edge cases.
- [x] **End-to-end byte-identity** (`cmd/root_test.go`): `TestRunCmd_LazyVsEager_Distribution_ByteIdentical` runs blis twice with same seed and asserts YAML + CSV bytes equal; `TestRunCmd_LazyGeneration_SameSeed_Deterministic` asserts INV-6.
- [x] **Replay flag** (`cmd/replay_test.go`): `TestReplayCmd_LazyGenerationFlag_AcceptedAsNoOp` asserts the flag is registered with the expected default.
- [x] **Real binary smoke**: `./blis run --seed 42 --num-requests 50 --rate 5.0 --trace-output …` produces byte-identical stdout/YAML/CSV with vs without `--lazy-generation` (distribution mode); same for chatbot preset.
- [x] **Time-varying fallback smoke**: `./blis run --workload-spec <spec-with-lifecycle-window-overrides> --lazy-generation` logs the expected one-line warning and completes successfully via eager.

## Files changed

- `sim/workload/generator.go` — extracts the spec-mutating prelude into a reusable `validateAndExpandSpec` helper. Behavior-preserving.
- `sim/workload/stream.go` — new. The `lazyRequestSource`, `clientStreamState`, priority queue, and `GenerateWorkloadLazy` factory.
- `sim/workload/stream_test.go` — new. Streaming-source unit tests.
- `cmd/root.go` — adds the `--lazy-generation` flag and wires the streaming source into `cluster.NewClusterSimulator`; routes saturation analysis through the arrival hook in lazy mode.
- `cmd/replay.go` — adds the `--lazy-generation` flag as a no-op.
- `cmd/root_test.go` — adds three end-to-end tests (flag registered, eager ≡ lazy byte-identity, same-seed determinism).
- `cmd/replay_test.go` — adds the no-op flag test.
- `CLAUDE.md` — documents the new flag and its fallback rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
