### PR TITLE
refactor: compact token IDs ([]int → []TokenID/int32)

### DIFF
--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -1087,9 +1087,9 @@ func adaptForSessionManager(original *sim.Request, record *RequestRecord) *sim.R
 	adapted.ProgressIndex = int64(len(original.InputTokens) + outputCount)
 
 	if outputCount > 0 {
-		adapted.OutputTokens = make([]int, outputCount)
+		adapted.OutputTokens = make([]sim.TokenID, outputCount)
 		for i := range adapted.OutputTokens {
-			adapted.OutputTokens[i] = i + 1
+			adapted.OutputTokens[i] = sim.TokenID(i + 1)
 		}
 	}
 
@@ -1099,14 +1099,14 @@ func adaptForSessionManager(original *sim.Request, record *RequestRecord) *sim.R
 // tokensToPrompt converts token IDs into a diverse prompt string using
 // prefixVocabulary. Each token ID selects a vocabulary word via modular
 // indexing, ensuring different token arrays produce different prompts.
-func tokensToPrompt(tokens []int, wordCount int) string {
+func tokensToPrompt(tokens []sim.TokenID, wordCount int) string {
 	vocabLen := len(prefixVocabulary)
 	var b strings.Builder
 	b.Grow(wordCount * 8) // average word ~7 chars + space
 	for i := 0; i < wordCount; i++ {
 		var idx int
 		if i < len(tokens) {
-			idx = tokens[i]
+			idx = int(tokens[i])
 		} else {
 			idx = i
 		}

--- a/cmd/observe_cmd_test.go
+++ b/cmd/observe_cmd_test.go
@@ -136,8 +136,8 @@ func TestObserveOrchestrator_OpenLoop_ConservationAndConcurrency(t *testing.T) {
 		requests[i] = &sim.Request{
 			ID:           fmt.Sprintf("request_%d", i),
 			ArrivalTime:  int64(i) * 10000, // 10ms apart in microseconds
-			InputTokens:  make([]int, 100),
-			OutputTokens: make([]int, 50),
+			InputTokens:  make([]sim.TokenID, 100),
+			OutputTokens: make([]sim.TokenID, 50),
 			MaxOutputLen: 50,
 			State:        sim.StateQueued,
 		}
@@ -307,7 +307,7 @@ func TestObserveOrchestrator_WarmupExclusion(t *testing.T) {
 	for i := range requests {
 		requests[i] = &sim.Request{
 			ID: fmt.Sprintf("request_%d", i), ArrivalTime: int64(i) * 1000,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			MaxOutputLen: 5, State: sim.StateQueued,
 		}
 	}
@@ -335,7 +335,7 @@ func TestObserveOrchestrator_WarmupExceedsTotal(t *testing.T) {
 	for i := range requests {
 		requests[i] = &sim.Request{
 			ID: fmt.Sprintf("request_%d", i), ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			MaxOutputLen: 5, State: sim.StateQueued,
 		}
 	}
@@ -374,7 +374,7 @@ func TestObserveOrchestrator_RecordITL_CapturesChunkTimestamps(t *testing.T) {
 	requests := []*sim.Request{
 		{
 			ID: "request_0", ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 3),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 3),
 			MaxOutputLen: 3, State: sim.StateQueued, Streaming: true,
 		},
 	}
@@ -416,7 +416,7 @@ func TestObserveOrchestrator_TimestampOrdering(t *testing.T) {
 
 	requests := []*sim.Request{{
 		ID: "request_0", ArrivalTime: 0,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 		MaxOutputLen: 5, State: sim.StateQueued,
 	}}
 
@@ -455,7 +455,7 @@ func TestObserveOrchestrator_TraceV2RoundTrip(t *testing.T) {
 	for i := range requests {
 		requests[i] = &sim.Request{
 			ID: fmt.Sprintf("request_%d", i), ArrivalTime: int64(i) * 100000,
-			InputTokens: make([]int, 100), OutputTokens: make([]int, 50),
+			InputTokens: make([]sim.TokenID, 100), OutputTokens: make([]sim.TokenID, 50),
 			MaxOutputLen: 50, State: sim.StateQueued, ClientID: "test-client",
 		}
 	}
@@ -510,7 +510,7 @@ func TestObserveOrchestrator_ErrorStormDrain(t *testing.T) {
 	for i := range requests {
 		requests[i] = &sim.Request{
 			ID: fmt.Sprintf("request_%d", i), ArrivalTime: int64(i) * 1000,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			MaxOutputLen: 5, State: sim.StateQueued,
 		}
 	}
@@ -551,7 +551,7 @@ func TestObserveOrchestrator_ContextCancellation(t *testing.T) {
 	for i := range requests {
 		requests[i] = &sim.Request{
 			ID: fmt.Sprintf("request_%d", i), ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			MaxOutputLen: 5, State: sim.StateQueued,
 		}
 	}
@@ -662,7 +662,7 @@ func TestRequestToPending_PrependsPrefixString(t *testing.T) {
 
 	req := &sim.Request{
 		ID:           "test",
-		InputTokens:  make([]int, 10),
+		InputTokens:  make([]sim.TokenID, 10),
 		PrefixGroup:  "shared",
 		PrefixLength: 64,
 	}
@@ -691,7 +691,7 @@ func TestRequestToPending_PrependsPrefixString(t *testing.T) {
 	// Without prefix group: no prefix
 	reqNoPrefix := &sim.Request{
 		ID:          "test2",
-		InputTokens: []int{5, 15, 25, 35, 45, 55, 65, 75, 85, 95},
+		InputTokens: []sim.TokenID{5, 15, 25, 35, 45, 55, 65, 75, 85, 95},
 	}
 	pendingNoPrefix := requestToPending(reqNoPrefix, 1, false, false, prefixes, prefixLengths, 1.0)
 	// Without prefix group, prompt should not start with the group prefix string
@@ -703,12 +703,12 @@ func TestRequestToPending_PrependsPrefixString(t *testing.T) {
 func TestRequestToPending_UsesPerRequestStreaming(t *testing.T) {
 	streamingReq := &sim.Request{
 		ID:          "stream-req",
-		InputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 5),
 		Streaming:   true,
 	}
 	nonStreamingReq := &sim.Request{
 		ID:          "nostream-req",
-		InputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 5),
 		Streaming:   false,
 	}
 
@@ -851,9 +851,9 @@ func TestRequestToPending_SuffixUsesTokenCountNotWordCount(t *testing.T) {
 		t.Fatalf("prefix word count = %d, want 50", len(prefixWords))
 	}
 
-	suffixTokens := make([]int, 200)
+	suffixTokens := make([]sim.TokenID, 200)
 	for i := range suffixTokens {
-		suffixTokens[i] = i * 3
+		suffixTokens[i] = sim.TokenID(i * 3)
 	}
 	req := &sim.Request{
 		ID:          "test",
@@ -875,11 +875,11 @@ func TestRequestToPending_NoPrefixDiversePrompt(t *testing.T) {
 	// Two requests with different random token IDs and no prefix group
 	req1 := &sim.Request{
 		ID:          "r1",
-		InputTokens: []int{10, 20, 30, 40, 50},
+		InputTokens: []sim.TokenID{10, 20, 30, 40, 50},
 	}
 	req2 := &sim.Request{
 		ID:          "r2",
-		InputTokens: []int{60, 70, 80, 90, 100},
+		InputTokens: []sim.TokenID{60, 70, 80, 90, 100},
 	}
 
 	// tokensPerWord=1.0 for direct word-to-token mapping
@@ -905,9 +905,9 @@ func TestRequestToPending_NoPrefixDiversePrompt(t *testing.T) {
 
 func TestRequestToPending_WordCountScaledByTokensPerWord(t *testing.T) {
 	// BC-5: with tokensPerWord=2.0, 100 tokens should produce 50 words
-	tokens := make([]int, 100)
+	tokens := make([]sim.TokenID, 100)
 	for i := range tokens {
-		tokens[i] = i * 7 // deterministic, diverse values
+		tokens[i] = sim.TokenID(i * 7) // deterministic, diverse values
 	}
 	req := &sim.Request{
 		ID:          "scaled",
@@ -929,7 +929,7 @@ func TestRequestToPending_UnknownPrefixGroupFallback(t *testing.T) {
 
 	req := &sim.Request{
 		ID:          "fallback",
-		InputTokens: []int{3, 17, 42, 88, 61},
+		InputTokens: []sim.TokenID{3, 17, 42, 88, 61},
 		PrefixGroup: "unknownGroup",
 	}
 	pending := requestToPending(req, 0, false, false, prefixes, prefixLengths, 1.0)
@@ -948,7 +948,7 @@ func TestRequestToPending_UnknownPrefixGroupFallback(t *testing.T) {
 }
 
 func TestTokensToPrompt_DiverseWords(t *testing.T) {
-	tokens := []int{0, 1, 50, 99, 100, 200}
+	tokens := []sim.TokenID{0, 1, 50, 99, 100, 200}
 	result := tokensToPrompt(tokens, 6)
 	words := strings.Fields(result)
 
@@ -996,7 +996,7 @@ func TestTokensToPrompt_EmptyTokens(t *testing.T) {
 
 func TestTokensToPrompt_NegativeTokenIDs(t *testing.T) {
 	// Negative token IDs should not panic (Go % preserves sign).
-	tokens := []int{-1, -100, -50, 7}
+	tokens := []sim.TokenID{-1, -100, -50, 7}
 	result := tokensToPrompt(tokens, 4)
 	words := strings.Fields(result)
 	if len(words) != 4 {
@@ -1017,7 +1017,7 @@ func TestRequestToPending_WordCountClampedToOne(t *testing.T) {
 	// 1 token with tokensPerWord=2.0 → round(0.5)=0 → clamped to 1
 	req := &sim.Request{
 		ID:          "tiny",
-		InputTokens: []int{42},
+		InputTokens: []sim.TokenID{42},
 	}
 	pending := requestToPending(req, 0, false, false, nil, nil, 2.0)
 	words := strings.Fields(pending.Prompt)
@@ -1072,7 +1072,7 @@ func TestRequestToPending_MinTokensPropagated(t *testing.T) {
 	// BC-1: MinTokens must equal MaxOutputLen per-request (not a global constant).
 	req := &sim.Request{
 		ID:           "per-req-min-tok",
-		InputTokens:  make([]int, 5),
+		InputTokens:  make([]sim.TokenID, 5),
 		MaxOutputLen: 128,
 	}
 	p := requestToPending(req, 0, false, false, nil, nil, 1.0)
@@ -1101,7 +1101,7 @@ func TestRequestToPending_MinTokensEqualsMaxOutputLen(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &sim.Request{
 				ID:           "r",
-				InputTokens:  make([]int, 5),
+				InputTokens:  make([]sim.TokenID, 5),
 				MaxOutputLen: tc.maxOutputLen,
 			}
 			p := requestToPending(req, 0, false, tc.unconstrained, nil, nil, 1.0)

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -1994,13 +1994,13 @@ func makeMinimalPDRequests(t *testing.T) []*sim.Request {
 	t.Helper()
 	reqs := make([]*sim.Request, 3)
 	for i := range reqs {
-		inputToks := make([]int, 10)
+		inputToks := make([]sim.TokenID, 10)
 		for j := range inputToks {
-			inputToks[j] = 100 + i*10 + j
+			inputToks[j] = sim.TokenID(100 + i*10 + j)
 		}
-		outputToks := make([]int, 5)
+		outputToks := make([]sim.TokenID, 5)
 		for j := range outputToks {
-			outputToks[j] = 200 + j
+			outputToks[j] = sim.TokenID(200 + j)
 		}
 		reqs[i] = &sim.Request{
 			ID:           fmt.Sprintf("request_%d", i),

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -49,6 +49,7 @@ inference-sim/
 │   └── internal/              # Shared internal packages
 │       ├── hash/              # Block-level hashing for prefix cache
 │       ├── testutil/          # Shared test infrastructure (golden dataset loading)
+│       ├── tokenid/           # TokenID (int32) type — defined-type compact token ID shared with sim/internal/hash
 │       └── util/              # General utility functions
 ├── sim/kv/                    # KV cache implementations (PKG-1)
 │   ├── cache.go               # KVCacheState (single-tier GPU)

--- a/sim/admission_test.go
+++ b/sim/admission_test.go
@@ -13,9 +13,9 @@ func TestAlwaysAdmit_AdmitsAll(t *testing.T) {
 		req   *Request
 		clock int64
 	}{
-		{name: "empty request", req: &Request{ID: "r0", InputTokens: []int{}}, clock: 0},
-		{name: "small request", req: &Request{ID: "r1", InputTokens: make([]int, 10)}, clock: 1000},
-		{name: "large request", req: &Request{ID: "r2", InputTokens: make([]int, 10000)}, clock: 5_000_000},
+		{name: "empty request", req: &Request{ID: "r0", InputTokens: []TokenID{}}, clock: 0},
+		{name: "small request", req: &Request{ID: "r1", InputTokens: make([]TokenID, 10)}, clock: 1000},
+		{name: "large request", req: &Request{ID: "r2", InputTokens: make([]TokenID, 10000)}, clock: 5_000_000},
 	}
 
 	for _, tt := range tests {
@@ -36,7 +36,7 @@ func TestAlwaysAdmit_AdmitsAll(t *testing.T) {
 func TestTokenBucket_AdmitAndReject(t *testing.T) {
 	t.Run("admits when tokens available", func(t *testing.T) {
 		tb := NewTokenBucket(100, 10)
-		req := &Request{ID: "r0", InputTokens: make([]int, 50)}
+		req := &Request{ID: "r0", InputTokens: make([]TokenID, 50)}
 		admitted, reason := tb.Admit(req, &RouterState{Clock: 0})
 		if !admitted {
 			t.Fatal("expected admission with sufficient tokens")
@@ -49,7 +49,7 @@ func TestTokenBucket_AdmitAndReject(t *testing.T) {
 	t.Run("rejects when tokens exhausted", func(t *testing.T) {
 		// Use tiny refill rate so tokens don't replenish within the test window
 		tb := NewTokenBucket(10, 0.001)
-		req := &Request{ID: "r0", InputTokens: make([]int, 10)}
+		req := &Request{ID: "r0", InputTokens: make([]TokenID, 10)}
 
 		admitted, _ := tb.Admit(req, &RouterState{Clock: 0})
 		if !admitted {
@@ -67,7 +67,7 @@ func TestTokenBucket_AdmitAndReject(t *testing.T) {
 
 	t.Run("refill restores tokens over time", func(t *testing.T) {
 		tb := NewTokenBucket(100, 1_000_000)
-		req := &Request{ID: "r0", InputTokens: make([]int, 100)}
+		req := &Request{ID: "r0", InputTokens: make([]TokenID, 100)}
 
 		admitted, _ := tb.Admit(req, &RouterState{Clock: 0})
 		if !admitted {
@@ -89,7 +89,7 @@ func TestTokenBucket_AdmitAndReject(t *testing.T) {
 
 	t.Run("capacity caps refill", func(t *testing.T) {
 		tb := NewTokenBucket(10, 1_000_000)
-		req := &Request{ID: "r0", InputTokens: make([]int, 5)}
+		req := &Request{ID: "r0", InputTokens: make([]TokenID, 5)}
 
 		admitted, _ := tb.Admit(req, &RouterState{Clock: 0})
 		if !admitted {
@@ -116,7 +116,7 @@ func TestTokenBucket_AdmitAndReject(t *testing.T) {
 	t.Run("zero-cost request always admitted", func(t *testing.T) {
 		// Even with minimal capacity, a zero-cost request (0 input tokens) is admitted
 		tb := NewTokenBucket(1, 1)
-		req := &Request{ID: "r0", InputTokens: []int{}}
+		req := &Request{ID: "r0", InputTokens: []TokenID{}}
 
 		admitted, _ := tb.Admit(req, &RouterState{Clock: 0})
 		if !admitted {
@@ -145,7 +145,7 @@ func TestTokenBucket_AdmitAndReject(t *testing.T) {
 
 // TestNewAdmissionPolicy_ValidNames verifies the factory produces correct behavioral policies.
 func TestNewAdmissionPolicy_ValidNames(t *testing.T) {
-	req := &Request{ID: "r0", InputTokens: make([]int, 10)}
+	req := &Request{ID: "r0", InputTokens: make([]TokenID, 10)}
 	state := &RouterState{Clock: 0}
 
 	t.Run("always-admit admits all", func(t *testing.T) {
@@ -203,8 +203,8 @@ func TestRejectAll_RejectsAll(t *testing.T) {
 		name string
 		req  *Request
 	}{
-		{name: "empty request", req: &Request{ID: "r0", InputTokens: []int{}}},
-		{name: "normal request", req: &Request{ID: "r1", InputTokens: make([]int, 100)}},
+		{name: "empty request", req: &Request{ID: "r0", InputTokens: []TokenID{}}},
+		{name: "normal request", req: &Request{ID: "r1", InputTokens: make([]TokenID, 100)}},
 	}
 
 	for _, tt := range tests {

--- a/sim/batch_formation_test.go
+++ b/sim/batch_formation_test.go
@@ -60,8 +60,8 @@ func TestVLLMBatchFormation_TokenBudgetEnforced(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		wq.Enqueue(&Request{
 			ID:           fmt.Sprintf("req-%d", i),
-			InputTokens:  make([]int, 30),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]TokenID, 30),
+			OutputTokens: make([]TokenID, 5),
 			State:        StateQueued,
 		})
 	}
@@ -114,8 +114,8 @@ func TestVLLMBatchFormation_BatchSizeEnforced(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		wq.Enqueue(&Request{
 			ID:           fmt.Sprintf("req-%d", i),
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]TokenID, 10),
+			OutputTokens: make([]TokenID, 5),
 			State:        StateQueued,
 		})
 	}
@@ -168,8 +168,8 @@ func TestVLLMBatchFormation_PreemptionReleasesKV(t *testing.T) {
 	// GIVEN two running requests: victim occupies 2 blocks, needy needs 3 blocks for prefill
 	victim := &Request{
 		ID:           "victim",
-		InputTokens:  make([]int, 20), // ceil(20/16) = 2 blocks
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 20), // ceil(20/16) = 2 blocks
+		OutputTokens: make([]TokenID, 5),
 		State:        StateRunning,
 	}
 	if ok := kvCache.AllocateKVBlocks(victim, 0, 20, []int64{}); !ok {
@@ -179,8 +179,8 @@ func TestVLLMBatchFormation_PreemptionReleasesKV(t *testing.T) {
 
 	needy := &Request{
 		ID:           "needy",
-		InputTokens:  make([]int, 40), // ceil(40/16) = 3 blocks, but only 1 free
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 40), // ceil(40/16) = 3 blocks, but only 1 free
+		OutputTokens: make([]TokenID, 5),
 		State:        StateRunning,
 	}
 	// needy is in running batch with ProgressIndex=0, so Phase 1 prefill triggers preemptForTokens
@@ -233,8 +233,8 @@ func TestVLLMBatchFormation_PreemptionStopsDequeue(t *testing.T) {
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
 
 	// GIVEN two running requests where req2's prefill will trigger preemption
-	req1 := &Request{ID: "r1", InputTokens: make([]int, 20), OutputTokens: make([]int, 5), State: StateRunning}
-	req2 := &Request{ID: "r2", InputTokens: make([]int, 20), OutputTokens: make([]int, 5), State: StateRunning}
+	req1 := &Request{ID: "r1", InputTokens: make([]TokenID, 20), OutputTokens: make([]TokenID, 5), State: StateRunning}
+	req2 := &Request{ID: "r2", InputTokens: make([]TokenID, 20), OutputTokens: make([]TokenID, 5), State: StateRunning}
 
 	// Allocate blocks for req1 (fills most of cache)
 	if ok := kvCache.AllocateKVBlocks(req1, 0, 20, []int64{}); !ok {
@@ -245,7 +245,7 @@ func TestVLLMBatchFormation_PreemptionStopsDequeue(t *testing.T) {
 	// req2 has ProgressIndex=0, so Phase 1 will try to allocate for its full prefill
 
 	// AND a waiting request that should NOT be dequeued after preemption
-	waitReq := &Request{ID: "wait", InputTokens: make([]int, 5), OutputTokens: make([]int, 2), State: StateQueued}
+	waitReq := &Request{ID: "wait", InputTokens: make([]TokenID, 5), OutputTokens: make([]TokenID, 2), State: StateQueued}
 	wq := &WaitQueue{}
 	wq.Enqueue(waitReq)
 
@@ -289,7 +289,7 @@ func TestVLLMBatchFormation_CircuitBreaker(t *testing.T) {
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
 
 	// GIVEN a request needing more blocks than total capacity
-	huge := &Request{ID: "huge", InputTokens: make([]int, 200), OutputTokens: make([]int, 5), State: StateQueued}
+	huge := &Request{ID: "huge", InputTokens: make([]TokenID, 200), OutputTokens: make([]TokenID, 5), State: StateQueued}
 	wq := &WaitQueue{}
 	wq.Enqueue(huge)
 
@@ -335,9 +335,9 @@ func TestVLLMBatchFormation_KVAllocationFailure_StopsDequeue(t *testing.T) {
 	kvCache := MustNewKVCacheState(cfg.TotalKVBlocks, cfg.BlockSizeTokens)
 
 	// GIVEN: first request fits, second needs too many blocks, third is small but can't skip
-	req1 := &Request{ID: "small", InputTokens: make([]int, 16), OutputTokens: make([]int, 2), State: StateQueued}
-	req2 := &Request{ID: "big", InputTokens: make([]int, 100), OutputTokens: make([]int, 2), State: StateQueued}
-	req3 := &Request{ID: "also-small", InputTokens: make([]int, 10), OutputTokens: make([]int, 2), State: StateQueued}
+	req1 := &Request{ID: "small", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 2), State: StateQueued}
+	req2 := &Request{ID: "big", InputTokens: make([]TokenID, 100), OutputTokens: make([]TokenID, 2), State: StateQueued}
+	req3 := &Request{ID: "also-small", InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 2), State: StateQueued}
 
 	wq := &WaitQueue{}
 	wq.Enqueue(req1)
@@ -393,8 +393,8 @@ func TestPreemptForTokens_CleansUpComputedTokens(t *testing.T) {
 	kv := MustNewKVCacheState(4, 4)
 	victim := &Request{
 		ID:           "victim",
-		InputTokens:  []int{1, 2, 3, 4, 5, 6, 7, 8},
-		OutputTokens: []int{100},
+		InputTokens:  []TokenID{1, 2, 3, 4, 5, 6, 7, 8},
+		OutputTokens: []TokenID{100},
 		State:        StateRunning,
 	}
 	kv.AllocateKVBlocks(victim, 0, 8, []int64{})
@@ -414,8 +414,8 @@ func TestPreemptForTokens_CleansUpComputedTokens(t *testing.T) {
 	// A new request that needs more tokens than available
 	newReq := &Request{
 		ID:           "newcomer",
-		InputTokens:  []int{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160},
-		OutputTokens: []int{100},
+		InputTokens:  []TokenID{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160},
+		OutputTokens: []TokenID{100},
 	}
 	bf := &VLLMBatchFormation{preemptionPolicy: PreemptionFCFS}
 
@@ -451,9 +451,9 @@ func TestVLLMBatchFormation_Phase1_EvictedNotRevisited(t *testing.T) {
 	// Total: 6 blocks = full cache.
 	// r1's decode needs a NEW block (last block full) → triggers preemption of r3 (tail).
 	// r2's decode fills its partial block (15→16) → NO new block needed, r2 survives.
-	r1 := &Request{ID: "r1", InputTokens: make([]int, 48), OutputTokens: make([]int, 100), State: StateRunning}
-	r2 := &Request{ID: "r2", InputTokens: make([]int, 31), OutputTokens: make([]int, 100), State: StateRunning}
-	r3 := &Request{ID: "r3", InputTokens: make([]int, 16), OutputTokens: make([]int, 100), State: StateRunning}
+	r1 := &Request{ID: "r1", InputTokens: make([]TokenID, 48), OutputTokens: make([]TokenID, 100), State: StateRunning}
+	r2 := &Request{ID: "r2", InputTokens: make([]TokenID, 31), OutputTokens: make([]TokenID, 100), State: StateRunning}
+	r3 := &Request{ID: "r3", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 100), State: StateRunning}
 
 	if ok := kvCache.AllocateKVBlocks(r1, 0, 48, []int64{}); !ok {
 		t.Fatal("setup: allocate r1")
@@ -573,8 +573,8 @@ func TestVLLMBatchFormation_LivelockResolution(t *testing.T) {
 		outputLen := 3200 + wlRng.Intn(397) // 3200-3596
 		req := &Request{
 			ID:           fmt.Sprintf("req_%d", i),
-			InputTokens:  make([]int, inputLen),
-			OutputTokens: make([]int, outputLen),
+			InputTokens:  make([]TokenID, inputLen),
+			OutputTokens: make([]TokenID, outputLen),
 			ArrivalTime:  arrivalTime,
 			State:        StateQueued,
 		}
@@ -619,8 +619,8 @@ func TestVLLMBatchFormation_MaxModelLen_ProactiveCap_Decode(t *testing.T) {
 	// so preemptForTokens is never called. The request stays in the batch with NumNewTokens=0.
 	req := &Request{
 		ID:            "near_cap",
-		InputTokens:   make([]int, 50),
-		OutputTokens:  make([]int, 200),
+		InputTokens:   make([]TokenID, 50),
+		OutputTokens:  make([]TokenID, 200),
 		State:         StateRunning,
 		ProgressIndex: 99,
 	}
@@ -654,8 +654,8 @@ func TestVLLMBatchFormation_MaxModelLen_ProactiveCap_Phase2(t *testing.T) {
 	// EnqueueRequest in production. Testing FormBatch cap in isolation.
 	req := &Request{
 		ID:           "new_req",
-		InputTokens:  make([]int, 80),
-		OutputTokens: make([]int, 50),
+		InputTokens:  make([]TokenID, 80),
+		OutputTokens: make([]TokenID, 50),
 		State:        StateQueued,
 	}
 	wq := &WaitQueue{}
@@ -688,8 +688,8 @@ func TestVLLMBatchFormation_MaxModelLen_Zero_NoClamp(t *testing.T) {
 
 	req := &Request{
 		ID:           "unlimited",
-		InputTokens:  make([]int, 500),
-		OutputTokens: make([]int, 500),
+		InputTokens:  make([]TokenID, 500),
+		OutputTokens: make([]TokenID, 500),
 		State:        StateQueued,
 	}
 	wq := &WaitQueue{}
@@ -729,7 +729,7 @@ func TestVLLMBatchFormation_ZeroInputRequest_SkipsDecodeOnlyPath(t *testing.T) {
 	req := &Request{
 		ID:           "zero-input",
 		InputTokens:  nil, // inputLen == 0
-		OutputTokens: make([]int, 5),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 		// ProgressIndex defaults to 0
 	}
@@ -777,11 +777,11 @@ func TestPreemption_FCFS_EvictsTail(t *testing.T) {
 	kvCache := MustNewKVCacheState(10, 16)
 	running := []*Request{
 		{ID: "first", SLOClass: "critical", ArrivalTime: 100, State: StateRunning,
-			InputTokens: make([]int, 48), OutputTokens: make([]int, 10)},
+			InputTokens: make([]TokenID, 48), OutputTokens: make([]TokenID, 10)},
 		{ID: "second", SLOClass: "standard", ArrivalTime: 200, State: StateRunning,
-			InputTokens: make([]int, 48), OutputTokens: make([]int, 10)},
+			InputTokens: make([]TokenID, 48), OutputTokens: make([]TokenID, 10)},
 		{ID: "third", SLOClass: "background", ArrivalTime: 300, State: StateRunning,
-			InputTokens: make([]int, 48), OutputTokens: make([]int, 10)},
+			InputTokens: make([]TokenID, 48), OutputTokens: make([]TokenID, 10)},
 	}
 	for _, req := range running {
 		// AllocateKVBlocks uses ProgressIndex < len(InputTokens) for prefill path.
@@ -789,7 +789,7 @@ func TestPreemption_FCFS_EvictsTail(t *testing.T) {
 		kvCache.AllocateKVBlocks(req, 0, 48, nil)
 		req.ProgressIndex = 48
 	}
-	newReq := &Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued}
+	newReq := &Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued}
 	wq := &WaitQueue{}
 	wq.Enqueue(newReq)
 
@@ -824,8 +824,8 @@ func makeRunningRequest(id, sloClass string, arrival int64, inputLen int, kvCach
 		SLOClass:     sloClass,
 		ArrivalTime:  arrival,
 		State:        StateRunning,
-		InputTokens:  make([]int, inputLen),
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]TokenID, inputLen),
+		OutputTokens: make([]TokenID, 10),
 		// Set Priority in vLLM convention (lower = more urgent) to match what
 		// Simulator.EnqueueRequest pre-processor would set at runtime.
 		Priority: float64(DefaultSLOPriorityMap().InvertForVLLM(sloClass)),
@@ -871,7 +871,7 @@ func TestPreemption_Priority_EvictsLeastUrgent(t *testing.T) {
 			}
 
 			wq := &WaitQueue{}
-			wq.Enqueue(&Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+			wq.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 			bf := NewBatchFormation("priority")
 			ctx := BatchContext{
@@ -912,7 +912,7 @@ func TestPreemption_Priority_SelfPreemption(t *testing.T) {
 	dummy := makeRunningRequest("dummy", "standard", 300, 48, kvCache) // 3 blocks → total 10
 
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{
@@ -960,7 +960,7 @@ func TestPreemption_Priority_TiebreakByLatestArrival(t *testing.T) {
 	new_ := makeRunningRequest("new", "standard", 300, 48, kvCache) // 3 blocks → 9 used, 1 free
 
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "trigger", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "trigger", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{
@@ -998,7 +998,7 @@ func TestPreemption_Priority_KVConservation(t *testing.T) {
 	usedBefore := kvCache.UsedBlocks()
 
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "new", InputTokens: make([]int, 48), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 48), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{
@@ -1031,7 +1031,7 @@ func TestPreemption_Priority_EmptyBatch_NoPanic(t *testing.T) {
 	// Circuit breaker at batch_formation.go returns (false, 0) immediately.
 	kvCache := MustNewKVCacheState(2, 16)
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "large", InputTokens: make([]int, 200), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "large", InputTokens: make([]TokenID, 200), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{
@@ -1080,7 +1080,7 @@ func TestPreemption_Priority_Phase1Completeness(t *testing.T) {
 	std := makeRunningRequest("std", "standard", 300, 48, kvCache)   // 3 blocks → 9 used, 1 free
 
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{
@@ -1143,12 +1143,12 @@ func TestPreemption_Priority_MultiEvictionOrdering(t *testing.T) {
 	// crit is still in prefill: ProgressIndex=0, needs all 64 tokens allocated
 	crit := &Request{
 		ID: "crit", SLOClass: "critical", ArrivalTime: 300, State: StateRunning,
-		InputTokens: make([]int, 64), OutputTokens: make([]int, 10),
+		InputTokens: make([]TokenID, 64), OutputTokens: make([]TokenID, 10),
 		ProgressIndex: 0, // still prefilling
 	}
 
 	wq := &WaitQueue{}
-	wq.Enqueue(&Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+	wq.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	bf := NewBatchFormation("priority")
 	ctx := BatchContext{

--- a/sim/cluster/arrival_hook_test.go
+++ b/sim/cluster/arrival_hook_test.go
@@ -137,8 +137,8 @@ func TestArrivalHook_FiresForSessionFollowUps(t *testing.T) {
 		return []*sim.Request{{
 			ID:           req.ID + "-followup",
 			ArrivalTime:  clock,
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{4, 5},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{4, 5},
 			Model:        req.Model,
 		}}
 	}
@@ -188,8 +188,8 @@ func TestArrivalHook_BeyondHorizonFollowUpsExcluded(t *testing.T) {
 		return []*sim.Request{{
 			ID:           beyondHorizonID,
 			ArrivalTime:  clock + beyondHorizonOffsetUs,
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{4, 5},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{4, 5},
 			Model:        req.Model,
 		}}
 	}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -106,7 +106,7 @@ type ClusterSimulator struct {
 	// cacheQueryFn maps instance IDs to KV cache query functions for precise
 	// prefix cache scoring. Built after instance construction; deferred instances
 	// are added in NodeReadyEvent.Execute. Nil when no instances exist yet.
-	cacheQueryFn map[string]func([]int) int
+	cacheQueryFn map[string]func([]sim.TokenID) int
 
 	// Cache block staleness is managed by CachedSnapshotProvider via
 	// ObservabilityConfig.CacheBlocks (unified in #1060).
@@ -605,13 +605,13 @@ func (cs *ClusterSimulator) registerInstanceCacheQueryFn(id InstanceID, inst *In
 		// to CacheQuery at call time, picking up refreshed snapshots automatically.
 		cs.snapshotProvider.AddCacheInstance(id, inst)
 		idStr := string(id)
-		cs.cacheQueryFn[idStr] = func(tokens []int) int {
+		cs.cacheQueryFn[idStr] = func(tokens []sim.TokenID) int {
 			return cs.snapshotProvider.CacheQuery(idStr, tokens)
 		}
 	} else {
 		// Oracle mode: closure captures inst directly for live-state queries.
 		idStr := string(id)
-		cs.cacheQueryFn[idStr] = func(tokens []int) int {
+		cs.cacheQueryFn[idStr] = func(tokens []sim.TokenID) int {
 			return inst.GetCachedBlockCount(tokens)
 		}
 	}

--- a/sim/cluster/cluster_tenant_test.go
+++ b/sim/cluster/cluster_tenant_test.go
@@ -16,8 +16,8 @@ func newTenantRequest(id string, arrivalTime int64, tenantID, sloClass string) *
 		ArrivalTime:  arrivalTime,
 		TenantID:     tenantID,
 		SLOClass:     sloClass,
-		InputTokens:  make([]int, 50),
-		OutputTokens: make([]int, 20),
+		InputTokens:  make([]sim.TokenID, 50),
+		OutputTokens: make([]sim.TokenID, 20),
 		State:        sim.StateQueued,
 	}
 }
@@ -229,10 +229,10 @@ func TestTenantAdmission_INV9_DoesNotReadOutputTokens(t *testing.T) {
 	makeReqs := func(zeroOutput bool) []*sim.Request {
 		reqs := make([]*sim.Request, 20)
 		for i := range reqs {
-			out := make([]int, 20)
+			out := make([]sim.TokenID, 20)
 			if !zeroOutput {
 				for j := range out {
-					out[j] = j + 1
+					out[j] = sim.TokenID(j + 1)
 				}
 			}
 			reqs[i] = &sim.Request{
@@ -240,7 +240,7 @@ func TestTenantAdmission_INV9_DoesNotReadOutputTokens(t *testing.T) {
 				ArrivalTime:  int64(i) * 5,
 				TenantID:     "alice",
 				SLOClass:     "sheddable",
-				InputTokens:  make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 50),
 				OutputTokens: out,
 				State:        sim.StateQueued,
 			}

--- a/sim/cluster/cluster_test.go
+++ b/sim/cluster/cluster_test.go
@@ -534,8 +534,8 @@ func TestInstanceSimulator_InjectAfterRun_Panics(t *testing.T) {
 		}
 	}()
 	inst.InjectRequest(&sim.Request{
-		ID: "req", ArrivalTime: 0, InputTokens: make([]int, 5),
-		OutputTokens: make([]int, 3), State: sim.StateQueued,
+		ID: "req", ArrivalTime: 0, InputTokens: make([]sim.TokenID, 5),
+		OutputTokens: make([]sim.TokenID, 3), State: sim.StateQueued,
 	})
 }
 
@@ -1684,9 +1684,9 @@ func TestClusterSimulator_FlowControl_NeverSaturated_PassThrough(t *testing.T) {
 	requestsCopy := make([]*sim.Request, len(requests))
 	for i, r := range requests {
 		cp := *r
-		cp.InputTokens = make([]int, len(r.InputTokens))
+		cp.InputTokens = make([]sim.TokenID, len(r.InputTokens))
 		copy(cp.InputTokens, r.InputTokens)
-		cp.OutputTokens = make([]int, len(r.OutputTokens))
+		cp.OutputTokens = make([]sim.TokenID, len(r.OutputTokens))
 		copy(cp.OutputTokens, r.OutputTokens)
 		requestsCopy[i] = &cp
 	}
@@ -1982,8 +1982,8 @@ func TestNewClusterSimulator_RooflineUsesPoolHWConfig(t *testing.T) {
 			reqs[i] = &sim.Request{
 				ID:           fmt.Sprintf("req_%d", i),
 				ArrivalTime:  int64(i) * 100,
-				InputTokens:  make([]int, 50),
-				OutputTokens: make([]int, 20),
+				InputTokens:  make([]sim.TokenID, 50),
+				OutputTokens: make([]sim.TokenID, 20),
 				State:        sim.StateQueued,
 			}
 		}
@@ -2051,8 +2051,8 @@ func TestNodeReadyEvent_RooflineUsesPoolHWConfig(t *testing.T) {
 			reqs[i] = &sim.Request{
 				ID:           fmt.Sprintf("req_%d", i),
 				ArrivalTime:  int64(i)*100 + 200, // arrive after node is ready (T=0)
-				InputTokens:  make([]int, 50),
-				OutputTokens: make([]int, 20),
+				InputTokens:  make([]sim.TokenID, 50),
+				OutputTokens: make([]sim.TokenID, 20),
 				State:        sim.StateQueued,
 			}
 		}
@@ -2310,8 +2310,8 @@ func TestClusterSimulator_SessionTerminalStateCompleteness(t *testing.T) {
 		seeds[i] = &sim.Request{
 			ID:           fmt.Sprintf("t21_sess_%d_r0", i),
 			ArrivalTime:  int64(i * 1_000_000),
-			InputTokens:  make([]int, 20),
-			OutputTokens: make([]int, 10),
+			InputTokens:  make([]sim.TokenID, 20),
+			OutputTokens: make([]sim.TokenID, 10),
 			MaxOutputLen: 10,
 			State:        sim.StateQueued,
 			SessionID:    sessID,
@@ -2390,8 +2390,8 @@ func TestClusterSimulator_SessionFollowUpCausality(t *testing.T) {
 		seeds[i] = &sim.Request{
 			ID:           fmt.Sprintf("t22_sess_%d_r0", i),
 			ArrivalTime:  int64(i * 2_000_000),
-			InputTokens:  make([]int, 20),
-			OutputTokens: make([]int, 10),
+			InputTokens:  make([]sim.TokenID, 20),
+			OutputTokens: make([]sim.TokenID, 10),
 			MaxOutputLen: 10,
 			State:        sim.StateQueued,
 			SessionID:    sessID,
@@ -2503,8 +2503,8 @@ func TestClusterSimulator_MultiTurnSession_EndToEnd(t *testing.T) {
 		seeds[i] = &sim.Request{
 			ID:           fmt.Sprintf("t23_sess_%d_r0", i),
 			ArrivalTime:  int64(i * 1_000_000),
-			InputTokens:  make([]int, 20),
-			OutputTokens: make([]int, 10),
+			InputTokens:  make([]sim.TokenID, 20),
+			OutputTokens: make([]sim.TokenID, 10),
 			MaxOutputLen: 10,
 			State:        sim.StateQueued,
 			SessionID:    sessID,
@@ -2659,8 +2659,8 @@ func TestPushArrival_CoInvariant_SessionFollowUpsProcessed(t *testing.T) {
 		return []*sim.Request{{
 			ID:           fmt.Sprintf("followup-%d", followUpsIssued),
 			ArrivalTime:  tick,
-			InputTokens:  make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens:  make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			MaxOutputLen: 20,
 			State:        sim.StateQueued,
 		}}
@@ -2696,8 +2696,8 @@ func newBatchTestRequests(n int, sloClass string) []*sim.Request {
 			ID:           fmt.Sprintf("req_%s_%d", sloClass, i),
 			ArrivalTime:  int64(i) * 10,
 			SLOClass:     sloClass,
-			InputTokens:  make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens:  make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			State:        sim.StateQueued,
 		}
 	}
@@ -2832,19 +2832,19 @@ func TestClusterSimulator_MixedOrphanedAndGenuineTimeout_CorrectMetrics(t *testi
 	requests := []*sim.Request{
 		{
 			ID: "r0", ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			State: sim.StateQueued, MaxOutputLen: 5,
 			Deadline: workload.DefaultTimeoutUs,
 		},
 		{
 			ID: "r1", ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			State: sim.StateQueued, MaxOutputLen: 5,
 			Deadline: workload.DefaultTimeoutUs,
 		},
 		{
 			ID: "r2", ArrivalTime: 0,
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 			State: sim.StateQueued, MaxOutputLen: 5,
 			Deadline: 5_000, // 5ms — r0 takes ~6ms, so r2 times out while queued
 		},
@@ -3007,18 +3007,18 @@ func TestClusterSimulator_FlowControl_Eviction_Conservation(t *testing.T) {
 	// then critical arrive and trigger eviction.
 	requests := make([]*sim.Request, 0, 10)
 	// Sheddable requests with long output (occupy instance for a long time)
-	longOutput := make([]int, 200)
+	longOutput := make([]sim.TokenID, 200)
 	for j := range longOutput {
-		longOutput[j] = j + 1
+		longOutput[j] = sim.TokenID(j + 1)
 	}
 	for i := 0; i < 3; i++ {
-		out := make([]int, len(longOutput))
+		out := make([]sim.TokenID, len(longOutput))
 		copy(out, longOutput)
 		r := &sim.Request{
 			ID:           fmt.Sprintf("shed-%d", i),
 			ArrivalTime:  int64(i * 1000), // arrive close together
 			SLOClass:     "sheddable",
-			InputTokens:  []int{1, 2, 3, 4, 5},
+			InputTokens:  []sim.TokenID{1, 2, 3, 4, 5},
 			OutputTokens: out,
 		}
 		requests = append(requests, r)
@@ -3029,8 +3029,8 @@ func TestClusterSimulator_FlowControl_Eviction_Conservation(t *testing.T) {
 			ID:           fmt.Sprintf("crit-%d", i),
 			ArrivalTime:  int64(50000 + i*1000), // arrive after sheddables are running
 			SLOClass:     "critical",
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{1, 2, 3},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{1, 2, 3},
 		}
 		requests = append(requests, r)
 	}
@@ -3096,18 +3096,18 @@ func TestClusterSimulator_FlowControl_NoEviction_Default(t *testing.T) {
 	// FlowControlInFlightEviction defaults to false
 
 	requests := make([]*sim.Request, 0, 6)
-	longOutput := make([]int, 200)
+	longOutput := make([]sim.TokenID, 200)
 	for j := range longOutput {
-		longOutput[j] = j + 1
+		longOutput[j] = sim.TokenID(j + 1)
 	}
 	for i := 0; i < 3; i++ {
-		out := make([]int, len(longOutput))
+		out := make([]sim.TokenID, len(longOutput))
 		copy(out, longOutput)
 		requests = append(requests, &sim.Request{
 			ID:           fmt.Sprintf("shed-%d", i),
 			ArrivalTime:  int64(i * 1000),
 			SLOClass:     "sheddable",
-			InputTokens:  []int{1, 2, 3, 4, 5},
+			InputTokens:  []sim.TokenID{1, 2, 3, 4, 5},
 			OutputTokens: out,
 		})
 	}
@@ -3116,8 +3116,8 @@ func TestClusterSimulator_FlowControl_NoEviction_Default(t *testing.T) {
 			ID:           fmt.Sprintf("crit-%d", i),
 			ArrivalTime:  int64(50000 + i*1000),
 			SLOClass:     "critical",
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{1, 2, 3},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{1, 2, 3},
 		})
 	}
 
@@ -3160,21 +3160,21 @@ func TestClusterSimulator_FlowControl_Eviction_PD(t *testing.T) {
 	config.FlowControlInFlightEviction = true
 	config.PDDecider = "never" // non-disaggregated: requests go directly to decode pod
 
-	longOutput := make([]int, 200)
+	longOutput := make([]sim.TokenID, 200)
 	for j := range longOutput {
-		longOutput[j] = j + 1
+		longOutput[j] = sim.TokenID(j + 1)
 	}
 
 	// Need enough sheddable to saturate: 2 instances × maxConcurrency=1 → saturates at 2 in-flight
 	requests := make([]*sim.Request, 0, 8)
 	for i := 0; i < 4; i++ {
-		out := make([]int, len(longOutput))
+		out := make([]sim.TokenID, len(longOutput))
 		copy(out, longOutput)
 		requests = append(requests, &sim.Request{
 			ID:           fmt.Sprintf("pd-shed-%d", i),
 			ArrivalTime:  int64(i * 1000),
 			SLOClass:     "sheddable",
-			InputTokens:  []int{1, 2, 3, 4, 5},
+			InputTokens:  []sim.TokenID{1, 2, 3, 4, 5},
 			OutputTokens: out,
 		})
 	}
@@ -3183,8 +3183,8 @@ func TestClusterSimulator_FlowControl_Eviction_PD(t *testing.T) {
 			ID:           fmt.Sprintf("pd-crit-%d", i),
 			ArrivalTime:  int64(50000 + i*1000),
 			SLOClass:     "critical",
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{1, 2, 3},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{1, 2, 3},
 		})
 	}
 

--- a/sim/cluster/cluster_tier_test.go
+++ b/sim/cluster/cluster_tier_test.go
@@ -19,8 +19,8 @@ func newTierTestRequests(n int, sloClass string) []*sim.Request {
 			ID:          fmt.Sprintf("req_%s_%d", sloClass, i),
 			ArrivalTime: int64(i) * 100,
 			SLOClass:    sloClass,
-			InputTokens: make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens: make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			State:       sim.StateQueued,
 		}
 	}
@@ -50,8 +50,8 @@ func TestTierShed_MonotonicSheddingOrder(t *testing.T) {
 				ID:           fmt.Sprintf("req_%s_%d", class, j),
 				ArrivalTime:  int64(i*nPerTier+j) * 10, // dense arrivals to force overload
 				SLOClass:     class,
-				InputTokens:  make([]int, 50),
-				OutputTokens: make([]int, 20),
+				InputTokens:  make([]sim.TokenID, 50),
+				OutputTokens: make([]sim.TokenID, 20),
 				State:        sim.StateQueued,
 			})
 		}
@@ -125,8 +125,8 @@ func TestTierShed_BatchBackgroundShedUnderOverload(t *testing.T) {
 				ID:           fmt.Sprintf("req_%s_%d", class, i),
 				ArrivalTime:  int64(i) * 5, // very dense
 				SLOClass:     class,
-				InputTokens:  make([]int, 100),
-				OutputTokens: make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 100),
+				OutputTokens: make([]sim.TokenID, 50),
 				State:        sim.StateQueued,
 			})
 		}
@@ -177,8 +177,8 @@ func TestGAIELegacy_INV1_Conservation(t *testing.T) {
 				ID:           fmt.Sprintf("req_%s_%d", class, i),
 				ArrivalTime:  int64(i) * 10, // dense arrivals
 				SLOClass:     class,
-				InputTokens:  make([]int, 100),
-				OutputTokens: make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 100),
+				OutputTokens: make([]sim.TokenID, 50),
 				State:        sim.StateQueued,
 			})
 		}
@@ -245,9 +245,9 @@ func TestGAIELegacy_LightLoadAdmitsAll(t *testing.T) {
 // so every request's SLO class should appear in the per-tier counter).
 func TestShedByTier_RejectAll_PopulatesTierCounts(t *testing.T) {
 	requests := []*sim.Request{
-		{ID: "r1", ArrivalTime: 0, SLOClass: "critical", InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
-		{ID: "r2", ArrivalTime: 10, SLOClass: "standard", InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
-		{ID: "r3", ArrivalTime: 20, SLOClass: "batch", InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
+		{ID: "r1", ArrivalTime: 0, SLOClass: "critical", InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5), State: sim.StateQueued},
+		{ID: "r2", ArrivalTime: 10, SLOClass: "standard", InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5), State: sim.StateQueued},
+		{ID: "r3", ArrivalTime: 20, SLOClass: "batch", InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5), State: sim.StateQueued},
 	}
 	cfg := newTestDeploymentConfig(2)
 	cfg.AdmissionPolicy = "reject-all"

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -13,7 +13,7 @@ import (
 func TestParentRequest_NewParentRequest(t *testing.T) {
 	req := &sim.Request{
 		ID:          "req_0",
-		InputTokens: make([]int, 100),
+		InputTokens: make([]sim.TokenID, 100),
 		ArrivalTime: 1000,
 	}
 	parent := NewParentRequest(req, 16) // blockSizeTokens=16
@@ -313,8 +313,8 @@ func newShortRequests(n int) []*sim.Request {
 	for i := 0; i < n; i++ {
 		requests[i] = &sim.Request{
 			ID:           fmt.Sprintf("request_%d", i),
-			InputTokens:  make([]int, 20), // 2 blocks at blockSize=16
-			OutputTokens: make([]int, 10),
+			InputTokens:  make([]sim.TokenID, 20), // 2 blocks at blockSize=16
+			OutputTokens: make([]sim.TokenID, 10),
 			State:        sim.StateQueued,
 			ArrivalTime:  int64(i * 100), // 100μs apart
 		}
@@ -499,7 +499,7 @@ func TestReserveTransferredKV_Success(t *testing.T) {
 
 	req := &sim.Request{
 		ID:          "decode_sub_0",
-		InputTokens: make([]int, 100),
+		InputTokens: make([]sim.TokenID, 100),
 		State:       sim.StateWaitingForRemoteKVs,
 	}
 
@@ -528,7 +528,7 @@ func TestReserveTransferredKV_InsufficientCapacity(t *testing.T) {
 
 	req := &sim.Request{
 		ID:          "decode_sub_0",
-		InputTokens: make([]int, 100), // Needs 7 blocks but only 2 available
+		InputTokens: make([]sim.TokenID, 100), // Needs 7 blocks but only 2 available
 		State:       sim.StateWaitingForRemoteKVs,
 	}
 
@@ -561,8 +561,8 @@ func TestPDDisagg_OneOutputToken_CompletesWith1Token(t *testing.T) {
 		{
 			ID:           "req-1output",
 			ArrivalTime:  0,
-			InputTokens:  make([]int, 20),
-			OutputTokens: []int{42}, // exactly 1 output token
+			InputTokens:  make([]sim.TokenID, 20),
+			OutputTokens: []sim.TokenID{42}, // exactly 1 output token
 			State:        sim.StateQueued,
 		},
 	}
@@ -603,14 +603,14 @@ func TestPrefixThreshold_BelowThresholdNotDisaggregated(t *testing.T) {
 	// Requests with 20 unique tokens: nonCached = 20, 20 <= 200 → should NOT disaggregate.
 	requests := make([]*sim.Request, 3)
 	for i := range requests {
-		tokens := make([]int, 20)
+		tokens := make([]sim.TokenID, 20)
 		for j := range tokens {
-			tokens[j] = j + i*1000 + 1 // unique across requests, no prefix cache hit
+			tokens[j] = sim.TokenID(j + i*1000 + 1) // unique across requests, no prefix cache hit
 		}
 		requests[i] = &sim.Request{
 			ID:           fmt.Sprintf("short_%d", i),
 			InputTokens:  tokens,
-			OutputTokens: make([]int, 5),
+			OutputTokens: make([]sim.TokenID, 5),
 			State:        sim.StateQueued,
 			ArrivalTime:  int64(i * 100000),
 		}
@@ -637,14 +637,14 @@ func TestPrefixThreshold_AboveThresholdDisaggregated(t *testing.T) {
 	// Requests with 400 unique tokens: nonCached = 400, 400 > 200 → must disaggregate.
 	requests := make([]*sim.Request, 3)
 	for i := range requests {
-		tokens := make([]int, 400)
+		tokens := make([]sim.TokenID, 400)
 		for j := range tokens {
-			tokens[j] = j + i*10000 + 1 // unique across requests, no prefix cache hit
+			tokens[j] = sim.TokenID(j + i*10000 + 1) // unique across requests, no prefix cache hit
 		}
 		requests[i] = &sim.Request{
 			ID:           fmt.Sprintf("long_%d", i),
 			InputTokens:  tokens,
-			OutputTokens: make([]int, 5),
+			OutputTokens: make([]sim.TokenID, 5),
 			State:        sim.StateQueued,
 			ArrivalTime:  int64(i * 500000),
 		}
@@ -692,14 +692,14 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	// req1: 400 tokens (25 complete blocks), no prior cache.
 	// nonCached = 400 > 300 → disaggregated; as req1 flows through the PD
 	// pipeline its KV cache blocks land on the selected decode pod.
-	prefix := make([]int, 400)
+	prefix := make([]sim.TokenID, 400)
 	for i := range prefix {
-		prefix[i] = i + 1
+		prefix[i] = sim.TokenID(i + 1)
 	}
 	req1 := &sim.Request{
 		ID:           "req-warm",
-		InputTokens:  append([]int{}, prefix...),
-		OutputTokens: make([]int, 5),
+		InputTokens:  append([]sim.TokenID{}, prefix...),
+		OutputTokens: make([]sim.TokenID, 5),
 		State:        sim.StateQueued,
 		ArrivalTime:  0,
 	}
@@ -709,15 +709,15 @@ func TestPrefixThreshold_PerPodCacheQuery(t *testing.T) {
 	// req2 arrives 2s after req1, well after req1's prefill + KV transfer + decode have populated
 	// the decode pod's KV cache. The `precise-prefix-cache` scorer configured above then routes
 	// req2 to the warm pod, so the PrefixThresholdDecider's cacheQueryFn lookup hits.
-	extended := make([]int, len(prefix)+50)
+	extended := make([]sim.TokenID, len(prefix)+50)
 	copy(extended, prefix)
 	for i := len(prefix); i < len(extended); i++ {
-		extended[i] = 10000 + i
+		extended[i] = sim.TokenID(10000 + i)
 	}
 	req2 := &sim.Request{
 		ID:           "req-follow",
 		InputTokens:  extended,
-		OutputTokens: make([]int, 5),
+		OutputTokens: make([]sim.TokenID, 5),
 		State:        sim.StateQueued,
 		ArrivalTime:  2000000, // req1's PrefillRoutingEvent fires at t=0+routingLatency=0; req2 arrives at t=2,000,000;
 		// ordering is guaranteed by event timestamps alone (t=0 < t=2,000,000), not the gap magnitude
@@ -1500,8 +1500,8 @@ func TestDisaggregation_SessionFollowUp_InjectsFollowUp(t *testing.T) {
 		return []*sim.Request{{
 			ID:           fmt.Sprintf("followup_%d", followUpCount),
 			ArrivalTime:  tick + 1000, // 1ms think time
-			InputTokens:  make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens:  make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			MaxOutputLen: 20,
 			State:        sim.StateQueued,
 			SessionID:    req.SessionID,
@@ -1631,8 +1631,8 @@ func TestDisaggregation_PD_SessionManager_GeneratesFollowUps(t *testing.T) {
 		reqs[i] = &sim.Request{
 			ID:           fmt.Sprintf("pd_sess_%d_r0", i),
 			ArrivalTime:  int64(i * 1000),
-			InputTokens:  make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens:  make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			MaxOutputLen: 20,
 			State:        sim.StateQueued,
 			SessionID:    fmt.Sprintf("pd_sess_%d", i),
@@ -1716,8 +1716,8 @@ func TestDisaggregation_PD_SessionManager_ContextAccumulation(t *testing.T) {
 		{
 			ID:           "acc_sess_0_r0",
 			ArrivalTime:  0,
-			InputTokens:  make([]int, round0InputLen),
-			OutputTokens: make([]int, round0OutputLen),
+			InputTokens:  make([]sim.TokenID, round0InputLen),
+			OutputTokens: make([]sim.TokenID, round0OutputLen),
 			MaxOutputLen: round0OutputLen,
 			State:        sim.StateQueued,
 			SessionID:    "acc_sess_0",

--- a/sim/cluster/flow_control_admission_test.go
+++ b/sim/cluster/flow_control_admission_test.go
@@ -194,8 +194,8 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 				TenantID:     fmt.Sprintf("tenant-%d", i%3),
 				SLOClass:     sloClasses[i%len(sloClasses)],
 				ArrivalTime:  int64(i * 100_000),
-				InputTokens:  make([]int, 100),
-				OutputTokens: make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 100),
+				OutputTokens: make([]sim.TokenID, 50),
 				MaxOutputLen: 200,
 			}
 		}
@@ -225,8 +225,8 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 				TenantID:     fmt.Sprintf("tenant-%d", i%2),
 				SLOClass:     sloClasses[i%len(sloClasses)],
 				ArrivalTime:  int64(i * 100_000),
-				InputTokens:  make([]int, 100),
-				OutputTokens: make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 100),
+				OutputTokens: make([]sim.TokenID, 50),
 				MaxOutputLen: 200,
 			}
 		}
@@ -254,8 +254,8 @@ func TestFlowControlAdmission_INV1_Conservation(t *testing.T) {
 				TenantID:     fmt.Sprintf("tenant-%d", i%2),
 				SLOClass:     "standard", // non-sheddable: overflow means rejection
 				ArrivalTime:  int64(i * 100_000),
-				InputTokens:  make([]int, 100),
-				OutputTokens: make([]int, 50),
+				InputTokens:  make([]sim.TokenID, 100),
+				OutputTokens: make([]sim.TokenID, 50),
 				MaxOutputLen: 200,
 			}
 		}

--- a/sim/cluster/gateway_queue_ttl_test.go
+++ b/sim/cluster/gateway_queue_ttl_test.go
@@ -24,9 +24,9 @@ func TestGatewayQueueTTL_ExpiresQueuedRequest(t *testing.T) {
 	cfg.Horizon = 100_000
 	reqs := []*sim.Request{
 		{ID: "r1", ArrivalTime: 0, SLOClass: "standard",
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5), State: sim.StateQueued},
 		{ID: "r2", ArrivalTime: 100, SLOClass: "batch",
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: sim.StateQueued},
+			InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5), State: sim.StateQueued},
 	}
 	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 	mustRun(t, cs)

--- a/sim/cluster/inflight_requests_test.go
+++ b/sim/cluster/inflight_requests_test.go
@@ -42,8 +42,8 @@ func TestClusterSimulator_InFlightRequests_VisibleInRoutingState(t *testing.T) {
 		reqs[i] = &sim.Request{
 			ID:           "vis_req_" + string(rune('a'+i)),
 			ArrivalTime:  0, // All arrive at t=0
-			InputTokens:  make([]int, 16),
-			OutputTokens: make([]int, 8),
+			InputTokens:  make([]sim.TokenID, 16),
+			OutputTokens: make([]sim.TokenID, 8),
 			State:        sim.StateQueued,
 		}
 	}
@@ -110,8 +110,8 @@ func TestClusterSimulator_InFlightRequests_CounterfactualIncludesInFlight(t *tes
 		reqs[i] = &sim.Request{
 			ID:           "cf_req_" + string(rune('a'+i)),
 			ArrivalTime:  0,
-			InputTokens:  make([]int, 16),
-			OutputTokens: make([]int, 8),
+			InputTokens:  make([]sim.TokenID, 16),
+			OutputTokens: make([]sim.TokenID, 8),
 			State:        sim.StateQueued,
 		}
 	}
@@ -204,8 +204,8 @@ func TestClusterSimulator_InFlightRequests_DroppedUnservable_Decrements(t *testi
 		reqs[i] = &sim.Request{
 			ID:           fmt.Sprintf("drop_req_%d", i),
 			ArrivalTime:  int64(i * 1000),
-			InputTokens:  make([]int, 200), // 200 tokens / 16 block_size = 13 blocks > 5 total
-			OutputTokens: make([]int, 8),
+			InputTokens:  make([]sim.TokenID, 200), // 200 tokens / 16 block_size = 13 blocks > 5 total
+			OutputTokens: make([]sim.TokenID, 8),
 			State:        sim.StateQueued,
 		}
 	}
@@ -256,8 +256,8 @@ func TestClusterSimulator_InFlightRequests_CompletionBasedDecrement(t *testing.T
 		reqs[i] = &sim.Request{
 			ID:           fmt.Sprintf("causal_req_%d", i),
 			ArrivalTime:  0,
-			InputTokens:  make([]int, 16),
-			OutputTokens: make([]int, 8),
+			InputTokens:  make([]sim.TokenID, 16),
+			OutputTokens: make([]sim.TokenID, 8),
 			State:        sim.StateQueued,
 		}
 	}

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -295,7 +295,7 @@ func (i *InstanceSimulator) MaxBatchSize() int {
 
 // GetCachedBlockCount returns the number of consecutive cached prefix blocks
 // matching the given token sequence. Used by precise prefix cache scoring.
-func (i *InstanceSimulator) GetCachedBlockCount(tokens []int) int {
+func (i *InstanceSimulator) GetCachedBlockCount(tokens []sim.TokenID) int {
 	if i.sim == nil {
 		return 0
 	}
@@ -306,7 +306,7 @@ func (i *InstanceSimulator) GetCachedBlockCount(tokens []int) int {
 // a frozen snapshot query function. Both KVCacheState and TieredKVCache implement this.
 // Used for stale cache signal simulation (issue #919).
 type cacheSnapshotCapable interface {
-	SnapshotCachedBlocksFn() func([]int) int
+	SnapshotCachedBlocksFn() func([]sim.TokenID) int
 }
 
 // SnapshotCacheQueryFn returns a function that queries a frozen copy of this
@@ -314,9 +314,9 @@ type cacheSnapshotCapable interface {
 // the live cache state has changed — it always returns results as of snapshot time.
 // Returns a zero-returning function if the simulator is nil or the KV cache
 // does not support snapshotting.
-func (i *InstanceSimulator) SnapshotCacheQueryFn() func([]int) int {
+func (i *InstanceSimulator) SnapshotCacheQueryFn() func([]sim.TokenID) int {
 	if i.sim == nil {
-		return func([]int) int { return 0 }
+		return func([]sim.TokenID) int { return 0 }
 	}
 	if cs, ok := i.sim.KVCache.(cacheSnapshotCapable); ok {
 		return cs.SnapshotCachedBlocksFn()
@@ -324,7 +324,7 @@ func (i *InstanceSimulator) SnapshotCacheQueryFn() func([]int) int {
 	// Fallback: live query (for KVStore implementations without snapshot support).
 	// Callers (CachedSnapshotProvider) are responsible for warning about stale-cache
 	// semantics not being honored — this function is intentionally side-effect-free.
-	return func(tokens []int) int {
+	return func(tokens []sim.TokenID) int {
 		return i.GetCachedBlockCount(tokens)
 	}
 }

--- a/sim/cluster/instance_lifecycle_test.go
+++ b/sim/cluster/instance_lifecycle_test.go
@@ -20,20 +20,20 @@ func TestInstanceLifecycle_WarmUpTTFTPenalty(t *testing.T) {
 	requests := []*sim.Request{
 		{
 			ID:           "req1",
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]sim.TokenID, 10),
+			OutputTokens: make([]sim.TokenID, 5),
 			ArrivalTime:  0,
 		},
 		{
 			ID:           "req2",
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]sim.TokenID, 10),
+			OutputTokens: make([]sim.TokenID, 5),
 			ArrivalTime:  1000,
 		},
 		{
 			ID:           "req3",
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]sim.TokenID, 10),
+			OutputTokens: make([]sim.TokenID, 5),
 			ArrivalTime:  2000,
 		},
 	}

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -372,8 +372,8 @@ func TestInstanceSimulator_BatchSize_NilRunningBatch(t *testing.T) {
 	req := &sim.Request{
 		ID:           "req_0",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 16),
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]sim.TokenID, 16),
+		OutputTokens: make([]sim.TokenID, 1),
 		State:        sim.StateQueued,
 	}
 	inst.InjectRequest(req)
@@ -400,8 +400,8 @@ func TestInstanceSimulator_ProcessNextEvent_ReturnsEventsWithMonotonicTimestamps
 	req := &sim.Request{
 		ID:           "req_return",
 		ArrivalTime:  100,
-		InputTokens:  make([]int, 16),
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]sim.TokenID, 16),
+		OutputTokens: make([]sim.TokenID, 1),
 		State:        sim.StateQueued,
 	}
 	inst.InjectRequestOnline(req, 200)
@@ -448,8 +448,8 @@ func TestInstanceSimulator_InjectRequestOnline(t *testing.T) {
 	req := &sim.Request{
 		ID:           "req_online",
 		ArrivalTime:  100,
-		InputTokens:  make([]int, 16),
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]sim.TokenID, 16),
+		OutputTokens: make([]sim.TokenID, 1),
 		State:        sim.StateQueued,
 	}
 
@@ -468,12 +468,12 @@ func TestInstanceSimulator_SnapshotCacheQueryFn_FrozenView(t *testing.T) {
 	cfg.BlockSizeTokens = 4
 	inst := NewInstanceSimulator("inst-0", cfg)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 	req := &sim.Request{
 		ID:           "r1",
 		ArrivalTime:  0,
 		InputTokens:  tokens,
-		OutputTokens: []int{100},
+		OutputTokens: []sim.TokenID{100},
 		State:        sim.StateQueued,
 	}
 	inst.InjectRequest(req)
@@ -497,7 +497,7 @@ func TestInstanceSimulator_SnapshotCacheQueryFn_NilSim(t *testing.T) {
 	fn := inst.SnapshotCacheQueryFn()
 
 	// THEN it returns 0 for any input
-	assert.Equal(t, 0, fn([]int{1, 2, 3, 4}))
+	assert.Equal(t, 0, fn([]sim.TokenID{1, 2, 3, 4}))
 }
 
 // BC-2: PostDecodeFixedOverhead() delegates to inner sim.Simulator.PostDecodeFixedOverhead().

--- a/sim/cluster/metrics_substrate_test.go
+++ b/sim/cluster/metrics_substrate_test.go
@@ -161,20 +161,20 @@ func TestClusterMetrics_ZeroOutput_NoPollution(t *testing.T) {
 	cfg := msClusterConfig(2)
 
 	// Inject a mix of zero-output and normal requests directly
-	makeTokens := func(n int) []int {
-		t := make([]int, n)
+	makeTokens := func(n int) []sim.TokenID {
+		t := make([]sim.TokenID, n)
 		for i := range t {
-			t[i] = i + 1
+			t[i] = sim.TokenID(i + 1)
 		}
 		return t
 	}
 	reqs := []*sim.Request{
-		{ID: "z0", InputTokens: makeTokens(32), OutputTokens: []int{}, ArrivalTime: 0, State: sim.StateQueued},
+		{ID: "z0", InputTokens: makeTokens(32), OutputTokens: []sim.TokenID{}, ArrivalTime: 0, State: sim.StateQueued},
 		{ID: "n1", InputTokens: makeTokens(32), OutputTokens: makeTokens(4), ArrivalTime: 100000, State: sim.StateQueued},
 		{ID: "z2", InputTokens: makeTokens(48), OutputTokens: nil, ArrivalTime: 200000, State: sim.StateQueued},
 		{ID: "n3", InputTokens: makeTokens(16), OutputTokens: makeTokens(3), ArrivalTime: 300000, State: sim.StateQueued},
 		{ID: "n4", InputTokens: makeTokens(32), OutputTokens: makeTokens(5), ArrivalTime: 400000, State: sim.StateQueued},
-		{ID: "z5", InputTokens: makeTokens(16), OutputTokens: []int{}, ArrivalTime: 500000, State: sim.StateQueued},
+		{ID: "z5", InputTokens: makeTokens(16), OutputTokens: []sim.TokenID{}, ArrivalTime: 500000, State: sim.StateQueued},
 	}
 	cs := NewClusterSimulator(cfg, NewSliceRequestSource(reqs), nil)
 

--- a/sim/cluster/multi_model_test.go
+++ b/sim/cluster/multi_model_test.go
@@ -28,8 +28,8 @@ func newModelRequest(id, model string, arrivalTime int64) *sim.Request {
 		ID:           id,
 		Model:        model,
 		ArrivalTime:  arrivalTime,
-		InputTokens:  []int{1, 2, 3, 4, 5},
-		OutputTokens: []int{1, 2, 3},
+		InputTokens:  []sim.TokenID{1, 2, 3, 4, 5},
+		OutputTokens: []sim.TokenID{1, 2, 3},
 		State:        sim.StateQueued,
 	}
 }

--- a/sim/cluster/parent_request_test.go
+++ b/sim/cluster/parent_request_test.go
@@ -26,7 +26,7 @@ func TestNewParentRequest_NumKVBlocks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &sim.Request{
 				ID:          "req-1",
-				InputTokens: make([]int, tc.inputLen),
+				InputTokens: make([]sim.TokenID, tc.inputLen),
 				ArrivalTime: 1000,
 			}
 			pr := NewParentRequest(req, tc.blockSize)
@@ -40,7 +40,7 @@ func TestNewParentRequest_NumKVBlocks(t *testing.T) {
 
 // TestNewParentRequest_SubRequestIDs verifies sub-request ID derivation convention.
 func TestNewParentRequest_SubRequestIDs(t *testing.T) {
-	req := &sim.Request{ID: "req-42", InputTokens: make([]int, 10), ArrivalTime: 500}
+	req := &sim.Request{ID: "req-42", InputTokens: make([]sim.TokenID, 10), ArrivalTime: 500}
 	pr := NewParentRequest(req, 16)
 
 	if pr.PrefillSubReqID != "req-42_prefill" {
@@ -53,7 +53,7 @@ func TestNewParentRequest_SubRequestIDs(t *testing.T) {
 
 // TestNewParentRequest_ArrivalTimePropagated verifies ArrivalTime is copied from original request.
 func TestNewParentRequest_ArrivalTimePropagated(t *testing.T) {
-	req := &sim.Request{ID: "req-1", InputTokens: make([]int, 10), ArrivalTime: 12345}
+	req := &sim.Request{ID: "req-1", InputTokens: make([]sim.TokenID, 10), ArrivalTime: 12345}
 	pr := NewParentRequest(req, 16)
 
 	if pr.ArrivalTime != 12345 {
@@ -63,7 +63,7 @@ func TestNewParentRequest_ArrivalTimePropagated(t *testing.T) {
 
 // TestNewParentRequest_OriginalRequestPreserved verifies the original request pointer is stored.
 func TestNewParentRequest_OriginalRequestPreserved(t *testing.T) {
-	req := &sim.Request{ID: "req-1", InputTokens: make([]int, 10), ArrivalTime: 100}
+	req := &sim.Request{ID: "req-1", InputTokens: make([]sim.TokenID, 10), ArrivalTime: 100}
 	pr := NewParentRequest(req, 16)
 
 	if pr.OriginalRequest != req {
@@ -81,7 +81,7 @@ func TestNewParentRequest_PanicOnZeroBlockSize(t *testing.T) {
 			t.Error("expected panic for blockSizeTokens == 0")
 		}
 	}()
-	req := &sim.Request{ID: "req-1", InputTokens: make([]int, 10)}
+	req := &sim.Request{ID: "req-1", InputTokens: make([]sim.TokenID, 10)}
 	NewParentRequest(req, 0)
 }
 
@@ -92,7 +92,7 @@ func TestNewParentRequest_PanicOnNegativeBlockSize(t *testing.T) {
 			t.Error("expected panic for blockSizeTokens < 0")
 		}
 	}()
-	req := &sim.Request{ID: "req-1", InputTokens: make([]int, 10)}
+	req := &sim.Request{ID: "req-1", InputTokens: make([]sim.TokenID, 10)}
 	NewParentRequest(req, -1)
 }
 
@@ -100,7 +100,7 @@ func TestNewParentRequest_PanicOnNegativeBlockSize(t *testing.T) {
 // constructor initializes EncodeInstanceID to the zero value (empty InstanceID),
 // indicating "encode did not fire for this parent" (GAP-4, issue #1264).
 func TestNewParentRequest_EncodeInstanceIDZero(t *testing.T) {
-	req := &sim.Request{ID: "req-enc-init", InputTokens: make([]int, 16)}
+	req := &sim.Request{ID: "req-enc-init", InputTokens: make([]sim.TokenID, 16)}
 	pr := NewParentRequest(req, 16)
 	if pr.EncodeInstanceID != "" {
 		t.Errorf("EncodeInstanceID = %q, want empty at construction", pr.EncodeInstanceID)

--- a/sim/cluster/pipeline_integration_test.go
+++ b/sim/cluster/pipeline_integration_test.go
@@ -27,16 +27,16 @@ func TestFullPipelineEndToEnd(t *testing.T) {
 			ID:           fmt.Sprintf("req-%d", i),
 			Model:        "test-model",
 			ArrivalTime:  int64(i) * 1_000_000, // 1s apart
-			InputTokens:  make([]int, 100),      // 100 input tokens
-			OutputTokens: make([]int, 50),        // 50 output tokens
+			InputTokens:  make([]sim.TokenID, 100),      // 100 input tokens
+			OutputTokens: make([]sim.TokenID, 50),        // 50 output tokens
 			State:        sim.StateQueued,
 		}
 		// Fill with dummy token IDs
 		for j := range requests[i].InputTokens {
-			requests[i].InputTokens[j] = j + 1
+			requests[i].InputTokens[j] = sim.TokenID(j + 1)
 		}
 		for j := range requests[i].OutputTokens {
-			requests[i].OutputTokens[j] = j + 1
+			requests[i].OutputTokens[j] = sim.TokenID(j + 1)
 		}
 	}
 

--- a/sim/cluster/prefix_routing_test.go
+++ b/sim/cluster/prefix_routing_test.go
@@ -16,31 +16,31 @@ func makeSharedPrefixRequests(numRequests int, sharedFraction float64,
 	prefixLen, suffixLen, outputLen int, interarrivalUs int64) []*sim.Request {
 
 	// Create the shared prefix
-	sharedPrefix := make([]int, prefixLen)
+	sharedPrefix := make([]sim.TokenID, prefixLen)
 	for i := range sharedPrefix {
-		sharedPrefix[i] = 1000 + i
+		sharedPrefix[i] = sim.TokenID(1000 + i)
 	}
 
 	sharedCount := int(float64(numRequests) * sharedFraction)
 	var requests []*sim.Request
 	for i := 0; i < numRequests; i++ {
-		var inputTokens []int
+		var inputTokens []sim.TokenID
 		if i < sharedCount {
 			// Shared prefix + unique suffix
-			inputTokens = append([]int{}, sharedPrefix...)
+			inputTokens = append([]sim.TokenID{}, sharedPrefix...)
 			for j := 0; j < suffixLen; j++ {
-				inputTokens = append(inputTokens, 50000+i*1000+j)
+				inputTokens = append(inputTokens, sim.TokenID(50000+i*1000+j))
 			}
 		} else {
 			// Completely unique tokens
-			inputTokens = make([]int, prefixLen+suffixLen)
+			inputTokens = make([]sim.TokenID, prefixLen+suffixLen)
 			for j := range inputTokens {
-				inputTokens[j] = 90000 + i*1000 + j
+				inputTokens[j] = sim.TokenID(90000 + i*1000 + j)
 			}
 		}
-		outputTokens := make([]int, outputLen)
+		outputTokens := make([]sim.TokenID, outputLen)
 		for j := range outputTokens {
-			outputTokens[j] = j
+			outputTokens[j] = sim.TokenID(j)
 		}
 		requests = append(requests, &sim.Request{
 			ID:           fmt.Sprintf("request_%d", i),
@@ -202,29 +202,29 @@ func TestPrefixAffinityRouting_MultiTurn_SessionAffinity(t *testing.T) {
 		sessionID := fmt.Sprintf("session_%d", s)
 
 		// Generate the session's base prefix (unique per session)
-		prefix := make([]int, 128) // 128 tokens = 8 blocks
+		prefix := make([]sim.TokenID, 128) // 128 tokens = 8 blocks
 		for i := range prefix {
-			prefix[i] = s*10000 + i
+			prefix[i] = sim.TokenID(s*10000 + i)
 		}
 
-		var contextPrefix []int
+		var contextPrefix []sim.TokenID
 		for r := 0; r < roundsPerSession; r++ {
 			// Build input: context prefix + new tokens for this round
-			newTokens := make([]int, 64) // 64 new tokens per round = 4 blocks
+			newTokens := make([]sim.TokenID, 64) // 64 new tokens per round = 4 blocks
 			for i := range newTokens {
-				newTokens[i] = s*10000 + r*1000 + 5000 + i
+				newTokens[i] = sim.TokenID(s*10000 + r*1000 + 5000 + i)
 			}
-			var inputTokens []int
+			var inputTokens []sim.TokenID
 			if r == 0 {
-				inputTokens = append([]int{}, prefix...)
+				inputTokens = append([]sim.TokenID{}, prefix...)
 				inputTokens = append(inputTokens, newTokens...)
 			} else {
-				inputTokens = append(append([]int{}, contextPrefix...), newTokens...)
+				inputTokens = append(append([]sim.TokenID{}, contextPrefix...), newTokens...)
 			}
 
-			outputTokens := make([]int, 32)
+			outputTokens := make([]sim.TokenID, 32)
 			for i := range outputTokens {
-				outputTokens[i] = i
+				outputTokens[i] = sim.TokenID(i)
 			}
 
 			requests = append(requests, &sim.Request{
@@ -240,7 +240,7 @@ func TestPrefixAffinityRouting_MultiTurn_SessionAffinity(t *testing.T) {
 
 			// Accumulate context for next round
 			if r == 0 {
-				contextPrefix = append(append([]int{}, prefix...), newTokens...)
+				contextPrefix = append(append([]sim.TokenID{}, prefix...), newTokens...)
 			} else {
 				contextPrefix = append(contextPrefix, newTokens...)
 			}
@@ -324,8 +324,8 @@ func copyRequests(reqs []*sim.Request) []*sim.Request {
 	out := make([]*sim.Request, len(reqs))
 	for i, r := range reqs {
 		cp := *r
-		cp.InputTokens = append([]int{}, r.InputTokens...)
-		cp.OutputTokens = append([]int{}, r.OutputTokens...)
+		cp.InputTokens = append([]sim.TokenID{}, r.InputTokens...)
+		cp.OutputTokens = append([]sim.TokenID{}, r.OutputTokens...)
 		out[i] = &cp
 	}
 	return out

--- a/sim/cluster/progress_hook_test.go
+++ b/sim/cluster/progress_hook_test.go
@@ -131,8 +131,8 @@ func TestClusterSimulator_ProgressHook_ShedByTier(t *testing.T) {
 			ID:           fmt.Sprintf("req_sheddable_%d", i),
 			ArrivalTime:  int64(i) * 50_000, // spread over 2_000_000µs to trigger periodic snapshots
 			SLOClass:     "sheddable",
-			InputTokens:  make([]int, 50),
-			OutputTokens: make([]int, 20),
+			InputTokens:  make([]sim.TokenID, 50),
+			OutputTokens: make([]sim.TokenID, 20),
 			State:        sim.StateQueued,
 		})
 	}
@@ -237,8 +237,8 @@ func TestClusterSimulator_ProgressHook_ShedByTierDeterminism(t *testing.T) {
 				ID:           fmt.Sprintf("req_sheddable_%d", i),
 				ArrivalTime:  int64(i) * 50_000, // spread to trigger periodic snapshots
 				SLOClass:     "sheddable",
-				InputTokens:  make([]int, 50),
-				OutputTokens: make([]int, 20),
+				InputTokens:  make([]sim.TokenID, 50),
+				OutputTokens: make([]sim.TokenID, 20),
 				State:        sim.StateQueued,
 			})
 		}

--- a/sim/cluster/snapshot.go
+++ b/sim/cluster/snapshot.go
@@ -81,7 +81,7 @@ type fieldTimestamps struct {
 // cacheEntry holds a live instance reference and its current stale snapshot closure.
 type cacheEntry struct {
 	inst    *InstanceSimulator
-	staleFn func([]int) int
+	staleFn func([]sim.TokenID) int
 }
 
 // CachedSnapshotProvider implements SnapshotProvider with configurable caching.
@@ -231,7 +231,7 @@ func (p *CachedSnapshotProvider) RefreshCacheIfNeeded(clock int64) {
 // When CacheBlocks.Mode == Periodic, returns stale snapshot data.
 // When CacheBlocks.Mode == Immediate, queries live instance state.
 // Returns 0 if the instance is unknown.
-func (p *CachedSnapshotProvider) CacheQuery(instanceID string, tokens []int) int {
+func (p *CachedSnapshotProvider) CacheQuery(instanceID string, tokens []sim.TokenID) int {
 	id := InstanceID(instanceID)
 	if p.config.CacheBlocks.Mode == Periodic {
 		if e, ok := p.cacheEntries[id]; ok {
@@ -249,7 +249,7 @@ func (p *CachedSnapshotProvider) CacheQuery(instanceID string, tokens []int) int
 
 // BuildCacheQueryFn returns a cacheQueryFn map where each closure delegates to
 // CacheQuery. The returned closures use the latest snapshot after RefreshCacheIfNeeded.
-func (p *CachedSnapshotProvider) BuildCacheQueryFn() map[string]func([]int) int {
+func (p *CachedSnapshotProvider) BuildCacheQueryFn() map[string]func([]sim.TokenID) int {
 	var ids []InstanceID
 	if p.config.CacheBlocks.Mode == Periodic {
 		ids = make([]InstanceID, 0, len(p.cacheEntries))
@@ -262,10 +262,10 @@ func (p *CachedSnapshotProvider) BuildCacheQueryFn() map[string]func([]int) int 
 			ids = append(ids, id)
 		}
 	}
-	result := make(map[string]func([]int) int, len(ids))
+	result := make(map[string]func([]sim.TokenID) int, len(ids))
 	for _, id := range ids {
 		idStr := string(id)
-		result[idStr] = func(tokens []int) int {
+		result[idStr] = func(tokens []sim.TokenID) int {
 			return p.CacheQuery(idStr, tokens)
 		}
 	}

--- a/sim/cluster/snapshot_test.go
+++ b/sim/cluster/snapshot_test.go
@@ -34,8 +34,8 @@ func TestSnapshot_Immutability(t *testing.T) {
 	req := &sim.Request{
 		ID:           "req_0",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 50),
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]sim.TokenID, 50),
+		OutputTokens: make([]sim.TokenID, 10),
 		State:        sim.StateQueued,
 	}
 	inst.InjectRequest(req)
@@ -50,8 +50,8 @@ func TestSnapshot_Immutability(t *testing.T) {
 	req2 := &sim.Request{
 		ID:           "req_1",
 		ArrivalTime:  100,
-		InputTokens:  make([]int, 30),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]sim.TokenID, 30),
+		OutputTokens: make([]sim.TokenID, 5),
 		State:        sim.StateQueued,
 	}
 	inst.InjectRequest(req2)
@@ -363,12 +363,12 @@ func TestCachedSnapshotProvider_DualTimers_IndependentRefresh(t *testing.T) {
 	obsConfig := newObservabilityConfig(200, 500)
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 
 	// Run a request to populate cache blocks.
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -413,7 +413,7 @@ func TestCachedSnapshotProvider_CacheQuery_StaleUntilRefresh(t *testing.T) {
 	obsConfig := newObservabilityConfig(0, 1000) // cache delay 1000µs
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 
 	// Initial snapshot — empty cache
 	assert.Equal(t, 0, provider.CacheQuery("inst-0", tokens))
@@ -421,7 +421,7 @@ func TestCachedSnapshotProvider_CacheQuery_StaleUntilRefresh(t *testing.T) {
 	// Populate cache via request
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -448,10 +448,10 @@ func TestCachedSnapshotProvider_CacheQuery_OracleMode(t *testing.T) {
 	obsConfig := newObservabilityConfig(0, 0) // oracle mode
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -473,7 +473,7 @@ func TestCachedSnapshotProvider_AddRemoveCacheInstance(t *testing.T) {
 	// AddInstance registers for scalar snapshots; AddCacheInstance for cache tracking.
 	provider.AddInstance("inst-new", inst)
 	provider.AddCacheInstance("inst-new", inst)
-	tokens := []int{1, 2, 3, 4}
+	tokens := []sim.TokenID{1, 2, 3, 4}
 	assert.Equal(t, 0, provider.CacheQuery("inst-new", tokens)) // empty cache
 
 	provider.RemoveCacheInstance("inst-new")
@@ -507,13 +507,13 @@ func TestCachedSnapshotProvider_AddCacheInstance_HonorsStaleBoundary(t *testing.
 	provider.AddInstance("inst-deferred", inst)
 	provider.AddCacheInstance("inst-deferred", inst) // snapshot taken here: cache empty
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 	cqf := provider.BuildCacheQueryFn()
 
 	// Populate cache after registration
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -543,12 +543,12 @@ func TestCachedSnapshotProvider_RefreshCacheIfNeeded_BoundaryAtIntervalMinusOne(
 	obsConfig := newObservabilityConfig(0, 1000) // stale mode, interval=1000
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 
 	// Populate cache
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -597,7 +597,7 @@ func TestCachedSnapshotProvider_BuildCacheQueryFn_DelegatesToStale(t *testing.T)
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
 	cqf := provider.BuildCacheQueryFn()
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 
 	// Initially returns 0 (empty cache in snapshot)
 	assert.Equal(t, 0, cqf["inst-0"](tokens))
@@ -605,7 +605,7 @@ func TestCachedSnapshotProvider_BuildCacheQueryFn_DelegatesToStale(t *testing.T)
 	// Populate cache
 	req := &sim.Request{
 		ID: "r1", ArrivalTime: 0, InputTokens: tokens,
-		OutputTokens: []int{100}, State: sim.StateQueued,
+		OutputTokens: []sim.TokenID{100}, State: sim.StateQueued,
 	}
 	inst.InjectRequest(req)
 	inst.Run()
@@ -629,7 +629,7 @@ func TestCachedSnapshotProvider_RemoveCacheInstance_Basic(t *testing.T) {
 	obsConfig := newObservabilityConfig(0, 1000)
 	provider := NewCachedSnapshotProvider(instances, obsConfig)
 
-	tokens := []int{1, 2, 3, 4}
+	tokens := []sim.TokenID{1, 2, 3, 4}
 
 	// Sanity: instance is queryable
 	assert.Equal(t, 0, provider.CacheQuery("inst-0", tokens))
@@ -693,9 +693,9 @@ func TestCluster_CacheSignalDelay_StaleRouting(t *testing.T) {
 		}
 	}
 
-	tokens := make([]int, 16) // 4 blocks of size 4
+	tokens := make([]sim.TokenID, 16) // 4 blocks of size 4
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 
 	// Generate N requests: r0 warms the cache, r1..r(N-1) share the same prefix.
@@ -707,7 +707,7 @@ func TestCluster_CacheSignalDelay_StaleRouting(t *testing.T) {
 				ID:           fmt.Sprintf("r%d", i),
 				ArrivalTime:  int64(i) * 50_000, // 50ms apart
 				InputTokens:  tokens,
-				OutputTokens: []int{1},
+				OutputTokens: []sim.TokenID{1},
 				State:        sim.StateQueued,
 			}
 		}
@@ -766,14 +766,14 @@ func TestCluster_CacheSignalDelay_Zero_OracleBehavior(t *testing.T) {
 		},
 	}
 
-	tokens := make([]int, 16)
+	tokens := make([]sim.TokenID, 16)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 
 	requests := []*sim.Request{
-		{ID: "r1", ArrivalTime: 0, InputTokens: tokens, OutputTokens: []int{1}, State: sim.StateQueued},
-		{ID: "r2", ArrivalTime: 100_000, InputTokens: tokens, OutputTokens: []int{1}, State: sim.StateQueued},
+		{ID: "r1", ArrivalTime: 0, InputTokens: tokens, OutputTokens: []sim.TokenID{1}, State: sim.StateQueued},
+		{ID: "r2", ArrivalTime: 100_000, InputTokens: tokens, OutputTokens: []sim.TokenID{1}, State: sim.StateQueued},
 	}
 
 	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)

--- a/sim/cluster/test_helpers_test.go
+++ b/sim/cluster/test_helpers_test.go
@@ -32,7 +32,7 @@ func testGenerateRequests(seed, horizon int64, rate float64,
 	for currentTime < horizon && reqIdx < numReqs {
 		promptLen := generateLengthGauss(workloadRNG, pMean, pStd, pMin, pMax)
 		prompt := sim.GenerateRandomTokenIDs(workloadRNG, promptLen)
-		input := append(append([]int{}, prefixTokens...), prompt...)
+		input := append(append([]sim.TokenID{}, prefixTokens...), prompt...)
 
 		outputLen := generateLengthGauss(workloadRNG, oMean, oStd, oMin, oMax)
 		output := sim.GenerateRandomTokenIDs(workloadRNG, outputLen)

--- a/sim/cluster/transfer_contention_test.go
+++ b/sim/cluster/transfer_contention_test.go
@@ -88,9 +88,9 @@ func TestTransferContention_BCP25_SingleTransferIdentical(t *testing.T) {
 	requests2 := make([]*sim.Request, len(requests1))
 	for i, r := range requests1 {
 		cp := *r
-		cp.InputTokens = make([]int, len(r.InputTokens))
+		cp.InputTokens = make([]sim.TokenID, len(r.InputTokens))
 		copy(cp.InputTokens, r.InputTokens)
-		cp.OutputTokens = make([]int, len(r.OutputTokens))
+		cp.OutputTokens = make([]sim.TokenID, len(r.OutputTokens))
 		copy(cp.OutputTokens, r.OutputTokens)
 		requests2[i] = &cp
 	}
@@ -324,13 +324,13 @@ func TestTransferContention_HorizonCutoff_RunReturnsNil(t *testing.T) {
 // N>1 behavioral coverage is provided by TestTransferContention_BCP26_FairShareDivision.
 func TestTransferContention_INVP22_EffectiveBandwidthFormula(t *testing.T) {
 	// 160 tokens → ceil(160/16) = 10 KV blocks
-	inputTokens := make([]int, 160)
+	inputTokens := make([]sim.TokenID, 160)
 	for i := range inputTokens {
-		inputTokens[i] = i + 1
+		inputTokens[i] = sim.TokenID(i + 1)
 	}
-	outputTokens := make([]int, 10)
+	outputTokens := make([]sim.TokenID, 10)
 	for i := range outputTokens {
-		outputTokens[i] = i + 1
+		outputTokens[i] = sim.TokenID(i + 1)
 	}
 	req := &sim.Request{
 		ID:           "request_0",
@@ -611,8 +611,8 @@ func TestTransferContention_NegativeGuard_SetsCorruptionFlag(t *testing.T) {
 		ID: "test-parent",
 		OriginalRequest: &sim.Request{
 			ID:           "test-req",
-			InputTokens:  []int{1, 2, 3},
-			OutputTokens: []int{1},
+			InputTokens:  []sim.TokenID{1, 2, 3},
+			OutputTokens: []sim.TokenID{1},
 		},
 		// With #1343 WaitingForRemoteKVs parity, KVTransferCompletedEvent
 		// requires DecodeSubReq (attached at transfer start). A nil

--- a/sim/cluster/waiting_for_remote_kvs_test.go
+++ b/sim/cluster/waiting_for_remote_kvs_test.go
@@ -163,12 +163,12 @@ func TestWaitingForRemoteKVs_ConcurrentReservationsDoNotStealBlocks(t *testing.T
 
 	reqA := &sim.Request{
 		ID:          "transferA_decode",
-		InputTokens: make([]int, 80), // exactly 5 blocks at blockSize=16
+		InputTokens: make([]sim.TokenID, 80), // exactly 5 blocks at blockSize=16
 		State:       sim.StateWaitingForRemoteKVs,
 	}
 	reqB := &sim.Request{
 		ID:          "transferB_decode",
-		InputTokens: make([]int, 16), // 1 block — minimum non-zero
+		InputTokens: make([]sim.TokenID, 16), // 1 block — minimum non-zero
 		State:       sim.StateWaitingForRemoteKVs,
 	}
 
@@ -214,7 +214,7 @@ func TestReserveTransferredKV_ReleaseFreesBlocks(t *testing.T) {
 
 	req := &sim.Request{
 		ID:          "reserved_req",
-		InputTokens: make([]int, 80), // 5 blocks
+		InputTokens: make([]sim.TokenID, 80), // 5 blocks
 		State:       sim.StateWaitingForRemoteKVs,
 	}
 

--- a/sim/disaggregation.go
+++ b/sim/disaggregation.go
@@ -100,7 +100,7 @@ func NewDisaggregationDecider(name string) DisaggregationDecider {
 type PrefixThresholdDecider struct {
 	threshold  int
 	blockSize  int
-	cacheQuery map[string]func([]int) int
+	cacheQuery map[string]func([]TokenID) int
 }
 
 // NewPrefixThresholdDecider creates a PrefixThresholdDecider with the given
@@ -110,7 +110,7 @@ type PrefixThresholdDecider struct {
 // when state.SelectedInstance is missing from the map, Decide returns
 // Disaggregate=false (conservative fallback, consistent with llm-d's
 // nil-endpoint guard at prefix_based_pd_decider.go:108-111).
-func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]func([]int) int) *PrefixThresholdDecider {
+func NewPrefixThresholdDecider(threshold, blockSize int, cacheQuery map[string]func([]TokenID) int) *PrefixThresholdDecider {
 	if threshold < 0 {
 		panic(fmt.Sprintf("NewPrefixThresholdDecider: threshold must be >= 0, got %d", threshold))
 	}

--- a/sim/disaggregation_test.go
+++ b/sim/disaggregation_test.go
@@ -9,7 +9,7 @@ import (
 // always returns Disaggregate=false regardless of input.
 func TestNeverDisaggregate_AlwaysReturnsFalse(t *testing.T) {
 	decider := &NeverDisaggregate{}
-	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
+	req := &Request{ID: "req-1", InputTokens: make([]TokenID, 100)}
 
 	decision := decider.Decide(req, (*RouterState)(nil))
 
@@ -22,7 +22,7 @@ func TestNeverDisaggregate_AlwaysReturnsFalse(t *testing.T) {
 // always returns Disaggregate=true regardless of input.
 func TestAlwaysDisaggregate_AlwaysReturnsTrue(t *testing.T) {
 	decider := &AlwaysDisaggregate{}
-	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
+	req := &Request{ID: "req-1", InputTokens: make([]TokenID, 100)}
 
 	decision := decider.Decide(req, (*RouterState)(nil))
 
@@ -41,7 +41,7 @@ func TestDisaggregationDecider_Interface(t *testing.T) {
 // TestNewDisaggregationDecider_Factory verifies factory dispatches correctly
 // by asserting observable behavior (Decide output), not concrete type names.
 func TestNewDisaggregationDecider_Factory(t *testing.T) {
-	req := &Request{ID: "req-1", InputTokens: make([]int, 10)}
+	req := &Request{ID: "req-1", InputTokens: make([]TokenID, 10)}
 	tests := []struct {
 		name             string
 		wantDisaggregate bool
@@ -139,13 +139,13 @@ func TestValidDisaggregationDeciderNames(t *testing.T) {
 // enforced by reading only InputTokens and MaxOutputLen. The test verifies the observable
 // behavior: decisions are the same regardless of OutputTokens content.
 func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
-	req1 := &Request{ID: "req-1", InputTokens: make([]int, 100), OutputTokens: nil}
-	req2 := &Request{ID: "req-2", InputTokens: make([]int, 100), OutputTokens: make([]int, 9999)}
+	req1 := &Request{ID: "req-1", InputTokens: make([]TokenID, 100), OutputTokens: nil}
+	req2 := &Request{ID: "req-2", InputTokens: make([]TokenID, 100), OutputTokens: make([]TokenID, 9999)}
 
 	// Stub cacheQuery returning 0 blocks for any instance — exercises Decide's
 	// formula path without depending on real cluster state.
-	stubCache := map[string]func([]int) int{
-		"decode_0": func([]int) int { return 0 },
+	stubCache := map[string]func([]TokenID) int{
+		"decode_0": func([]TokenID) int { return 0 },
 	}
 	state := &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
@@ -173,7 +173,7 @@ func TestDisaggregationDecider_INV9_OracleBoundary(t *testing.T) {
 // this list anymore: after GAP-3, its decision depends on state.SelectedInstance
 // and the cache query map; it has its own dedicated tests below.
 func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
-	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
+	req := &Request{ID: "req-1", InputTokens: make([]TokenID, 100)}
 	nilState := (*RouterState)(nil)
 	populated := &RouterState{
 		Snapshots: []RoutingSnapshot{
@@ -205,9 +205,9 @@ func TestDisaggregationDecider_StateAgnostic(t *testing.T) {
 // here pins the contract: every built-in caller can safely ignore these fields,
 // and any regression that accidentally populates one will fail this test.
 func TestDisaggregationDecider_BuiltinsReturnNoOverrides(t *testing.T) {
-	req := &Request{ID: "req-1", InputTokens: make([]int, 100)}
-	stubCache := map[string]func([]int) int{
-		"decode_0": func([]int) int { return 0 },
+	req := &Request{ID: "req-1", InputTokens: make([]TokenID, 100)}
+	stubCache := map[string]func([]TokenID) int{
+		"decode_0": func([]TokenID) int { return 0 },
 	}
 	state := &RouterState{
 		Snapshots:        []RoutingSnapshot{{ID: "decode_0"}},
@@ -268,16 +268,16 @@ func coldState(selectedID string) *RouterState {
 // closure always returns 0 cached blocks. Pair with coldState(selectedID) to
 // exercise the decider's formula with cachedBlocks=0 — i.e. the selected pod
 // is known but has none of the input cached.
-func coldCache(selectedID string) map[string]func([]int) int {
-	return map[string]func([]int) int{
-		selectedID: func([]int) int { return 0 },
+func coldCache(selectedID string) map[string]func([]TokenID) int {
+	return map[string]func([]TokenID) int{
+		selectedID: func([]TokenID) int { return 0 },
 	}
 }
 
 // TestPrefixThresholdDecider_EmptyTokens verifies BC-3: empty input returns Disaggregate=false.
 func TestPrefixThresholdDecider_EmptyTokens(t *testing.T) {
 	decider := NewPrefixThresholdDecider(512, 16, coldCache("decode_0"))
-	req := &Request{ID: "req-empty", InputTokens: []int{}}
+	req := &Request{ID: "req-empty", InputTokens:  []TokenID{}}
 
 	decision := decider.Decide(req, coldState("decode_0"))
 
@@ -303,9 +303,9 @@ func TestPrefixThresholdDecider_AboveThreshold(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tokens := make([]int, tc.tokens)
+			tokens := make([]TokenID, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1 // unique tokens
+				tokens[i] = TokenID(i + 1) // unique tokens
 			}
 			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
 
@@ -335,9 +335,9 @@ func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tokens := make([]int, tc.tokens)
+			tokens := make([]TokenID, tc.tokens)
 			for i := range tokens {
-				tokens[i] = i + 1000 // unique tokens
+				tokens[i] = TokenID(i + 1000) // unique tokens
 			}
 			req := &Request{ID: fmt.Sprintf("req-%s", tc.name), InputTokens: tokens}
 
@@ -367,15 +367,15 @@ func TestPrefixThresholdDecider_BelowOrAtThreshold(t *testing.T) {
 func TestPrefixThresholdDecider_PerPodCacheQuery(t *testing.T) {
 	const blockSize = 16
 	const threshold = 512
-	cacheQuery := map[string]func([]int) int{
-		"decode_A": func([]int) int { return 40 },
-		"decode_B": func([]int) int { return 0 },
+	cacheQuery := map[string]func([]TokenID) int{
+		"decode_A": func([]TokenID) int { return 40 },
+		"decode_B": func([]TokenID) int { return 0 },
 	}
 	decider := NewPrefixThresholdDecider(threshold, blockSize, cacheQuery)
 
-	tokens := make([]int, 840)
+	tokens := make([]TokenID, 840)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	req := &Request{ID: "req-multi-pod", InputTokens: tokens}
 
@@ -419,15 +419,15 @@ func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
 	// Request is large enough that if the selected-pod path were taken with a
 	// 0-blocks closure, the decision would be Disaggregate=true. So any test
 	// that observes Disaggregate=false proves the early-return fired.
-	tokens := make([]int, 400) // 400 > 100 threshold
+	tokens := make([]TokenID, 400) // 400 > 100 threshold
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	req := &Request{ID: "req-missing", InputTokens: tokens}
 
 	tests := []struct {
 		name       string
-		cacheQuery map[string]func([]int) int
+		cacheQuery map[string]func([]TokenID) int
 		state      *RouterState
 	}{
 		{
@@ -447,7 +447,7 @@ func TestPrefixThresholdDecider_MissingSelection_ReturnsFalse(t *testing.T) {
 		},
 		{
 			name: "nil_closure_in_map",
-			cacheQuery: map[string]func([]int) int{
+			cacheQuery: map[string]func([]TokenID) int{
 				"decode_0": nil,
 			},
 			state: coldState("decode_0"),
@@ -477,9 +477,9 @@ func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
 
 	// Case 1: cold pod, any non-empty input → disaggregate.
 	decider := NewPrefixThresholdDecider(0, blockSize, coldCache("decode_0"))
-	tokens := make([]int, 100)
+	tokens := make([]TokenID, 100)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	req := &Request{ID: "req-zero-thresh-cold", InputTokens: tokens}
 	if !decider.Decide(req, coldState("decode_0")).Disaggregate {
@@ -491,13 +491,13 @@ func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
 	//
 	// This pins the strict > semantics at the boundary, guarding against an
 	// accidental >= flip in the formula.
-	fullCache := map[string]func([]int) int{
-		"decode_0": func(t []int) int { return len(t) / blockSize },
+	fullCache := map[string]func([]TokenID) int{
+		"decode_0": func(t []TokenID) int { return len(t) / blockSize },
 	}
 	fullyCachedDecider := NewPrefixThresholdDecider(0, blockSize, fullCache)
-	exactBlocks := make([]int, 64) // 64 tokens = 4 full blocks
+	exactBlocks := make([]TokenID, 64) // 64 tokens = 4 full blocks
 	for i := range exactBlocks {
-		exactBlocks[i] = i + 1
+		exactBlocks[i] = TokenID(i + 1)
 	}
 	reqFull := &Request{ID: "req-fully-cached", InputTokens: exactBlocks}
 	if fullyCachedDecider.Decide(reqFull, coldState("decode_0")).Disaggregate {
@@ -512,15 +512,15 @@ func TestPrefixThresholdDecider_ZeroThreshold(t *testing.T) {
 // rejected; we implement option (a) — query only the selected pod).
 func TestPrefixThresholdDecider_QueriesOnlySelectedPod(t *testing.T) {
 	var aCalls, bCalls int
-	cacheQuery := map[string]func([]int) int{
-		"decode_A": func([]int) int { aCalls++; return 0 },
-		"decode_B": func([]int) int { bCalls++; return 0 },
+	cacheQuery := map[string]func([]TokenID) int{
+		"decode_A": func([]TokenID) int { aCalls++; return 0 },
+		"decode_B": func([]TokenID) int { bCalls++; return 0 },
 	}
 	decider := NewPrefixThresholdDecider(512, 16, cacheQuery)
 
-	req := &Request{ID: "req-isolation", InputTokens: make([]int, 100)}
+	req := &Request{ID: "req-isolation", InputTokens: make([]TokenID, 100)}
 	for i := range req.InputTokens {
-		req.InputTokens[i] = i + 1
+		req.InputTokens[i] = TokenID(i + 1)
 	}
 	state := &RouterState{
 		Snapshots: []RoutingSnapshot{
@@ -548,7 +548,7 @@ func TestPrefixThresholdDecider_QueriesOnlySelectedPod(t *testing.T) {
 func TestAlwaysEncode(t *testing.T) {
 	d := &AlwaysEncode{}
 	cases := []*Request{
-		{ID: "text", InputTokens: make([]int, 32)},
+		{ID: "text", InputTokens: make([]TokenID, 32)},
 		{ID: "image", ImageTokenCount: 10},
 		{ID: "nil-tokens", OutputTokens: nil},
 	}
@@ -619,7 +619,7 @@ func TestMultimodalEncodeDecider_False(t *testing.T) {
 func TestMultimodalEncodeDecider_IgnoresOutputTokens(t *testing.T) {
 	d := &MultimodalEncodeDecider{}
 	reqNoOutput := &Request{ID: "oracle-probe-nil", ImageTokenCount: 5, OutputTokens: nil}
-	reqLargeOutput := &Request{ID: "oracle-probe-large", ImageTokenCount: 5, OutputTokens: make([]int, 9999)}
+	reqLargeOutput := &Request{ID: "oracle-probe-large", ImageTokenCount: 5, OutputTokens: make([]TokenID, 9999)}
 	decisionNil := d.ShouldEncode(reqNoOutput, "inst_0")
 	decisionLarge := d.ShouldEncode(reqLargeOutput, "inst_0")
 	if !decisionNil {

--- a/sim/examples_test.go
+++ b/sim/examples_test.go
@@ -94,7 +94,7 @@ func TestExampleConfigs_EPPEstimatePrefix_RoutingBehavior(t *testing.T) {
 	}
 
 	// WHEN routing a request
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
 	decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN a valid decision is made
@@ -130,7 +130,7 @@ func TestExampleConfigs_EPPPrecisePrefix_RoutingBehavior(t *testing.T) {
 	}
 
 	// WHEN routing a request
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
 	decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN a valid decision is made
@@ -166,9 +166,9 @@ func TestExampleConfigs_EPPPrecisePrefix_WeightRatioEffect(t *testing.T) {
 	}
 
 	// Route first request (no prefix cache yet)
-	tokens := make([]int, 32) // 2 blocks at block_size=16
+	tokens := make([]TokenID, 32) // 2 blocks at block_size=16
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	req1 := &Request{ID: "req1", InputTokens: tokens}
 	decision1 := policy.Route(req1, &RouterState{Snapshots: snapshots, Clock: 1000})
@@ -222,7 +222,7 @@ func TestExampleConfigs_EPPEstimatePrefix_LoadBalanceMonotonicity(t *testing.T) 
 		{ID: "high", QueueDepth: 20, BatchSize: 0}, // highest load
 	}
 
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3}}
 	decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN lower load instances score higher (monotonicity)
@@ -262,7 +262,7 @@ func TestExampleConfigs_EPPPrecisePrefix_QueueDepthMonotonicity(t *testing.T) {
 		{ID: "full", QueueDepth: 10, BatchSize: 0},   // highest load
 	}
 
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3}}
 	decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN lower queue depth scores higher (monotonicity)
@@ -302,7 +302,7 @@ func TestExampleConfigs_EPPPrecisePrefix_KVUtilizationMonotonicity(t *testing.T)
 		{ID: "full", KVUtilization: 1.0},   // highest utilization
 	}
 
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3}}
 	decision := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// THEN lower utilization scores higher (monotonicity)

--- a/sim/internal/hash/hash.go
+++ b/sim/internal/hash/hash.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+
+	"github.com/inference-sim/inference-sim/sim/internal/tokenid"
 )
 
 // HashBlock computes a SHA256 hash of a token block chained with the previous block's hash.
@@ -15,7 +17,7 @@ import (
 // This creates hierarchical block hashes for prefix caching.
 // Also inlined in ComputeBlockHashes for hasher reuse.
 // TestComputeBlockHashes_MatchesManualChaining guards consistency between the two paths.
-func HashBlock(prevHash string, tokens []int) string {
+func HashBlock(prevHash string, tokens []tokenid.TokenID) string {
 	h := sha256.New()
 	h.Write([]byte(prevHash))
 	var buf [20]byte // stack buffer: max int64 (19 digits) + pipe
@@ -33,7 +35,7 @@ func HashBlock(prevHash string, tokens []int) string {
 // Produces the same output as calling HashBlock sequentially, but reuses a
 // single SHA256 hasher instance across blocks to reduce allocations.
 // Output equivalence is enforced by TestComputeBlockHashes_MatchesManualChaining.
-func ComputeBlockHashes(blockSize int, tokens []int) []string {
+func ComputeBlockHashes(blockSize int, tokens []tokenid.TokenID) []string {
 	if blockSize <= 0 {
 		panic(fmt.Sprintf("ComputeBlockHashes: blockSize must be > 0, got %d", blockSize))
 	}

--- a/sim/internal/hash/hash_test.go
+++ b/sim/internal/hash/hash_test.go
@@ -1,9 +1,17 @@
 package hash
 
-import "testing"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim/internal/tokenid"
+)
 
 func TestHashBlock_ChainsDeterministically(t *testing.T) {
-	tokens := []int{10, 20, 30}
+	tokens := []tokenid.TokenID{10, 20, 30}
 	h1 := HashBlock("", tokens)
 	h2 := HashBlock("", tokens)
 	if h1 != h2 {
@@ -17,7 +25,7 @@ func TestHashBlock_ChainsDeterministically(t *testing.T) {
 }
 
 func TestComputeBlockHashes_MatchesManualChaining(t *testing.T) {
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []tokenid.TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 	blockSize := 4
 	hashes := ComputeBlockHashes(blockSize, tokens)
 	if len(hashes) != 2 {
@@ -36,7 +44,7 @@ func TestComputeBlockHashes_MatchesManualChaining(t *testing.T) {
 
 func TestComputeBlockHashes_PartialBlock(t *testing.T) {
 	// 5 tokens with block size 4 = 1 full block (partial block ignored)
-	tokens := []int{1, 2, 3, 4, 5}
+	tokens := []tokenid.TokenID{1, 2, 3, 4, 5}
 	hashes := ComputeBlockHashes(4, tokens)
 	if len(hashes) != 1 {
 		t.Fatalf("expected 1 block hash, got %d", len(hashes))
@@ -44,7 +52,7 @@ func TestComputeBlockHashes_PartialBlock(t *testing.T) {
 }
 
 func TestComputeBlockHashes_Empty(t *testing.T) {
-	hashes := ComputeBlockHashes(4, []int{1, 2})
+	hashes := ComputeBlockHashes(4, []tokenid.TokenID{1, 2})
 	if hashes != nil {
 		t.Errorf("expected nil for fewer tokens than block size, got %v", hashes)
 	}
@@ -54,7 +62,7 @@ func TestComputeBlockHashes_Empty(t *testing.T) {
 // equivalence with HashBlock across 4 blocks, catching any h.Reset()
 // placement bugs that could leak state across blocks.
 func TestComputeBlockHashes_FourBlocks_MatchesManualChaining(t *testing.T) {
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	tokens := []tokenid.TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	blockSize := 4
 	hashes := ComputeBlockHashes(blockSize, tokens)
 	if len(hashes) != 4 {
@@ -79,11 +87,43 @@ func TestComputeBlockHashes_FourBlocks_MatchesManualChaining(t *testing.T) {
 	}
 }
 
+// TestHashBlock_ByteEquivalentToInt64String verifies BC-4: the hash digest
+// produced from a []tokenid.TokenID slice is byte-identical to the digest that
+// would be produced for the same numeric values via a manual reconstruction of
+// HashBlock's wire format (prevHash bytes, then for each token: decimal int64
+// representation + '|'). This is the proof that the type swap from []int to
+// []TokenID does not change KV cache hashes for any value that fits in int32
+// (i.e., every realistic LLM vocabulary): the implementation widens to int64
+// via strconv.AppendInt(buf, int64(t), 10) before stringification, so int vs
+// int32 with the same numeric value produce identical byte streams.
+//
+// Covers in-range max (math.MaxInt32), zero, mid-range (typical vocab IDs),
+// and the smallest positive values.
+func TestHashBlock_ByteEquivalentToInt64String(t *testing.T) {
+	tokens := []tokenid.TokenID{0, 1, 128000, math.MaxInt32 - 1, math.MaxInt32}
+
+	// Reconstruct the byte stream HashBlock writes for the same numeric values
+	// (with prevHash = "abc") via the same int64 widening path.
+	h := sha256.New()
+	prevHash := "abc"
+	h.Write([]byte(prevHash))
+	for _, v := range []int64{0, 1, 128000, math.MaxInt32 - 1, math.MaxInt32} {
+		h.Write([]byte(strconv.FormatInt(v, 10)))
+		h.Write([]byte{'|'})
+	}
+	want := hex.EncodeToString(h.Sum(nil))
+
+	got := HashBlock(prevHash, tokens)
+	if got != want {
+		t.Fatalf("HashBlock byte-equivalence failed\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
 func BenchmarkHashBlock(b *testing.B) {
 	// Simulate a typical block: 16 tokens with values in [0, 128000]
-	tokens := make([]int, 16)
+	tokens := make([]tokenid.TokenID, 16)
 	for i := range tokens {
-		tokens[i] = i * 1000
+		tokens[i] = tokenid.TokenID(i * 1000)
 	}
 	prevHash := "abc123"
 	b.ResetTimer()
@@ -94,9 +134,9 @@ func BenchmarkHashBlock(b *testing.B) {
 
 func BenchmarkComputeBlockHashes(b *testing.B) {
 	// Simulate a reasoning workload: 2048 tokens, block size 16 = 128 blocks
-	tokens := make([]int, 2048)
+	tokens := make([]tokenid.TokenID, 2048)
 	for i := range tokens {
-		tokens[i] = i * 100
+		tokens[i] = tokenid.TokenID(i * 100)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -106,9 +146,9 @@ func BenchmarkComputeBlockHashes(b *testing.B) {
 
 func BenchmarkComputeBlockHashes_LargeContext(b *testing.B) {
 	// Simulate a long reasoning context: 20480 tokens, block size 16 = 1280 blocks
-	tokens := make([]int, 20480)
+	tokens := make([]tokenid.TokenID, 20480)
 	for i := range tokens {
-		tokens[i] = i
+		tokens[i] = tokenid.TokenID(i)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/sim/internal/tokenid/tokenid.go
+++ b/sim/internal/tokenid/tokenid.go
@@ -1,0 +1,11 @@
+// Package tokenid defines the simulator's compact token-ID type.
+// Kept in a tiny leaf package so any sim/* package can import it without
+// risking an import cycle through sim itself.
+package tokenid
+
+// TokenID is the simulator's representation of a tokenizer vocabulary ID.
+// 32 bits is sufficient for all real LLM vocabularies (the simulator's
+// MaxTokenID is 128000, well below 2^31). It is a defined type, NOT a
+// type alias, so mixing with int requires an explicit conversion — the
+// compile-time check is the point.
+type TokenID int32

--- a/sim/kv/cache.go
+++ b/sim/kv/cache.go
@@ -26,7 +26,7 @@ type KVBlock struct {
 	RefCount int      // Number of active requests referencing this block
 	InUse    bool     // Whether the block is currently in use by an active (batched) request
 	Hash     string   // Prefix hash identifying this block's content and its lineage (if full)
-	Tokens   []int    // Actual tokens stored in this block; full if len(Tokens) == BlockSizeTokens
+	Tokens   []sim.TokenID // Actual tokens stored in this block; full if len(Tokens) == BlockSizeTokens
 	PrevFree *KVBlock // LRU doubly linked list: previous free block
 	NextFree *KVBlock // LRU doubly linked list: next free block
 }
@@ -123,7 +123,7 @@ func (kvc *KVCacheState) removeFromFreeList(block *KVBlock) {
 // CO-CHANGE: SnapshotCachedBlocksFn (same file) replicates this algorithm on a
 // frozen map[string]int64 snapshot. If this loop, the hash chain logic, or the
 // break condition changes, update SnapshotCachedBlocksFn to match.
-func (kvc *KVCacheState) GetCachedBlocks(tokens []int) (blockIDs []int64) {
+func (kvc *KVCacheState) GetCachedBlocks(tokens []sim.TokenID) (blockIDs []int64) {
 	n := util.Len64(tokens) / kvc.BlockSizeTokens
 	prevHash := ""
 	for i := int64(0); i < n; i++ {
@@ -151,13 +151,13 @@ func (kvc *KVCacheState) GetCachedBlocks(tokens []int) (blockIDs []int64) {
 // CO-CHANGE: GetCachedBlocks (same file) implements the same algorithm on live
 // HashToBlock state. If this loop, the hash chain logic, or the break condition
 // changes, update GetCachedBlocks to match.
-func (kvc *KVCacheState) SnapshotCachedBlocksFn() func([]int) int {
+func (kvc *KVCacheState) SnapshotCachedBlocksFn() func([]sim.TokenID) int {
 	snapshot := make(map[string]int64, len(kvc.HashToBlock))
 	for k, v := range kvc.HashToBlock {
 		snapshot[k] = v
 	}
 	blockSize := kvc.BlockSizeTokens
-	return func(tokens []int) int {
+	return func(tokens []sim.TokenID) int {
 		n := int64(len(tokens)) / blockSize
 		prevHash := ""
 		count := 0
@@ -183,7 +183,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 	reqID := req.ID
 	logrus.Debugf("AllocateBlock for ReqID: %s, Num Inputs: %d, startIndex = %d, endIndex = %d", req.ID, len(req.InputTokens), startIndex, endIndex)
 
-	var newTokens []int
+	var newTokens []sim.TokenID
 	var numNewBlocks int64
 	if req.ProgressIndex < util.Len64(req.InputTokens) {
 		// request is in prefill (could be chunked)
@@ -344,7 +344,7 @@ func (kvc *KVCacheState) AllocateKVBlocks(req *sim.Request, startIndex int64, en
 					end = util.Len64(newTokens)
 				}
 				tok := newTokens[start:end]
-				blk.Tokens = append([]int{}, tok...) // copy tokens
+				blk.Tokens = append([]sim.TokenID{}, tok...) // copy tokens
 				blk.RefCount = 1
 				blk.InUse = true
 				kvc.CacheMisses++

--- a/sim/kv/cache_test.go
+++ b/sim/kv/cache_test.go
@@ -31,7 +31,7 @@ func TestAllocateKVBlocks_PartialBlockFill_AdvancesByActualTokenCount(t *testing
 	kvc := NewKVCacheState(10, 4)
 	req := &sim.Request{
 		ID:          "r1",
-		InputTokens: []int{10, 20, 30, 40, 50, 60},
+		InputTokens: []sim.TokenID{10, 20, 30, 40, 50, 60},
 	}
 	// Allocate first 2 tokens (creates a partial block with 2 tokens)
 	ok := kvc.AllocateKVBlocks(req, 0, 2, []int64{})
@@ -70,12 +70,12 @@ func TestAllocateKVBlocks_PartialBlockFill_AdvancesByActualTokenCount(t *testing
 
 	// THEN the filled block's hash equals HashBlock("", [10,20,30,40]) and is findable
 	// via GetCachedBlocks (partial-fill path with len(ids)==1 → prevHash="")
-	expectedHash := hash.HashBlock("", []int{10, 20, 30, 40})
+	expectedHash := hash.HashBlock("", []sim.TokenID{10, 20, 30, 40})
 	if blk.Hash != expectedHash {
 		t.Errorf("partial-fill block hash mismatch:\n  got  %s\n  want %s", blk.Hash, expectedHash)
 	}
 	kvc.ReleaseKVBlocks(req)
-	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40})
+	cached := kvc.GetCachedBlocks([]sim.TokenID{10, 20, 30, 40})
 	if len(cached) != 1 {
 		t.Errorf("expected 1 cached block after partial-fill + release, got %d", len(cached))
 	}
@@ -88,7 +88,7 @@ func TestAllocateKVBlocks_PartialBlockFill_MultiBlock_ChainsFromPreviousBlock(t 
 	kvc := NewKVCacheState(10, 4) // blockSize=4
 	req := &sim.Request{
 		ID:          "r1",
-		InputTokens: []int{10, 20, 30, 40, 50, 60, 70, 80},
+		InputTokens: []sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80},
 	}
 
 	// Allocate 5 tokens: block 0 full [10,20,30,40], block 1 partial [50]
@@ -109,15 +109,15 @@ func TestAllocateKVBlocks_PartialBlockFill_MultiBlock_ChainsFromPreviousBlock(t 
 	}
 
 	// THEN block 1's hash chains from block 0's hash (len(ids)>=2 branch)
-	block0Hash := hash.HashBlock("", []int{10, 20, 30, 40})
-	expectedBlock1Hash := hash.HashBlock(block0Hash, []int{50, 60, 70, 80})
+	block0Hash := hash.HashBlock("", []sim.TokenID{10, 20, 30, 40})
+	expectedBlock1Hash := hash.HashBlock(block0Hash, []sim.TokenID{50, 60, 70, 80})
 	blk1 := kvc.Blocks[kvc.RequestMap["r1"][1]]
 	if blk1.Hash != expectedBlock1Hash {
 		t.Errorf("block 1 hash should chain from block 0:\n  got  %s\n  want %s", blk1.Hash, expectedBlock1Hash)
 	}
 
 	// BC-3 consistency: both hashes match ComputeBlockHashes
-	expected := hash.ComputeBlockHashes(4, []int{10, 20, 30, 40, 50, 60, 70, 80})
+	expected := hash.ComputeBlockHashes(4, []sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80})
 	if len(expected) != 2 {
 		t.Fatalf("expected 2 hashes from ComputeBlockHashes, got %d", len(expected))
 	}
@@ -131,7 +131,7 @@ func TestAllocateKVBlocks_PartialBlockFill_MultiBlock_ChainsFromPreviousBlock(t 
 
 	// Behavioral: round-trip via GetCachedBlocks
 	kvc.ReleaseKVBlocks(req)
-	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40, 50, 60, 70, 80})
+	cached := kvc.GetCachedBlocks([]sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80})
 	if len(cached) != 2 {
 		t.Errorf("expected 2 cached blocks after multi-block partial-fill round-trip, got %d", len(cached))
 	}
@@ -144,12 +144,12 @@ func TestAllocateKVBlocks_CachedPrefixToNewBlocks_HashChainingRoundTrip(t *testi
 	kvc := NewKVCacheState(8, 2) // 8 blocks, blockSize=2
 
 	// Step 1: Allocate [1,2,3,4] (2 blocks), then release to populate cache
-	req1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req1 := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
 	kvc.ReleaseKVBlocks(req1)
 
 	// Step 2: Allocate [1,2,3,4,5,6,7,8] — 2 cached blocks + 2 new blocks
-	req2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	req2 := &sim.Request{ID: "r2", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	cached := kvc.GetCachedBlocks(req2.InputTokens)
 	if len(cached) != 2 {
 		t.Fatalf("expected 2 cached blocks, got %d", len(cached))
@@ -161,13 +161,13 @@ func TestAllocateKVBlocks_CachedPrefixToNewBlocks_HashChainingRoundTrip(t *testi
 
 	// Step 3: Release and verify full 4-block prefix is findable
 	kvc.ReleaseKVBlocks(req2)
-	fullCached := kvc.GetCachedBlocks([]int{1, 2, 3, 4, 5, 6, 7, 8})
+	fullCached := kvc.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8})
 	if len(fullCached) != 4 {
 		t.Errorf("expected 4 cached blocks after cached-prefix + new-block round-trip, got %d", len(fullCached))
 	}
 
 	// Verify hashes match ComputeBlockHashes (BC-3)
-	expected := hash.ComputeBlockHashes(2, []int{1, 2, 3, 4, 5, 6, 7, 8})
+	expected := hash.ComputeBlockHashes(2, []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8})
 	if len(expected) != 4 {
 		t.Fatalf("expected 4 hashes from ComputeBlockHashes, got %d", len(expected))
 	}
@@ -184,7 +184,7 @@ func TestAllocateKVBlocks_ChunkedPrefill_HierarchicalHashChaining(t *testing.T) 
 	kvc := NewKVCacheState(10, 4)
 	req := &sim.Request{
 		ID:          "r1",
-		InputTokens: []int{10, 20, 30, 40, 50, 60, 70, 80},
+		InputTokens: []sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80},
 	}
 
 	// Allocate first chunk (tokens 0-3) — block 1 gets hash of InputTokens[:4]
@@ -194,7 +194,7 @@ func TestAllocateKVBlocks_ChunkedPrefill_HierarchicalHashChaining(t *testing.T) 
 	}
 
 	// Verify first block has correct hierarchical hash (chained from "")
-	expectedHash1 := hash.HashBlock("", []int{10, 20, 30, 40})
+	expectedHash1 := hash.HashBlock("", []sim.TokenID{10, 20, 30, 40})
 	ids1 := kvc.RequestMap["r1"]
 	blk1 := kvc.Blocks[ids1[0]]
 	if blk1.Hash != expectedHash1 {
@@ -214,12 +214,12 @@ func TestAllocateKVBlocks_ChunkedPrefill_HierarchicalHashChaining(t *testing.T) 
 		t.Fatalf("expected at least 2 blocks, got %d", len(ids2))
 	}
 	blk2 := kvc.Blocks[ids2[1]]
-	expectedHash2 := hash.HashBlock(expectedHash1, []int{50, 60, 70, 80})
+	expectedHash2 := hash.HashBlock(expectedHash1, []sim.TokenID{50, 60, 70, 80})
 	if blk2.Hash != expectedHash2 {
 		t.Errorf("second block hash mismatch:\n  got  %s\n  want %s", blk2.Hash, expectedHash2)
 	}
 	// Verify the two hashes match what ComputeBlockHashes produces (BC-3 consistency)
-	allHashes := hash.ComputeBlockHashes(4, []int{10, 20, 30, 40, 50, 60, 70, 80})
+	allHashes := hash.ComputeBlockHashes(4, []sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80})
 	if len(allHashes) != 2 {
 		t.Fatalf("expected 2 block hashes from ComputeBlockHashes, got %d", len(allHashes))
 	}
@@ -232,7 +232,7 @@ func TestAllocateKVBlocks_ChunkedPrefill_HierarchicalHashChaining(t *testing.T) 
 
 	// Behavioral assertion: release and verify full prefix is findable via GetCachedBlocks
 	kvc.ReleaseKVBlocks(req)
-	cached := kvc.GetCachedBlocks([]int{10, 20, 30, 40, 50, 60, 70, 80})
+	cached := kvc.GetCachedBlocks([]sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80})
 	if len(cached) != 2 {
 		t.Errorf("expected 2 cached blocks after chunked-prefill + release round-trip, got %d", len(cached))
 	}
@@ -246,7 +246,7 @@ func TestAllocateKVBlocks_BlockConservation_AfterAllocateReleaseCycles(t *testin
 	for i := 0; i < 5; i++ {
 		req := &sim.Request{
 			ID:          fmt.Sprintf("r%d", i),
-			InputTokens: []int{i*10 + 1, i*10 + 2, i*10 + 3, i*10 + 4},
+			InputTokens: []sim.TokenID{sim.TokenID(i*10 + 1), sim.TokenID(i*10 + 2), sim.TokenID(i*10 + 3), sim.TokenID(i*10 + 4)},
 		}
 		ok := kvc.AllocateKVBlocks(req, 0, 4, []int64{})
 		if !ok {
@@ -274,8 +274,8 @@ func TestAllocateKVBlocks_DecodeWithBlockSize1_NoPrefixHashPanic(t *testing.T) {
 	kvc := NewKVCacheState(20, 1)
 	req := &sim.Request{
 		ID:           "r1",
-		InputTokens:  []int{10, 20, 30, 40},
-		OutputTokens: []int{100, 200},
+		InputTokens:  []sim.TokenID{10, 20, 30, 40},
+		OutputTokens: []sim.TokenID{100, 200},
 	}
 
 	// Prefill: allocate 4 input tokens (4 blocks with BlockSize=1)
@@ -303,7 +303,7 @@ func TestAllocateKVBlocks_DecodeWithBlockSize1_NoPrefixHashPanic(t *testing.T) {
 func TestGetCachedBlocks_IsPureQuery_DoesNotAffectCacheHitRate(t *testing.T) {
 	// GIVEN a KV cache with cached prefix blocks after one allocation cycle
 	kvc := NewKVCacheState(4, 2)
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req, 0, 4, []int64{})
 	kvc.ReleaseKVBlocks(req)
 	// After allocate+release: CacheHitRate is 0 (all misses, no hits)
@@ -311,12 +311,12 @@ func TestGetCachedBlocks_IsPureQuery_DoesNotAffectCacheHitRate(t *testing.T) {
 	rateBefore := kvc.CacheHitRate()
 
 	// WHEN GetCachedBlocks is called multiple times (pure query — BC-3)
-	cached := kvc.GetCachedBlocks([]int{1, 2, 3, 4})
+	cached := kvc.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4})
 	if len(cached) != 2 {
 		t.Fatalf("expected 2 cached blocks, got %d", len(cached))
 	}
-	_ = kvc.GetCachedBlocks([]int{1, 2, 3, 4})
-	_ = kvc.GetCachedBlocks([]int{1, 2, 3, 4})
+	_ = kvc.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4})
+	_ = kvc.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4})
 
 	// THEN CacheHitRate is unchanged — lookups alone don't affect metrics
 	rateAfter := kvc.CacheHitRate()
@@ -328,17 +328,17 @@ func TestGetCachedBlocks_IsPureQuery_DoesNotAffectCacheHitRate(t *testing.T) {
 func TestAllocateKVBlocks_CachedPrefixReuse_IncreasesHitRate(t *testing.T) {
 	// GIVEN a KV cache with 2 cached prefix blocks from a prior allocation
 	kvc := NewKVCacheState(8, 2)
-	req1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req1 := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
 	kvc.ReleaseKVBlocks(req1)
 	// After r1: 2 misses, 0 hits → CacheHitRate = 0
 
 	// WHEN allocating a new request that reuses the cached prefix (BC-4)
-	cached := kvc.GetCachedBlocks([]int{1, 2, 3, 4, 5, 6})
+	cached := kvc.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4, 5, 6})
 	if len(cached) != 2 {
 		t.Fatalf("expected 2 cached blocks, got %d", len(cached))
 	}
-	req2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	req2 := &sim.Request{ID: "r2", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	ok := kvc.AllocateKVBlocks(req2, 4, 6, cached)
 	if !ok {
 		t.Fatal("allocation should succeed")
@@ -357,18 +357,18 @@ func TestAllocateKVBlocks_CachedPrefixReuse_IncreasesHitRate(t *testing.T) {
 func TestAllocateKVBlocks_PreCheckRejection_CacheHitRateUnchanged(t *testing.T) {
 	// GIVEN a KV cache with 2 cached prefix blocks and tight free-block budget
 	kvc := NewKVCacheState(4, 2)
-	req1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req1 := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
 	kvc.ReleaseKVBlocks(req1)
 
 	// Consume 1 block to make the next allocation fail
-	filler := &sim.Request{ID: "filler", InputTokens: []int{90, 91}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{90, 91}}
 	kvc.AllocateKVBlocks(filler, 0, 2, []int64{})
 
 	rateBefore := kvc.CacheHitRate()
 
 	// WHEN allocating with cached prefix + new tokens that exceed capacity (BC-5)
-	req2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	req2 := &sim.Request{ID: "r2", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	cached := kvc.GetCachedBlocks(req2.InputTokens)
 	ok := kvc.AllocateKVBlocks(req2, 4, 8, cached)
 
@@ -465,9 +465,9 @@ func TestAllocateKVBlocks_PartialBlockFill_PreCheckAccountsForExistingBlock(t *t
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			kvc := NewKVCacheState(tc.totalBlocks, tc.blockSize)
-			tokens := make([]int, tc.totalInput)
+			tokens := make([]sim.TokenID, tc.totalInput)
 			for i := range tokens {
-				tokens[i] = (i + 1) * 10
+				tokens[i] = sim.TokenID((i + 1) * 10)
 			}
 			req := &sim.Request{ID: "r1", InputTokens: tokens}
 
@@ -513,7 +513,7 @@ func TestAllocateKVBlocks_FirstAllocation_PreCheckUnaffectedByFix(t *testing.T) 
 	// Verifies the fix does not alter behavior for first-ever allocations (no prior blocks).
 	// When RequestMap has no entry, the partial-block adjustment is skipped entirely.
 	kvc := NewKVCacheState(2, 4) // 2 blocks, blockSize=4
-	req := &sim.Request{ID: "r1", InputTokens: []int{10, 20, 30, 40, 50}}
+	req := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{10, 20, 30, 40, 50}}
 
 	// 5 tokens → ceil(5/4)=2 blocks needed, 2 free → should succeed
 	ok := kvc.AllocateKVBlocks(req, 0, 5, []int64{})
@@ -526,7 +526,7 @@ func TestAllocateKVBlocks_FirstAllocation_PreCheckUnaffectedByFix(t *testing.T) 
 
 	// Same scenario but insufficient blocks: 5 tokens need 2 blocks, only 1 available
 	kvc2 := NewKVCacheState(1, 4)
-	req2 := &sim.Request{ID: "r2", InputTokens: []int{10, 20, 30, 40, 50}}
+	req2 := &sim.Request{ID: "r2", InputTokens: []sim.TokenID{10, 20, 30, 40, 50}}
 	ok = kvc2.AllocateKVBlocks(req2, 0, 5, []int64{})
 	if ok {
 		t.Fatal("first allocation should fail when blocks are insufficient")
@@ -539,8 +539,8 @@ func TestAllocateKVBlocks_ChunkedPrefill_NoPhantomBlocks(t *testing.T) {
 	kvc := NewKVCacheState(20, 4) // 20 blocks, size 4
 	req := &sim.Request{
 		ID:            "phantom-test",
-		InputTokens:   []int{1, 2, 3, 4, 5, 6, 7, 8},
-		OutputTokens:  []int{100},
+		InputTokens:   []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8},
+		OutputTokens:  []sim.TokenID{100},
 		ProgressIndex: 0,
 	}
 
@@ -582,7 +582,7 @@ func TestAllocateKVBlocks_Failure_NoWarnOutput(t *testing.T) {
 	kvc := NewKVCacheState(1, 16)
 	filler := &sim.Request{
 		ID:          "filler",
-		InputTokens: make([]int, 16),
+		InputTokens: make([]sim.TokenID, 16),
 	}
 	ok := kvc.AllocateKVBlocks(filler, 0, 16, nil)
 	require.True(t, ok, "setup: filler allocation must succeed")
@@ -599,7 +599,7 @@ func TestAllocateKVBlocks_Failure_NoWarnOutput(t *testing.T) {
 	// WHEN a second request tries to allocate and fails
 	victim := &sim.Request{
 		ID:          "victim",
-		InputTokens: make([]int, 16),
+		InputTokens: make([]sim.TokenID, 16),
 	}
 	ok = kvc.AllocateKVBlocks(victim, 0, 16, nil)
 
@@ -611,7 +611,7 @@ func TestAllocateKVBlocks_Failure_NoWarnOutput(t *testing.T) {
 func TestFreeBlockCnt_DirectCounter_MatchesFreeListLength(t *testing.T) {
 	kvc := NewKVCacheState(10, 4)
 
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	req := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	ok := kvc.AllocateKVBlocks(req, 0, 8, []int64{})
 	require.True(t, ok)
 
@@ -645,8 +645,8 @@ func TestAllocateKVBlocks_DecodeFailure_PreservesExistingBlocks(t *testing.T) {
 	kvc := NewKVCacheState(3, 4) // 3 blocks total
 	req := &sim.Request{
 		ID:           "r1",
-		InputTokens:  []int{1, 2, 3, 4, 5, 6, 7, 8},
-		OutputTokens: []int{100, 200},
+		InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8},
+		OutputTokens: []sim.TokenID{100, 200},
 	}
 	// Allocate prefill (2 blocks for 8 tokens, blockSize=4)
 	ok := kvc.AllocateKVBlocks(req, 0, 8, []int64{})
@@ -655,7 +655,7 @@ func TestAllocateKVBlocks_DecodeFailure_PreservesExistingBlocks(t *testing.T) {
 	require.Len(t, kvc.RequestMap["r1"], 2)
 
 	// Consume the last free block with a filler
-	filler := &sim.Request{ID: "filler", InputTokens: []int{90, 91, 92, 93}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{90, 91, 92, 93}}
 	ok = kvc.AllocateKVBlocks(filler, 0, 4, []int64{})
 	require.True(t, ok)
 	require.Equal(t, int64(0), kvc.countFreeBlocks())
@@ -675,8 +675,8 @@ func TestAllocateKVBlocks_DecodePreCheck_SucceedsWhenLastBlockHasSpare(t *testin
 	kvc := NewKVCacheState(2, 4)
 	req := &sim.Request{
 		ID:           "r1",
-		InputTokens:  []int{1, 2, 3}, // 3 tokens = 1 partial block (3/4)
-		OutputTokens: []int{100},
+		InputTokens:  []sim.TokenID{1, 2, 3}, // 3 tokens = 1 partial block (3/4)
+		OutputTokens: []sim.TokenID{100},
 	}
 	ok := kvc.AllocateKVBlocks(req, 0, 3, []int64{})
 	req.ProgressIndex = 3 // now past prefill, in decode
@@ -684,7 +684,7 @@ func TestAllocateKVBlocks_DecodePreCheck_SucceedsWhenLastBlockHasSpare(t *testin
 	require.Equal(t, int64(1), kvc.countFreeBlocks())
 
 	// Consume the last free block
-	filler := &sim.Request{ID: "filler", InputTokens: []int{90, 91, 92, 93}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{90, 91, 92, 93}}
 	ok = kvc.AllocateKVBlocks(filler, 0, 4, []int64{})
 	require.True(t, ok)
 	require.Equal(t, int64(0), kvc.countFreeBlocks())
@@ -701,14 +701,14 @@ func TestAllocateKVBlocks_PreCheck_CatchesCachedBlockBudgetExhaustion(t *testing
 	// Previously: cached blocks consumed free budget mid-loop, triggering rollback.
 	// Now: pre-check accounts for cached blocks and rejects upfront.
 	kvc := NewKVCacheState(4, 2)
-	req1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req1 := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
 	kvc.ReleaseKVBlocks(req1)
 
-	filler := &sim.Request{ID: "filler", InputTokens: []int{90, 91}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{90, 91}}
 	kvc.AllocateKVBlocks(filler, 0, 2, []int64{})
 
-	req2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	req2 := &sim.Request{ID: "r2", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	cached := kvc.GetCachedBlocks(req2.InputTokens)
 	require.Len(t, cached, 2)
 
@@ -730,8 +730,8 @@ func TestPreemptForTokens_RetryPreservesRequestMap(t *testing.T) {
 
 	r1 := &sim.Request{
 		ID:           "r1",
-		InputTokens:  []int{1, 2, 3, 4, 5, 6, 7, 8},
-		OutputTokens: []int{100},
+		InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8},
+		OutputTokens: []sim.TokenID{100},
 	}
 	ok := kvc.AllocateKVBlocks(r1, 0, 8, []int64{})
 	r1.ProgressIndex = 8 // now past prefill, in decode
@@ -740,7 +740,7 @@ func TestPreemptForTokens_RetryPreservesRequestMap(t *testing.T) {
 
 	r2 := &sim.Request{
 		ID:          "r2",
-		InputTokens: []int{10, 20, 30, 40, 50, 60, 70, 80},
+		InputTokens: []sim.TokenID{10, 20, 30, 40, 50, 60, 70, 80},
 	}
 	ok = kvc.AllocateKVBlocks(r2, 0, 8, []int64{})
 	require.True(t, ok)
@@ -770,7 +770,7 @@ func TestPreemptForTokens_RetryPreservesRequestMap(t *testing.T) {
 
 func TestVerifyBlockConservation_DetectsOrphanedBlocks(t *testing.T) {
 	kvc := NewKVCacheState(10, 4)
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens: []sim.TokenID{1, 2, 3, 4}}
 	kvc.AllocateKVBlocks(req, 0, 4, []int64{})
 
 	err := kvc.verifyBlockConservation()
@@ -787,7 +787,7 @@ func TestVerifyBlockConservation_DetectsOrphanedBlocks(t *testing.T) {
 func TestKVCacheState_SnapshotCachedBlocksFn_FrozenView(t *testing.T) {
 	// GIVEN a KVCacheState with some cached blocks
 	kvc := NewKVCacheState(100, 4)
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8} // 2 blocks
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8} // 2 blocks
 	req := &sim.Request{ID: "r1", InputTokens: tokens}
 	ok := kvc.AllocateKVBlocks(req, 0, 8, nil)
 	require.True(t, ok)
@@ -796,7 +796,7 @@ func TestKVCacheState_SnapshotCachedBlocksFn_FrozenView(t *testing.T) {
 	snapshotFn := kvc.SnapshotCachedBlocksFn()
 
 	// AND then allocate more blocks (tokens 9-16 = 2 more blocks)
-	tokens2 := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	tokens2 := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	req2 := &sim.Request{ID: "r2", InputTokens: tokens2}
 	ok = kvc.AllocateKVBlocks(req2, 8, 16, kvc.GetCachedBlocks(tokens2))
 	require.True(t, ok)
@@ -815,7 +815,7 @@ func TestAllocateKVBlocks_DecodeNoExistingBlocks_FailsWhenCacheFull(t *testing.T
 	kvc := NewKVCacheState(2, 4)
 
 	// Fill the cache completely
-	filler := &sim.Request{ID: "filler", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	ok := kvc.AllocateKVBlocks(filler, 0, 8, []int64{})
 	require.True(t, ok)
 	require.Equal(t, int64(0), kvc.countFreeBlocks())
@@ -824,8 +824,8 @@ func TestAllocateKVBlocks_DecodeNoExistingBlocks_FailsWhenCacheFull(t *testing.T
 	// but has no RequestMap entry (blocks were released during preemption)
 	req := &sim.Request{
 		ID:            "preempted",
-		InputTokens:   []int{10, 20, 30, 40},
-		OutputTokens:  []int{100},
+		InputTokens:   []sim.TokenID{10, 20, 30, 40},
+		OutputTokens:  []sim.TokenID{100},
 		ProgressIndex: 4, // past prefill
 	}
 	// Note: no AllocateKVBlocks call for prefill — RequestMap["preempted"] does not exist
@@ -846,15 +846,15 @@ func TestAllocateKVBlocks_DecodeNoExistingBlocks_SucceedsWhenFreeAvailable(t *te
 	kvc := NewKVCacheState(3, 4)
 
 	// Fill 2 of 3 blocks
-	filler := &sim.Request{ID: "filler", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	filler := &sim.Request{ID: "filler", InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	ok := kvc.AllocateKVBlocks(filler, 0, 8, []int64{})
 	require.True(t, ok)
 	require.Equal(t, int64(1), kvc.countFreeBlocks())
 
 	req := &sim.Request{
 		ID:            "preempted",
-		InputTokens:   []int{10, 20, 30, 40},
-		OutputTokens:  []int{100},
+		InputTokens:   []sim.TokenID{10, 20, 30, 40},
+		OutputTokens:  []sim.TokenID{100},
 		ProgressIndex: 4,
 	}
 
@@ -891,9 +891,9 @@ func TestLazyHashDeletion_PreemptedRequestFindsCache(t *testing.T) {
 	kvc := NewKVCacheState(totalBlocks, blockSize)
 
 	// Build input tokens for r1 (16384 tokens => 1024 full blocks)
-	inputTokens := make([]int, prefixLen)
+	inputTokens := make([]sim.TokenID, prefixLen)
 	for i := range inputTokens {
-		inputTokens[i] = i + 1
+		inputTokens[i] = sim.TokenID(i + 1)
 	}
 	r1 := &sim.Request{ID: "r1", InputTokens: inputTokens}
 	ok := kvc.AllocateKVBlocks(r1, 0, int64(prefixLen), []int64{})
@@ -916,9 +916,9 @@ func TestLazyHashDeletion_PreemptedRequestFindsCache(t *testing.T) {
 	// r1's blocks in reverse order (block 1023 first -> head), so popFreeBlock
 	// takes r1's blocks 1023, 1022, ..., 896. Lazy deletion clears those hashes
 	// when r2 fills the blocks with new content.
-	r2Tokens := make([]int, reuseBlocks*blockSize)
+	r2Tokens := make([]sim.TokenID, reuseBlocks*blockSize)
 	for i := range r2Tokens {
-		r2Tokens[i] = 90000 + i // distinct tokens so hashes differ from r1
+		r2Tokens[i] = sim.TokenID(90000 + i) // distinct tokens so hashes differ from r1
 	}
 	r2 := &sim.Request{ID: "r2", InputTokens: r2Tokens}
 	ok = kvc.AllocateKVBlocks(r2, 0, int64(len(r2Tokens)), []int64{})
@@ -948,7 +948,7 @@ func TestLazyHashDeletion_HashClearedOnReuse(t *testing.T) {
 	kvc := NewKVCacheState(2, 4) // blockSize=4, only 2 blocks total
 	reqA := &sim.Request{
 		ID:          "reqA",
-		InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}, // 2 blocks
+		InputTokens: []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}, // 2 blocks
 	}
 
 	// Allocate Request A
@@ -956,8 +956,8 @@ func TestLazyHashDeletion_HashClearedOnReuse(t *testing.T) {
 	require.True(t, ok, "Request A allocation should succeed")
 
 	// Compute expected hashes for Request A's blocks
-	h1_A := hash.HashBlock("", []int{1, 2, 3, 4})
-	h2_A := hash.HashBlock(h1_A, []int{5, 6, 7, 8})
+	h1_A := hash.HashBlock("", []sim.TokenID{1, 2, 3, 4})
+	h2_A := hash.HashBlock(h1_A, []sim.TokenID{5, 6, 7, 8})
 
 	// Verify Request A's hashes are in HashToBlock
 	_, foundH1A := kvc.HashToBlock[h1_A]
@@ -978,14 +978,14 @@ func TestLazyHashDeletion_HashClearedOnReuse(t *testing.T) {
 	// (only 2 blocks exist, so B must reuse A's released blocks)
 	reqB := &sim.Request{
 		ID:          "reqB",
-		InputTokens: []int{100, 200, 300, 400, 500, 600, 700, 800}, // 2 blocks, different tokens
+		InputTokens: []sim.TokenID{100, 200, 300, 400, 500, 600, 700, 800}, // 2 blocks, different tokens
 	}
 	ok = kvc.AllocateKVBlocks(reqB, 0, int64(len(reqB.InputTokens)), []int64{})
 	require.True(t, ok, "Request B allocation should succeed")
 
 	// Compute expected hashes for Request B's blocks
-	h1_B := hash.HashBlock("", []int{100, 200, 300, 400})
-	h2_B := hash.HashBlock(h1_B, []int{500, 600, 700, 800})
+	h1_B := hash.HashBlock("", []sim.TokenID{100, 200, 300, 400})
+	h2_B := hash.HashBlock(h1_B, []sim.TokenID{500, 600, 700, 800})
 
 	// THEN Request A's hashes should be deleted (replaced by B's hashes)
 	// Behavioral assertion: GetCachedBlocks should find no cache hits for reqA's tokens
@@ -1012,10 +1012,10 @@ func TestLazyHashDeletion_PartialEviction(t *testing.T) {
 	kvc := NewKVCacheState(1024, 16)
 	reqA := &sim.Request{
 		ID:          "reqA",
-		InputTokens: make([]int, 16384), // 1024 blocks * 16 tokens/block
+		InputTokens: make([]sim.TokenID, 16384), // 1024 blocks * 16 tokens/block
 	}
 	for i := range reqA.InputTokens {
-		reqA.InputTokens[i] = i + 1000
+		reqA.InputTokens[i] = sim.TokenID(i + 1000)
 	}
 
 	// Allocate and release Request A
@@ -1031,10 +1031,10 @@ func TestLazyHashDeletion_PartialEviction(t *testing.T) {
 	// from block 0), while blocks 512-1023 are overwritten with B's content.
 	reqB := &sim.Request{
 		ID:          "reqB",
-		InputTokens: make([]int, 8192), // 512 blocks * 16 tokens/block
+		InputTokens: make([]sim.TokenID, 8192), // 512 blocks * 16 tokens/block
 	}
 	for i := range reqB.InputTokens {
-		reqB.InputTokens[i] = i + 50000 // Different tokens
+		reqB.InputTokens[i] = sim.TokenID(i + 50000) // Different tokens
 	}
 	ok = kvc.AllocateKVBlocks(reqB, 0, int64(len(reqB.InputTokens)), []int64{})
 	require.True(t, ok, "Request B allocation should succeed")

--- a/sim/kv/preemption_cycle_test.go
+++ b/sim/kv/preemption_cycle_test.go
@@ -24,9 +24,9 @@ func TestPreemptionCycle_With16KPrefixes(t *testing.T) {
 	kvc := NewKVCacheState(totalBlocks, blockSize)
 
 	// Shared prefix (64 blocks = 1024 tokens)
-	sharedPrefix := make([]int, 1024) // 64 * 16
+	sharedPrefix := make([]sim.TokenID, 1024) // 64 * 16
 	for i := range sharedPrefix {
-		sharedPrefix[i] = i + 10000
+		sharedPrefix[i] = sim.TokenID(i + 10000)
 	}
 
 	// Create 3 requests with shared prefix + unique suffix
@@ -35,10 +35,10 @@ func TestPreemptionCycle_With16KPrefixes(t *testing.T) {
 		req := &sim.Request{
 			ID: fmt.Sprintf("request_%d", i),
 		}
-		req.InputTokens = append([]int{}, sharedPrefix...)
-		uniqueSuffix := make([]int, 1024) // 64 more blocks
+		req.InputTokens = append([]sim.TokenID{}, sharedPrefix...)
+		uniqueSuffix := make([]sim.TokenID, 1024) // 64 more blocks
 		for j := range uniqueSuffix {
-			uniqueSuffix[j] = (i+1)*100000 + j
+			uniqueSuffix[j] = sim.TokenID((i+1)*100000 + j)
 		}
 		req.InputTokens = append(req.InputTokens, uniqueSuffix...)
 		// Each request: 2048 tokens = 128 blocks

--- a/sim/kv/store_test.go
+++ b/sim/kv/store_test.go
@@ -101,7 +101,7 @@ func setupTieredWithLatency(t *testing.T) *TieredKVCache {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 10)
 
 	// Step 1: Allocate r1 (2 blocks) and mirror to CPU
-	r1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	r1 := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	assert.True(t, tiered.AllocateKVBlocks(r1, 0, 4, []int64{}), "r1 alloc")
 	tiered.MirrorToCPU([]*sim.Request{r1})
 
@@ -110,7 +110,7 @@ func setupTieredWithLatency(t *testing.T) *TieredKVCache {
 
 	// Step 3: Fill GPU completely to evict r1's hashes via popFreeBlock
 	for i := 0; i < 6; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens: []int{i*2 + 20, i*2 + 21}}
+		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 20), sim.TokenID(i*2 + 21)}}
 		assert.True(t, tiered.AllocateKVBlocks(f, 0, 2, []int64{}), fmt.Sprintf("f%d alloc", i))
 	}
 	// GPU: 6 used, 0 free. r1's hashes cleared by popFreeBlock.
@@ -121,7 +121,7 @@ func setupTieredWithLatency(t *testing.T) *TieredKVCache {
 	// Step 5: Request same prefix [1,2,3,4] → need 2 blocks, 1 free → fails → reload.
 	// Reload: 1 block from CPU (limited by maxReloads=1).
 	// pendingLatency = 1 × (10 + ceil(2/1.0)) = 12.
-	r2 := &sim.Request{ID: "r2", InputTokens: []int{1, 2, 3, 4}}
+	r2 := &sim.Request{ID: "r2", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(r2, 0, 4, []int64{}) // may not fully succeed
 
 	latency := tiered.PendingTransferLatency()

--- a/sim/kv/stress_test.go
+++ b/sim/kv/stress_test.go
@@ -30,13 +30,13 @@ func assertAllBlocksFree(t *testing.T, kvc *KVCacheState) {
 // Input tokens are sequential integers starting from baseToken.
 // Output tokens (if outputLen > 0) are sequential integers starting from baseToken+inputLen.
 func makeRequest(id string, inputLen, outputLen int, baseToken int) *sim.Request {
-	input := make([]int, inputLen)
+	input := make([]sim.TokenID, inputLen)
 	for i := range input {
-		input[i] = baseToken + i
+		input[i] = sim.TokenID(baseToken + i)
 	}
-	output := make([]int, outputLen)
+	output := make([]sim.TokenID, outputLen)
 	for i := range output {
-		output[i] = baseToken + inputLen + i
+		output[i] = sim.TokenID(baseToken + inputLen + i)
 	}
 	return &sim.Request{
 		ID:           id,
@@ -210,7 +210,7 @@ func TestStress_CachedBlockBudgetExhaustionUnderPressure(t *testing.T) {
 
 	// Step 1: Allocate and release a request to populate prefix cache.
 	// 4 tokens = 2 blocks become cached on the free list.
-	req1 := &sim.Request{ID: "prefix-seed", InputTokens: []int{1, 2, 3, 4}}
+	req1 := &sim.Request{ID: "prefix-seed", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	ok := kvc.AllocateKVBlocks(req1, 0, 4, []int64{})
 	require.True(t, ok)
 	kvc.ReleaseKVBlocks(req1)
@@ -223,7 +223,7 @@ func TestStress_CachedBlockBudgetExhaustionUnderPressure(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		fillers[i] = &sim.Request{
 			ID:          fmt.Sprintf("filler%d", i),
-			InputTokens: []int{100 + i*10, 101 + i*10, 102 + i*10, 103 + i*10},
+			InputTokens:  []sim.TokenID{sim.TokenID(100 + i*10), sim.TokenID(101 + i*10), sim.TokenID(102 + i*10), sim.TokenID(103 + i*10)},
 		}
 		ok := kvc.AllocateKVBlocks(fillers[i], 0, 4, []int64{})
 		require.True(t, ok, "filler %d allocation should succeed", i)
@@ -236,7 +236,7 @@ func TestStress_CachedBlockBudgetExhaustionUnderPressure(t *testing.T) {
 	// Prefix [1,2,3,4] = 2 cached blocks (will be claimed from free list).
 	// New tokens [5,6,7,8] = 2 more blocks needed from free list.
 	// After claiming cached blocks: 0 free remain. Need 2 more -> should fail.
-	req2 := &sim.Request{ID: "pressure-req", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	req2 := &sim.Request{ID: "pressure-req", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	cached := kvc.GetCachedBlocks(req2.InputTokens)
 	require.Len(t, cached, 2, "should find 2 cached prefix blocks")
 

--- a/sim/kv/tiered.go
+++ b/sim/kv/tiered.go
@@ -15,7 +15,7 @@ import (
 // Identified by content hash (not GPU block ID) for content-addressable reload.
 type cpuBlock struct {
 	hash   string    // prefix hash (map key, identifies content)
-	tokens []int     // token content (for GPU reload); pre-allocated slice, copy-into
+	tokens []sim.TokenID // token content (for GPU reload); pre-allocated slice, copy-into
 	prev   *cpuBlock // LRU doubly-linked list: older block
 	next   *cpuBlock // LRU doubly-linked list: newer block
 }
@@ -32,7 +32,7 @@ type cpuTier struct {
 
 	// Pre-allocated token slices for CPU blocks (eliminates per-mirror GC pressure).
 	// Pool of free slices returned on eviction, consumed on store.
-	freeTokenSlices [][]int
+	freeTokenSlices [][]sim.TokenID
 
 	evictionCount int64 // total CPU LRU evictions
 }
@@ -45,9 +45,9 @@ func newCpuTier(capacity int64, blockSize int64) *cpuTier {
 	if blockSize <= 0 {
 		panic(fmt.Sprintf("newCpuTier: blockSize must be > 0, got %d", blockSize))
 	}
-	slices := make([][]int, capacity)
+	slices := make([][]sim.TokenID, capacity)
 	for i := int64(0); i < capacity; i++ {
-		slices[i] = make([]int, blockSize)
+		slices[i] = make([]sim.TokenID, blockSize)
 	}
 	return &cpuTier{
 		blocks:          make(map[string]*cpuBlock),
@@ -59,7 +59,7 @@ func newCpuTier(capacity int64, blockSize int64) *cpuTier {
 
 // store adds a block to the CPU tier. If at capacity, evicts LRU-oldest first.
 // If the hash already exists, this is a no-op (use touch instead).
-func (c *cpuTier) store(hash string, tokens []int) {
+func (c *cpuTier) store(hash string, tokens []sim.TokenID) {
 	if _, exists := c.blocks[hash]; exists {
 		return // already present — caller should use touch
 	}
@@ -68,13 +68,13 @@ func (c *cpuTier) store(hash string, tokens []int) {
 		c.evictHead()
 	}
 	// Get a pre-allocated token slice from pool, or allocate as fallback
-	var tokSlice []int
+	var tokSlice []sim.TokenID
 	if len(c.freeTokenSlices) > 0 {
 		tokSlice = c.freeTokenSlices[len(c.freeTokenSlices)-1]
 		c.freeTokenSlices = c.freeTokenSlices[:len(c.freeTokenSlices)-1]
 		copy(tokSlice, tokens)
 	} else {
-		tokSlice = append([]int{}, tokens...) // fallback: allocate
+		tokSlice = append([]sim.TokenID{}, tokens...) // fallback: allocate
 	}
 	blk := &cpuBlock{hash: hash, tokens: tokSlice}
 	c.blocks[hash] = blk
@@ -265,7 +265,7 @@ func (t *TieredKVCache) AllocateKVBlocks(req *sim.Request, startIndex, endIndex 
 // The maxReloads guard ensures we never pop the same GPU free block twice —
 // each reload uses a distinct free block. Without this, pop+append creates
 // a cycle where block A's hash is destroyed on the second pop.
-func (t *TieredKVCache) reloadPrefixFromCPU(tokens []int) bool {
+func (t *TieredKVCache) reloadPrefixFromCPU(tokens []sim.TokenID) bool {
 	n := util.Len64(tokens) / t.gpu.BlockSize()
 	maxReloads := t.gpu.countFreeBlocks() // limit to distinct free blocks
 	prevHash := ""
@@ -332,13 +332,13 @@ func (t *TieredKVCache) reloadPrefixFromCPU(tokens []int) bool {
 	return reloaded
 }
 
-func (t *TieredKVCache) GetCachedBlocks(tokens []int) []int64 {
+func (t *TieredKVCache) GetCachedBlocks(tokens []sim.TokenID) []int64 {
 	return t.gpu.GetCachedBlocks(tokens)
 }
 
 // SnapshotCachedBlocksFn returns a snapshot query function for the GPU tier.
 // See KVCacheState.SnapshotCachedBlocksFn for details.
-func (t *TieredKVCache) SnapshotCachedBlocksFn() func([]int) int {
+func (t *TieredKVCache) SnapshotCachedBlocksFn() func([]sim.TokenID) int {
 	return t.gpu.SnapshotCachedBlocksFn()
 }
 

--- a/sim/kv/tiered_test.go
+++ b/sim/kv/tiered_test.go
@@ -17,9 +17,9 @@ func TestCpuTier_Store_EvictsOldestWhenFull(t *testing.T) {
 	cpu := newCpuTier(2, 4) // capacity=2, blockSize=4 tokens
 
 	// WHEN we store 3 blocks
-	cpu.store("hash-a", []int{1, 2, 3, 4})
-	cpu.store("hash-b", []int{5, 6, 7, 8})
-	cpu.store("hash-c", []int{9, 10, 11, 12})
+	cpu.store("hash-a", []sim.TokenID{1, 2, 3, 4})
+	cpu.store("hash-b", []sim.TokenID{5, 6, 7, 8})
+	cpu.store("hash-c", []sim.TokenID{9, 10, 11, 12})
 
 	// THEN oldest (hash-a) is evicted, newest two remain
 	assert.Nil(t, cpu.lookup("hash-a"), "oldest block should be evicted")
@@ -32,14 +32,14 @@ func TestCpuTier_Store_EvictsOldestWhenFull(t *testing.T) {
 func TestCpuTier_Touch_MovesToTail(t *testing.T) {
 	// BC-1 (touch): GIVEN CPU tier with 2 blocks
 	cpu := newCpuTier(2, 4)
-	cpu.store("hash-a", []int{1, 2, 3, 4})
-	cpu.store("hash-b", []int{5, 6, 7, 8})
+	cpu.store("hash-a", []sim.TokenID{1, 2, 3, 4})
+	cpu.store("hash-b", []sim.TokenID{5, 6, 7, 8})
 
 	// WHEN we touch hash-a (refreshes recency)
 	cpu.touch("hash-a")
 
 	// AND store a third block (triggers eviction)
-	cpu.store("hash-c", []int{9, 10, 11, 12})
+	cpu.store("hash-c", []sim.TokenID{9, 10, 11, 12})
 
 	// THEN hash-b is evicted (it's now oldest), hash-a survives (was touched)
 	assert.Nil(t, cpu.lookup("hash-b"), "untouched block should be evicted")
@@ -54,18 +54,18 @@ func TestCpuTier_Lookup_ReturnsNilForMissing(t *testing.T) {
 
 func TestCpuTier_Store_DuplicateHashIsNoOp(t *testing.T) {
 	cpu := newCpuTier(10, 2)
-	cpu.store("h1", []int{1, 2})
-	cpu.store("h1", []int{99, 99}) // duplicate — should not overwrite
+	cpu.store("h1", []sim.TokenID{1, 2})
+	cpu.store("h1", []sim.TokenID{99, 99}) // duplicate — should not overwrite
 
 	blk := cpu.lookup("h1")
 	assert.NotNil(t, blk)
-	assert.Equal(t, []int{1, 2}, blk.tokens, "original tokens preserved")
+	assert.Equal(t, []sim.TokenID{1, 2}, blk.tokens, "original tokens preserved")
 	assert.Equal(t, int64(1), cpu.used, "no duplicate storage")
 }
 
 func TestCpuTier_Touch_NoOpForMissing(t *testing.T) {
 	cpu := newCpuTier(10, 2)
-	cpu.store("h1", []int{1, 2})
+	cpu.store("h1", []sim.TokenID{1, 2})
 	cpu.touch("nonexistent") // should not panic
 	assert.Equal(t, int64(1), cpu.used)
 }
@@ -81,24 +81,24 @@ func TestCpuTier_TokenSlicePoolRecycling(t *testing.T) {
 	cpu := newCpuTier(2, 4)
 	assert.Equal(t, 2, len(cpu.freeTokenSlices), "pool should start with capacity slices")
 
-	cpu.store("h1", []int{1, 2, 3, 4}) // consumes 1 slice
+	cpu.store("h1", []sim.TokenID{1, 2, 3, 4}) // consumes 1 slice
 	assert.Equal(t, 1, len(cpu.freeTokenSlices))
 
-	cpu.store("h2", []int{5, 6, 7, 8}) // consumes last slice
+	cpu.store("h2", []sim.TokenID{5, 6, 7, 8}) // consumes last slice
 	assert.Equal(t, 0, len(cpu.freeTokenSlices))
 
 	// store("h3") evicts h1 (returns slice to pool), then immediately consumes
 	// that returned slice for h3. Net pool effect: 0 → 1 → 0.
-	cpu.store("h3", []int{9, 10, 11, 12})
+	cpu.store("h3", []sim.TokenID{9, 10, 11, 12})
 	assert.Equal(t, 0, len(cpu.freeTokenSlices), "evicted slice consumed by new block")
 
 	// Verify content — h3 reused h1's pre-allocated slice via copy
 	blk := cpu.lookup("h3")
 	assert.NotNil(t, blk)
-	assert.Equal(t, []int{9, 10, 11, 12}, blk.tokens)
+	assert.Equal(t, []sim.TokenID{9, 10, 11, 12}, blk.tokens)
 
 	// Now evict h2 by storing h4 — h2's slice returns to pool, h4 consumes it
-	cpu.store("h4", []int{13, 14, 15, 16})
+	cpu.store("h4", []sim.TokenID{13, 14, 15, 16})
 	assert.Equal(t, 0, len(cpu.freeTokenSlices))
 
 	// Release a block explicitly and verify pool grows
@@ -133,20 +133,20 @@ func TestTieredKVCache_TargetedReload_OnlyPrefixBlocks(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 10)
 
 	// Step 1: Allocate 3-block prefix, mirror to CPU, release
-	prefixReq := &sim.Request{ID: "prefix", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	prefixReq := &sim.Request{ID: "prefix", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	tiered.AllocateKVBlocks(prefixReq, 0, 6, []int64{})
 	h0 := gpu.Blocks[gpu.RequestMap["prefix"][0]].Hash
 	h1 := gpu.Blocks[gpu.RequestMap["prefix"][1]].Hash
 	h2 := gpu.Blocks[gpu.RequestMap["prefix"][2]].Hash
-	tiered.cpu.store(h0, []int{1, 2})
-	tiered.cpu.store(h1, []int{3, 4})
-	tiered.cpu.store(h2, []int{5, 6})
-	tiered.cpu.store("unrelated-hash", []int{99, 99})
+	tiered.cpu.store(h0, []sim.TokenID{1, 2})
+	tiered.cpu.store(h1, []sim.TokenID{3, 4})
+	tiered.cpu.store(h2, []sim.TokenID{5, 6})
+	tiered.cpu.store("unrelated-hash", []sim.TokenID{99, 99})
 	tiered.ReleaseKVBlocks(prefixReq)
 
 	// Step 2: Fill GPU completely (8 blocks) to evict prefix hashes
 	for i := 0; i < 8; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("fill%d", i), InputTokens: []int{i*2 + 20, i*2 + 21}}
+		f := &sim.Request{ID: fmt.Sprintf("fill%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 20), sim.TokenID(i*2 + 21)}}
 		tiered.AllocateKVBlocks(f, 0, 2, []int64{})
 	}
 
@@ -156,18 +156,18 @@ func TestTieredKVCache_TargetedReload_OnlyPrefixBlocks(t *testing.T) {
 	tiered.ReleaseKVBlocks(&sim.Request{ID: "fill2"})
 
 	// Verify: prefix evicted from GPU
-	cached := tiered.GetCachedBlocks([]int{1, 2, 3, 4, 5, 6})
+	cached := tiered.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4, 5, 6})
 	assert.Equal(t, 0, len(cached), "prefix should be evicted from GPU")
 
 	// WHEN: Request same prefix [1,2,3,4,5,6] → 3 blocks needed, 3 free.
 	// Fresh alloc would succeed (3 free >= 3 needed). But prefix is on CPU.
 	// GPU alloc succeeds as cache misses. To force reload, we need fresh alloc to fail.
 	// Fill one more to leave only 2 free (need 3).
-	fExtra := &sim.Request{ID: "fExtra", InputTokens: []int{80, 81}}
+	fExtra := &sim.Request{ID: "fExtra", InputTokens:  []sim.TokenID{80, 81}}
 	tiered.AllocateKVBlocks(fExtra, 0, 2, []int64{})
 	// GPU: 6 used, 2 free. Need 3 → fresh alloc fails → reload triggered.
 
-	newReq := &sim.Request{ID: "new", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	newReq := &sim.Request{ID: "new", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	tiered.AllocateKVBlocks(newReq, 0, 6, []int64{}) // may or may not succeed
 
 	// The key test is that CPU hit count > 0 (reload was triggered and found blocks)
@@ -195,17 +195,17 @@ func TestTieredKVCache_TargetedReload_TransferLatency(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 2.0, 100) // bandwidth=2.0, baseLat=100
 
 	// Allocate, mirror, release
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(req, 0, 4, []int64{})
 	h0 := gpu.Blocks[gpu.RequestMap["r1"][0]].Hash
 	h1 := gpu.Blocks[gpu.RequestMap["r1"][1]].Hash
-	tiered.cpu.store(h0, []int{1, 2})
-	tiered.cpu.store(h1, []int{3, 4})
+	tiered.cpu.store(h0, []sim.TokenID{1, 2})
+	tiered.cpu.store(h1, []sim.TokenID{3, 4})
 	tiered.ReleaseKVBlocks(req)
 
 	// Fill GPU completely to evict prefix hashes
 	for i := 0; i < 6; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens: []int{i*2 + 20, i*2 + 21}}
+		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 20), sim.TokenID(i*2 + 21)}}
 		tiered.AllocateKVBlocks(f, 0, 2, []int64{})
 	}
 
@@ -213,7 +213,7 @@ func TestTieredKVCache_TargetedReload_TransferLatency(t *testing.T) {
 	tiered.ReleaseKVBlocks(&sim.Request{ID: "f0"})
 
 	// Trigger reload attempt
-	newReq := &sim.Request{ID: "new", InputTokens: []int{1, 2, 3, 4}}
+	newReq := &sim.Request{ID: "new", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(newReq, 0, 4, []int64{}) // may fail (1 free < 2 needed)
 
 	// THEN: Transfer latency accumulated for 1 reloaded block
@@ -229,15 +229,15 @@ func TestTieredKVCache_TargetedReload_MaxReloadsGuard(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 0)
 
 	// Allocate prefix and capture hashes
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(req, 0, 4, []int64{})
 	h0 := gpu.Blocks[gpu.RequestMap["r1"][0]].Hash
 	h1 := gpu.Blocks[gpu.RequestMap["r1"][1]].Hash
 	tiered.ReleaseKVBlocks(req)
 
 	// Place both blocks on CPU
-	tiered.cpu.store(h0, []int{1, 2})
-	tiered.cpu.store(h1, []int{3, 4})
+	tiered.cpu.store(h0, []sim.TokenID{1, 2})
+	tiered.cpu.store(h1, []sim.TokenID{3, 4})
 
 	// Clear GPU hashes
 	for _, blk := range gpu.Blocks {
@@ -249,12 +249,12 @@ func TestTieredKVCache_TargetedReload_MaxReloadsGuard(t *testing.T) {
 	}
 
 	// Fill GPU: 2 used, 1 free (F=1, M=2)
-	filler := &sim.Request{ID: "f1", InputTokens: []int{10, 11, 12, 13}}
+	filler := &sim.Request{ID: "f1", InputTokens:  []sim.TokenID{10, 11, 12, 13}}
 	tiered.AllocateKVBlocks(filler, 0, 4, []int64{})
 	// GPU: 2 used, 1 free
 
 	// Attempt reload — should reload only 1 block (h0), not destroy it
-	newReq := &sim.Request{ID: "new", InputTokens: []int{1, 2, 3, 4}}
+	newReq := &sim.Request{ID: "new", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(newReq, 0, 4, []int64{})
 	// Allocation may fail (only 1 prefix block reloaded, need 2 total)
 	// but h0 should still be in GPU HashToBlock
@@ -269,15 +269,15 @@ func TestTieredKVCache_TargetedReload_TouchesCPUOnReload(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 3, 0.0, 1.0, 0) // small CPU: 3 blocks
 
 	// Place 3 blocks on CPU: older → h0, h1, h2 (newest)
-	tiered.cpu.store("h0", []int{1, 2})
-	tiered.cpu.store("h1", []int{3, 4})
-	tiered.cpu.store("h2", []int{5, 6})
+	tiered.cpu.store("h0", []sim.TokenID{1, 2})
+	tiered.cpu.store("h1", []sim.TokenID{3, 4})
+	tiered.cpu.store("h2", []sim.TokenID{5, 6})
 
 	// Simulate reload of h0 by calling touch directly (testing the touch effect)
 	tiered.cpu.touch("h0") // h0 moves to tail (newest)
 
 	// Store h3 — should evict h1 (oldest), not h0 (was touched)
-	tiered.cpu.store("h3", []int{7, 8})
+	tiered.cpu.store("h3", []sim.TokenID{7, 8})
 	assert.NotNil(t, tiered.cpu.lookup("h0"), "h0 should survive (was touched)")
 	assert.Nil(t, tiered.cpu.lookup("h1"), "h1 should be evicted (oldest)")
 	assert.NotNil(t, tiered.cpu.lookup("h2"), "h2 should survive")
@@ -293,7 +293,7 @@ func TestTieredKVCache_MirrorToCPU_StoresNewBlocks(t *testing.T) {
 	gpu := NewKVCacheState(10, 2)
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 0)
 
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(req, 0, 4, []int64{})
 
 	gpuHashesBefore := len(gpu.HashToBlock)
@@ -317,12 +317,12 @@ func TestTieredKVCache_MirrorToCPU_TouchesExistingBlocks(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 3, 0.0, 1.0, 0) // small CPU: 3 blocks
 
 	// Allocate and mirror r1 (2 blocks)
-	r1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	r1 := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(r1, 0, 4, []int64{})
 	tiered.MirrorToCPU([]*sim.Request{r1})
 
 	// Mirror r2 (1 block) — now CPU has 3 blocks, full
-	r2 := &sim.Request{ID: "r2", InputTokens: []int{10, 20}}
+	r2 := &sim.Request{ID: "r2", InputTokens:  []sim.TokenID{10, 20}}
 	tiered.AllocateKVBlocks(r2, 0, 2, []int64{})
 	tiered.MirrorToCPU([]*sim.Request{r2})
 	assert.Equal(t, int64(3), tiered.cpu.used)
@@ -331,7 +331,7 @@ func TestTieredKVCache_MirrorToCPU_TouchesExistingBlocks(t *testing.T) {
 	tiered.MirrorToCPU([]*sim.Request{r1})
 
 	// Now mirror r3 (1 block) — should evict r2's block (oldest untouched), not r1's
-	r3 := &sim.Request{ID: "r3", InputTokens: []int{30, 40}}
+	r3 := &sim.Request{ID: "r3", InputTokens:  []sim.TokenID{30, 40}}
 	tiered.AllocateKVBlocks(r3, 0, 2, []int64{})
 	tiered.MirrorToCPU([]*sim.Request{r3})
 
@@ -357,7 +357,7 @@ func TestTieredKVCache_MirrorToCPU_SkipsPartialAndUnhashedBlocks(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 0)
 
 	// Allocate 3 tokens into a 4-token block → partial block (no hash)
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3}}
 	tiered.AllocateKVBlocks(req, 0, 3, []int64{})
 
 	tiered.MirrorToCPU([]*sim.Request{req})
@@ -374,7 +374,7 @@ func TestTieredKVCache_ReleaseKVBlocks_PreservesGPUHashes(t *testing.T) {
 	gpu := NewKVCacheState(10, 2)
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 0)
 
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(req, 0, 4, []int64{})
 
 	// Capture hashes before release
@@ -393,7 +393,7 @@ func TestTieredKVCache_ReleaseKVBlocks_PreservesGPUHashes(t *testing.T) {
 	assert.True(t, h1InGPU, "block 1 hash should remain on GPU after release")
 
 	// AND: GetCachedBlocks still finds the prefix
-	cached := tiered.GetCachedBlocks([]int{1, 2, 3, 4})
+	cached := tiered.GetCachedBlocks([]sim.TokenID{1, 2, 3, 4})
 	assert.Equal(t, 2, len(cached), "prefix should still be cached on GPU after release")
 }
 
@@ -412,14 +412,14 @@ func TestTieredKVCache_CPUExtendsGPUPrefixLifetime(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 10) // baseLat=10
 
 	// Step 1: Allocate 3-block prefix, mirror to CPU, release
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	tiered.AllocateKVBlocks(req, 0, 6, []int64{})
 	tiered.MirrorToCPU([]*sim.Request{req})
 	tiered.ReleaseKVBlocks(req)
 
 	// Step 2: Fill GPU completely to evict prefix hashes
 	for i := 0; i < 6; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens: []int{i*2 + 20, i*2 + 21}}
+		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 20), sim.TokenID(i*2 + 21)}}
 		tiered.AllocateKVBlocks(f, 0, 2, []int64{})
 	}
 
@@ -428,7 +428,7 @@ func TestTieredKVCache_CPUExtendsGPUPrefixLifetime(t *testing.T) {
 	tiered.ReleaseKVBlocks(&sim.Request{ID: "f1"})
 
 	// Step 4: Re-request prefix — triggers targeted reload from CPU
-	newReq := &sim.Request{ID: "new", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	newReq := &sim.Request{ID: "new", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	tiered.AllocateKVBlocks(newReq, 0, 6, []int64{}) // may partially succeed
 
 	// THEN: CPU hits > 0 (prefix blocks found on CPU after GPU eviction)
@@ -446,7 +446,7 @@ func TestTieredKVCache_KVThrashingRate_ReturnsCPUEvictionRate(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, 2, 0.0, 1.0, 0) // tiny CPU: 2 blocks
 
 	// Mirror 3 blocks → 1 eviction
-	r1 := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4, 5, 6}}
+	r1 := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4, 5, 6}}
 	tiered.AllocateKVBlocks(r1, 0, 6, []int64{})
 	tiered.MirrorToCPU([]*sim.Request{r1})
 	// 3 blocks mirrored, CPU capacity=2, so 1 eviction
@@ -487,7 +487,7 @@ func TestTieredKVCache_Conservation_MirrorReloadCycle(t *testing.T) {
 	}
 
 	// Allocate, mirror, release — check INV-4 at every step
-	req := &sim.Request{ID: "r1", InputTokens: []int{1, 2, 3, 4}}
+	req := &sim.Request{ID: "r1", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(req, 0, 4, []int64{})
 	checkINV4("after alloc")
 	assert.Equal(t, int64(2), gpu.UsedBlocks())
@@ -503,7 +503,7 @@ func TestTieredKVCache_Conservation_MirrorReloadCycle(t *testing.T) {
 
 	// Fill and release to trigger reload path
 	for i := 0; i < 6; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens: []int{i*2 + 20, i*2 + 21}}
+		f := &sim.Request{ID: fmt.Sprintf("f%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 20), sim.TokenID(i*2 + 21)}}
 		tiered.AllocateKVBlocks(f, 0, 2, []int64{})
 	}
 	checkINV4("after fill")
@@ -512,7 +512,7 @@ func TestTieredKVCache_Conservation_MirrorReloadCycle(t *testing.T) {
 	checkINV4("after partial release")
 
 	// Trigger reload
-	newReq := &sim.Request{ID: "new", InputTokens: []int{1, 2, 3, 4}}
+	newReq := &sim.Request{ID: "new", InputTokens:  []sim.TokenID{1, 2, 3, 4}}
 	tiered.AllocateKVBlocks(newReq, 0, 4, []int64{})
 	checkINV4("after reload attempt")
 
@@ -554,9 +554,9 @@ func TestTieredKVCache_ReloadGuard_CommitsBlocksForRunningRequest(t *testing.T) 
 	tiered := NewTieredKVCache(gpu, cpuBlocks, 0, 1.0, 0)
 
 	// Create tokens for 4 blocks (16 tokens total)
-	tokens := make([]int, 4*blockSize)
+	tokens := make([]sim.TokenID, 4*blockSize)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 
 	// Seed request: allocate all 4 blocks, mirror to CPU, then release.
@@ -581,7 +581,7 @@ func TestTieredKVCache_ReloadGuard_CommitsBlocksForRunningRequest(t *testing.T) 
 	for gpu.countFreeBlocks() > 0 {
 		filler := &sim.Request{
 			ID:          fmt.Sprintf("filler-%d", fillerCount),
-			InputTokens: []int{800 + fillerCount*4, 801 + fillerCount*4, 802 + fillerCount*4, 803 + fillerCount*4},
+			InputTokens:  []sim.TokenID{sim.TokenID(800 + fillerCount*4), sim.TokenID(801 + fillerCount*4), sim.TokenID(802 + fillerCount*4), sim.TokenID(803 + fillerCount*4)},
 		}
 		if tiered.AllocateKVBlocks(filler, 0, blockSize, []int64{}) {
 			fillerCount++
@@ -630,9 +630,9 @@ func TestTieredKVCache_ReloadGuard_NonBlockAlignedStartIndex_NoDuplicates(t *tes
 	tiered := NewTieredKVCache(gpu, cpuBlocks, 0, 1.0, 0)
 
 	// Tokens for 4 blocks
-	tokens := make([]int, 4*blockSize)
+	tokens := make([]sim.TokenID, 4*blockSize)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 
 	// Seed: allocate, mirror to CPU, release
@@ -656,7 +656,7 @@ func TestTieredKVCache_ReloadGuard_NonBlockAlignedStartIndex_NoDuplicates(t *tes
 	for gpu.countFreeBlocks() > 0 {
 		filler := &sim.Request{
 			ID:          fmt.Sprintf("filler2-%d", fillerCount),
-			InputTokens: []int{700 + fillerCount*4, 701 + fillerCount*4, 702 + fillerCount*4, 703 + fillerCount*4},
+			InputTokens:  []sim.TokenID{sim.TokenID(700 + fillerCount*4), sim.TokenID(701 + fillerCount*4), sim.TokenID(702 + fillerCount*4), sim.TokenID(703 + fillerCount*4)},
 		}
 		if tiered.AllocateKVBlocks(filler, 0, blockSize, []int64{}) {
 			fillerCount++
@@ -705,9 +705,9 @@ func TestTieredKVCache_ReloadGuard_CommitsBlocksForNewRequest(t *testing.T) {
 	tiered := NewTieredKVCache(gpu, cpuBlocks, 0, 1.0, 0)
 
 	// Create tokens for 2 blocks
-	tokens := make([]int, 2*blockSize)
+	tokens := make([]sim.TokenID, 2*blockSize)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 
 	// Seed: allocate, mirror to CPU, release (leaves blocks on CPU + GPU free list hashes)
@@ -722,7 +722,7 @@ func TestTieredKVCache_ReloadGuard_CommitsBlocksForNewRequest(t *testing.T) {
 	for gpu.countFreeBlocks() > 0 {
 		filler := &sim.Request{
 			ID:          fmt.Sprintf("filler-bc1-%d", fillerCount),
-			InputTokens: []int{900 + fillerCount*4, 901 + fillerCount*4, 902 + fillerCount*4, 903 + fillerCount*4},
+			InputTokens:  []sim.TokenID{sim.TokenID(900 + fillerCount*4), sim.TokenID(901 + fillerCount*4), sim.TokenID(902 + fillerCount*4), sim.TokenID(903 + fillerCount*4)},
 		}
 		if tiered.AllocateKVBlocks(filler, 0, blockSize, []int64{}) {
 			fillerCount++
@@ -760,9 +760,9 @@ func TestPreemption_ClearsRequestMap_EnablesNewRequestPath(t *testing.T) {
 	gpuBlocks := int64(10)
 	gpu := NewKVCacheState(gpuBlocks, blockSize)
 
-	tokens := make([]int, 2*blockSize)
+	tokens := make([]sim.TokenID, 2*blockSize)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = sim.TokenID(i + 1)
 	}
 	req := &sim.Request{
 		ID:            "req-preempt-bc5",
@@ -814,18 +814,18 @@ func TestTieredKVCache_PartialReload_RunningRequest_BlocksCommitted(t *testing.T
 	totalBlocks := int64(8)
 	gpu := NewKVCacheState(totalBlocks, blockSize)
 
-	tokens := make([]int, 20)
+	tokens := make([]sim.TokenID, 20)
 	for i := range tokens {
-		tokens[i] = i + 10 // distinct values
+		tokens[i] = sim.TokenID(i + 10) // distinct values
 	}
 
 	req1 := &sim.Request{ID: "req1", InputTokens: tokens}
 	require.True(t, gpu.AllocateKVBlocks(req1, 0, 8, nil)) // blocks [0,1]
 
-	req2 := &sim.Request{ID: "req2", InputTokens: make([]int, 8)}
+	req2 := &sim.Request{ID: "req2", InputTokens: make([]sim.TokenID, 8)}
 	require.True(t, gpu.AllocateKVBlocks(req2, 0, 8, nil)) // blocks [2,3]
 
-	req3 := &sim.Request{ID: "req3", InputTokens: make([]int, 8)}
+	req3 := &sim.Request{ID: "req3", InputTokens: make([]sim.TokenID, 8)}
 	require.True(t, gpu.AllocateKVBlocks(req3, 0, 8, nil)) // blocks [4,5]
 	// Free: [6,7]
 
@@ -885,15 +885,15 @@ func TestTieredKVCache_PartialReload_NewRequest_Revised(t *testing.T) {
 	totalBlocks := int64(7)
 	gpu := NewKVCacheState(totalBlocks, blockSize)
 
-	tokens := make([]int, 12)
+	tokens := make([]sim.TokenID, 12)
 	for i := range tokens {
-		tokens[i] = i + 100
+		tokens[i] = sim.TokenID(i + 100)
 	}
 
 	// Fill 5 blocks using two filler requests
-	f1 := &sim.Request{ID: "f1", InputTokens: make([]int, 12)}
+	f1 := &sim.Request{ID: "f1", InputTokens: make([]sim.TokenID, 12)}
 	require.True(t, gpu.AllocateKVBlocks(f1, 0, 12, nil)) // blocks [0,1,2]
-	f2 := &sim.Request{ID: "f2", InputTokens: make([]int, 8)}
+	f2 := &sim.Request{ID: "f2", InputTokens: make([]sim.TokenID, 8)}
 	require.True(t, gpu.AllocateKVBlocks(f2, 0, 8, nil)) // blocks [3,4]
 	// 2 free: [5,6]
 
@@ -935,7 +935,7 @@ func TestTieredKVCache_SnapshotCachedBlocksFn_FrozenView(t *testing.T) {
 	gpu := NewKVCacheState(100, 4)
 	tiered := NewTieredKVCache(gpu, 10, 0.0, 1.0, 10)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8} // 2 blocks
+	tokens := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8} // 2 blocks
 	req := &sim.Request{ID: "r1", InputTokens: tokens}
 	tiered.AllocateKVBlocks(req, 0, 8, nil)
 
@@ -946,7 +946,7 @@ func TestTieredKVCache_SnapshotCachedBlocksFn_FrozenView(t *testing.T) {
 	assert.Equal(t, 2, snapshotFn(tokens), "snapshot should see 2 cached blocks")
 
 	// AND then allocate more blocks (extending the prefix)
-	tokens2 := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	tokens2 := []sim.TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	req2 := &sim.Request{ID: "r2", InputTokens: tokens2}
 	cached := gpu.GetCachedBlocks(tokens2)
 	tiered.AllocateKVBlocks(req2, 8, 16, cached)
@@ -967,7 +967,7 @@ func TestTieredLazyHashDeletion_CPUReload(t *testing.T) {
 
 	reqA := &sim.Request{
 		ID:          "reqA",
-		InputTokens: []int{10, 20, 30, 40, 50, 60}, // 3 blocks (blockSize=2)
+		InputTokens:  []sim.TokenID{10, 20, 30, 40, 50, 60}, // 3 blocks (blockSize=2)
 	}
 
 	// Allocate Request A (3 blocks on GPU)
@@ -975,9 +975,9 @@ func TestTieredLazyHashDeletion_CPUReload(t *testing.T) {
 	require.True(t, ok, "Request A allocation should succeed")
 
 	// Compute expected hashes for Request A
-	h0_A := hash.HashBlock("", []int{10, 20})
-	h1_A := hash.HashBlock(h0_A, []int{30, 40})
-	h2_A := hash.HashBlock(h1_A, []int{50, 60})
+	h0_A := hash.HashBlock("", []sim.TokenID{10, 20})
+	h1_A := hash.HashBlock(h0_A, []sim.TokenID{30, 40})
+	h2_A := hash.HashBlock(h1_A, []sim.TokenID{50, 60})
 
 	_, foundH0A := gpu.HashToBlock[h0_A]
 	_, foundH2A := gpu.HashToBlock[h2_A]
@@ -996,7 +996,7 @@ func TestTieredLazyHashDeletion_CPUReload(t *testing.T) {
 
 	// Fill GPU completely with 6 filler blocks to evict all prefix hashes
 	for i := 0; i < 6; i++ {
-		f := &sim.Request{ID: fmt.Sprintf("fill%d", i), InputTokens: []int{i*2 + 200, i*2 + 201}}
+		f := &sim.Request{ID: fmt.Sprintf("fill%d", i), InputTokens:  []sim.TokenID{sim.TokenID(i*2 + 200), sim.TokenID(i*2 + 201)}}
 		tiered.AllocateKVBlocks(f, 0, 2, []int64{})
 	}
 	require.Equal(t, int64(0), gpu.countFreeBlocks(), "All GPU blocks used by fillers")

--- a/sim/kv_store.go
+++ b/sim/kv_store.go
@@ -4,7 +4,7 @@ package sim
 // kv.KVCacheState (single-tier GPU) and kv.TieredKVCache (GPU+CPU) both implement this.
 type KVStore interface {
 	AllocateKVBlocks(req *Request, startIndex, endIndex int64, cachedBlocks []int64) bool
-	GetCachedBlocks(tokens []int) []int64
+	GetCachedBlocks(tokens []TokenID) []int64
 	ReleaseKVBlocks(req *Request)
 	BlockSize() int64
 	UsedBlocks() int64

--- a/sim/latency/latency_test.go
+++ b/sim/latency/latency_test.go
@@ -23,14 +23,14 @@ func TestRooflineLatencyModel_StepTime_PositiveAndMonotonic(t *testing.T) {
 
 	smallBatch := []*sim.Request{
 		{
-			InputTokens:   make([]int, 100),
+			InputTokens:   make([]sim.TokenID, 100),
 			ProgressIndex: 0,
 			NumNewTokens:  100,
 		},
 	}
 	largeBatch := []*sim.Request{
 		{
-			InputTokens:   make([]int, 1000),
+			InputTokens:   make([]sim.TokenID, 1000),
 			ProgressIndex: 0,
 			NumNewTokens:  1000,
 		},
@@ -71,7 +71,7 @@ func TestRooflineLatencyModel_StepTime_EmptyBatch(t *testing.T) {
 	// AND a non-empty batch must produce a longer step time
 	nonEmptyBatch := []*sim.Request{
 		{
-			InputTokens:   make([]int, 100),
+			InputTokens:   make([]sim.TokenID, 100),
 			ProgressIndex: 0,
 			NumNewTokens:  100,
 		},
@@ -95,7 +95,7 @@ func TestRooflineLatencyModel_QueueingTime_Positive(t *testing.T) {
 		alphaCoeffs: []float64{100, 1, 100},
 	}
 
-	req := &sim.Request{InputTokens: make([]int, 50)}
+	req := &sim.Request{InputTokens: make([]sim.TokenID, 50)}
 	result := model.QueueingTime(req)
 
 	if result <= 0 {
@@ -118,7 +118,7 @@ func TestNewLatencyModel_RooflineMode(t *testing.T) {
 	// THEN the model must produce positive results for a non-empty batch
 	batch := []*sim.Request{
 		{
-			InputTokens:   make([]int, 100),
+			InputTokens:   make([]sim.TokenID, 100),
 			ProgressIndex: 0,
 			NumNewTokens:  100,
 		},
@@ -144,7 +144,7 @@ func TestNewLatencyModel_EmptyBackendDefaultsToRoofline(t *testing.T) {
 	// Verify it behaves as roofline (produces positive step time from FLOPs/bandwidth)
 	batch := []*sim.Request{
 		{
-			InputTokens:   make([]int, 100),
+			InputTokens:   make([]sim.TokenID, 100),
 			ProgressIndex: 0,
 			NumNewTokens:  100,
 		},
@@ -240,8 +240,8 @@ func TestNewLatencyModel_NegativeCoefficients_ReturnsError(t *testing.T) {
 func TestRoofline_ZeroOutputTokens_ConsistentClassification(t *testing.T) {
 	// GIVEN a request past prefill with 0 output tokens (edge case)
 	req := &sim.Request{
-		InputTokens:   []int{1, 2, 3},
-		OutputTokens:  []int{},
+		InputTokens:   []sim.TokenID{1, 2, 3},
+		OutputTokens:  []sim.TokenID{},
 		ProgressIndex: 3,
 		NumNewTokens:  0,
 	}
@@ -432,7 +432,7 @@ func TestNewLatencyModel_RemainingBackendsWork(t *testing.T) {
 			// AND the model must compute positive step time
 			batch := []*sim.Request{
 				{
-					InputTokens:   make([]int, 100),
+					InputTokens:   make([]sim.TokenID, 100),
 					ProgressIndex: 0,
 					NumNewTokens:  10,
 				},

--- a/sim/latency/trained_physics_model_test.go
+++ b/sim/latency/trained_physics_model_test.go
@@ -176,8 +176,8 @@ func TestTrainedPhysicsModel_OverheadMethods(t *testing.T) {
 	m := newTestTrainedPhysicsModel(t, trainedPhysicsTestModelConfig(), testHardwareConfig(), testCoeffs())
 
 	t.Run("QueueingTime_is_constant", func(t *testing.T) {
-		req1 := &sim.Request{InputTokens: make([]int, 100)}
-		req2 := &sim.Request{InputTokens: make([]int, 500)}
+		req1 := &sim.Request{InputTokens: make([]sim.TokenID, 100)}
+		req2 := &sim.Request{InputTokens: make([]sim.TokenID, 500)}
 
 		time1 := m.QueueingTime(req1)
 		time2 := m.QueueingTime(req2)
@@ -378,10 +378,10 @@ func makePrefillBatch(count, tokens int) []*sim.Request {
 	batch := make([]*sim.Request, count)
 	for i := 0; i < count; i++ {
 		batch[i] = &sim.Request{
-			InputTokens:   make([]int, tokens),
+			InputTokens:   make([]sim.TokenID, tokens),
 			ProgressIndex: 0,
 			NumNewTokens:  tokens,
-			OutputTokens:  []int{},
+			OutputTokens:  []sim.TokenID{},
 		}
 	}
 	return batch
@@ -391,8 +391,8 @@ func makeDecodeBatch(count, seqLen int) []*sim.Request {
 	batch := make([]*sim.Request, count)
 	for i := 0; i < count; i++ {
 		batch[i] = &sim.Request{
-			InputTokens:   make([]int, seqLen),
-			OutputTokens:  make([]int, 10), // Generated so far
+			InputTokens:   make([]sim.TokenID, seqLen),
+			OutputTokens:  make([]sim.TokenID, 10), // Generated so far
 			ProgressIndex: int64(seqLen + 10),
 			NumNewTokens:  1, // Decode generates 1 token per step
 		}

--- a/sim/metrics_substrate_test.go
+++ b/sim/metrics_substrate_test.go
@@ -61,10 +61,10 @@ func msConfig(horizon int64) SimConfig {
 
 // msMakeTokens creates a token slice of the given length (values 1..n).
 // Named with ms prefix to avoid collision with routing_prefix_scorer_test.go.
-func msMakeTokens(n int) []int {
-	tokens := make([]int, n)
+func msMakeTokens(n int) []TokenID {
+	tokens := make([]TokenID, n)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	return tokens
 }
@@ -312,7 +312,7 @@ func TestMetrics_AllITLs_Sum_WithZeroOutputRequests(t *testing.T) {
 
 	// Mix of zero-output and normal requests
 	s.InjectArrival(&Request{
-		ID: "z0", InputTokens: msMakeTokens(32), OutputTokens: []int{},
+		ID: "z0", InputTokens: msMakeTokens(32), OutputTokens: []TokenID{},
 		ArrivalTime: 0, State: StateQueued,
 	})
 	s.InjectArrival(&Request{
@@ -479,9 +479,9 @@ func TestMetrics_ZeroOutput_ValidTTFTAndE2E(t *testing.T) {
 	// Test both empty slice and nil OutputTokens (Go zero-value).
 	for _, tc := range []struct {
 		name   string
-		output []int
+		output []TokenID
 	}{
-		{"empty-slice", []int{}},
+		{"empty-slice", []TokenID{}},
 		{"nil", nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -529,7 +529,7 @@ func TestMetrics_ZeroOutput_DoesNotContaminateITL(t *testing.T) {
 	sMix.InjectArrival(&Request{
 		ID:           "mix-zero",
 		InputTokens:  msMakeTokens(32),
-		OutputTokens: []int{},
+		OutputTokens: []TokenID{},
 		ArrivalTime:  0,
 		State:        StateQueued,
 	})
@@ -703,9 +703,9 @@ func TestMetrics_TTFT_NonMonotonic_WithPrefixCaching(t *testing.T) {
 		ArrivalTime:  500000,
 		State:        StateQueued,
 	}
-	reqCTokens := make([]int, 64)
+	reqCTokens := make([]TokenID, 64)
 	for i := range reqCTokens {
-		reqCTokens[i] = 50000 + i // distinct tokens — no cache overlap
+		reqCTokens[i] = TokenID(50000 + i) // distinct tokens — no cache overlap
 	}
 	reqC := &Request{
 		ID:           "uncached",

--- a/sim/metrics_test.go
+++ b/sim/metrics_test.go
@@ -299,7 +299,7 @@ func TestSaveResults_PerRequestITL_InMilliseconds(t *testing.T) {
 	m.SimEndedTime = 1e6 // 1 second in ticks (prevents division by zero in ResponsesPerSec)
 	m.TotalOutputTokens = 10
 	m.Requests["r1"] = NewRequestMetrics(
-		&Request{ID: "r1", InputTokens: make([]int, 5), OutputTokens: make([]int, 10)},
+		&Request{ID: "r1", InputTokens: make([]TokenID, 5), OutputTokens: make([]TokenID, 10)},
 		0,
 	)
 	m.RequestTTFTs["r1"] = 10000.0  // 10000 ticks = 10 ms
@@ -341,7 +341,7 @@ func TestSaveResults_ZeroRuntime_NoInfinity(t *testing.T) {
 	m.RequestITLs["r1"] = 50.0
 	m.AllITLs = []int64{50}
 	m.RequestSchedulingDelays["r1"] = 100
-	m.Requests["r1"] = NewRequestMetrics(&Request{ID: "r1", InputTokens: make([]int, 10), OutputTokens: make([]int, 5)}, 0)
+	m.Requests["r1"] = NewRequestMetrics(&Request{ID: "r1", InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5)}, 0)
 
 	err := m.SaveResults("test", 1000000, 100, "", nil)
 	if err != nil {

--- a/sim/metrics_utils_test.go
+++ b/sim/metrics_utils_test.go
@@ -14,8 +14,8 @@ func TestNewRequestMetrics_PropagatesAllFields(t *testing.T) {
 	req := &Request{
 		ID:               "test_req_1",
 		ArrivalTime:      2000000, // 2 seconds in ticks
-		InputTokens:      make([]int, 128),
-		OutputTokens:     make([]int, 64),
+		InputTokens:      make([]TokenID, 128),
+		OutputTokens:     make([]TokenID, 64),
 		SLOClass:         "critical",
 		TenantID:         "tenant_alpha",
 		AssignedInstance: "instance_3",
@@ -66,8 +66,8 @@ func TestNewRequestMetrics_ZeroValueFields_AreEmptyStrings(t *testing.T) {
 	req := &Request{
 		ID:           "csv_req_1",
 		ArrivalTime:  1000000,
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 5),
 	}
 
 	// WHEN NewRequestMetrics is called
@@ -91,7 +91,7 @@ func TestNewRequestMetrics_ZeroValueFields_AreEmptyStrings(t *testing.T) {
 func TestNewRequestMetrics_GatewayQueueDelay(t *testing.T) {
 	req := &Request{
 		ID:                  "r1",
-		InputTokens:         make([]int, 10),
+		InputTokens:         make([]TokenID, 10),
 		GatewayEnqueueTime:  1000, // enqueued at 1ms
 		GatewayDispatchTime: 5000, // dispatched at 5ms
 	}
@@ -103,7 +103,7 @@ func TestNewRequestMetrics_GatewayQueueDelay(t *testing.T) {
 }
 
 func TestNewRequestMetrics_GatewayQueueDelay_ZeroWhenNotQueued(t *testing.T) {
-	req := &Request{ID: "r1", InputTokens: make([]int, 10)}
+	req := &Request{ID: "r1", InputTokens: make([]TokenID, 10)}
 	rm := NewRequestMetrics(req, 0.0)
 	if rm.GatewayQueueDelay != 0.0 {
 		t.Errorf("GatewayQueueDelay = %f, want 0.0 when not queued", rm.GatewayQueueDelay)
@@ -116,8 +116,8 @@ func TestNewRequestMetrics_SessionFields(t *testing.T) {
 		ID:               "req-1",
 		SessionID:        "sess-abc",
 		RoundIndex:       2,
-		InputTokens:      []int{1, 2, 3},
-		OutputTokens:     []int{4, 5},
+		InputTokens:  []TokenID{1, 2, 3},
+		OutputTokens: []TokenID{4, 5},
 		SLOClass:         "standard",
 		TenantID:         "tenant-x",
 		AssignedInstance: "inst-0",
@@ -132,7 +132,7 @@ func TestNewRequestMetrics_SessionFields(t *testing.T) {
 	}
 
 	// GIVEN a non-session request
-	req2 := &Request{ID: "req-2", InputTokens: []int{1}, OutputTokens: []int{2}}
+	req2 := &Request{ID: "req-2", InputTokens:  []TokenID{1}, OutputTokens: []TokenID{2}}
 	rm2 := NewRequestMetrics(req2, 500.0)
 	if rm2.SessionID != "" {
 		t.Errorf("non-session SessionID: got %q, want empty", rm2.SessionID)

--- a/sim/prefix_cache_index.go
+++ b/sim/prefix_cache_index.go
@@ -57,7 +57,7 @@ func NewPrefixCacheIndex(blockSize int, lruCapacity int) *PrefixCacheIndex {
 // hashes: two requests sharing the first K blocks produce identical hashes for those K blocks.
 // Tokens shorter than one block produce an empty slice.
 // Delegates to hash.ComputeBlockHashes for the shared implementation (BC-3).
-func (idx *PrefixCacheIndex) ComputeBlockHashes(tokens []int) []string {
+func (idx *PrefixCacheIndex) ComputeBlockHashes(tokens []TokenID) []string {
 	return hash.ComputeBlockHashes(idx.blockSize, tokens)
 }
 

--- a/sim/prefix_cache_index_test.go
+++ b/sim/prefix_cache_index_test.go
@@ -13,8 +13,8 @@ func TestPrefixCacheIndex_HierarchicalHashing_SharedPrefix(t *testing.T) {
 	idx := NewPrefixCacheIndex(4, 100) // block size 4, capacity 100
 
 	// GIVEN two token sequences sharing first 8 tokens (2 blocks) but different suffix
-	tokensA := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}  // 3 blocks
-	tokensB := []int{1, 2, 3, 4, 5, 6, 7, 8, 99, 98, 97, 96} // 3 blocks, different block 3
+	tokensA := []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}  // 3 blocks
+	tokensB := []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 99, 98, 97, 96} // 3 blocks, different block 3
 
 	hashesA := idx.ComputeBlockHashes(tokensA)
 	hashesB := idx.ComputeBlockHashes(tokensB)
@@ -35,7 +35,7 @@ func TestPrefixCacheIndex_ShortPrefix_ZeroBlocks(t *testing.T) {
 	idx := NewPrefixCacheIndex(16, 100) // block size 16
 
 	// GIVEN 10 tokens (< 16 block size)
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	tokens := []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	hashes := idx.ComputeBlockHashes(tokens)
 
 	// THEN no block hashes produced
@@ -47,12 +47,12 @@ func TestPrefixCacheIndex_MatchLength_ConsecutiveFromStart(t *testing.T) {
 	idx := NewPrefixCacheIndex(4, 100)
 
 	// Record 3 blocks for instance "inst_0"
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	tokens := []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 	hashes := idx.ComputeBlockHashes(tokens)
 	idx.RecordBlocks(hashes, "inst_0")
 
 	// WHEN looking up a request with same 2-block prefix but different third block
-	queryTokens := []int{1, 2, 3, 4, 5, 6, 7, 8, 99, 98, 97, 96}
+	queryTokens := []TokenID{1, 2, 3, 4, 5, 6, 7, 8, 99, 98, 97, 96}
 	queryHashes := idx.ComputeBlockHashes(queryTokens)
 
 	// THEN match length is 2 (first 2 consecutive blocks match)
@@ -70,24 +70,24 @@ func TestPrefixCacheIndex_LRUEviction_BoundsCapacity(t *testing.T) {
 
 	// Record 5 single-block hashes for "inst_0" (exceeds capacity of 3)
 	for i := 0; i < 5; i++ {
-		hashes := idx.ComputeBlockHashes([]int{i * 10}) // each is 1 block
+		hashes := idx.ComputeBlockHashes([]TokenID{TokenID(i * 10)}) // each is 1 block
 		idx.RecordBlocks(hashes, "inst_0")
 	}
 
 	// THEN cache is bounded at capacity (3 blocks)
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"))
 	// THEN oldest blocks (tokens 0, 10) were evicted; newest (20, 30, 40) remain
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{0}), "inst_0"))
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{10}), "inst_0"))
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{20}), "inst_0"))
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{30}), "inst_0"))
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{40}), "inst_0"))
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{0}), "inst_0"))
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{10}), "inst_0"))
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{20}), "inst_0"))
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{30}), "inst_0"))
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{40}), "inst_0"))
 }
 
 // TestPrefixCacheIndex_EmptyTokens_NoHashes verifies edge case.
 func TestPrefixCacheIndex_EmptyTokens_NoHashes(t *testing.T) {
 	idx := NewPrefixCacheIndex(16, 100)
-	hashes := idx.ComputeBlockHashes([]int{})
+	hashes := idx.ComputeBlockHashes([]TokenID{})
 	assert.Len(t, hashes, 0)
 }
 
@@ -96,7 +96,7 @@ func TestPrefixCacheIndex_Deterministic(t *testing.T) {
 	idx1 := NewPrefixCacheIndex(4, 100)
 	idx2 := NewPrefixCacheIndex(4, 100)
 
-	tokens := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	tokens := []TokenID{1, 2, 3, 4, 5, 6, 7, 8}
 
 	h1 := idx1.ComputeBlockHashes(tokens)
 	h2 := idx2.ComputeBlockHashes(tokens)
@@ -109,23 +109,23 @@ func TestPrefixCacheIndex_RecordTouches_PreventEviction(t *testing.T) {
 	idx := NewPrefixCacheIndex(1, 3) // capacity 3
 
 	// Record blocks A, B, C for inst_0
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{1}), "inst_0") // A
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{2}), "inst_0") // B
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{3}), "inst_0") // C
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{1}), "inst_0") // A
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{2}), "inst_0") // B
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{3}), "inst_0") // C
 
 	// Touch A again (re-record it)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{1}), "inst_0") // A refreshed
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{1}), "inst_0") // A refreshed
 
 	// Record D — should evict B (oldest untouched), not A
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{4}), "inst_0") // D
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{4}), "inst_0") // D
 
 	// A should still be present (was refreshed)
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{1}), "inst_0"), "A should survive (touched)")
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{1}), "inst_0"), "A should survive (touched)")
 	// B should be evicted
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{2}), "inst_0"), "B should be evicted")
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{2}), "inst_0"), "B should be evicted")
 	// C and D should be present
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{3}), "inst_0"), "C should survive")
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{4}), "inst_0"), "D should be present")
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{3}), "inst_0"), "C should survive")
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{4}), "inst_0"), "D should be present")
 }
 
 // TestPrefixCacheIndex_Capacity1_HeadEqualsTail verifies the capacity-1 edge case
@@ -135,25 +135,25 @@ func TestPrefixCacheIndex_Capacity1_HeadEqualsTail(t *testing.T) {
 	idx := NewPrefixCacheIndex(1, 1) // capacity 1
 
 	// GIVEN a single block recorded
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{10}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{10}), "inst_0")
 	assert.Equal(t, 1, idx.InstanceBlockCount("inst_0"))
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{10}), "inst_0"))
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{10}), "inst_0"))
 
 	// WHEN a new block is recorded (triggers eviction of the only element)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{20}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{20}), "inst_0")
 
 	// THEN capacity remains 1, old block evicted, new block present
 	assert.Equal(t, 1, idx.InstanceBlockCount("inst_0"))
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{10}), "inst_0"), "old block should be evicted")
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{20}), "inst_0"), "new block should be present")
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{10}), "inst_0"), "old block should be evicted")
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{20}), "inst_0"), "new block should be present")
 
 	// WHEN touching the existing block and adding another (evict + insert cycle)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{20}), "inst_0") // touch
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{30}), "inst_0") // replace
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{20}), "inst_0") // touch
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{30}), "inst_0") // replace
 
 	assert.Equal(t, 1, idx.InstanceBlockCount("inst_0"))
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{20}), "inst_0"), "touched block evicted by new insert")
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{30}), "inst_0"), "newest block present")
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{20}), "inst_0"), "touched block evicted by new insert")
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{30}), "inst_0"), "newest block present")
 }
 
 // TestPrefixCacheIndex_RecordBlocks_BatchEvictionRetainsNewest verifies that
@@ -165,7 +165,7 @@ func TestPrefixCacheIndex_RecordBlocks_BatchEvictionRetainsNewest(t *testing.T) 
 	idx := NewPrefixCacheIndex(1, 3) // block size 1, capacity 3
 
 	// GIVEN 6 single-token blocks recorded in one call (exceeds capacity of 3)
-	tokens := []int{10, 20, 30, 40, 50, 60}
+	tokens := []TokenID{10, 20, 30, 40, 50, 60}
 	hashes := idx.ComputeBlockHashes(tokens)
 	require.Len(t, hashes, 6)
 	idx.RecordBlocks(hashes, "inst_0")
@@ -194,22 +194,22 @@ func TestPrefixCacheIndex_MatchLength_DoesNotRefreshLRU(t *testing.T) {
 	idx := NewPrefixCacheIndex(1, 3) // capacity 3
 
 	// GIVEN A (oldest), B, C recorded
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{1}), "inst_0") // A
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{2}), "inst_0") // B
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{3}), "inst_0") // C
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{1}), "inst_0") // A
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{2}), "inst_0") // B
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{3}), "inst_0") // C
 
 	// WHEN A is read via MatchLength (should NOT refresh its LRU position)
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{1}), "inst_0"))
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{1}), "inst_0"))
 
 	// AND a new block D is inserted (triggers eviction)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{4}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{4}), "inst_0")
 
 	// THEN A is evicted (still oldest despite being read), not B
-	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]int{1}), "inst_0"),
+	assert.Equal(t, 0, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{1}), "inst_0"),
 		"A should be evicted — MatchLength must not refresh LRU")
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{2}), "inst_0"),
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{2}), "inst_0"),
 		"B should survive")
-	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]int{4}), "inst_0"),
+	assert.Equal(t, 1, idx.MatchLength(idx.ComputeBlockHashes([]TokenID{4}), "inst_0"),
 		"D should be present")
 }
 
@@ -220,32 +220,32 @@ func TestPrefixCacheIndex_BlockCount_ConsistentThroughMixedOps(t *testing.T) {
 	idx := NewPrefixCacheIndex(1, 3) // capacity 3
 
 	// Step 1: Insert A — count should be 1
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{1}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{1}), "inst_0")
 	assert.Equal(t, 1, idx.InstanceBlockCount("inst_0"), "after insert A")
 
 	// Step 2: Insert B — count should be 2
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{2}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{2}), "inst_0")
 	assert.Equal(t, 2, idx.InstanceBlockCount("inst_0"), "after insert B")
 
 	// Step 3: Touch A — count stays 2 (no new entry)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{1}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{1}), "inst_0")
 	assert.Equal(t, 2, idx.InstanceBlockCount("inst_0"), "after touch A")
 
 	// Step 4: Insert C — count should be 3 (at capacity)
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{3}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{3}), "inst_0")
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"), "after insert C (at capacity)")
 
 	// Step 5: Insert D — triggers eviction, count stays 3
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{4}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{4}), "inst_0")
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"), "after insert D (eviction)")
 
 	// Step 6: Touch C — count stays 3
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{3}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{3}), "inst_0")
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"), "after touch C")
 
 	// Step 7: Insert E, F — two evictions, count stays 3
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{5}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{5}), "inst_0")
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"), "after insert E")
-	idx.RecordBlocks(idx.ComputeBlockHashes([]int{6}), "inst_0")
+	idx.RecordBlocks(idx.ComputeBlockHashes([]TokenID{6}), "inst_0")
 	assert.Equal(t, 3, idx.InstanceBlockCount("inst_0"), "after insert F")
 }

--- a/sim/progress_hook_test.go
+++ b/sim/progress_hook_test.go
@@ -54,13 +54,13 @@ func newTestSimulatorForHook(t *testing.T) *Simulator {
 }
 
 func newTestRequest(id string, arrivalTime int64, inputLen, outputLen int) *Request {
-	input := make([]int, inputLen)
-	output := make([]int, outputLen)
+	input := make([]TokenID, inputLen)
+	output := make([]TokenID, outputLen)
 	for i := range input {
-		input[i] = i % MaxTokenID
+		input[i] = TokenID(i % MaxTokenID)
 	}
 	for i := range output {
-		output[i] = i % MaxTokenID
+		output[i] = TokenID(i % MaxTokenID)
 	}
 	return &Request{
 		ID:           id,

--- a/sim/request.go
+++ b/sim/request.go
@@ -6,7 +6,17 @@ package sim
 import (
 	"fmt"
 	"math/rand"
+
+	"github.com/inference-sim/inference-sim/sim/internal/tokenid"
 )
+
+// TokenID is the simulator's compact representation of a tokenizer ID.
+// Re-exported from sim/internal/tokenid as an alias at the package boundary,
+// so callers write sim.TokenID. The underlying type (tokenid.TokenID) is a
+// defined type (NOT a Go type alias of int32), so assignments from int still
+// require an explicit conversion — the compile-time mixed-arithmetic check
+// is the point.
+type TokenID = tokenid.TokenID
 
 // Request models a single request's lifecycle in the simulation.
 // Each request has:
@@ -30,8 +40,8 @@ const (
 type Request struct {
 	ID string // Unique identifier for the request
 
-	InputTokens  []int // Prompt tokens
-	OutputTokens []int // Pre-specified output tokens (already known for the simulation)
+	InputTokens  []TokenID // Prompt tokens
+	OutputTokens []TokenID // Pre-specified output tokens (already known for the simulation)
 	MaxOutputLen int   // Client output budget (vLLM max_tokens); 0 = no budget (input-only check, runtime stop enforces limit)
 
 	State         RequestState // queued, running, completed
@@ -117,10 +127,10 @@ func (req *Request) IsMultimodal() bool {
 
 // GenerateRandomTokenIDs creates a slice of random token IDs in [0, MaxTokenID).
 // RNG calls: length × Intn(MaxTokenID).
-func GenerateRandomTokenIDs(rng *rand.Rand, length int) []int {
-	tokens := make([]int, length)
+func GenerateRandomTokenIDs(rng *rand.Rand, length int) []TokenID {
+	tokens := make([]TokenID, length)
 	for i := range tokens {
-		tokens[i] = rng.Intn(MaxTokenID)
+		tokens[i] = TokenID(rng.Intn(MaxTokenID))
 	}
 	return tokens
 }

--- a/sim/request_tokenid_test.go
+++ b/sim/request_tokenid_test.go
@@ -1,0 +1,79 @@
+package sim_test
+
+import (
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// TestTokenID_DefinedType_NotAlias verifies BC-1: TokenID is a defined type, not
+// a transparent alias for int32. A raw int32 must NOT be assignable to a TokenID
+// without an explicit conversion — the compile-time mixed-arithmetic check is the
+// whole point of this PR.
+func TestTokenID_DefinedType_NotAlias(t *testing.T) {
+	var x sim.TokenID
+	rt := reflect.TypeOf(x)
+	if rt.Kind() != reflect.Int32 {
+		t.Fatalf("TokenID kind = %v, want int32", rt.Kind())
+	}
+	if rt.Name() != "TokenID" {
+		t.Fatalf("TokenID type name = %q, want %q", rt.Name(), "TokenID")
+	}
+	// Defined-type identity: the reflect.Type for TokenID must differ from int32.
+	// (A Go type alias `type TokenID = int32` would make these reflect.Types equal.)
+	if rt == reflect.TypeOf(int32(0)) {
+		t.Fatalf("TokenID must be a defined type, not a transparent alias of int32")
+	}
+}
+
+// TestRequest_TokenFields_AreTokenIDSlices verifies BC-2: Request.InputTokens
+// and Request.OutputTokens are typed []TokenID.
+func TestRequest_TokenFields_AreTokenIDSlices(t *testing.T) {
+	var req sim.Request
+	rt := reflect.TypeOf(req)
+	for _, name := range []string{"InputTokens", "OutputTokens"} {
+		f, ok := rt.FieldByName(name)
+		if !ok {
+			t.Fatalf("Request.%s field not found", name)
+		}
+		if f.Type.Kind() != reflect.Slice {
+			t.Fatalf("Request.%s kind = %v, want slice", name, f.Type.Kind())
+		}
+		elem := f.Type.Elem()
+		if elem.Name() != "TokenID" {
+			t.Errorf("Request.%s element type = %q, want %q", name, elem.Name(), "TokenID")
+		}
+	}
+}
+
+// TestGenerateRandomTokenIDs_ReturnsTokenIDSlice verifies BC-3: the generator
+// returns []TokenID and respects the [0, MaxTokenID) range.
+func TestGenerateRandomTokenIDs_ReturnsTokenIDSlice(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	got := sim.GenerateRandomTokenIDs(rng, 8)
+	if len(got) != 8 {
+		t.Fatalf("len = %d, want 8", len(got))
+	}
+	if reflect.TypeOf(got).Elem().Name() != "TokenID" {
+		t.Fatalf("element type = %q, want TokenID", reflect.TypeOf(got).Elem().Name())
+	}
+	for i, v := range got {
+		if int(v) < 0 || int(v) >= sim.MaxTokenID {
+			t.Errorf("got[%d] = %d, out of [0, %d)", i, v, sim.MaxTokenID)
+		}
+	}
+}
+
+// TestTokenID_HoldsValuesNearInt32Max guards against accidental narrowing of
+// the underlying type (e.g., to int16). MaxTokenID is well below MaxInt32, but
+// TokenID must be representable up to MaxInt32 to satisfy the issue's invariant
+// "vocabulary sizes never approach 2^31".
+func TestTokenID_HoldsValuesNearInt32Max(t *testing.T) {
+	var maxTok sim.TokenID = math.MaxInt32
+	if int64(maxTok) != int64(math.MaxInt32) {
+		t.Fatalf("TokenID cannot hold MaxInt32: got %d", maxTok)
+	}
+}

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -278,7 +278,7 @@ func NewRoutingPolicy(name string, scorerConfigs []ScorerConfig, blockSize int64
 // and no-hit-lru scorers. cacheFn maps instance ID to a function returning the count of
 // consecutive cached prefix blocks for given tokens; pass nil to disable those scorers
 // (equivalent to calling NewRoutingPolicy).
-func NewRoutingPolicyWithCache(name string, scorerConfigs []ScorerConfig, blockSize int64, rng *rand.Rand, cacheFn map[string]func([]int) int) RoutingPolicy {
+func NewRoutingPolicyWithCache(name string, scorerConfigs []ScorerConfig, blockSize int64, rng *rand.Rand, cacheFn map[string]func([]TokenID) int) RoutingPolicy {
 	return newRoutingPolicyInternal(name, scorerConfigs, blockSize, rng, cacheQueryFn(cacheFn))
 }
 

--- a/sim/routing_nohit_lru_scorer_test.go
+++ b/sim/routing_nohit_lru_scorer_test.go
@@ -7,15 +7,15 @@ import "testing"
 func TestNoHitLRU_ColdRequestDistribution(t *testing.T) {
 	// All instances return 0 cached blocks (cold)
 	cacheQueryFn := cacheQueryFn{
-		"a": func(tokens []int) int { return 0 },
-		"b": func(tokens []int) int { return 0 },
-		"c": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 0 },
+		"b": func(tokens []TokenID) int { return 0 },
+		"c": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, obs := newNoHitLRUScorer(cacheQueryFn)
 	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}, {ID: "c"}}
 
 	// First cold request: all never-used → a=1.0, b=0.5, c=0.0 (positional)
-	req1 := &Request{ID: "r1", InputTokens: []int{1}}
+	req1 := &Request{ID: "r1", InputTokens:  []TokenID{1}}
 	scores1 := scorer(req1, snapshots)
 	if scores1["a"] != 1.0 {
 		t.Errorf("r1: a got %.3f, want 1.0 (first never-used)", scores1["a"])
@@ -32,7 +32,7 @@ func TestNoHitLRU_ColdRequestDistribution(t *testing.T) {
 
 	// Second cold request: "a" is now most-recently-used
 	// b, c are never-used (rank 0, 1), a is used (rank 2)
-	req2 := &Request{ID: "r2", InputTokens: []int{1}}
+	req2 := &Request{ID: "r2", InputTokens:  []TokenID{1}}
 	scores2 := scorer(req2, snapshots)
 	if scores2["b"] != 1.0 {
 		t.Errorf("r2: b got %.3f, want 1.0 (first never-used)", scores2["b"])
@@ -46,7 +46,7 @@ func TestNoHitLRU_ColdRequestDistribution(t *testing.T) {
 
 	// Route to "b", then third request: a is older than b
 	obs(req2, "b")
-	req3 := &Request{ID: "r3", InputTokens: []int{1}}
+	req3 := &Request{ID: "r3", InputTokens:  []TokenID{1}}
 	scores3 := scorer(req3, snapshots)
 	// c is never-used (rank 0 → 1.0), a is oldest-used (rank 1 → 0.5), b is newest-used (rank 2 → 0.0)
 	if scores3["c"] != 1.0 {
@@ -63,12 +63,12 @@ func TestNoHitLRU_ColdRequestDistribution(t *testing.T) {
 // TestNoHitLRU_WarmRequestNeutral verifies BC-4: warm requests → all 0.5.
 func TestNoHitLRU_WarmRequestNeutral(t *testing.T) {
 	cacheQueryFn := cacheQueryFn{
-		"a": func(tokens []int) int { return 3 }, // has cached blocks
-		"b": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 3 }, // has cached blocks
+		"b": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, _ := newNoHitLRUScorer(cacheQueryFn)
 	scores := scorer(
-		&Request{ID: "r1", InputTokens: []int{1}},
+		&Request{ID: "r1", InputTokens:  []TokenID{1}},
 		[]RoutingSnapshot{{ID: "a"}, {ID: "b"}},
 	)
 	for id, score := range scores {
@@ -83,25 +83,25 @@ func TestNoHitLRU_ObserverColdOnly(t *testing.T) {
 	// Use a mutable flag so we can switch from warm to cold mid-test.
 	warmA := true
 	cacheQueryFn := cacheQueryFn{
-		"a": func(tokens []int) int {
+		"a": func(tokens []TokenID) int {
 			if warmA {
 				return 3
 			}
 			return 0
 		},
-		"b": func(tokens []int) int { return 0 },
+		"b": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, obs := newNoHitLRUScorer(cacheQueryFn)
 	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}}
 
 	// Route a warm request to "a" — observer should NOT update LRU
-	req := &Request{ID: "r1", InputTokens: []int{1}}
+	req := &Request{ID: "r1", InputTokens:  []TokenID{1}}
 	scorer(req, snapshots)
 	obs(req, "a") // should NOT update LRU (warm)
 
 	// Switch to cold and verify "a" is still never-used (LRU not updated by warm routing)
 	warmA = false
-	req2 := &Request{ID: "r2", InputTokens: []int{1}}
+	req2 := &Request{ID: "r2", InputTokens:  []TokenID{1}}
 	scores := scorer(req2, snapshots)
 	if scores["a"] != 1.0 {
 		t.Errorf("a got %.3f, want 1.0 (never-used — warm routing should not update LRU)", scores["a"])
@@ -111,11 +111,11 @@ func TestNoHitLRU_ObserverColdOnly(t *testing.T) {
 // TestNoHitLRU_SingleInstanceCold verifies single instance cold → score 1.0.
 func TestNoHitLRU_SingleInstanceCold(t *testing.T) {
 	cacheQueryFn := cacheQueryFn{
-		"only": func(tokens []int) int { return 0 },
+		"only": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, _ := newNoHitLRUScorer(cacheQueryFn)
 	scores := scorer(
-		&Request{ID: "r1", InputTokens: []int{1}},
+		&Request{ID: "r1", InputTokens:  []TokenID{1}},
 		[]RoutingSnapshot{{ID: "only"}},
 	)
 	if scores["only"] != 1.0 {
@@ -127,7 +127,7 @@ func TestNoHitLRU_SingleInstanceCold(t *testing.T) {
 func TestNoHitLRU_NilCacheQueryFn(t *testing.T) {
 	scorer, _ := newNoHitLRUScorer(nil)
 	scores := scorer(
-		&Request{ID: "r1", InputTokens: []int{1}},
+		&Request{ID: "r1", InputTokens:  []TokenID{1}},
 		[]RoutingSnapshot{{ID: "a"}, {ID: "b"}},
 	)
 	for id, score := range scores {
@@ -142,16 +142,16 @@ func TestNoHitLRU_NilCacheQueryFn(t *testing.T) {
 func TestNoHitLRU_Determinism(t *testing.T) {
 	makeCacheQueryFn := func() cacheQueryFn {
 		return cacheQueryFn{
-			"a": func(tokens []int) int { return 0 },
-			"b": func(tokens []int) int { return 0 },
-			"c": func(tokens []int) int { return 0 },
+			"a": func(tokens []TokenID) int { return 0 },
+			"b": func(tokens []TokenID) int { return 0 },
+			"c": func(tokens []TokenID) int { return 0 },
 		}
 	}
 	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}, {ID: "c"}}
 	requests := []*Request{
-		{ID: "r1", InputTokens: []int{1}},
-		{ID: "r2", InputTokens: []int{2}},
-		{ID: "r3", InputTokens: []int{3}},
+		{ID: "r1", InputTokens:  []TokenID{1}},
+		{ID: "r2", InputTokens:  []TokenID{2}},
+		{ID: "r3", InputTokens:  []TokenID{3}},
 	}
 	routeTargets := []string{"a", "b", "a"}
 
@@ -191,23 +191,23 @@ func TestNoHitLRU_Determinism(t *testing.T) {
 // re-promotes it to most-recently-used, producing correct LRU rank scores.
 func TestNoHitLRU_LRURepromotion(t *testing.T) {
 	cqf := cacheQueryFn{
-		"a": func(tokens []int) int { return 0 },
-		"b": func(tokens []int) int { return 0 },
-		"c": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 0 },
+		"b": func(tokens []TokenID) int { return 0 },
+		"c": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, obs := newNoHitLRUScorer(cqf)
 	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}, {ID: "c"}}
 
 	// Route: a, b, a (re-promote a to most-recently-used)
 	for _, target := range []string{"a", "b", "a"} {
-		req := &Request{ID: "r-" + target, InputTokens: []int{1}}
+		req := &Request{ID: "r-" + target, InputTokens:  []TokenID{1}}
 		scorer(req, snapshots)
 		obs(req, target)
 	}
 
 	// After [a, b, a]: lruOrder = [a, b]. c is never-used.
 	// c=1.0 (never-used, rank 0), b=0.5 (oldest-used, rank 1), a=0.0 (newest-used, rank 2)
-	req := &Request{ID: "r-check", InputTokens: []int{1}}
+	req := &Request{ID: "r-check", InputTokens:  []TokenID{1}}
 	scores := scorer(req, snapshots)
 	if scores["c"] != 1.0 {
 		t.Errorf("c: got %.3f, want 1.0 (never-used)", scores["c"])
@@ -225,22 +225,22 @@ func TestNoHitLRU_LRURepromotion(t *testing.T) {
 // stale LRU updates).
 func TestNoHitLRU_ObserverMismatchedReqID(t *testing.T) {
 	cqf := cacheQueryFn{
-		"a": func(tokens []int) int { return 0 },
-		"b": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 0 },
+		"b": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, obs := newNoHitLRUScorer(cqf)
 	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}}
 
 	// Score req1 (cold) — sets lastReqID = "r1"
-	req1 := &Request{ID: "r1", InputTokens: []int{1}}
+	req1 := &Request{ID: "r1", InputTokens:  []TokenID{1}}
 	scorer(req1, snapshots)
 
 	// Call observer with DIFFERENT request — should NOT update LRU
-	req2 := &Request{ID: "r2", InputTokens: []int{1}}
+	req2 := &Request{ID: "r2", InputTokens:  []TokenID{1}}
 	obs(req2, "a")
 
 	// Score req3 (cold) — "a" should still be never-used (observer was no-op)
-	req3 := &Request{ID: "r3", InputTokens: []int{1}}
+	req3 := &Request{ID: "r3", InputTokens:  []TokenID{1}}
 	scores := scorer(req3, snapshots)
 	if scores["a"] != 1.0 {
 		t.Errorf("a: got %.3f, want 1.0 (never-used — mismatched observer should be no-op)", scores["a"])

--- a/sim/routing_precise_prefix_scorer_test.go
+++ b/sim/routing_precise_prefix_scorer_test.go
@@ -6,12 +6,12 @@ import "testing"
 // produces correct scores for varying cached block counts.
 func TestPrecisePrefixCache_MinMaxNormalization(t *testing.T) {
 	cacheQueryFn := cacheQueryFn{
-		"inst-0": func(tokens []int) int { return 5 },
-		"inst-1": func(tokens []int) int { return 3 },
-		"inst-2": func(tokens []int) int { return 0 },
+		"inst-0": func(tokens []TokenID) int { return 5 },
+		"inst-1": func(tokens []TokenID) int { return 3 },
+		"inst-2": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, _ := newPrecisePrefixCacheScorer(cacheQueryFn)
-	req := &Request{ID: "r1", InputTokens: []int{1, 2, 3, 4, 5}}
+	req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2, 3, 4, 5}}
 	snapshots := []RoutingSnapshot{
 		{ID: "inst-0"},
 		{ID: "inst-1"},
@@ -54,10 +54,10 @@ func TestPrecisePrefixCache_AllEqual(t *testing.T) {
 			ids := []string{"a", "b", "c"}
 			for _, id := range ids {
 				count := tt.counts[id]
-				cqf[id] = func(tokens []int) int { return count }
+				cqf[id] = func(tokens []TokenID) int { return count }
 			}
 			scorer, _ := newPrecisePrefixCacheScorer(cqf)
-			req := &Request{ID: "r1", InputTokens: []int{1}}
+			req := &Request{ID: "r1", InputTokens:  []TokenID{1}}
 			var snapshots []RoutingSnapshot
 			for _, id := range ids {
 				snapshots = append(snapshots, RoutingSnapshot{ID: id})
@@ -83,10 +83,10 @@ func TestPrecisePrefixCache_ObserverIsNil(t *testing.T) {
 // TestPrecisePrefixCache_SingleInstance verifies single instance scores 1.0.
 func TestPrecisePrefixCache_SingleInstance(t *testing.T) {
 	cacheQueryFn := cacheQueryFn{
-		"only": func(tokens []int) int { return 3 },
+		"only": func(tokens []TokenID) int { return 3 },
 	}
 	scorer, _ := newPrecisePrefixCacheScorer(cacheQueryFn)
-	scores := scorer(&Request{ID: "r1", InputTokens: []int{1}}, []RoutingSnapshot{{ID: "only"}})
+	scores := scorer(&Request{ID: "r1", InputTokens:  []TokenID{1}}, []RoutingSnapshot{{ID: "only"}})
 	if scores["only"] != 1.0 {
 		t.Errorf("single instance: got %.3f, want 1.0", scores["only"])
 	}
@@ -95,7 +95,7 @@ func TestPrecisePrefixCache_SingleInstance(t *testing.T) {
 // TestPrecisePrefixCache_NilCacheQueryFn verifies nil cacheQueryFn → all 1.0.
 func TestPrecisePrefixCache_NilCacheQueryFn(t *testing.T) {
 	scorer, _ := newPrecisePrefixCacheScorer(nil)
-	scores := scorer(&Request{ID: "r1", InputTokens: []int{1}}, []RoutingSnapshot{
+	scores := scorer(&Request{ID: "r1", InputTokens:  []TokenID{1}}, []RoutingSnapshot{
 		{ID: "a"}, {ID: "b"},
 	})
 	for id, score := range scores {
@@ -111,12 +111,12 @@ func TestPrecisePrefixCache_NilCacheQueryFn(t *testing.T) {
 func TestPrecisePrefixCache_MissingInstanceInCacheQueryFn(t *testing.T) {
 	// cacheQueryFn has "a" and "b" but NOT "c"
 	cqf := cacheQueryFn{
-		"a": func(tokens []int) int { return 5 },
-		"b": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 5 },
+		"b": func(tokens []TokenID) int { return 0 },
 	}
 	scorer, _ := newPrecisePrefixCacheScorer(cqf)
 	scores := scorer(
-		&Request{ID: "r1", InputTokens: []int{1}},
+		&Request{ID: "r1", InputTokens:  []TokenID{1}},
 		[]RoutingSnapshot{{ID: "a"}, {ID: "b"}, {ID: "c"}},
 	)
 	// "c" missing from cacheQueryFn → treated as 0 cached blocks (same as "b")

--- a/sim/routing_prefix_scorer_test.go
+++ b/sim/routing_prefix_scorer_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 // makeTokens creates a sequential token slice of the given length.
-func makeTokens(n int) []int {
-	tokens := make([]int, n)
+func makeTokens(n int) []TokenID {
+	tokens := make([]TokenID, n)
 	for i := range tokens {
-		tokens[i] = i + 1
+		tokens[i] = TokenID(i + 1)
 	}
 	return tokens
 }
@@ -88,10 +88,10 @@ func TestPrefixAffinityScorer_ProportionalScoring(t *testing.T) {
 	policy.Route(req1, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// Route partial-match request to inst_1 (shares first 16 tokens, rest different)
-	partialTokens := make([]int, 64)
+	partialTokens := make([]TokenID, 64)
 	copy(partialTokens[:16], fullTokens[:16]) // same first block
 	for i := 16; i < 64; i++ {
-		partialTokens[i] = 9000 + i // different remaining blocks
+		partialTokens[i] = TokenID(9000 + i) // different remaining blocks
 	}
 	req2 := &Request{ID: "r2", InputTokens: partialTokens}
 	// Force route to inst_1 by giving inst_0 high load
@@ -124,7 +124,7 @@ func TestPrefixAffinityScorer_ShortPrefix_ZeroScore(t *testing.T) {
 	policy.Route(longReq, &RouterState{Snapshots: snapshots, Clock: 1000})
 
 	// WHEN routing a short request (< 1 block)
-	shortReq := &Request{ID: "r2", InputTokens: []int{1, 2, 3}}
+	shortReq := &Request{ID: "r2", InputTokens:  []TokenID{1, 2, 3}}
 	d := policy.Route(shortReq, &RouterState{Snapshots: snapshots, Clock: 2000})
 
 	// THEN all scores are 0 (no blocks to match)
@@ -207,10 +207,10 @@ func TestPrefixAffinityScorer_WeightSensitivity_ConcentratesRouting(t *testing.T
 	buildWorkload := func() []*Request {
 		var reqs []*Request
 		for i := 0; i < numRequests; i++ {
-			tokens := append([]int{}, sharedPrefix...)
+			tokens := append([]TokenID{}, sharedPrefix...)
 			// Add unique suffix (1 block = 16 tokens)
 			for j := 0; j < 16; j++ {
-				tokens = append(tokens, i*100+j)
+				tokens = append(tokens, TokenID(i*100+j))
 			}
 			reqs = append(reqs, &Request{ID: fmt.Sprintf("r%d", i), InputTokens: tokens})
 		}
@@ -321,16 +321,16 @@ func TestPrefixAffinityScorer_ObserverFallback_RecomputesHashes(t *testing.T) {
 	snapshots := []RoutingSnapshot{{ID: "inst_0"}, {ID: "inst_1"}}
 
 	// GIVEN: scorer called for request A (caches A's hashes)
-	reqA := &Request{ID: "rA", InputTokens: []int{1, 2, 3, 4, 5, 6, 7, 8}}
+	reqA := &Request{ID: "rA", InputTokens:  []TokenID{1, 2, 3, 4, 5, 6, 7, 8}}
 	scorer(reqA, snapshots)
 
 	// WHEN: observer called for a DIFFERENT request B (triggers fallback recompute)
-	reqB := &Request{ID: "rB", InputTokens: []int{10, 20, 30, 40}}
+	reqB := &Request{ID: "rB", InputTokens:  []TokenID{10, 20, 30, 40}}
 	observer(reqB, "inst_1")
 
 	// THEN: inst_1 should have reqB's blocks, not reqA's blocks
 	// Verify by scoring a new request with reqB's prefix — inst_1 should match
-	reqB2 := &Request{ID: "rB2", InputTokens: []int{10, 20, 30, 40}}
+	reqB2 := &Request{ID: "rB2", InputTokens:  []TokenID{10, 20, 30, 40}}
 	scores := scorer(reqB2, snapshots)
 	assert.Equal(t, 1.0, scores["inst_1"], "inst_1 should have reqB's prefix cached (observer recomputed)")
 	assert.Equal(t, 0.0, scores["inst_0"], "inst_0 should not have reqB's prefix")
@@ -347,7 +347,7 @@ func TestPrefixAffinityScorer_NonWeightedPolicies_Unchanged(t *testing.T) {
 	for _, name := range policies {
 		t.Run(name, func(t *testing.T) {
 			policy := NewRoutingPolicy(name, nil, 16, nil)
-			req := &Request{ID: "r1", InputTokens: []int{1, 2, 3}}
+			req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2, 3}}
 			d := policy.Route(req, &RouterState{Snapshots: snapshots, Clock: 1000})
 			// Just verify it doesn't panic and returns valid target
 			assert.Contains(t, []string{"inst_0", "inst_1"}, d.TargetInstance)

--- a/sim/routing_scorers.go
+++ b/sim/routing_scorers.go
@@ -23,7 +23,7 @@ type scorerFunc func(req *Request, snapshots []RoutingSnapshot) map[string]float
 // cacheQueryFn maps instance IDs to functions that return the count of
 // consecutive cached prefix blocks for given tokens. Used by precise
 // prefix cache scoring. Nil for sim-level tests without cluster instances.
-type cacheQueryFn map[string]func([]int) int
+type cacheQueryFn map[string]func([]TokenID) int
 
 // scoreVLLMDP computes per-instance scores using vLLM's data-parallel formula.
 // Formula: raw = QueueDepth × 4 + BatchSize, then inverted min-max normalization.

--- a/sim/routing_scorers_test.go
+++ b/sim/routing_scorers_test.go
@@ -390,9 +390,9 @@ func TestAllScorers_ReturnScoreForEveryInstance(t *testing.T) {
 		{ID: "c", QueueDepth: 0, KVUtilization: 0.0},
 	}
 	cacheQueryFn := cacheQueryFn{
-		"a": func(tokens []int) int { return 2 },
-		"b": func(tokens []int) int { return 0 },
-		"c": func(tokens []int) int { return 1 },
+		"a": func(tokens []TokenID) int { return 2 },
+		"b": func(tokens []TokenID) int { return 0 },
+		"c": func(tokens []TokenID) int { return 1 },
 	}
 	precisePrefixScorer, _ := newPrecisePrefixCacheScorer(cacheQueryFn)
 	noHitLRUScorer, _ := newNoHitLRUScorer(cacheQueryFn)
@@ -410,7 +410,7 @@ func TestAllScorers_ReturnScoreForEveryInstance(t *testing.T) {
 		{"precise-prefix-cache", precisePrefixScorer},
 		{"no-hit-lru", noHitLRUScorer},
 	}
-	req := &Request{ID: "r1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2, 3}}
 	for _, sf := range scorerFns {
 		t.Run(sf.name, func(t *testing.T) {
 			scores := sf.fn(req, snapshots)
@@ -444,14 +444,14 @@ func TestAllScorers_ReturnScoreForEveryInstance(t *testing.T) {
 // correctly wires precise-prefix-cache and no-hit-lru scorers via NewRoutingPolicyWithCache.
 func TestNewScorerFactory_PrecisePrefixAndNoHitLRU(t *testing.T) {
 	cacheQueryFn := cacheQueryFn{
-		"a": func(tokens []int) int { return 5 },
-		"b": func(tokens []int) int { return 0 },
+		"a": func(tokens []TokenID) int { return 5 },
+		"b": func(tokens []TokenID) int { return 0 },
 	}
 	policy := NewRoutingPolicyWithCache("weighted", []ScorerConfig{
 		{Name: "precise-prefix-cache", Weight: 1.0},
 	}, 16, nil, cacheQueryFn)
 
-	req := &Request{ID: "r1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2, 3}}
 	state := &RouterState{
 		Snapshots: []RoutingSnapshot{{ID: "a"}, {ID: "b"}},
 		Clock:     1000,

--- a/sim/routing_test.go
+++ b/sim/routing_test.go
@@ -13,7 +13,7 @@ func TestRoutingPolicy_Interface_Contract(t *testing.T) {
 	policy := NewRoutingPolicy("round-robin", nil, 16, nil)
 
 	// WHEN Route() is called with valid inputs
-	req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
+	req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3}}
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 5},
 		{ID: "instance_1", QueueDepth: 3},
@@ -409,7 +409,7 @@ func TestRoutingDecision_TargetSet(t *testing.T) {
 				Snapshots: []RoutingSnapshot{{ID: "instance_0", QueueDepth: 1}},
 				Clock:     1000,
 			}
-			req := &Request{ID: "req1", InputTokens: []int{1, 2, 3}}
+			req := &Request{ID: "req1", InputTokens:  []TokenID{1, 2, 3}}
 			decision := policy.Route(req, state)
 
 			if decision.TargetInstance == "" {
@@ -424,7 +424,7 @@ func TestRoutingDecision_TargetSet(t *testing.T) {
 // TestAlwaysBusiest_RouteToHighestLoad verifies BC-6.
 func TestAlwaysBusiest_RouteToHighestLoad(t *testing.T) {
 	policy := NewRoutingPolicy("always-busiest", nil, 16, nil)
-	req := &Request{ID: "r1", InputTokens: []int{1, 2}}
+	req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2}}
 	snapshots := []RoutingSnapshot{
 		{ID: "instance_0", QueueDepth: 2, BatchSize: 1},
 		{ID: "instance_1", QueueDepth: 10, BatchSize: 5},

--- a/sim/scheduler_test.go
+++ b/sim/scheduler_test.go
@@ -97,9 +97,9 @@ func TestSJFScheduler_SortsByInputTokensAscending(t *testing.T) {
 	// BC-4: shorter jobs first
 	sched := &SJFScheduler{}
 	reqs := []*Request{
-		{ID: "long", ArrivalTime: 100, InputTokens: make([]int, 500)},
-		{ID: "short", ArrivalTime: 200, InputTokens: make([]int, 50)},
-		{ID: "medium", ArrivalTime: 50, InputTokens: make([]int, 200)},
+		{ID: "long", ArrivalTime: 100, InputTokens: make([]TokenID, 500)},
+		{ID: "short", ArrivalTime: 200, InputTokens: make([]TokenID, 50)},
+		{ID: "medium", ArrivalTime: 50, InputTokens: make([]TokenID, 200)},
 	}
 	sched.OrderQueue(reqs, 0)
 
@@ -114,8 +114,8 @@ func TestSJFScheduler_TieBreakByArrivalTime(t *testing.T) {
 	// BC-4: same length → earlier arrival first
 	sched := &SJFScheduler{}
 	reqs := []*Request{
-		{ID: "late", ArrivalTime: 300, InputTokens: make([]int, 100)},
-		{ID: "early", ArrivalTime: 100, InputTokens: make([]int, 100)},
+		{ID: "late", ArrivalTime: 300, InputTokens: make([]TokenID, 100)},
+		{ID: "early", ArrivalTime: 100, InputTokens: make([]TokenID, 100)},
 	}
 	sched.OrderQueue(reqs, 0)
 
@@ -130,8 +130,8 @@ func TestSJFScheduler_TieBreakByID(t *testing.T) {
 	// BC-4 + BC-8: same length + same arrival → lexicographic ID
 	sched := &SJFScheduler{}
 	reqs := []*Request{
-		{ID: "bravo", ArrivalTime: 100, InputTokens: make([]int, 100)},
-		{ID: "alpha", ArrivalTime: 100, InputTokens: make([]int, 100)},
+		{ID: "bravo", ArrivalTime: 100, InputTokens: make([]TokenID, 100)},
+		{ID: "alpha", ArrivalTime: 100, InputTokens: make([]TokenID, 100)},
 	}
 	sched.OrderQueue(reqs, 0)
 
@@ -156,9 +156,9 @@ func TestScheduler_AnyPolicy_PreservesAllRequests(t *testing.T) {
 	for _, tc := range schedulers {
 		t.Run(tc.name, func(t *testing.T) {
 			reqs := []*Request{
-				{ID: "a", ArrivalTime: 100, Priority: 1.0, InputTokens: make([]int, 50)},
-				{ID: "b", ArrivalTime: 200, Priority: 2.0, InputTokens: make([]int, 100)},
-				{ID: "c", ArrivalTime: 300, Priority: 3.0, InputTokens: make([]int, 25)},
+				{ID: "a", ArrivalTime: 100, Priority: 1.0, InputTokens: make([]TokenID, 50)},
+				{ID: "b", ArrivalTime: 200, Priority: 2.0, InputTokens: make([]TokenID, 100)},
+				{ID: "c", ArrivalTime: 300, Priority: 3.0, InputTokens: make([]TokenID, 25)},
 			}
 			tc.sched.OrderQueue(reqs, 0)
 
@@ -185,9 +185,9 @@ func TestNewScheduler_ValidNames_ReturnsBehaviorallyCorrectScheduler(t *testing.
 	// BC-3: empty string and "fcfs" return a scheduler that preserves input order (FCFS)
 	reqs := func() []*Request {
 		return []*Request{
-			{ID: "c", ArrivalTime: 300, Priority: 1.0, InputTokens: make([]int, 50)},
-			{ID: "a", ArrivalTime: 100, Priority: 3.0, InputTokens: make([]int, 10)},
-			{ID: "b", ArrivalTime: 200, Priority: 2.0, InputTokens: make([]int, 30)},
+			{ID: "c", ArrivalTime: 300, Priority: 1.0, InputTokens: make([]TokenID, 50)},
+			{ID: "a", ArrivalTime: 100, Priority: 3.0, InputTokens: make([]TokenID, 10)},
+			{ID: "b", ArrivalTime: 200, Priority: 2.0, InputTokens: make([]TokenID, 30)},
 		}
 	}
 
@@ -254,16 +254,16 @@ func TestSimulator_PriorityFCFS_SchedulesHighPriorityFirst(t *testing.T) {
 	// Inject it first so FCFS would schedule it first — but priority should override.
 	reqNewer := &Request{
 		ID:           "req_newer",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 5),
 		ArrivalTime:  500000,
 		State:        StateQueued,
 	}
 	// reqOlder arrives earlier (higher age → higher priority)
 	reqOlder := &Request{
 		ID:           "req_older",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 5),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
@@ -303,15 +303,15 @@ func TestSimulator_DefaultConfig_MatchesFCFS(t *testing.T) {
 	// Inject two requests with same arrival time; FCFS should schedule first-injected first
 	reqFirst := &Request{
 		ID:           "req_first",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
 	reqSecond := &Request{
 		ID:           "req_second",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
@@ -373,16 +373,16 @@ func TestSimulator_SJF_SchedulesShortJobFirst(t *testing.T) {
 	// Long request injected first — SJF should move it behind short
 	reqLong := &Request{
 		ID:           "req_long",
-		InputTokens:  make([]int, 200),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 200),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
 	// Short request injected second — SJF should move it to front
 	reqShort := &Request{
 		ID:           "req_short",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
@@ -426,16 +426,16 @@ func TestSimulator_PriorityFCFS_ArrivalTimeTiebreak_OlderFirst(t *testing.T) {
 	// Newer request injected first (arrives at t=500000)
 	reqNew := &Request{
 		ID:           "req_new",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  500000,
 		State:        StateQueued,
 	}
 	// Older request injected second (arrives at t=0)
 	reqOld := &Request{
 		ID:           "req_old",
-		InputTokens:  make([]int, 20),
-		OutputTokens: make([]int, 2),
+		InputTokens:  make([]TokenID, 20),
+		OutputTokens: make([]TokenID, 2),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -4,6 +4,7 @@ package sim
 import (
 	"container/heap"
 	"fmt"
+	"math"
 	"math/rand"
 
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,13 @@ import (
 )
 
 const MaxTokenID = 128000 // Max token ID in request input/output
+
+// Compile-time guard: MaxTokenID must fit in TokenID's underlying int32 range.
+// If MaxTokenID is ever raised above math.MaxInt32 (~2.1B), the int→TokenID
+// cast in GenerateRandomTokenIDs would silently truncate. This expression
+// evaluates to a negative integer constant when MaxTokenID > MaxInt32, which
+// is not representable as uint and fails to compile.
+const _ = uint(math.MaxInt32 - MaxTokenID)
 
 // eventEntry wraps an Event with a sequence ID for deterministic ordering.
 // The EventQueue orders by (Timestamp, Priority, seqID), matching the

--- a/sim/simulator_decode_test.go
+++ b/sim/simulator_decode_test.go
@@ -20,8 +20,8 @@ func TestSimulator_DecodePhase_RequestCompletesSuccessfully(t *testing.T) {
 	// Create a request with known input/output that exercises decode phase
 	req := &Request{
 		ID:           "decode_test",
-		InputTokens:  []int{1, 2, 3, 4, 5, 6, 7, 8},
-		OutputTokens: []int{100, 200, 300},
+		InputTokens:  []TokenID{1, 2, 3, 4, 5, 6, 7, 8},
+		OutputTokens: []TokenID{100, 200, 300},
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}

--- a/sim/simulator_preempt_test.go
+++ b/sim/simulator_preempt_test.go
@@ -22,8 +22,8 @@ func TestPreempt_EmptyBatch_ReturnsFalse(t *testing.T) {
 	// AND a request that needs far more blocks than available, in the wait queue
 	req := &Request{
 		ID:           "large-req",
-		InputTokens:  make([]int, 200), // needs ~13 blocks, only 2 available
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]TokenID, 200), // needs ~13 blocks, only 2 available
+		OutputTokens: make([]TokenID, 1),
 		State:        StateQueued,
 	}
 	wq := &WaitQueue{}
@@ -76,8 +76,8 @@ func TestPreempt_InsufficientBlocks_EvictsAllThenReturnsFalse(t *testing.T) {
 	// AND one small request in the running batch with KV blocks allocated
 	existing := &Request{
 		ID:           "existing",
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 1),
 		State:        StateRunning,
 	}
 	if ok := kvCache.AllocateKVBlocks(existing, 0, 10, []int64{}); !ok {
@@ -88,8 +88,8 @@ func TestPreempt_InsufficientBlocks_EvictsAllThenReturnsFalse(t *testing.T) {
 	// This forces Phase 1 to try allocating for huge, fail, and trigger preemption.
 	huge := &Request{
 		ID:           "huge-req",
-		InputTokens:  make([]int, 200), // needs 13 blocks, only 2 total
-		OutputTokens: make([]int, 1),
+		InputTokens:  make([]TokenID, 200), // needs 13 blocks, only 2 total
+		OutputTokens: make([]TokenID, 1),
 		State:        StateRunning,
 	}
 
@@ -151,28 +151,28 @@ func TestNewSimulator_CustomSLOPriorityMap_AffectsPreemption(t *testing.T) {
 
 	// Inject three running requests to saturate cache (9/10 blocks used).
 	// Distinct input tokens prevent prefix cache sharing across requests.
-	critTokens := make([]int, 48)
+	critTokens := make([]TokenID, 48)
 	for i := range critTokens {
-		critTokens[i] = i + 1
+		critTokens[i] = TokenID(i + 1)
 	}
-	batchTokens := make([]int, 48)
+	batchTokens := make([]TokenID, 48)
 	for i := range batchTokens {
-		batchTokens[i] = i + 101
+		batchTokens[i] = TokenID(i + 101)
 	}
-	bgTokens := make([]int, 48)
+	bgTokens := make([]TokenID, 48)
 	for i := range bgTokens {
-		bgTokens[i] = i + 201
+		bgTokens[i] = TokenID(i + 201)
 	}
 	// Compute vLLM-convention priorities using the override map (mirrors what EnqueueRequest does).
 	overrideMap := NewSLOPriorityMap(cfg.SLOPriorityOverrides)
 	critReq := &Request{ID: "crit", SLOClass: "critical", ArrivalTime: 100, State: StateRunning,
-		InputTokens: critTokens, OutputTokens: make([]int, 10),
+		InputTokens: critTokens, OutputTokens: make([]TokenID, 10),
 		Priority: float64(overrideMap.InvertForVLLM("critical"))}
 	batchReq := &Request{ID: "batch-req", SLOClass: "batch", ArrivalTime: 200, State: StateRunning,
-		InputTokens: batchTokens, OutputTokens: make([]int, 10),
+		InputTokens: batchTokens, OutputTokens: make([]TokenID, 10),
 		Priority: float64(overrideMap.InvertForVLLM("batch"))}
 	bgReq := &Request{ID: "bg-req", SLOClass: "background", ArrivalTime: 300, State: StateRunning,
-		InputTokens: bgTokens, OutputTokens: make([]int, 10),
+		InputTokens: bgTokens, OutputTokens: make([]TokenID, 10),
 		Priority: float64(overrideMap.InvertForVLLM("background"))}
 
 	for _, req := range []*Request{critReq, batchReq, bgReq} {
@@ -186,7 +186,7 @@ func TestNewSimulator_CustomSLOPriorityMap_AffectsPreemption(t *testing.T) {
 	//   index=2: empty (batch-req removed). Loop exits at len=2.
 	// Without override: victim = background(-3, GAIE default least urgent). bg-req evicted instead.
 	s.RunningBatch = &Batch{Requests: []*Request{critReq, bgReq, batchReq}}
-	s.WaitQ.Enqueue(&Request{ID: "new", InputTokens: make([]int, 16), OutputTokens: make([]int, 1), State: StateQueued})
+	s.WaitQ.Enqueue(&Request{ID: "new", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 1), State: StateQueued})
 
 	result := s.batchFormation.FormBatch(BatchContext{
 		RunningBatch:       s.RunningBatch,

--- a/sim/simulator_test.go
+++ b/sim/simulator_test.go
@@ -90,11 +90,11 @@ func TestExecuteBatchStep_FiltersIdleRequests_BC2(t *testing.T) {
 		t.Fatalf("NewSimulator: %v", err)
 	}
 
-	active1 := &Request{ID: "active1", InputTokens: make([]int, 32), OutputTokens: make([]int, 10),
+	active1 := &Request{ID: "active1", InputTokens: make([]TokenID, 32), OutputTokens: make([]TokenID, 10),
 		ProgressIndex: 32, NumNewTokens: 1, State: StateRunning}
-	active2 := &Request{ID: "active2", InputTokens: make([]int, 16), OutputTokens: make([]int, 5),
+	active2 := &Request{ID: "active2", InputTokens: make([]TokenID, 16), OutputTokens: make([]TokenID, 5),
 		ProgressIndex: 16, NumNewTokens: 1, State: StateRunning}
-	idle := &Request{ID: "idle", InputTokens: make([]int, 64), OutputTokens: make([]int, 20),
+	idle := &Request{ID: "idle", InputTokens: make([]TokenID, 64), OutputTokens: make([]TokenID, 20),
 		ProgressIndex: 64, NumNewTokens: 0, State: StateRunning}
 
 	s.RunningBatch = &Batch{Requests: []*Request{active1, active2, idle}}
@@ -136,9 +136,9 @@ func TestExecuteBatchStep_IdleRequestsPersist_BC3(t *testing.T) {
 		t.Fatalf("NewSimulator: %v", err)
 	}
 
-	active := &Request{ID: "active", InputTokens: make([]int, 32), OutputTokens: make([]int, 10),
+	active := &Request{ID: "active", InputTokens: make([]TokenID, 32), OutputTokens: make([]TokenID, 10),
 		ProgressIndex: 32, NumNewTokens: 1, State: StateRunning}
-	idle := &Request{ID: "idle", InputTokens: make([]int, 64), OutputTokens: make([]int, 20),
+	idle := &Request{ID: "idle", InputTokens: make([]TokenID, 64), OutputTokens: make([]TokenID, 20),
 		ProgressIndex: 64, NumNewTokens: 0, State: StateRunning}
 
 	s.RunningBatch = &Batch{Requests: []*Request{active, idle}}
@@ -706,8 +706,8 @@ func TestInjectArrival_RequestCompletes(t *testing.T) {
 	req := &Request{
 		ID:           "request_0",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	}
 
@@ -734,8 +734,8 @@ func TestInjectArrival_HandledByEmpty_StandaloneMode(t *testing.T) {
 	req := &Request{
 		ID:           "request_0",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	}
 	sim.InjectArrival(req)
@@ -759,8 +759,8 @@ func TestInjectArrival_MultipleRequests(t *testing.T) {
 		req := &Request{
 			ID:           fmt.Sprintf("request_%d", i),
 			ArrivalTime:  int64(i * 100000),
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]TokenID, 10),
+			OutputTokens: make([]TokenID, 5),
 			State:        StateQueued,
 		}
 		sim.InjectArrival(req)
@@ -806,8 +806,8 @@ func TestStep_KVAllocFailAtCompletion_RequestNotSilentlyDropped(t *testing.T) {
 	req := &Request{
 		ID:           "req-0",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 16), // 1 block worth of prefill
-		OutputTokens: make([]int, 3),  // 3 decode tokens
+		InputTokens:  make([]TokenID, 16), // 1 block worth of prefill
+		OutputTokens: make([]TokenID, 3),  // 3 decode tokens
 		State:        StateQueued,
 	}
 	sim.InjectArrival(req)
@@ -927,8 +927,8 @@ func TestSimulator_RequestConservation_FiniteHorizon_ThreeTermEquation(t *testin
 		sim.InjectArrival(&Request{
 			ID:           fmt.Sprintf("early_%d", i),
 			ArrivalTime:  int64(i * 10000), // 0 to 90,000 ticks (well before 500k horizon)
-			InputTokens:  make([]int, 20),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]TokenID, 20),
+			OutputTokens: make([]TokenID, 5),
 			State:        StateQueued,
 		})
 	}
@@ -938,8 +938,8 @@ func TestSimulator_RequestConservation_FiniteHorizon_ThreeTermEquation(t *testin
 		sim.InjectArrival(&Request{
 			ID:           fmt.Sprintf("late_%d", i),
 			ArrivalTime:  int64(300_000 + i*40_000), // 300,000 to 460,000 (all < 500k horizon)
-			InputTokens:  make([]int, 200),          // large prefill
-			OutputTokens: make([]int, 100),          // many decode tokens
+			InputTokens:  make([]TokenID, 200),          // large prefill
+			OutputTokens: make([]TokenID, 100),          // many decode tokens
 			State:        StateQueued,
 		})
 	}
@@ -1088,8 +1088,8 @@ func TestInjectArrival_BeyondHorizon_Warns(t *testing.T) {
 	}
 	sim := mustNewSimulator(t, cfg)
 	req := &Request{
-		ID: "beyond_horizon", InputTokens: make([]int, 16),
-		OutputTokens: make([]int, 4), ArrivalTime: 2000, State: StateQueued,
+		ID: "beyond_horizon", InputTokens: make([]TokenID, 16),
+		OutputTokens: make([]TokenID, 4), ArrivalTime: 2000, State: StateQueued,
 	}
 	sim.InjectArrival(req) // should not panic
 	// Request is registered (backward compatible)
@@ -1232,7 +1232,7 @@ func TestSimulator_ObservationMethods_MatchDirectAccess(t *testing.T) {
 	// Inject a request and verify QueueDepth
 	req := &Request{
 		ID: "obs-test-1", ArrivalTime: 0,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 		State: StateQueued,
 	}
 	s.InjectArrival(req)
@@ -1268,15 +1268,15 @@ func TestWorkConserving_StepRestartsWhenWaitQNonEmpty(t *testing.T) {
 	// Request A: arrives at t=0
 	s.InjectArrival(&Request{
 		ID: "req-A", ArrivalTime: 0,
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	})
 	// Request B: arrives at t=1 (during A's service time, which is ~6000μs)
 	s.InjectArrival(&Request{
 		ID: "req-B", ArrivalTime: 1,
-		InputTokens:  make([]int, 10),
-		OutputTokens: make([]int, 5),
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	})
 
@@ -1352,7 +1352,7 @@ func TestEnqueueRequest_OversizedInput_DroppedNotEnqueued(t *testing.T) {
 	// AND a request with 200 input tokens (needs ceil(200/16) = 13 blocks > 10 total)
 	oversized := &Request{
 		ID:          "oversized_req",
-		InputTokens: make([]int, 200),
+		InputTokens: make([]TokenID, 200),
 		State:       StateQueued,
 	}
 	// Register it in Metrics.Requests (simulating InjectArrival behavior)
@@ -1406,7 +1406,7 @@ func TestEnqueueRequest_NormalInput_Enqueued(t *testing.T) {
 	// AND a request that fits (100 tokens needs ceil(100/16) = 7 blocks <= 100 total)
 	normal := &Request{
 		ID:          "normal_req",
-		InputTokens: make([]int, 100),
+		InputTokens: make([]TokenID, 100),
 		State:       StateQueued,
 	}
 
@@ -1444,8 +1444,8 @@ func TestEnqueueRequest_MaxModelLen_Exceeded_Dropped(t *testing.T) {
 	// Request: 300 input + 300 budget = 600 > MaxModelLen(512)
 	req := &Request{
 		ID:           "too_long",
-		InputTokens:  make([]int, 300),
-		OutputTokens: make([]int, 300),
+		InputTokens:  make([]TokenID, 300),
+		OutputTokens: make([]TokenID, 300),
 		MaxOutputLen: 300, // client declares output budget
 		State:        StateQueued,
 	}
@@ -1479,8 +1479,8 @@ func TestEnqueueRequest_MaxModelLen_Zero_FallsThroughToKV(t *testing.T) {
 	// Large request that fits KV (100 tokens, 1000 blocks available) but would fail MaxModelLen if it were set
 	req := &Request{
 		ID:           "large_but_fits_kv",
-		InputTokens:  make([]int, 100),
-		OutputTokens: make([]int, 1000),
+		InputTokens:  make([]TokenID, 100),
+		OutputTokens: make([]TokenID, 1000),
 		State:        StateQueued,
 	}
 
@@ -1509,8 +1509,8 @@ func TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary(t *testing.T) {
 	// The control plane still doesn't peek at len(OutputTokens) (INV-9 preserved).
 	reqFits := &Request{
 		ID:           "input_fits_oracle",
-		InputTokens:  make([]int, 200),
-		OutputTokens: make([]int, 1000), // actual output exceeds context, but control plane can't see this
+		InputTokens:  make([]TokenID, 200),
+		OutputTokens: make([]TokenID, 1000), // actual output exceeds context, but control plane can't see this
 		MaxOutputLen: 0,                 // auto-filled to maxModelLen - input = 312
 		State:        StateQueued,
 	}
@@ -1522,8 +1522,8 @@ func TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary(t *testing.T) {
 	// Case 2: MaxOutputLen=0, input exceeds MaxModelLen → dropped
 	reqInputTooBig := &Request{
 		ID:           "input_too_big",
-		InputTokens:  make([]int, 600), // 600 > 512
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]TokenID, 600), // 600 > 512
+		OutputTokens: make([]TokenID, 10),
 		MaxOutputLen: 0,
 		State:        StateQueued,
 	}
@@ -1539,8 +1539,8 @@ func TestEnqueueRequest_MaxOutputLen_OracleKnowledgeBoundary(t *testing.T) {
 	// Case 3: MaxOutputLen=400 (client budget) → total: 200 + 400 = 600 > 512 → dropped
 	reqBudgetExceeds := &Request{
 		ID:           "budget_exceeds",
-		InputTokens:  make([]int, 200),
-		OutputTokens: make([]int, 100), // actual output is 100, but client budget says 400
+		InputTokens:  make([]TokenID, 200),
+		OutputTokens: make([]TokenID, 100), // actual output is 100, but client budget says 400
 		MaxOutputLen: 400,
 		State:        StateQueued,
 	}
@@ -1570,8 +1570,8 @@ func TestEnqueueRequest_InputEqualsMaxModelLen_Dropped(t *testing.T) {
 	// input == MaxModelLen: fills the entire context, no room for output
 	req := &Request{
 		ID:           "exact_boundary",
-		InputTokens:  make([]int, 512), // == MaxModelLen
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]TokenID, 512), // == MaxModelLen
+		OutputTokens: make([]TokenID, 10),
 		State:        StateQueued,
 	}
 	sim.Metrics.Requests[req.ID] = NewRequestMetrics(req, 0)
@@ -1600,8 +1600,8 @@ func TestEnqueueRequest_ExactFit_Accepted(t *testing.T) {
 	// input=200 + budget=312 = 512 == MaxModelLen → exact fit, should be accepted
 	req := &Request{
 		ID:           "exact_fit",
-		InputTokens:  make([]int, 200),
-		OutputTokens: make([]int, 312),
+		InputTokens:  make([]TokenID, 200),
+		OutputTokens: make([]TokenID, 312),
 		MaxOutputLen: 312,
 		State:        StateQueued,
 	}
@@ -1625,8 +1625,8 @@ func TestEnqueueRequest_NegativeMaxOutputLen_Dropped(t *testing.T) {
 
 	req := &Request{
 		ID:           "neg_budget",
-		InputTokens:  make([]int, 100),
-		OutputTokens: make([]int, 50),
+		InputTokens:  make([]TokenID, 100),
+		OutputTokens: make([]TokenID, 50),
 		MaxOutputLen: -1,
 		State:        StateQueued,
 	}
@@ -1661,8 +1661,8 @@ func TestProcessCompletions_RuntimeLengthCap(t *testing.T) {
 	// Create a request with ProgressIndex at MaxModelLen boundary (bypassing enqueue guard)
 	req := &Request{
 		ID:            "length_capped",
-		InputTokens:   make([]int, 50),
-		OutputTokens:  make([]int, 200), // would normally be longer than MaxModelLen
+		InputTokens:   make([]TokenID, 50),
+		OutputTokens:  make([]TokenID, 200), // would normally be longer than MaxModelLen
 		State:         StateRunning,
 		ProgressIndex: 100, // == MaxModelLen → should be force-completed
 		ArrivalTime:   0,
@@ -1956,16 +1956,16 @@ func TestSimulator_OversizedRequests_TerminatesNoLivelock(t *testing.T) {
 	// Request 0: 900 tokens → ceil(900/16) = 57 blocks > 50 → dropped
 	oversized := &Request{
 		ID:           "request_oversized",
-		InputTokens:  make([]int, 900),
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]TokenID, 900),
+		OutputTokens: make([]TokenID, 10),
 		ArrivalTime:  100_000,
 		State:        StateQueued,
 	}
 	// Request 1: 100 tokens → ceil(100/16) = 7 blocks <= 50 → fits
 	normal := &Request{
 		ID:           "request_normal",
-		InputTokens:  make([]int, 100),
-		OutputTokens: make([]int, 10),
+		InputTokens:  make([]TokenID, 100),
+		OutputTokens: make([]TokenID, 10),
 		ArrivalTime:  200_000,
 		State:        StateQueued,
 	}
@@ -2023,8 +2023,8 @@ func TestSimulator_AllOversized_TerminatesEmpty(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		req := &Request{
 			ID:           fmt.Sprintf("request_%d", i),
-			InputTokens:  make([]int, 200),
-			OutputTokens: make([]int, 10),
+			InputTokens:  make([]TokenID, 200),
+			OutputTokens: make([]TokenID, 10),
 			ArrivalTime:  int64(i) * 100_000,
 			State:        StateQueued,
 		}
@@ -2062,8 +2062,8 @@ func TestRequestLifecycle_ValidTransitions(t *testing.T) {
 
 	req := &Request{
 		ID:           "lifecycle_test",
-		InputTokens:  make([]int, 16),
-		OutputTokens: make([]int, 4),
+		InputTokens:  make([]TokenID, 16),
+		OutputTokens: make([]TokenID, 4),
 		ArrivalTime:  0,
 		State:        StateQueued,
 	}
@@ -2115,8 +2115,8 @@ func TestStep_ZeroOutputTokens_TTFTBeforeE2E(t *testing.T) {
 	req := &Request{
 		ID:           "zero-output",
 		ArrivalTime:  0,
-		InputTokens:  make([]int, 10),
-		OutputTokens: []int{}, // zero output tokens
+		InputTokens:  make([]TokenID, 10),
+		OutputTokens: []TokenID{}, // zero output tokens
 		State:        StateQueued,
 	}
 	sim.InjectArrival(req)
@@ -2289,8 +2289,8 @@ func TestEnqueueRequest_AutoFill_MaxOutputLen(t *testing.T) {
 
 			req := &Request{
 				ID:           "test-req",
-				InputTokens:  make([]int, tc.inputLen),
-				OutputTokens: make([]int, 100),
+				InputTokens:  make([]TokenID, tc.inputLen),
+				OutputTokens: make([]TokenID, 100),
 				MaxOutputLen: tc.initialMOL,
 				State:        StateQueued,
 			}
@@ -2408,8 +2408,8 @@ func TestProcessCompletions_LengthCapped_MetricsRefreshed(t *testing.T) {
 
 	req := &Request{
 		ID:            "capped",
-		InputTokens:   make([]int, 50),
-		OutputTokens:  make([]int, 200),
+		InputTokens:   make([]TokenID, 50),
+		OutputTokens:  make([]TokenID, 200),
 		State:         StateRunning,
 		ProgressIndex: 99, // >= maxModelLen-1 (100-1=99) → BC-5 fires
 		ArrivalTime:   0,
@@ -2445,8 +2445,8 @@ func TestRecordRequestCompletion_LengthCapped_ITL(t *testing.T) {
 	// 200 pre-determined output tokens, but only 3 actual decode steps (ITL entries)
 	req := &Request{
 		ID:             "capped_itl",
-		InputTokens:    make([]int, 50),
-		OutputTokens:   make([]int, 200),
+		InputTokens:    make([]TokenID, 50),
+		OutputTokens:   make([]TokenID, 200),
 		State:          StateCompleted,
 		LengthCapped:   true,
 		ArrivalTime:    0,
@@ -2479,8 +2479,8 @@ func TestRecordRequestCompletion_NormalRequest_ITL(t *testing.T) {
 
 	req := &Request{
 		ID:             "normal",
-		InputTokens:    make([]int, 50),
-		OutputTokens:   make([]int, 10),
+		InputTokens:    make([]TokenID, 50),
+		OutputTokens:   make([]TokenID, 10),
 		State:          StateCompleted,
 		ArrivalTime:    0,
 		FirstTokenTime: 10000,
@@ -2519,7 +2519,7 @@ func TestSimulator_Conservation_FiveTermWithTimeout(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		sim.InjectArrival(&Request{
 			ID: fmt.Sprintf("normal_%d", i), ArrivalTime: int64(i * 5000),
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 			MaxOutputLen: 5, State: StateQueued,
 		})
 		injectedCount++
@@ -2529,7 +2529,7 @@ func TestSimulator_Conservation_FiveTermWithTimeout(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		sim.InjectArrival(&Request{
 			ID: fmt.Sprintf("timeout_%d", i), ArrivalTime: int64(i * 5000),
-			InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+			InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 			MaxOutputLen: 5, State: StateQueued,
 			Deadline: int64(i*5000 + 3000), // short deadline
 		})
@@ -2540,7 +2540,7 @@ func TestSimulator_Conservation_FiveTermWithTimeout(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		sim.InjectArrival(&Request{
 			ID: fmt.Sprintf("dropped_%d", i), ArrivalTime: int64(i * 5000),
-			InputTokens: make([]int, 100), OutputTokens: make([]int, 5), // 100 tokens > 5 blocks * 16 = 80
+			InputTokens: make([]TokenID, 100), OutputTokens: make([]TokenID, 5), // 100 tokens > 5 blocks * 16 = 80
 			MaxOutputLen: 5, State: StateQueued,
 		})
 		injectedCount++
@@ -2593,7 +2593,7 @@ func TestSimulator_Timeout_KVConservation(t *testing.T) {
 	// Request with short deadline — will start running but timeout before completing
 	sim.InjectArrival(&Request{
 		ID: "timeout_kv", ArrivalTime: 0,
-		InputTokens: make([]int, 50), OutputTokens: make([]int, 100),
+		InputTokens: make([]TokenID, 50), OutputTokens: make([]TokenID, 100),
 		MaxOutputLen: 100, State: StateQueued,
 		Deadline: 20000, // timeout at 20ms — step time is 5ms per step, not enough for 100 output tokens
 	})
@@ -2636,8 +2636,8 @@ func TestEnqueueDecodeSubRequest_StepEventAtClusterTime(t *testing.T) {
 	const clusterTime = int64(50000)
 	req := &Request{
 		ID:            "dec-1",
-		InputTokens:   make([]int, 10),
-		OutputTokens:  make([]int, 5),
+		InputTokens:   make([]TokenID, 10),
+		OutputTokens:  make([]TokenID, 5),
 		State:         StateQueued,
 		ArrivalTime:   clusterTime,
 		ProgressIndex: 10, // KV pre-allocated past input (as done by AllocateTransferredKV)
@@ -2681,7 +2681,7 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 	// Advance the simulator's internal clock by processing a real request.
 	s.InjectArrival(&Request{
 		ID: "req-advance", ArrivalTime: 0,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 		State: StateQueued,
 	})
 	s.Run()
@@ -2698,7 +2698,7 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 	// Advance s2's clock by processing an arrival event.
 	s2.InjectArrival(&Request{
 		ID: "req-prime", ArrivalTime: 0,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 		State: StateQueued,
 	})
 	for s2.HasPendingEvents() {
@@ -2717,8 +2717,8 @@ func TestEnqueueDecodeSubRequest_SimClockAhead_StepEventAtSimClock(t *testing.T)
 
 	req := &Request{
 		ID:            "dec-behind",
-		InputTokens:   make([]int, 10),
-		OutputTokens:  make([]int, 5),
+		InputTokens:   make([]TokenID, 10),
+		OutputTokens:  make([]TokenID, 5),
 		State:         StateQueued,
 		ArrivalTime:   clusterTime,
 		ProgressIndex: 10,
@@ -2775,19 +2775,19 @@ func TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption(t *testing.T) 
 	s := mustNewSimulator(t, cfg)
 
 	// Distinct non-zero token slices prevent prefix-cache sharing between A and B.
-	bInput := make([]int, 32)
+	bInput := make([]TokenID, 32)
 	for i := range bInput {
-		bInput[i] = i + 1
+		bInput[i] = TokenID(i + 1)
 	}
-	aInput := make([]int, 16)
+	aInput := make([]TokenID, 16)
 	for i := range aInput {
-		aInput[i] = 1000 + i
+		aInput[i] = TokenID(1000 + i)
 	}
 
 	// B injected first → WaitQ front → running batch head (index 0), never evicted.
 	// A injected second → running batch tail (index 1), eviction candidate.
-	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]int, 5)})
-	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]int, 5)})
+	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]TokenID, 5)})
+	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]TokenID, 5)})
 
 	for s.HasPendingEvents() {
 		s.ProcessNextEvent()
@@ -2834,17 +2834,17 @@ func TestSimulator_ITL_NoDuplicateEntriesAfterPreemption(t *testing.T) {
 	}
 	s := mustNewSimulator(t, cfg)
 
-	bInput := make([]int, 32)
+	bInput := make([]TokenID, 32)
 	for i := range bInput {
-		bInput[i] = i + 1
+		bInput[i] = TokenID(i + 1)
 	}
-	aInput := make([]int, 16)
+	aInput := make([]TokenID, 16)
 	for i := range aInput {
-		aInput[i] = 1000 + i
+		aInput[i] = TokenID(1000 + i)
 	}
 
-	bOutput := make([]int, 5)
-	aOutput := make([]int, 5)
+	bOutput := make([]TokenID, 5)
+	aOutput := make([]TokenID, 5)
 	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: bOutput})
 	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: aOutput})
 
@@ -2883,17 +2883,17 @@ func TestSimulator_TTFTSum_NoDoubleCountAfterPreemption(t *testing.T) {
 	}
 	s := mustNewSimulator(t, cfg)
 
-	bInput := make([]int, 32)
+	bInput := make([]TokenID, 32)
 	for i := range bInput {
-		bInput[i] = i + 1
+		bInput[i] = TokenID(i + 1)
 	}
-	aInput := make([]int, 16)
+	aInput := make([]TokenID, 16)
 	for i := range aInput {
-		aInput[i] = 1000 + i
+		aInput[i] = TokenID(1000 + i)
 	}
 
-	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]int, 5)})
-	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]int, 5)})
+	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]TokenID, 5)})
+	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]TokenID, 5)})
 
 	for s.HasPendingEvents() {
 		s.ProcessNextEvent()
@@ -3032,14 +3032,14 @@ func TestSimulator_TTFT_UpdatedAfterPreemption(t *testing.T) {
 		ID:           "A",
 		ArrivalTime:  0,
 		InputTokens:  GenerateRandomTokenIDs(s.WorkloadRNG(), 16),
-		OutputTokens: make([]int, 5),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	}
 	reqB := &Request{
 		ID:           "B",
 		ArrivalTime:  0,
 		InputTokens:  GenerateRandomTokenIDs(s.WorkloadRNG(), 32),
-		OutputTokens: make([]int, 5),
+		OutputTokens: make([]TokenID, 5),
 		State:        StateQueued,
 	}
 	s.InjectArrival(reqA)
@@ -3106,7 +3106,7 @@ func TestEnqueueRequest_SetsVLLMConventionPriority(t *testing.T) {
 			req := &Request{
 				ID:          "r1",
 				SLOClass:    tt.sloClass,
-				InputTokens: make([]int, 10),
+				InputTokens: make([]TokenID, 10),
 				ArrivalTime: 1,
 			}
 			s.EnqueueRequest(req)
@@ -3133,7 +3133,7 @@ func TestSimulator_PriorityIsStatic_NotRecomputedEachStep(t *testing.T) {
 	req := &Request{
 		ID:          "r1",
 		SLOClass:    "critical",
-		InputTokens: make([]int, 10),
+		InputTokens: make([]TokenID, 10),
 		ArrivalTime: 1,
 	}
 	s.EnqueueRequest(req)
@@ -3177,8 +3177,8 @@ func TestEnqueueDecodeSubRequest_SetsVLLMConventionPriority(t *testing.T) {
 			req := &Request{
 				ID:            "decode-r1",
 				SLOClass:      tt.sloClass,
-				InputTokens:   make([]int, 10),
-				OutputTokens:  make([]int, 5),
+				InputTokens:   make([]TokenID, 10),
+				OutputTokens:  make([]TokenID, 5),
 				ProgressIndex: 10, // already past prefill (decode-only)
 				ArrivalTime:   1,
 			}

--- a/sim/test_helpers_test.go
+++ b/sim/test_helpers_test.go
@@ -30,7 +30,7 @@ func testGenerateRequests(seed, horizon int64, rate float64,
 	for currentTime < horizon && reqIdx < numReqs {
 		promptLen := generateLengthGauss(workloadRNG, pMean, pStd, pMin, pMax)
 		prompt := GenerateRandomTokenIDs(workloadRNG, promptLen)
-		input := append(append([]int{}, prefixTokens...), prompt...)
+		input := append(append([]TokenID{}, prefixTokens...), prompt...)
 
 		outputLen := generateLengthGauss(workloadRNG, oMean, oStd, oMin, oMax)
 		output := GenerateRandomTokenIDs(workloadRNG, outputLen)

--- a/sim/timeout_test.go
+++ b/sim/timeout_test.go
@@ -78,8 +78,8 @@ func TestTimeout_QueuedRequest_TimesOut(t *testing.T) {
 	sim := mustNewSimulator(t, cfg)
 
 	// Two requests: r1 arrives at 0 (will run), r2 arrives at 0 with short deadline (will timeout while queued)
-	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]int, 10), OutputTokens: make([]int, 100), State: StateQueued, MaxOutputLen: 100}
-	r2 := &Request{ID: "r2", ArrivalTime: 0, InputTokens: make([]int, 10), OutputTokens: make([]int, 100), State: StateQueued, MaxOutputLen: 100, Deadline: 5000} // timeout at tick 5000
+	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 100), State: StateQueued, MaxOutputLen: 100}
+	r2 := &Request{ID: "r2", ArrivalTime: 0, InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 100), State: StateQueued, MaxOutputLen: 100, Deadline: 5000} // timeout at tick 5000
 
 	sim.InjectArrival(r1)
 	sim.InjectArrival(r2)
@@ -112,7 +112,7 @@ func TestTimeout_CompletedRequest_NoOp(t *testing.T) {
 	sim := mustNewSimulator(t, cfg)
 
 	// One request with a deadline far in the future — will complete normally
-	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]int, 10), OutputTokens: make([]int, 5), State: StateQueued, MaxOutputLen: 5, Deadline: 999_999}
+	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5), State: StateQueued, MaxOutputLen: 5, Deadline: 999_999}
 
 	sim.InjectArrival(r1)
 	sim.Run()
@@ -145,7 +145,7 @@ func TestTimeout_CompletionWinsAtEqualTimestamp(t *testing.T) {
 	// Request with 1 input token, 1 output token. Step time = 1000µs.
 	// Prefill step at t=0 completes at t=1000. Decode step at t=1000 completes at t=2000.
 	// Set deadline = 2000 (same tick as completion).
-	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]int, 1), OutputTokens: make([]int, 1), State: StateQueued, MaxOutputLen: 1, Deadline: 2000}
+	r1 := &Request{ID: "r1", ArrivalTime: 0, InputTokens: make([]TokenID, 1), OutputTokens: make([]TokenID, 1), State: StateQueued, MaxOutputLen: 1, Deadline: 2000}
 
 	sim.InjectArrival(r1)
 	sim.Run()
@@ -213,7 +213,7 @@ func TestTimeout_RunningRequest_StateAndBatchCleanup(t *testing.T) {
 	// Single request: will start running, then timeout before completing
 	r1 := &Request{
 		ID: "r1", ArrivalTime: 0,
-		InputTokens: make([]int, 50), OutputTokens: make([]int, 100),
+		InputTokens: make([]TokenID, 50), OutputTokens: make([]TokenID, 100),
 		MaxOutputLen: 100, State: StateQueued,
 		Deadline: 15000, // times out at 15ms — only ~2 decode steps complete
 	}
@@ -252,14 +252,14 @@ func TestTimeout_PreemptThenTimeout_SafeNoOp(t *testing.T) {
 	// r1: large request that will cause KV pressure and preempt r2
 	r1 := &Request{
 		ID: "r1", ArrivalTime: 0,
-		InputTokens: make([]int, 60), OutputTokens: make([]int, 10),
+		InputTokens: make([]TokenID, 60), OutputTokens: make([]TokenID, 10),
 		MaxOutputLen: 10, State: StateQueued,
 	}
 	// r2: small request with short deadline — will be preempted by r1's KV demand,
 	// then timeout while back in queue
 	r2 := &Request{
 		ID: "r2", ArrivalTime: 0,
-		InputTokens: make([]int, 30), OutputTokens: make([]int, 5),
+		InputTokens: make([]TokenID, 30), OutputTokens: make([]TokenID, 5),
 		MaxOutputLen: 5, State: StateQueued,
 		Deadline: 10000, // short deadline
 	}
@@ -309,7 +309,7 @@ func TestTimeout_OrphanedTimeout_DoesNotInflateSimEndedTime(t *testing.T) {
 
 	r1 := &Request{
 		ID: "r1", ArrivalTime: 0,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]TokenID, 10), OutputTokens: make([]TokenID, 5),
 		State: StateQueued, MaxOutputLen: 5,
 		Deadline: testDefaultTimeoutUs,
 	}
@@ -370,8 +370,8 @@ func TestTimeout_OrphanedTimeout_MultipleOrphans_NoneInflateClock(t *testing.T) 
 		requests[i] = &Request{
 			ID:           fmt.Sprintf("r%d", i),
 			ArrivalTime:  arrivalTime,
-			InputTokens:  make([]int, 10),
-			OutputTokens: make([]int, 5),
+			InputTokens:  make([]TokenID, 10),
+			OutputTokens: make([]TokenID, 5),
 			State:        StateQueued,
 			MaxOutputLen: 5,
 			Deadline:     arrivalTime + testDefaultTimeoutUs,
@@ -465,8 +465,8 @@ func TestTimeout_CascadeDoesNotCreateOrphanedStepEvents(t *testing.T) {
 		sim.InjectArrival(&Request{
 			ID:           fmt.Sprintf("r%d", i),
 			ArrivalTime:  0,
-			InputTokens:  make([]int, inputLen),
-			OutputTokens: make([]int, outputLen),
+			InputTokens:  make([]TokenID, inputLen),
+			OutputTokens: make([]TokenID, outputLen),
 			MaxOutputLen: outputLen,
 			State:        StateQueued,
 			Deadline:     deadline,

--- a/sim/workload/client.go
+++ b/sim/workload/client.go
@@ -98,8 +98,8 @@ func windowsOverlap(a, b *LifecycleSpec) bool {
 // Clients in the same group get the same prefix tokens. The length is determined
 // by the first client in the group that specifies prefix_length; others in the
 // same group inherit it. If no client specifies prefix_length, defaultPrefixLength is used.
-func generatePrefixTokens(clients []ClientSpec, rng *rand.Rand) map[string][]int {
-	prefixes := make(map[string][]int)
+func generatePrefixTokens(clients []ClientSpec, rng *rand.Rand) map[string][]sim.TokenID {
+	prefixes := make(map[string][]sim.TokenID)
 	for i := range clients {
 		group := clients[i].PrefixGroup
 		if group == "" {

--- a/sim/workload/distribution_test.go
+++ b/sim/workload/distribution_test.go
@@ -693,7 +693,7 @@ func TestParseThinkTimeDist_Lognormal_INV10_SessionCausality(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "inv10-test", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	completionTick := int64(100_000)
 	follow := sm.OnComplete(req0, completionTick)

--- a/sim/workload/generator.go
+++ b/sim/workload/generator.go
@@ -143,7 +143,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 		}
 
 		// Get prefix for this client's group
-		var prefix []int
+		var prefix []sim.TokenID
 		if client.PrefixGroup != "" {
 			prefix = prefixes[client.PrefixGroup]
 		}
@@ -190,7 +190,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				// double-prepend with context accumulation.
 				if len(prefix) > 0 {
 					for _, req := range reasoningReqs {
-						req.InputTokens = append(append([]int{}, prefix...), req.InputTokens...)
+						req.InputTokens = append(append([]sim.TokenID{}, prefix...), req.InputTokens...)
 						req.PrefixLength = len(prefix)
 					}
 				}
@@ -248,7 +248,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				// Prepend shared prefix to each round's input (BC-2, #516)
 				if len(prefix) > 0 {
 					for _, req := range reasoningReqs {
-						req.InputTokens = append(append([]int{}, prefix...), req.InputTokens...)
+						req.InputTokens = append(append([]sim.TokenID{}, prefix...), req.InputTokens...)
 						req.PrefixLength = len(prefix)
 					}
 				}
@@ -303,8 +303,8 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 				continue
 			}
 
-			var inputTokens []int
-			var outputTokens []int
+			var inputTokens []sim.TokenID
+			var outputTokens []sim.TokenID
 			var textCount, imageCount, audioCount, videoCount int
 
 			if client.Multimodal != nil {
@@ -326,7 +326,7 @@ func GenerateRequests(spec *WorkloadSpec, horizon int64, maxRequests int64) ([]*
 
 			var prefixLength int
 			if len(prefix) > 0 {
-				inputTokens = append(append([]int{}, prefix...), inputTokens...)
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
 				prefixLength = len(prefix)
 			}
 
@@ -459,13 +459,13 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 		// to pass to the SessionBlueprint for follow-up round generation.
 		// Match by ClientID to avoid conflating clients that share TenantID/SLOClass
 		// (e.g. all stages in a multi-stage workload share the same prefixGroup TenantID).
-		var prefixTokens []int
+		var prefixTokens []sim.TokenID
 		if client.PrefixGroup != "" && client.PrefixLength > 0 {
 			for _, req := range reqs {
 				if req.SessionID != "" && req.RoundIndex == 0 && req.ClientID == client.ID {
 					// The first PrefixLength tokens of InputTokens are the prefix
 					if len(req.InputTokens) >= client.PrefixLength {
-						prefixTokens = make([]int, client.PrefixLength)
+						prefixTokens = make([]sim.TokenID, client.PrefixLength)
 						copy(prefixTokens, req.InputTokens[:client.PrefixLength])
 					}
 					break
@@ -576,7 +576,7 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 			return nil, fmt.Errorf("client %q output distribution: %w", client.ID, err)
 		}
 
-		var prefix []int
+		var prefix []sim.TokenID
 		if client.PrefixGroup != "" {
 			prefix = prefixes[client.PrefixGroup]
 		}
@@ -605,7 +605,7 @@ func GenerateWorkload(spec *WorkloadSpec, horizon int64, maxRequests int64) (*Ge
 
 			var prefixLength int
 			if len(prefix) > 0 {
-				inputTokens = append(append([]int{}, prefix...), inputTokens...)
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
 				prefixLength = len(prefix)
 			}
 
@@ -865,7 +865,7 @@ func generateRequestsForWindow(
 	allClients []ClientSpec,
 	aggregateRate float64,
 	rng *rand.Rand,
-	prefix []int,
+	prefix []sim.TokenID,
 ) ([]*sim.Request, error) {
 	// Step 1: Resolve parameters with fallback to client-level defaults.
 	arrival, inputDist, outputDist, _ := resolveWindowParameters(client, window)
@@ -943,7 +943,7 @@ func generateRequestsForWindow(
 			// BC-2: Prepend shared prefix to each round's input
 			if len(prefix) > 0 {
 				for _, req := range reasoningReqs {
-					req.InputTokens = append(append([]int{}, prefix...), req.InputTokens...)
+					req.InputTokens = append(append([]sim.TokenID{}, prefix...), req.InputTokens...)
 					req.PrefixLength = len(prefix)
 				}
 			}
@@ -989,7 +989,7 @@ func generateRequestsForWindow(
 			// BC-2: Prepend shared prefix to each round's input
 			if len(prefix) > 0 {
 				for _, req := range reasoningReqs {
-					req.InputTokens = append(append([]int{}, prefix...), req.InputTokens...)
+					req.InputTokens = append(append([]sim.TokenID{}, prefix...), req.InputTokens...)
 					req.PrefixLength = len(prefix)
 				}
 			}

--- a/sim/workload/generator_test.go
+++ b/sim/workload/generator_test.go
@@ -3039,7 +3039,7 @@ func TestGenerateRequestsForWindow_ReasoningWithPrefix(t *testing.T) {
 	// BC-2: Prefix prepending in time-varying reasoning
 	rng := rand.New(rand.NewSource(12345))
 
-	prefixTokens := []int{999, 888, 777} // 3-token shared prefix
+	prefixTokens := []sim.TokenID{999, 888, 777} // 3-token shared prefix
 
 	client := ClientSpec{
 		ID:           "reasoning-client-with-prefix",

--- a/sim/workload/multimodal.go
+++ b/sim/workload/multimodal.go
@@ -10,7 +10,7 @@ import (
 // GenerateMultimodalTokens generates input tokens for a multimodal request.
 // Returns the combined input tokens, per-modality counts, and any error.
 // Total input = text + image*imageCount + audio*audioCount + video*videoCount.
-func GenerateMultimodalTokens(rng *rand.Rand, mm *MultimodalSpec) ([]int, int, int, int, int, error) {
+func GenerateMultimodalTokens(rng *rand.Rand, mm *MultimodalSpec) ([]sim.TokenID, int, int, int, int, error) {
 	textLen := 0
 	imageLen := 0
 	audioLen := 0

--- a/sim/workload/reasoning.go
+++ b/sim/workload/reasoning.go
@@ -39,7 +39,7 @@ func GenerateReasoningRequests(
 	sessionID := fmt.Sprintf("sess_%d", rng.Int63())
 	var requests []*sim.Request
 	currentTime := startTime
-	var contextPrefix []int // accumulated context from prior rounds (actual tokens)
+	var contextPrefix []sim.TokenID // accumulated context from prior rounds (actual tokens)
 
 	for round := 0; round < mt.MaxRounds; round++ {
 		inputLen := inputSampler.Sample(rng)
@@ -50,9 +50,9 @@ func GenerateReasoningRequests(
 		outputTokens := sim.GenerateRandomTokenIDs(rng, outputLen)
 
 		// Build input: prepend accumulated context if accumulating
-		var inputTokens []int
+		var inputTokens []sim.TokenID
 		if mt.ContextGrowth == "accumulate" && round > 0 {
-			inputTokens = append(append([]int{}, contextPrefix...), newInputTokens...)
+			inputTokens = append(append([]sim.TokenID{}, contextPrefix...), newInputTokens...)
 		} else {
 			inputTokens = newInputTokens
 		}

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -59,7 +59,7 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 	rng := rand.New(rand.NewSource(seed))
 
 	// Generate shared prefix tokens per prefix group using trace-specified length
-	prefixTokens := make(map[string][]int)
+	prefixTokens := make(map[string][]sim.TokenID)
 	for _, rec := range trace.Records {
 		if rec.PrefixGroup != "" && rec.PrefixLength > 0 {
 			if _, exists := prefixTokens[rec.PrefixGroup]; !exists {
@@ -76,7 +76,7 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 		// Prepend prefix if in a group
 		if rec.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[rec.PrefixGroup]; ok {
-				inputTokens = append(append([]int{}, prefix...), inputTokens...)
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
 			}
 		}
 
@@ -139,7 +139,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	rng := rand.New(rand.NewSource(seed))
 
 	// Generate shared prefix tokens per prefix group (same as LoadTraceV2Requests)
-	prefixTokens := make(map[string][]int)
+	prefixTokens := make(map[string][]sim.TokenID)
 	for _, rec := range trace.Records {
 		if rec.PrefixGroup != "" && rec.PrefixLength > 0 {
 			if _, exists := prefixTokens[rec.PrefixGroup]; !exists {
@@ -227,12 +227,12 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		inputTokens := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(r0.InputTokens, r0.ServerInputTokens, r0.PrefixGroup))
 		if r0.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[r0.PrefixGroup]; ok {
-				inputTokens = append(append([]int{}, prefix...), inputTokens...)
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
 			}
 		}
 		outputTokens := sim.GenerateRandomTokenIDs(sessionRNG, r0.OutputTokens)
 
-		var prefix []int
+		var prefix []sim.TokenID
 		if r0.PrefixGroup != "" {
 			prefix = prefixTokens[r0.PrefixGroup]
 		}
@@ -287,7 +287,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		inputTokens := sim.GenerateRandomTokenIDs(rng, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
 		if rec.PrefixGroup != "" {
 			if prefix, ok := prefixTokens[rec.PrefixGroup]; ok {
-				inputTokens = append(append([]int{}, prefix...), inputTokens...)
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
 			}
 		}
 		outputTokens := sim.GenerateRandomTokenIDs(rng, rec.OutputTokens)

--- a/sim/workload/saturation_test.go
+++ b/sim/workload/saturation_test.go
@@ -778,8 +778,8 @@ func generateSyntheticRequestsWithHorizon(arrivalRate float64, numRequests int) 
 			TTFTSet:        state == sim.StateCompleted,
 			ITL:            itl,
 			State:          state,
-			InputTokens:    make([]int, 100),
-			OutputTokens:   make([]int, 50),
+			InputTokens:    make([]sim.TokenID, 100),
+			OutputTokens:   make([]sim.TokenID, 50),
 		}
 		requests[i] = req
 	}
@@ -854,8 +854,8 @@ func TestSaturationClassification_ManualScenarios(t *testing.T) {
 				TTFTSet:        true,
 				ITL:            []int64{(completionUs - arrivalUs) / 2},
 				State:          sim.StateCompleted,
-				InputTokens:    []int{0},
-				OutputTokens:   []int{0},
+				InputTokens:    []sim.TokenID{0},
+				OutputTokens:   []sim.TokenID{0},
 			})
 		}
 
@@ -913,8 +913,8 @@ func TestSaturationClassification_ManualScenarios(t *testing.T) {
 				TTFTSet:        ttftSet,
 				ITL:            itl,
 				State:          state,
-				InputTokens:    []int{0},
-				OutputTokens:   []int{0},
+				InputTokens:    []sim.TokenID{0},
+				OutputTokens:   []sim.TokenID{0},
 			})
 		}
 
@@ -944,8 +944,8 @@ func createManualRequests(timings []requestTiming) []*sim.Request {
 			TTFTSet:        true,
 			ITL:            []int64{ttft / 2},
 			State:          sim.StateCompleted,
-			InputTokens:    []int{0},
-			OutputTokens:   []int{0},
+			InputTokens:    []sim.TokenID{0},
+			OutputTokens:   []sim.TokenID{0},
 		}
 	}
 	return requests
@@ -1110,8 +1110,8 @@ func generateTestWorkload(rate float64, numRequests int, horizonUs int64) []*sim
 			TTFTSet:        ttftSet,
 			ITL:            itl,
 			State:          state,
-			InputTokens:    make([]int, 100),
-			OutputTokens:   make([]int, 50),
+			InputTokens:    make([]sim.TokenID, 100),
+			OutputTokens:   make([]sim.TokenID, 50),
 		})
 	}
 

--- a/sim/workload/session.go
+++ b/sim/workload/session.go
@@ -39,7 +39,7 @@ type SessionBlueprint struct {
 	OutputSampler    LengthSampler
 	RNG              *rand.Rand    // per-session, seeded deterministically from client RNG
 	ThinkTimeSampler LengthSampler // optional: per-round think time in µs; nil = use constant ThinkTimeUs
-	Prefix           []int         // shared system prompt tokens
+	Prefix           []sim.TokenID // shared system prompt tokens
 	TenantID         string
 	SLOClass         string
 	Model            string
@@ -50,7 +50,7 @@ type SessionBlueprint struct {
 type activeSession struct {
 	blueprint     *SessionBlueprint
 	currentRound  int
-	contextTokens []int // accumulated input + output from prior rounds
+	contextTokens []sim.TokenID // accumulated input + output from prior rounds
 	state         sessionState
 }
 
@@ -172,7 +172,7 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 	// For length-capped requests, ProgressIndex - len(InputTokens) gives actual output count.
 	actualOutputLen := max(int(req.ProgressIndex)-len(req.InputTokens), 0)
 
-	var inputTokens []int
+	var inputTokens []sim.TokenID
 	if bp.ContextGrowth == "accumulate" {
 		// contextTokens is prefix-free (invariant: GenerateReasoningRequests accumulates
 		// raw newInputTokens, never the prefix; generator.go warns about double-prepend).
@@ -202,14 +202,14 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 			}
 			sess.contextTokens = append(sess.contextTokens, outTokens...)
 		}
-		inputTokens = append(append([]int{}, sess.contextTokens...), newInputTokens...)
+		inputTokens = append(append([]sim.TokenID{}, sess.contextTokens...), newInputTokens...)
 	} else {
 		inputTokens = newInputTokens
 	}
 
 	// Prepend prefix
 	if len(bp.Prefix) > 0 {
-		inputTokens = append(append([]int{}, bp.Prefix...), inputTokens...)
+		inputTokens = append(append([]sim.TokenID{}, bp.Prefix...), inputTokens...)
 	}
 
 	sess.currentRound++

--- a/sim/workload/session_test.go
+++ b/sim/workload/session_test.go
@@ -41,7 +41,7 @@ func TestSession_RoundGeneration_CorrectArrivalTime(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess1", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15, // 10 input + 5 output
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req0, 5000)
@@ -69,7 +69,7 @@ func TestSession_TimeoutCancels_NoMoreRounds(t *testing.T) {
 	req := &sim.Request{
 		ID: "r2", SessionID: "sess2", RoundIndex: 2,
 		State: sim.StateTimedOut,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req, 10000)
@@ -81,7 +81,7 @@ func TestSession_TimeoutCancels_NoMoreRounds(t *testing.T) {
 	req2 := &sim.Request{
 		ID: "r2b", SessionID: "sess2", RoundIndex: 2,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow2 := sm.OnComplete(req2, 11000)
 	if follow2 != nil {
@@ -190,7 +190,7 @@ func TestSession_ContextAccumulation_WithPrefix(t *testing.T) {
 
 	// Round 0: InputTokens = [prefix(5) | content(10)] = 15 tokens, actual output = 5
 	content0 := sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(8)), 10)
-	inputR0 := append(append([]int{}, bp.Prefix...), content0...)
+	inputR0 := append(append([]sim.TokenID{}, bp.Prefix...), content0...)
 	outputR0 := sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(9)), 5)
 
 	req0 := &sim.Request{
@@ -235,7 +235,7 @@ func TestSession_ContextAccumulation_WithPrefix_MultiStep(t *testing.T) {
 	sm := NewSessionManager([]SessionBlueprint{bp})
 
 	// Round 0: [prefix(5) | content(10)] = 15 tokens, actual output = 5
-	inputR0 := append(append([]int{}, bp.Prefix...), sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(11)), 10)...)
+	inputR0 := append(append([]sim.TokenID{}, bp.Prefix...), sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(11)), 10)...)
 	outputR0 := sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(12)), 5)
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess-prefix-multi", RoundIndex: 0,
@@ -281,7 +281,7 @@ func TestSession_ContextAccumulation_WithPrefix_PrefixOnly(t *testing.T) {
 
 	// Round 0: InputTokens = prefix only (no conversation content), actual output = 5
 	// This exercises the edge case where len(rawConversation) == 0.
-	inputR0 := append([]int{}, bp.Prefix...) // InputTokens == Prefix exactly
+	inputR0 := append([]sim.TokenID{}, bp.Prefix...) // InputTokens == Prefix exactly
 	outputR0 := sim.GenerateRandomTokenIDs(rand.New(rand.NewSource(14)), 5)
 
 	req0 := &sim.Request{
@@ -319,7 +319,7 @@ func TestSession_ContextAccumulation_ZeroSuffix(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess-zero-suffix", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 5,
-		InputTokens: []int{}, OutputTokens: outputR0,
+		InputTokens:  []sim.TokenID{}, OutputTokens: outputR0,
 	}
 	follow1 := sm.OnComplete(req0, 5000)
 	if len(follow1) != 1 {
@@ -341,7 +341,7 @@ func TestSession_BeyondHorizon_NotGenerated(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess4", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req0, 5500)
@@ -362,7 +362,7 @@ func TestSession_HorizonInterrupted_IsTerminal(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess-hz-term", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	// Next arrival = 5500 + 1000 = 6500 > horizon → horizon-interrupted
 	follow := sm.OnComplete(req0, 5500)
@@ -377,7 +377,7 @@ func TestSession_HorizonInterrupted_IsTerminal(t *testing.T) {
 	req0b := &sim.Request{
 		ID: "r0b", SessionID: "sess-hz-term", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow2 := sm.OnComplete(req0b, 5500)
 	if follow2 != nil {
@@ -395,7 +395,7 @@ func TestSession_DroppedFollowUp_CancelsSession(t *testing.T) {
 	req := &sim.Request{
 		ID: "r1", SessionID: "sess5", RoundIndex: 1,
 		State: sim.StateQueued,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req, 10000)
@@ -415,7 +415,7 @@ func TestSession_LengthCapped_ContinuesSession(t *testing.T) {
 		ID: "r0", SessionID: "sess6", RoundIndex: 0,
 		State: sim.StateCompleted, LengthCapped: true,
 		ProgressIndex: 13, // 10 input + 3 actual output (out of 5 oracle)
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req, 5000)
@@ -437,7 +437,7 @@ func TestSession_FinalRound_Completes(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess7", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow0 := sm.OnComplete(req0, 5000)
 	if len(follow0) != 1 {
@@ -448,7 +448,7 @@ func TestSession_FinalRound_Completes(t *testing.T) {
 	req1 := &sim.Request{
 		ID: "r1", SessionID: "sess7", RoundIndex: 1,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow1 := sm.OnComplete(req1, 7000)
 	if follow1 != nil {
@@ -482,7 +482,7 @@ func TestSession_ThinkTimeSampler_UsedWhenPresent(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "tts1", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req0, 5000)
@@ -505,7 +505,7 @@ func TestSession_ThinkTimeSampler_NilFallsBack(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "tts2", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 
 	follow := sm.OnComplete(req0, 5000)
@@ -537,7 +537,7 @@ func TestSession_UnlimitedRounds_ContinuesPastMaxRounds(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess-unlim", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow := sm.OnComplete(req0, 5000)
 	if len(follow) != 1 {
@@ -556,7 +556,7 @@ func TestSession_FollowUpBudget_StopsWhenExhausted(t *testing.T) {
 	req1 := &sim.Request{
 		ID: "r1-0", SessionID: "sess-b1", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow1 := sm.OnComplete(req1, 5000)
 	if len(follow1) != 1 {
@@ -566,7 +566,7 @@ func TestSession_FollowUpBudget_StopsWhenExhausted(t *testing.T) {
 	req2 := &sim.Request{
 		ID: "r2-0", SessionID: "sess-b2", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow2 := sm.OnComplete(req2, 6000)
 	if len(follow2) != 1 {
@@ -576,7 +576,7 @@ func TestSession_FollowUpBudget_StopsWhenExhausted(t *testing.T) {
 	req1b := &sim.Request{
 		ID: "r1-1", SessionID: "sess-b1", RoundIndex: 1,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow1b := sm.OnComplete(req1b, 8000)
 	if follow1b != nil {
@@ -615,7 +615,7 @@ func TestSession_NoContextAccumulation_FreshTokens(t *testing.T) {
 	req0 := &sim.Request{
 		ID: "r0", SessionID: "sess-fresh", RoundIndex: 0,
 		State: sim.StateCompleted, ProgressIndex: 15,
-		InputTokens: make([]int, 10), OutputTokens: make([]int, 5),
+		InputTokens: make([]sim.TokenID, 10), OutputTokens: make([]sim.TokenID, 5),
 	}
 	follow := sm.OnComplete(req0, 5000)
 	if len(follow) != 1 {

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -614,7 +614,7 @@ func TraceRecordsToRequests(records []TraceRecord) []*sim.Request {
 	for _, rec := range records {
 		req := &sim.Request{
 			ArrivalTime:  rec.ArrivalTimeUs,
-			OutputTokens: []int{rec.OutputTokens},
+			OutputTokens: []sim.TokenID{sim.TokenID(rec.OutputTokens)},
 		}
 
 		// TTFTSet and FirstTokenTime

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -423,7 +423,7 @@ func TestParseTraceRecord_NegativeDeadlineUs_ReturnsError(t *testing.T) {
 }
 
 // TestParseTraceRecord_NegativeInputTokens_ReturnsError verifies R3 for
-// input_tokens (prevents make([]int, negative) panic in replay).
+// input_tokens (prevents make([]sim.TokenID, negative) panic in replay).
 func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 	row := make([]string, 27)
 	for i := range row {
@@ -442,7 +442,7 @@ func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 }
 
 // TestParseTraceRecord_NegativeOutputTokens_ReturnsError verifies R3 for
-// output_tokens (prevents make([]int, negative) panic in replay).
+// output_tokens (prevents make([]sim.TokenID, negative) panic in replay).
 func TestParseTraceRecord_NegativeOutputTokens_ReturnsError(t *testing.T) {
 	row := make([]string, 27)
 	for i := range row {
@@ -618,8 +618,8 @@ func TestRequestMetadataFields(t *testing.T) {
 	req := &sim.Request{
 		ID:             "request_0",
 		State:          sim.StateCompleted,
-		InputTokens:    []int{1, 2, 3},
-		OutputTokens:   []int{4, 5},
+		InputTokens:  []sim.TokenID{1, 2, 3},
+		OutputTokens: []sim.TokenID{4, 5},
 		ArrivalTime:    1000,
 		TTFTSet:        true,
 		FirstTokenTime: 500,
@@ -669,8 +669,8 @@ func TestRequestsToTraceRecords_FieldMapping(t *testing.T) {
 	req := &sim.Request{
 		ID:              "request_0",
 		State:           sim.StateCompleted,
-		InputTokens:     make([]int, 512),
-		OutputTokens:    make([]int, 256),
+		InputTokens:     make([]sim.TokenID, 512),
+		OutputTokens:    make([]sim.TokenID, 256),
 		ProgressIndex:   512 + 256,
 		ArrivalTime:     10000,
 		TTFTSet:         true,
@@ -760,8 +760,8 @@ func TestRequestsToTraceRecords_StatusMapping(t *testing.T) {
 		req := &sim.Request{
 			ID:           "request_0",
 			State:        tc.state,
-			InputTokens:  []int{1},
-			OutputTokens: []int{2},
+			InputTokens:  []sim.TokenID{1},
+			OutputTokens: []sim.TokenID{2},
 		}
 		records := RequestsToTraceRecords([]*sim.Request{req})
 		if records[0].Status != tc.want {
@@ -774,8 +774,8 @@ func TestRequestsToTraceRecords_TimingCausality(t *testing.T) {
 	req := &sim.Request{
 		ID:             "request_0",
 		State:          sim.StateCompleted,
-		InputTokens:    make([]int, 100),
-		OutputTokens:   make([]int, 50),
+		InputTokens:    make([]sim.TokenID, 100),
+		OutputTokens:   make([]sim.TokenID, 50),
 		ArrivalTime:    5000,
 		TTFTSet:        true,
 		FirstTokenTime: 3000,
@@ -800,8 +800,8 @@ func TestRequestsToTraceRecords_PrefillTimeout(t *testing.T) {
 	req := &sim.Request{
 		ID:           "request_0",
 		State:        sim.StateTimedOut,
-		InputTokens:  make([]int, 100),
-		OutputTokens: make([]int, 50),
+		InputTokens:  make([]sim.TokenID, 100),
+		OutputTokens: make([]sim.TokenID, 50),
 		ArrivalTime:  5000,
 		TTFTSet:      false,
 	}
@@ -825,8 +825,8 @@ func TestRequestsToTraceRecords_RecordCount(t *testing.T) {
 		reqs[i] = &sim.Request{
 			ID:           "request_0",
 			State:        sim.StateCompleted,
-			InputTokens:  []int{1},
-			OutputTokens: []int{2},
+			InputTokens:  []sim.TokenID{1},
+			OutputTokens: []sim.TokenID{2},
 		}
 	}
 	records := RequestsToTraceRecords(reqs)
@@ -840,8 +840,8 @@ func TestRequestsToTraceRecords_RoundTrip(t *testing.T) {
 		{
 			ID:             "request_0",
 			State:          sim.StateCompleted,
-			InputTokens:    make([]int, 512),
-			OutputTokens:   make([]int, 128),
+			InputTokens:    make([]sim.TokenID, 512),
+			OutputTokens:   make([]sim.TokenID, 128),
 			ArrivalTime:    1000,
 			TTFTSet:        true,
 			FirstTokenTime: 500,
@@ -855,8 +855,8 @@ func TestRequestsToTraceRecords_RoundTrip(t *testing.T) {
 		{
 			ID:           "request_1",
 			State:        sim.StateTimedOut,
-			InputTokens:  make([]int, 256),
-			OutputTokens: make([]int, 64),
+			InputTokens:  make([]sim.TokenID, 256),
+			OutputTokens: make([]sim.TokenID, 64),
 			ArrivalTime:  2000,
 			TTFTSet:      false,
 			TenantID:     "t2",
@@ -937,24 +937,24 @@ func TestRequestsToTraceRecords_VLLMPriority_AlwaysZero(t *testing.T) {
 			ID:            "req1",
 			State:         sim.StateCompleted,
 			SLOClass:      "critical",
-			InputTokens:   make([]int, 10),
-			OutputTokens:  make([]int, 5),
+			InputTokens:   make([]sim.TokenID, 10),
+			OutputTokens:  make([]sim.TokenID, 5),
 			ProgressIndex: 15,
 		},
 		{
 			ID:            "req2",
 			State:         sim.StateCompleted,
 			SLOClass:      "batch",
-			InputTokens:   make([]int, 20),
-			OutputTokens:  make([]int, 10),
+			InputTokens:   make([]sim.TokenID, 20),
+			OutputTokens:  make([]sim.TokenID, 10),
 			ProgressIndex: 30,
 		},
 		{
 			ID:            "req3",
 			State:         sim.StateCompleted,
 			SLOClass:      "", // no SLO class
-			InputTokens:   make([]int, 5),
-			OutputTokens:  make([]int, 2),
+			InputTokens:   make([]sim.TokenID, 5),
+			OutputTokens:  make([]sim.TokenID, 2),
 			ProgressIndex: 7,
 		},
 	}


### PR DESCRIPTION
## Summary

Halves the size of every token slice in the simulator by switching `Request.InputTokens` / `Request.OutputTokens` from `[]int` (8 B/elem on amd64) to `[]TokenID` where `TokenID` is a defined `int32` type. Real LLM vocabularies fit well below 2³¹ (`MaxTokenID = 128000`), so 32 bits is sufficient. Using a *defined* type (not a Go alias) means mixing call sites is a compile error rather than a silent bug — the compiler becomes the audit.

Representation-only change. No behavioral logic moves.

## Behavioral Contracts

- **BC-1:** `TokenID` is a defined type, not a transparent alias of `int32` (`int → TokenID` requires an explicit cast).
- **BC-2:** `Request.InputTokens` and `Request.OutputTokens` are typed `[]TokenID`.
- **BC-3:** `GenerateRandomTokenIDs` returns `[]TokenID`.
- **BC-4:** `hash.HashBlock` digest is byte-identical to the pre-PR `[]int` digest for any value that fits in `int32`. The implementation widens to `int64` via `strconv.AppendInt(buf, int64(t), 10)` before stringification, so `int` vs `int32` with the same numeric value produce identical byte streams.
- **BC-5:** Determinism preserved (INV-6) — verified by diffing two `blis run` invocations with the same seed.
- **BC-6:** Run/replay parity preserved (INV-13) — TraceV2 schema unchanged (it persists token *counts*, not IDs).

## Architecture

`TokenID` lives in a tiny leaf package `sim/internal/tokenid` (no dependencies). Both `sim/` and `sim/internal/hash/` import it, avoiding an import cycle through `sim`. `sim/` re-exports as `type TokenID = tokenid.TokenID` — the Go alias at the re-export boundary preserves the defined-type property, because `tokenid.TokenID` itself is a defined type (not an alias of `int32`). The compile-time check on mixing remains intact.

## Out of scope

- On-disk TraceV2 format is unaffected. It persists token *counts* (`InputTokens int` / `OutputTokens int` in `sim/workload/tracev2.go`), and token IDs are regenerated lazily during replay via `GenerateRandomTokenIDs`. No schema change.
- KV-cache hash function changes only in *input slice type*; the wire format and hex digest are byte-identical for any in-`int32`-range value (BC-4).
- Performance optimizations beyond the size reduction. No vectorization, no SIMD.

## Closes

Fixes #1444. (Change B of tracker #1438.)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass
- [x] New `sim/request_tokenid_test.go`: BC-1, BC-2, BC-3 + a regression guard against accidental narrowing below `int32` range
- [x] New `TestHashBlock_ByteEquivalentToInt64String` in `sim/internal/hash/hash_test.go`: BC-4 — reconstructs the wire format independently from the algorithm spec (not a golden value)
- [x] Determinism (INV-6) — verified: two `blis run` invocations with identical seed + flags produce byte-identical stdout
- [x] All existing run/replay parity tests pass (INV-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)