### PR TITLE
feat(lora): PR2 — per-instance resident-adapter set + capacity + LRU eviction (#1465)

### DIFF
--- a/sim/cluster/adapter_metrics_aggregation_test.go
+++ b/sim/cluster/adapter_metrics_aggregation_test.go
@@ -1,0 +1,88 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// TestClusterSimulator_AdapterMetrics_AggregatedAcrossInstances_E2E drives a real
+// 2-instance cluster end to end: every request targets the same adapter, round-robin
+// spreads them across both instances, each instance cold-loads the adapter once (its
+// first request; the rest are warm), and the cluster aggregate sums to one load per
+// instance. This exercises the full pipeline — scheduling hook populates each
+// instance's counts, aggregateMetrics sums them cluster-wide — complementing the
+// direct-input unit test below.
+func TestClusterSimulator_AdapterMetrics_AggregatedAcrossInstances_E2E(t *testing.T) {
+	config := newTestDeploymentConfig(2)
+	config.RoutingPolicy = "round-robin"
+	capVal := 8 // capacity >> 1 adapter, so no evictions
+	config.LoRAConfig = sim.LoRAConfig{
+		AdapterCapacity: &capVal,
+		Adapters:        []sim.AdapterSpec{{ID: "adapter_shared", Rank: 8}},
+	}
+
+	requests := newTestRequests(6)
+	for _, r := range requests {
+		r.Adapter = "adapter_shared"
+	}
+
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
+	mustRun(t, cs)
+
+	agg := cs.AggregatedMetrics()
+	// One cold load per instance (round-robin gives each instance ≥1 request); the
+	// shared adapter's counts must sum across the two instances.
+	if got := agg.AdapterLoadCounts["adapter_shared"]; got != 2 {
+		t.Errorf("cluster LoadCount[adapter_shared] = %d, want 2 (one cold load per instance)", got)
+	}
+	if got := agg.AdapterEvictionCounts["adapter_shared"]; got != 0 {
+		t.Errorf("cluster EvictionCount[adapter_shared] = %d, want 0 (capacity 8, single adapter)", got)
+	}
+}
+
+// TestAggregateMetrics_AdapterCountsSummedAcrossInstances verifies that per-adapter
+// resident-set load/eviction counts (#1465) are summed across instances during
+// cluster aggregation. The same adapter can be resident on multiple instances, so
+// its counts must add up cluster-wide rather than being dropped or overwritten
+// (unlike globally-unique request ids). This guards the aggregateMetrics gap where
+// the new adapter maps were initially not merged.
+func TestAggregateMetrics_AdapterCountsSummedAcrossInstances(t *testing.T) {
+	config := newTestDeploymentConfig(2)
+	cs := NewClusterSimulator(config, NewSliceRequestSource(newTestRequests(1)), nil)
+
+	instances := cs.Instances()
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+
+	// Simulate per-instance residency events. adapter_shared is resident on both
+	// instances (its counts must sum); adapter_a / adapter_b are instance-local.
+	m0 := instances[0].Metrics()
+	m0.AdapterLoadCounts["adapter_shared"] = 3
+	m0.AdapterLoadCounts["adapter_a"] = 1
+	m0.AdapterEvictionCounts["adapter_shared"] = 1
+
+	m1 := instances[1].Metrics()
+	m1.AdapterLoadCounts["adapter_shared"] = 2
+	m1.AdapterLoadCounts["adapter_b"] = 5
+	m1.AdapterEvictionCounts["adapter_b"] = 2
+
+	agg := cs.aggregateMetrics()
+
+	wantLoads := map[string]int64{"adapter_shared": 5, "adapter_a": 1, "adapter_b": 5}
+	for id, want := range wantLoads {
+		if got := agg.AdapterLoadCounts[id]; got != want {
+			t.Errorf("aggregated LoadCount[%s] = %d, want %d", id, got, want)
+		}
+	}
+	wantEvictions := map[string]int64{"adapter_shared": 1, "adapter_b": 2}
+	for id, want := range wantEvictions {
+		if got := agg.AdapterEvictionCounts[id]; got != want {
+			t.Errorf("aggregated EvictionCount[%s] = %d, want %d", id, got, want)
+		}
+	}
+	if got := agg.AdapterEvictionCounts["adapter_a"]; got != 0 {
+		t.Errorf("adapter_a had no evictions, aggregated EvictionCount = %d, want 0", got)
+	}
+}

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1709,6 +1709,17 @@ func (c *ClusterSimulator) aggregateMetrics() *sim.Metrics {
 		}
 		merged.AllITLs = append(merged.AllITLs, m.AllITLs...)
 		merged.RequestStepCounters = append(merged.RequestStepCounters, m.RequestStepCounters...)
+
+		// Per-adapter resident-set counts are keyed by adapter id, which — unlike the
+		// globally-unique request ids above — legitimately recurs across instances (the
+		// same adapter can be loaded on many instances). Sum them for a cluster-wide
+		// total per adapter rather than merging (which would warn and overwrite).
+		for k, v := range m.AdapterLoadCounts {
+			merged.AdapterLoadCounts[k] += v
+		}
+		for k, v := range m.AdapterEvictionCounts {
+			merged.AdapterEvictionCounts[k] += v
+		}
 		merged.PreemptionCount += m.PreemptionCount
 		merged.KVAllocationFailures += m.KVAllocationFailures
 		merged.DroppedUnservable += m.DroppedUnservable

--- a/sim/cluster/lora_import_test.go
+++ b/sim/cluster/lora_import_test.go
@@ -1,0 +1,7 @@
+package cluster_test
+
+// Blank import triggers sim/lora's init(), registering NewResidentAdapterSetFunc so
+// per-instance Simulators in cluster tests build a real resident-adapter set. sim/lora
+// imports sim (not sim/cluster), so there is no import cycle. Mirrors the sim package's
+// lora_import_test.go.
+import _ "github.com/inference-sim/inference-sim/sim/lora"

--- a/sim/lora/register.go
+++ b/sim/lora/register.go
@@ -10,4 +10,7 @@ func init() {
 	sim.NewAdapterRegistryFunc = func(adapters []sim.AdapterSpec) (sim.AdapterRegistry, error) {
 		return NewRegistry(adapters)
 	}
+	sim.NewResidentAdapterSetFunc = func(capacity int) sim.ResidentAdapterSet {
+		return newResidentSet(capacity)
+	}
 }

--- a/sim/lora/registry_test.go
+++ b/sim/lora/registry_test.go
@@ -117,3 +117,20 @@ func TestNewAdapterRegistryFunc_Registered(t *testing.T) {
 		t.Errorf("factory-built registry RankOf(a) = (%d,%v), want (8,true)", r, ok)
 	}
 }
+
+// TestNewResidentAdapterSetFunc_Registered verifies sim/lora's init() wired the
+// resident-set factory into the sim package (mirrors NewAdapterRegistryFunc). A
+// refactor that breaks this seam would otherwise silently leave the Simulator's
+// resident set nil and zero every adapter metric with no test failure.
+func TestNewResidentAdapterSetFunc_Registered(t *testing.T) {
+	if sim.NewResidentAdapterSetFunc == nil {
+		t.Fatalf("sim.NewResidentAdapterSetFunc must be registered by sim/lora init()")
+	}
+	set := sim.NewResidentAdapterSetFunc(2)
+	if set == nil {
+		t.Fatalf("factory returned nil resident set")
+	}
+	if set.Len() != 0 {
+		t.Errorf("fresh resident set Len() = %d, want 0", set.Len())
+	}
+}

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -1,0 +1,149 @@
+package lora
+
+import "fmt"
+
+// residentEntry is one adapter slot in the resident set's LRU doubly-linked
+// list. pinCount is the number of in-flight requests currently using the
+// adapter; a positive count protects the entry from eviction.
+type residentEntry struct {
+	id       string
+	pinCount int
+	prev     *residentEntry // older — toward the LRU head (evicted first)
+	next     *residentEntry // newer — toward the MRU tail
+}
+
+// residentSet models the finite per-instance GPU adapter slots as a capacity-
+// bounded LRU over adapter ids (data-model.md "Resident-Adapter Set"). It reuses
+// the cpuTier hash + doubly-linked-list pattern (sim/kv/tiered.go): O(1) store
+// and touch; eviction is O(1) amortized, scanning from the LRU head past any
+// pinned entries. Adapters required by in-flight requests are pinned
+// (reference-counted) and are never chosen as an eviction victim, so the
+// capacity bound len(entries) ≤ capacity holds at all times.
+//
+// Eviction order is a pure function of access order (LRU over touches) with no
+// randomness, so a given sequence of operations is deterministic (INV-6).
+//
+// Its exported methods satisfy sim.ResidentAdapterSet; the type stays unexported
+// because callers outside sim/lora only ever hold the interface (wired via
+// sim.NewResidentAdapterSetFunc). Not safe for concurrent use: each Simulator
+// owns one and mutates it only on the single simulation goroutine.
+type residentSet struct {
+	capacity int
+	entries  map[string]*residentEntry // id → entry, O(1) lookup
+	lruHead  *residentEntry            // least recently used (evicted first)
+	lruTail  *residentEntry            // most recently used
+}
+
+// newResidentSet creates an empty resident set with the given slot capacity.
+// A non-positive capacity is a programming error (LoRAConfig.Validate rejects it
+// upstream) and panics, mirroring newCpuTier.
+func newResidentSet(capacity int) *residentSet {
+	if capacity <= 0 {
+		panic(fmt.Sprintf("newResidentSet: capacity must be > 0, got %d", capacity))
+	}
+	return &residentSet{
+		capacity: capacity,
+		entries:  make(map[string]*residentEntry, capacity),
+	}
+}
+
+// Len reports the number of currently resident adapters.
+func (s *residentSet) Len() int { return len(s.entries) }
+
+// IsResident reports whether id currently occupies a slot.
+func (s *residentSet) IsResident(id string) bool {
+	_, ok := s.entries[id]
+	return ok
+}
+
+// Touch moves a resident id to the MRU tail. No-op if id is not resident.
+func (s *residentSet) Touch(id string) {
+	e, ok := s.entries[id]
+	if !ok {
+		return
+	}
+	s.unlink(e)
+	s.appendToTail(e)
+}
+
+// Store makes id resident at the MRU tail. If id is already resident this is
+// equivalent to Touch and returns ("", true). For a new id at capacity, the
+// least-recently-used non-pinned entry is evicted first and its id returned. If
+// the set is full and every entry is pinned, id is not admitted and ("", false)
+// is returned — the caller (cold-load gate) must wait for an in-flight request
+// to complete and unpin a slot.
+func (s *residentSet) Store(id string) (evicted string, ok bool) {
+	if _, exists := s.entries[id]; exists {
+		s.Touch(id)
+		return "", true
+	}
+	if len(s.entries) >= s.capacity {
+		if evicted, ok = s.EvictLRU(); !ok {
+			return "", false // full and every resident adapter is pinned
+		}
+	}
+	e := &residentEntry{id: id}
+	s.entries[id] = e
+	s.appendToTail(e)
+	return evicted, true
+}
+
+// EvictLRU removes the least-recently-used non-pinned entry, scanning from the
+// LRU head toward the tail so pinned entries are skipped in recency order.
+// Returns the evicted id and true, or ("", false) if the set is empty or every
+// entry is pinned.
+func (s *residentSet) EvictLRU() (string, bool) {
+	for e := s.lruHead; e != nil; e = e.next {
+		if e.pinCount == 0 {
+			s.unlink(e)
+			delete(s.entries, e.id)
+			return e.id, true
+		}
+	}
+	return "", false
+}
+
+// Pin increments the in-flight reference count protecting id from eviction.
+// No-op if id is not resident.
+func (s *residentSet) Pin(id string) {
+	if e, ok := s.entries[id]; ok {
+		e.pinCount++
+	}
+}
+
+// Unpin decrements the in-flight reference count; the adapter becomes evictable
+// once no in-flight request references it. No-op if id is not resident or its
+// count is already zero.
+func (s *residentSet) Unpin(id string) {
+	if e, ok := s.entries[id]; ok && e.pinCount > 0 {
+		e.pinCount--
+	}
+}
+
+// appendToTail links e at the MRU tail (mirrors cpuTier.appendToTail).
+func (s *residentSet) appendToTail(e *residentEntry) {
+	e.next = nil
+	e.prev = s.lruTail
+	if s.lruTail != nil {
+		s.lruTail.next = e
+	} else {
+		s.lruHead = e
+	}
+	s.lruTail = e
+}
+
+// unlink removes e from the LRU doubly-linked list (mirrors cpuTier.unlink).
+func (s *residentSet) unlink(e *residentEntry) {
+	if e.prev != nil {
+		e.prev.next = e.next
+	} else {
+		s.lruHead = e.next
+	}
+	if e.next != nil {
+		e.next.prev = e.prev
+	} else {
+		s.lruTail = e.prev
+	}
+	e.prev = nil
+	e.next = nil
+}

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -95,9 +95,9 @@ func (s *residentSet) Store(id string) (evicted string, ok bool) {
 // Returns the evicted id and true, or ("", false) if the set is empty or every
 // entry is pinned.
 //
-// Exported (unlike the enclosing unexported residentSet) because the cold-load
+// Exported (unlike the enclosing unexported residentSet) because the LoRA cold-load
 // gate will drive eviction directly once pin/unpin join the ResidentAdapterSet
-// interface (#1464); the uppercase name is deliberate, not an accidental export.
+// interface; the uppercase name is deliberate, not an accidental export.
 func (s *residentSet) EvictLRU() (string, bool) {
 	for e := s.lruHead; e != nil; e = e.next {
 		if e.pinCount == 0 {

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -7,14 +7,15 @@ import "fmt"
 // adapter; a positive count protects the entry from eviction.
 type residentEntry struct {
 	id       string
-	pinCount int
+	pinCount uint
 	prev     *residentEntry // older — toward the LRU head (evicted first)
 	next     *residentEntry // newer — toward the MRU tail
 }
 
 // residentSet models the finite per-instance GPU adapter slots as a capacity-
-// bounded LRU over adapter ids (data-model.md "Resident-Adapter Set"). It reuses
-// the cpuTier hash + doubly-linked-list pattern (sim/kv/tiered.go): O(1) store
+// bounded LRU over adapter ids (specs/007-lora-control-plane/data-model.md
+// §"Entity: Resident-Adapter Set (per instance)"). It reuses the cpuTier map +
+// doubly-linked-list pattern (sim/kv/tiered.go): O(1) store
 // and touch; eviction is O(1) amortized, scanning from the LRU head past any
 // pinned entries. Adapters required by in-flight requests are pinned
 // (reference-counted) and are never chosen as an eviction victim, so the

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -16,8 +16,9 @@ type residentEntry struct {
 // bounded LRU over adapter ids (specs/007-lora-control-plane/data-model.md
 // §"Entity: Resident-Adapter Set (per instance)"). It reuses the cpuTier map +
 // doubly-linked-list pattern (sim/kv/tiered.go): O(1) store
-// and touch; eviction is O(1) amortized, scanning from the LRU head past any
-// pinned entries. Adapters required by in-flight requests are pinned
+// and touch; eviction scans from the LRU head past pinned entries — O(1) in the
+// common case (few or no pins), O(capacity) worst-case (all entries pinned).
+// Adapters required by in-flight requests are pinned
 // (reference-counted) and are never chosen as an eviction victim, so the
 // capacity bound len(entries) ≤ capacity holds at all times.
 //
@@ -93,6 +94,10 @@ func (s *residentSet) Store(id string) (evicted string, ok bool) {
 // LRU head toward the tail so pinned entries are skipped in recency order.
 // Returns the evicted id and true, or ("", false) if the set is empty or every
 // entry is pinned.
+//
+// Exported (unlike the enclosing unexported residentSet) because the cold-load
+// gate will drive eviction directly once pin/unpin join the ResidentAdapterSet
+// interface (#1464); the uppercase name is deliberate, not an accidental export.
 func (s *residentSet) EvictLRU() (string, bool) {
 	for e := s.lruHead; e != nil; e = e.next {
 		if e.pinCount == 0 {

--- a/sim/lora/resident_set_test.go
+++ b/sim/lora/resident_set_test.go
@@ -199,6 +199,23 @@ func TestResidentSet_EvictLRUAllPinned(t *testing.T) {
 	}
 }
 
+// TestResidentSet_UnpinAtZeroIsNoop verifies the Unpin guard: unpinning more
+// times than an id was pinned neither wraps the count (uint underflow) nor leaves
+// the entry stuck pinned — after balancing the single Pin, a second Unpin is a
+// no-op and the adapter remains evictable.
+func TestResidentSet_UnpinAtZeroIsNoop(t *testing.T) {
+	s := newResidentSet(1)
+	s.Store("a")
+	s.Pin("a")
+	s.Unpin("a") // balances the pin
+	s.Unpin("a") // extra unpin: must be a no-op, not an underflow
+
+	// The adapter is now unpinned, so it is a valid eviction victim.
+	if evicted, ok := s.EvictLRU(); !ok || evicted != "a" {
+		t.Fatalf("EvictLRU after balanced+extra Unpin: got (%q, %v), want (\"a\", true)", evicted, ok)
+	}
+}
+
 // TestResidentSet_ZeroCapacityPanics verifies the constructor rejects a
 // non-positive capacity (mirrors newCpuTier; capacity is validated > 0 upstream).
 func TestResidentSet_ZeroCapacityPanics(t *testing.T) {

--- a/sim/lora/resident_set_test.go
+++ b/sim/lora/resident_set_test.go
@@ -3,7 +3,8 @@ package lora
 import "testing"
 
 // The resident-adapter set models the finite per-instance GPU adapter slots
-// (data-model.md "Resident-Adapter Set"): a capacity-bounded LRU over adapter
+// (specs/007-lora-control-plane/data-model.md §"Entity: Resident-Adapter Set
+// (per instance)"): a capacity-bounded LRU over adapter
 // ids with pinning for in-flight requests. These contract tests assert the
 // observable laws — capacity bound, LRU eviction order, and pin protection —
 // independent of the internal linked-list representation.
@@ -172,12 +173,29 @@ func TestResidentSet_PinRefcount(t *testing.T) {
 	}
 }
 
-// TestResidentSet_EvictLRUEmpty verifies evictLRU on an empty (or fully pinned)
-// set reports no victim rather than panicking.
+// TestResidentSet_EvictLRUEmpty verifies EvictLRU on an empty set reports no victim
+// rather than panicking (the lruHead == nil immediate-return path).
 func TestResidentSet_EvictLRUEmpty(t *testing.T) {
 	s := newResidentSet(2)
 	if evicted, ok := s.EvictLRU(); ok || evicted != "" {
 		t.Fatalf("evictLRU on empty set: got (%q, %v), want (\"\", false)", evicted, ok)
+	}
+}
+
+// TestResidentSet_EvictLRUAllPinned verifies EvictLRU on a full set whose every
+// entry is pinned reports no victim (the loop scans the whole list, skipping all
+// pinned entries — distinct from the empty-set immediate return).
+func TestResidentSet_EvictLRUAllPinned(t *testing.T) {
+	s := newResidentSet(2)
+	s.Store("a")
+	s.Store("b")
+	s.Pin("a")
+	s.Pin("b")
+	if evicted, ok := s.EvictLRU(); ok || evicted != "" {
+		t.Fatalf("evictLRU on fully pinned set: got (%q, %v), want (\"\", false)", evicted, ok)
+	}
+	if s.Len() != 2 {
+		t.Fatalf("Len after failed eviction = %d, want 2 (no entry removed)", s.Len())
 	}
 }
 

--- a/sim/lora/resident_set_test.go
+++ b/sim/lora/resident_set_test.go
@@ -1,0 +1,193 @@
+package lora
+
+import "testing"
+
+// The resident-adapter set models the finite per-instance GPU adapter slots
+// (data-model.md "Resident-Adapter Set"): a capacity-bounded LRU over adapter
+// ids with pinning for in-flight requests. These contract tests assert the
+// observable laws — capacity bound, LRU eviction order, and pin protection —
+// independent of the internal linked-list representation.
+
+// TestResidentSet_StoreMakesResident verifies a stored id becomes resident at
+// MRU and that touch/store on an absent id behave as documented.
+func TestResidentSet_StoreMakesResident(t *testing.T) {
+	s := newResidentSet(2)
+	if s.Len() != 0 {
+		t.Fatalf("new set: len = %d, want 0", s.Len())
+	}
+
+	if evicted, ok := s.Store("a"); !ok || evicted != "" {
+		t.Fatalf("store(a) into empty set: got (%q, %v), want (\"\", true)", evicted, ok)
+	}
+	if !s.IsResident("a") {
+		t.Fatalf("store(a): a not resident")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("after store(a): len = %d, want 1", s.Len())
+	}
+
+	// touch on an absent id is a no-op (does not make it resident).
+	s.Touch("ghost")
+	if s.IsResident("ghost") {
+		t.Fatalf("touch(ghost) made an absent id resident")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("touch(absent) changed len to %d, want 1", s.Len())
+	}
+
+	// re-storing a resident id is idempotent on membership (equivalent to touch).
+	if evicted, ok := s.Store("a"); !ok || evicted != "" {
+		t.Fatalf("store(a) again: got (%q, %v), want (\"\", true)", evicted, ok)
+	}
+	if s.Len() != 1 {
+		t.Fatalf("re-store(a): len = %d, want 1", s.Len())
+	}
+}
+
+// TestResidentSet_CapacityInvariant verifies len never exceeds capacity as more
+// distinct adapters than slots are stored (new invariant: resident ≤ capacity).
+func TestResidentSet_CapacityInvariant(t *testing.T) {
+	const capacity = 3
+	s := newResidentSet(capacity)
+	ids := []string{"a", "b", "c", "d", "e", "f"}
+	for _, id := range ids {
+		s.Store(id)
+		if s.Len() > capacity {
+			t.Fatalf("after store(%s): len = %d exceeds capacity %d", id, s.Len(), capacity)
+		}
+	}
+	if s.Len() != capacity {
+		t.Fatalf("final len = %d, want %d (full)", s.Len(), capacity)
+	}
+}
+
+// TestResidentSet_EvictsLeastRecentlyUsed pins down the LRU order deterministically:
+// touch promotes to MRU so the next store evicts the true least-recently-used id.
+// No randomness is involved — the eviction victim is a pure function of access order.
+func TestResidentSet_EvictsLeastRecentlyUsed(t *testing.T) {
+	s := newResidentSet(3)
+	s.Store("a")
+	s.Store("b")
+	s.Store("c") // LRU order (old→new): a, b, c
+
+	s.Touch("a") // promote a to MRU: b, c, a
+
+	// Storing d is at capacity → evicts the LRU, which is now b.
+	evicted, ok := s.Store("d")
+	if !ok {
+		t.Fatalf("store(d): ok = false, want true (b is evictable)")
+	}
+	if evicted != "b" {
+		t.Fatalf("store(d) evicted %q, want \"b\" (least recently used)", evicted)
+	}
+	if s.IsResident("b") {
+		t.Fatalf("b should have been evicted")
+	}
+	for _, id := range []string{"a", "c", "d"} {
+		if !s.IsResident(id) {
+			t.Fatalf("%s should still be resident after evicting b", id)
+		}
+	}
+
+	// Next store evicts c (now the LRU: c, a, d → c).
+	if evicted, ok := s.Store("e"); !ok || evicted != "c" {
+		t.Fatalf("store(e) evicted (%q, %v), want (\"c\", true)", evicted, ok)
+	}
+}
+
+// TestResidentSet_PinnedNeverEvicted verifies a pinned (in-flight) adapter is
+// never chosen as an eviction victim even when it is the least recently used
+// (US2 scenario 3). Eviction falls through to the next non-pinned candidate.
+func TestResidentSet_PinnedNeverEvicted(t *testing.T) {
+	s := newResidentSet(3)
+	s.Store("a")
+	s.Store("b")
+	s.Store("c") // LRU order: a, b, c
+
+	s.Pin("a") // a is in use — protected despite being LRU
+
+	evicted, ok := s.Store("d")
+	if !ok {
+		t.Fatalf("store(d): ok = false, want true (b/c are evictable)")
+	}
+	if evicted == "a" {
+		t.Fatalf("evicted pinned adapter a")
+	}
+	if evicted != "b" {
+		t.Fatalf("store(d) evicted %q, want \"b\" (LRU non-pinned)", evicted)
+	}
+	if !s.IsResident("a") {
+		t.Fatalf("pinned a must remain resident")
+	}
+}
+
+// TestResidentSet_AllPinnedAtCapacityRejects verifies that when the set is full
+// and every resident adapter is pinned, a new store is refused (ok=false) rather
+// than violating the capacity bound or evicting an in-use adapter. The cold-load
+// gate (PR3) makes such a request wait.
+func TestResidentSet_AllPinnedAtCapacityRejects(t *testing.T) {
+	s := newResidentSet(2)
+	s.Store("a")
+	s.Store("b")
+	s.Pin("a")
+	s.Pin("b")
+
+	evicted, ok := s.Store("c")
+	if ok {
+		t.Fatalf("store(c) with all pinned: ok = true, want false")
+	}
+	if evicted != "" {
+		t.Fatalf("store(c) with all pinned: evicted %q, want \"\"", evicted)
+	}
+	if s.IsResident("c") {
+		t.Fatalf("c admitted despite full+all-pinned set")
+	}
+	if s.Len() != 2 {
+		t.Fatalf("len = %d after refused store, want 2", s.Len())
+	}
+}
+
+// TestResidentSet_PinRefcount verifies pinning is reference-counted: an adapter
+// used by multiple concurrent in-flight requests stays protected until the last
+// user unpins it. This guards against unpinning a still-in-use adapter.
+func TestResidentSet_PinRefcount(t *testing.T) {
+	s := newResidentSet(2)
+	s.Store("a")
+	s.Store("b") // LRU: a, b
+
+	s.Pin("a")
+	s.Pin("a") // two in-flight requests use a
+
+	s.Unpin("a") // one completes — a still has one user, still pinned
+
+	// b is unpinned and LRU-newer than a, but a is still protected, so evicting
+	// forces b out.
+	if evicted, ok := s.EvictLRU(); !ok || evicted != "b" {
+		t.Fatalf("evictLRU with a still pinned: got (%q, %v), want (\"b\", true)", evicted, ok)
+	}
+
+	s.Unpin("a") // last user completes — a now evictable
+	if evicted, ok := s.EvictLRU(); !ok || evicted != "a" {
+		t.Fatalf("evictLRU after a fully unpinned: got (%q, %v), want (\"a\", true)", evicted, ok)
+	}
+}
+
+// TestResidentSet_EvictLRUEmpty verifies evictLRU on an empty (or fully pinned)
+// set reports no victim rather than panicking.
+func TestResidentSet_EvictLRUEmpty(t *testing.T) {
+	s := newResidentSet(2)
+	if evicted, ok := s.EvictLRU(); ok || evicted != "" {
+		t.Fatalf("evictLRU on empty set: got (%q, %v), want (\"\", false)", evicted, ok)
+	}
+}
+
+// TestResidentSet_ZeroCapacityPanics verifies the constructor rejects a
+// non-positive capacity (mirrors newCpuTier; capacity is validated > 0 upstream).
+func TestResidentSet_ZeroCapacityPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("newResidentSet(0) did not panic")
+		}
+	}()
+	newResidentSet(0)
+}

--- a/sim/lora_import_test.go
+++ b/sim/lora_import_test.go
@@ -1,0 +1,7 @@
+package sim_test
+
+// Blank import triggers sim/lora's init(), which registers NewAdapterRegistryFunc
+// and NewResidentAdapterSetFunc. This lets package sim's internal test files build
+// a real resident-adapter set without importing sim/lora directly (which would
+// create an import cycle, since sim/lora imports sim). Mirrors latency_import_test.go.
+import _ "github.com/inference-sim/inference-sim/sim/lora"

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -47,7 +47,8 @@ type Metrics struct {
 	NumRunningBatchRequests []int                     // number of request in runningBatch over different steps
 	Requests                map[string]RequestMetrics // request metrics list
 
-	// Per-adapter resident-set event counts (#1464, LoRA). AdapterLoadCounts[id] is
+	// Per-adapter resident-set event counts (LoRA control-plane subsystem).
+	// AdapterLoadCounts[id] is
 	// incremented each time id is cold-loaded into an instance's resident set;
 	// AdapterEvictionCounts[id] each time id is evicted. These are cumulative EVENT
 	// counts, not distinct-adapter or request counts — a hot adapter loaded/evicted
@@ -206,7 +207,7 @@ func buildAdapterMetrics(m *Metrics, vllmRuntime float64) map[string]AdapterMetr
 	if len(ttftsByAdapter) == 0 && len(m.AdapterLoadCounts) == 0 && len(m.AdapterEvictionCounts) == 0 {
 		return nil
 	}
-	idSet := make(map[string]struct{}, len(ttftsByAdapter)+len(m.AdapterLoadCounts))
+	idSet := make(map[string]struct{}, len(ttftsByAdapter)+len(m.AdapterLoadCounts)+len(m.AdapterEvictionCounts))
 	for id := range ttftsByAdapter {
 		idSet[id] = struct{}{}
 	}

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -46,6 +46,19 @@ type Metrics struct {
 	NumWaitQRequests        []int                     // number of requests in waitQ over different steps
 	NumRunningBatchRequests []int                     // number of request in runningBatch over different steps
 	Requests                map[string]RequestMetrics // request metrics list
+
+	// Per-adapter resident-set event counts (#1464, LoRA). AdapterLoadCounts[id] is
+	// incremented each time id is cold-loaded into an instance's resident set;
+	// AdapterEvictionCounts[id] each time id is evicted. These are cumulative EVENT
+	// counts, not distinct-adapter or request counts — a hot adapter loaded/evicted
+	// repeatedly accrues one per transition, so totals scale with adapter churn (and
+	// thus horizon), not just the registry size. Bounded in size by the declared
+	// adapter registry. In cluster mode they are summed per adapter across instances
+	// (cluster.aggregateMetrics). Both are always non-nil (allocated in NewMetrics) but
+	// empty (a missing key reads as 0) unless the LoRA subsystem is active, so an
+	// adapter-blind run produces no adapter output (INV-6). Surfaced via buildAdapterMetrics.
+	AdapterLoadCounts     map[string]int64
+	AdapterEvictionCounts map[string]int64
 }
 
 func NewMetrics() *Metrics {
@@ -60,6 +73,8 @@ func NewMetrics() *Metrics {
 		NumWaitQRequests:        []int{},
 		NumRunningBatchRequests: []int{},
 		Requests:                make(map[string]RequestMetrics),
+		AdapterLoadCounts:       make(map[string]int64),
+		AdapterEvictionCounts:   make(map[string]int64),
 	}
 }
 
@@ -184,19 +199,45 @@ func buildAdapterMetrics(m *Metrics, vllmRuntime float64) map[string]AdapterMetr
 		ttftsByAdapter[rm.Adapter] = append(ttftsByAdapter[rm.Adapter], m.RequestTTFTs[id])
 		outTokensByAdapter[rm.Adapter] += int64(rm.NumDecodeTokens)
 	}
-	if len(ttftsByAdapter) == 0 {
+	// An adapter surfaces if it served a completed request OR saw a resident-set
+	// event (load/eviction), so counts appear even for an adapter loaded then
+	// evicted before any of its requests completed in-window. All three empty =>
+	// adapter-blind run => nil (INV-6 no-op).
+	if len(ttftsByAdapter) == 0 && len(m.AdapterLoadCounts) == 0 && len(m.AdapterEvictionCounts) == 0 {
 		return nil
 	}
-	adapters := make(map[string]AdapterMetrics, len(ttftsByAdapter))
-	for adapter, ttfts := range ttftsByAdapter {
-		sort.Float64s(ttfts)
+	idSet := make(map[string]struct{}, len(ttftsByAdapter)+len(m.AdapterLoadCounts))
+	for id := range ttftsByAdapter {
+		idSet[id] = struct{}{}
+	}
+	for id := range m.AdapterLoadCounts {
+		idSet[id] = struct{}{}
+	}
+	for id := range m.AdapterEvictionCounts {
+		idSet[id] = struct{}{}
+	}
+	// Build in sorted id order (R2). The output is a map (JSON marshals keys sorted),
+	// so this is defensive rather than load-bearing, but it keeps any future
+	// order-sensitive accumulation here deterministic without a second audit.
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	adapters := make(map[string]AdapterMetrics, len(ids))
+	for _, adapter := range ids {
 		am := AdapterMetrics{
-			// CalculatePercentile returns ms (÷1000); ×1000 recovers µs for the _us fields.
-			TTFTP50Us: CalculatePercentile(ttfts, 50) * 1000,
-			TTFTP99Us: CalculatePercentile(ttfts, 99) * 1000,
+			LoadCount:     m.AdapterLoadCounts[adapter],
+			EvictionCount: m.AdapterEvictionCounts[adapter],
 		}
-		if vllmRuntime > 0 {
-			am.ThroughputTokPerS = float64(outTokensByAdapter[adapter]) / vllmRuntime
+		if ttfts, ok := ttftsByAdapter[adapter]; ok {
+			sort.Float64s(ttfts)
+			// CalculatePercentile returns ms (÷1000); ×1000 recovers µs for the _us fields.
+			am.TTFTP50Us = CalculatePercentile(ttfts, 50) * 1000
+			am.TTFTP99Us = CalculatePercentile(ttfts, 99) * 1000
+			if vllmRuntime > 0 {
+				am.ThroughputTokPerS = float64(outTokensByAdapter[adapter]) / vllmRuntime
+			}
 		}
 		adapters[adapter] = am
 	}

--- a/sim/metrics_adapter_test.go
+++ b/sim/metrics_adapter_test.go
@@ -27,7 +27,7 @@ func newAdapterTestMetrics() *Metrics {
 
 // TestBuildOutput_PerAdapterMetrics verifies the per-adapter aggregate block (US1):
 // present with per-adapter TTFT/throughput when adapters are attributed; base-model
-// requests attributed to no adapter (contracts/metrics.md).
+// requests attributed to no adapter (specs/007-lora-control-plane/contracts/metrics.md).
 func TestBuildOutput_PerAdapterMetrics(t *testing.T) {
 	m := newAdapterTestMetrics()
 	out := m.BuildOutput("cluster", nil)

--- a/sim/metrics_adapter_test.go
+++ b/sim/metrics_adapter_test.go
@@ -51,9 +51,44 @@ func TestBuildOutput_PerAdapterMetrics(t *testing.T) {
 	if a0.ThroughputTokPerS <= 0 {
 		t.Errorf("adapter_0 throughput_tok_per_s should be > 0, got %v", a0.ThroughputTokPerS)
 	}
-	// LoadCount / EvictionCount are placeholders in PR1 (no resident set yet).
+	// This fixture records only request metrics — no resident-set events — so
+	// load/eviction counts are 0 (they are driven by the scheduling hook, exercised
+	// in the run-level tests). Counts surfacing from the maps is covered separately
+	// by TestBuildOutput_AdapterEventCountsSurface.
 	if a0.LoadCount != 0 || a0.EvictionCount != 0 {
-		t.Errorf("PR1 placeholder: load/eviction counts should be 0, got %d/%d", a0.LoadCount, a0.EvictionCount)
+		t.Errorf("no resident-set events in this fixture: counts should be 0, got %d/%d", a0.LoadCount, a0.EvictionCount)
+	}
+}
+
+// TestBuildOutput_AdapterEventCountsSurface verifies buildAdapterMetrics carries
+// per-adapter load/eviction counts into the output, including for an adapter that
+// saw resident-set events but completed no request in-window (loaded-then-evicted).
+func TestBuildOutput_AdapterEventCountsSurface(t *testing.T) {
+	m := newAdapterTestMetrics()
+	m.AdapterLoadCounts["adapter_0"] = 3
+	m.AdapterEvictionCounts["adapter_0"] = 1
+	// adapter_2 saw events but has no completed request attributed to it.
+	m.AdapterLoadCounts["adapter_2"] = 2
+	m.AdapterEvictionCounts["adapter_2"] = 2
+
+	out := m.BuildOutput("cluster", nil)
+
+	a0 := out.Adapters["adapter_0"]
+	if a0.LoadCount != 3 || a0.EvictionCount != 1 {
+		t.Errorf("adapter_0 counts = %d/%d, want 3/1", a0.LoadCount, a0.EvictionCount)
+	}
+	if a0.TTFTP50Us <= 0 {
+		t.Errorf("adapter_0 should still carry TTFT from its completed requests, got %v", a0.TTFTP50Us)
+	}
+	a2, ok := out.Adapters["adapter_2"]
+	if !ok {
+		t.Fatal("adapter_2 (events but no completion) must still surface in the adapters block")
+	}
+	if a2.LoadCount != 2 || a2.EvictionCount != 2 {
+		t.Errorf("adapter_2 counts = %d/%d, want 2/2", a2.LoadCount, a2.EvictionCount)
+	}
+	if a2.TTFTP50Us != 0 || a2.ThroughputTokPerS != 0 {
+		t.Errorf("adapter_2 has no completed request: TTFT/throughput should be 0, got %v/%v", a2.TTFTP50Us, a2.ThroughputTokPerS)
 	}
 }
 

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -108,9 +108,9 @@ type MetricsOutput struct {
 // percentiles are in microseconds (ticks); throughput is completed output tokens per
 // second. LoadCount/EvictionCount are cumulative resident-set event counts populated
 // by the per-instance resident set (#1465): LoadCount per cold load, EvictionCount per
-// LRU eviction. They are 0 for an adapter that was referenced but never triggered a
-// resident-set event (e.g. no capacity configured), and absent entirely on an
-// adapter-blind run (INV-6).
+// LRU eviction. They are 0 for an adapter whose requests all hit a warm slot (touch
+// only — no cold loads or evictions), and absent entirely on an adapter-blind run
+// (INV-6).
 type AdapterMetrics struct {
 	LoadCount         int64   `json:"load_count"`
 	EvictionCount     int64   `json:"eviction_count"`

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -104,7 +104,8 @@ type MetricsOutput struct {
 	Adapters map[string]AdapterMetrics `json:"adapters,omitempty"`
 }
 
-// AdapterMetrics is the per-adapter aggregate section (contracts/metrics.md). TTFT
+// AdapterMetrics is the per-adapter aggregate section
+// (specs/007-lora-control-plane/contracts/metrics.md). TTFT
 // percentiles are in microseconds (ticks); throughput is completed output tokens per
 // second. LoadCount/EvictionCount are cumulative resident-set event counts populated
 // by the per-instance resident set (#1465): LoadCount per cold load, EvictionCount per

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -106,8 +106,11 @@ type MetricsOutput struct {
 
 // AdapterMetrics is the per-adapter aggregate section (contracts/metrics.md). TTFT
 // percentiles are in microseconds (ticks); throughput is completed output tokens per
-// second. LoadCount/EvictionCount are populated by the resident set in a later PR and
-// are 0 here (PR1 has no per-instance adapter residency yet).
+// second. LoadCount/EvictionCount are cumulative resident-set event counts populated
+// by the per-instance resident set (#1465): LoadCount per cold load, EvictionCount per
+// LRU eviction. They are 0 for an adapter that was referenced but never triggered a
+// resident-set event (e.g. no capacity configured), and absent entirely on an
+// adapter-blind run (INV-6).
 type AdapterMetrics struct {
 	LoadCount         int64   `json:"load_count"`
 	EvictionCount     int64   `json:"eviction_count"`

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -97,8 +97,8 @@ type MetricsOutput struct {
 	SLOAttainment float64     `json:"slo_attainment,omitempty"`
 	PerClass      interface{} `json:"per_class,omitempty"`
 
-	// Adapters holds per-LoRA-adapter aggregate metrics, keyed by adapter id
-	// (#1464). omitempty: absent when no request is attributed to an adapter, so an
+	// Adapters holds per-LoRA-adapter aggregate metrics, keyed by adapter id.
+	// omitempty: absent when no request is attributed to an adapter, so an
 	// adapter-blind run adds no stdout fields (INV-6, SC-001). encoding/json emits
 	// map string keys in sorted order, giving deterministic output (R2).
 	Adapters map[string]AdapterMetrics `json:"adapters,omitempty"`
@@ -108,8 +108,8 @@ type MetricsOutput struct {
 // (specs/007-lora-control-plane/contracts/metrics.md). TTFT
 // percentiles are in microseconds (ticks); throughput is completed output tokens per
 // second. LoadCount/EvictionCount are cumulative resident-set event counts populated
-// by the per-instance resident set (#1465): LoadCount per cold load, EvictionCount per
-// LRU eviction. They are 0 for an adapter whose requests all hit a warm slot (touch
+// by the per-instance resident set: LoadCount per cold load, EvictionCount per
+// eviction. They are 0 for an adapter whose requests all hit a warm slot (touch
 // only — no cold loads or evictions), and absent entirely on an adapter-blind run
 // (INV-6).
 type AdapterMetrics struct {

--- a/sim/resident_adapter_set.go
+++ b/sim/resident_adapter_set.go
@@ -10,14 +10,14 @@ package sim
 //
 // The interface is intentionally scoped to what the scheduling hook needs today
 // (R13). The concrete set additionally supports pin/unpin and explicit eviction;
-// those enter this interface when the cold-load gate (a later PR) consumes them.
+// those enter this interface when the cold-load gate (#1464) consumes them.
 type ResidentAdapterSet interface {
 	// IsResident reports whether id currently occupies a slot.
 	IsResident(id string) bool
 	// Touch moves a resident id to most-recently-used. No-op if id is absent.
 	Touch(id string)
 	// Store makes id resident at most-recently-used, evicting an entry per the set's
-	// replacement policy (LRU here), skipping pinned entries, when it is at capacity.
+	// replacement policy when at capacity, skipping pinned entries.
 	// Returns the evicted id ("" if none) and whether id is now resident (false only
 	// when the set is full and every slot is pinned). Storing an already-resident id
 	// is equivalent to Touch.

--- a/sim/resident_adapter_set.go
+++ b/sim/resident_adapter_set.go
@@ -1,16 +1,16 @@
 package sim
 
 // ResidentAdapterSet is the per-instance view of the finite resident LoRA adapter
-// slots: a capacity-bounded LRU over adapter ids. The Simulator uses it to track
-// which adapters are "loaded" on the instance as requests are scheduled. The
-// concrete implementation (the LRU) lives in sim/lora and is wired in via
+// slots: a capacity-bounded resident set of adapter ids. The Simulator uses it to
+// track which adapters are "loaded" on the instance as requests are scheduled. The
+// concrete implementation (an LRU) lives in sim/lora and is wired in via
 // NewResidentAdapterSetFunc, mirroring NewAdapterRegistryFunc / NewLatencyModelFunc,
 // so sim/ can own the state without importing sim/lora (Principle I: no reverse
 // import).
 //
-// The interface is intentionally scoped to what the scheduling hook needs today
-// (R13). The concrete set additionally supports pin/unpin and explicit eviction;
-// those enter this interface when the cold-load gate (#1464) consumes them.
+// The interface is intentionally scoped to what the scheduling hook needs (R13).
+// The concrete set additionally supports pin/unpin and explicit eviction; those
+// enter this interface when the LoRA cold-load gate consumes them.
 type ResidentAdapterSet interface {
 	// IsResident reports whether id currently occupies a slot.
 	IsResident(id string) bool

--- a/sim/resident_adapter_set.go
+++ b/sim/resident_adapter_set.go
@@ -1,0 +1,32 @@
+package sim
+
+// ResidentAdapterSet is the per-instance view of the finite resident LoRA adapter
+// slots: a capacity-bounded LRU over adapter ids. The Simulator uses it to track
+// which adapters are "loaded" on the instance as requests are scheduled. The
+// concrete implementation (the LRU) lives in sim/lora and is wired in via
+// NewResidentAdapterSetFunc, mirroring NewAdapterRegistryFunc / NewLatencyModelFunc,
+// so sim/ can own the state without importing sim/lora (Principle I: no reverse
+// import).
+//
+// The interface is intentionally scoped to what the scheduling hook needs today
+// (R13). The concrete set additionally supports pin/unpin and explicit eviction;
+// those enter this interface when the cold-load gate (a later PR) consumes them.
+type ResidentAdapterSet interface {
+	// IsResident reports whether id currently occupies a slot.
+	IsResident(id string) bool
+	// Touch moves a resident id to most-recently-used. No-op if id is absent.
+	Touch(id string)
+	// Store makes id resident at most-recently-used, evicting an entry per the set's
+	// replacement policy (LRU here), skipping pinned entries, when it is at capacity.
+	// Returns the evicted id ("" if none) and whether id is now resident (false only
+	// when the set is full and every slot is pinned). Storing an already-resident id
+	// is equivalent to Touch.
+	Store(id string) (evicted string, admitted bool)
+	// Len returns the number of resident adapters (always ≤ capacity).
+	Len() int
+}
+
+// NewResidentAdapterSetFunc builds a ResidentAdapterSet with the given per-instance
+// slot capacity. Registered by sim/lora's init() (import sim/lora to wire it); nil
+// until then, in which case the Simulator leaves the LoRA subsystem inert (INV-6).
+var NewResidentAdapterSetFunc func(capacity int) ResidentAdapterSet

--- a/sim/resident_adapter_wiring_test.go
+++ b/sim/resident_adapter_wiring_test.go
@@ -1,0 +1,177 @@
+package sim
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestResidentAdapterSet_CapacityBoundAcrossRun is the T022/T024 integration
+// invariant test (SC-003, new invariant resident ≤ capacity). It drives a real
+// resident-adapter set (from sim/lora, wired via the blank import in
+// lora_import_test.go) through a full simulation where more distinct adapters (M)
+// are scheduled than the per-instance slot capacity (N < M), and asserts:
+//
+//   - the resident set never exceeds capacity (checked at end; guaranteed across
+//     all steps by the set's structural bound, unit-proven in sim/lora),
+//   - every distinct adapter is cold-loaded exactly once (M loads total),
+//   - the overflow is evicted (M − N evictions total),
+//
+// observed through the exported per-adapter metrics (LoadCount/EvictionCount),
+// which is how downstream tooling sees residency behavior.
+func TestResidentAdapterSet_CapacityBoundAcrossRun(t *testing.T) {
+	const (
+		capacity    = 2
+		numAdapters = 5 // M > N
+	)
+
+	cfg := newTestSimConfig()
+	capVal := capacity
+	adapters := make([]AdapterSpec, numAdapters)
+	for i := range adapters {
+		adapters[i] = AdapterSpec{ID: fmt.Sprintf("adapter_%d", i), Rank: 8}
+	}
+	cfg.LoRAConfig = LoRAConfig{AdapterCapacity: &capVal, Adapters: adapters}
+
+	sim := mustNewSimulator(t, cfg)
+	if sim.residentAdapters == nil {
+		t.Fatal("residentAdapters is nil: LoRA subsystem not wired (is sim/lora blank-imported?)")
+	}
+
+	// One request per distinct adapter, staggered so scheduling order is unambiguous.
+	for i := 0; i < numAdapters; i++ {
+		req := newTestRequest(fmt.Sprintf("r%d", i), int64(i), 8, 4)
+		req.Adapter = fmt.Sprintf("adapter_%d", i)
+		sim.InjectArrival(req)
+	}
+
+	sim.Run()
+
+	// The capacity bound holds: with M > N distinct adapters, the set ends full.
+	if got := sim.residentAdapters.Len(); got > capacity {
+		t.Fatalf("resident set size %d exceeds capacity %d", got, capacity)
+	}
+	if got := sim.residentAdapters.Len(); got != capacity {
+		t.Fatalf("resident set size = %d, want %d (full after M>N distinct adapters)", got, capacity)
+	}
+
+	out := sim.Metrics.BuildOutput("test-instance", nil)
+	if len(out.Adapters) != numAdapters {
+		t.Fatalf("expected %d adapters in metrics, got %d", numAdapters, len(out.Adapters))
+	}
+
+	var totalLoads, totalEvictions int64
+	for id, am := range out.Adapters {
+		if am.LoadCount != 1 {
+			t.Errorf("adapter %s: LoadCount = %d, want 1 (each distinct adapter cold-loaded once)", id, am.LoadCount)
+		}
+		totalLoads += am.LoadCount
+		totalEvictions += am.EvictionCount
+	}
+	if totalLoads != numAdapters {
+		t.Errorf("total loads = %d, want %d (M)", totalLoads, numAdapters)
+	}
+	if want := int64(numAdapters - capacity); totalEvictions != want {
+		t.Errorf("total evictions = %d, want %d (M − N)", totalEvictions, want)
+	}
+
+	// Eviction attribution: with staggered arrivals the schedule order is r0..r4, so
+	// the LRU victims are the first-scheduled adapters (adapter_0/1/2), each evicted
+	// once; the two still-resident adapters (adapter_3/4) are never evicted. This
+	// pins that evictions are counted against the EVICTED id, not the incoming one.
+	for _, id := range []string{"adapter_0", "adapter_1", "adapter_2"} {
+		if got := out.Adapters[id].EvictionCount; got != 1 {
+			t.Errorf("%s EvictionCount = %d, want 1 (LRU victim)", id, got)
+		}
+	}
+	for _, id := range []string{"adapter_3", "adapter_4"} {
+		if got := out.Adapters[id].EvictionCount; got != 0 {
+			t.Errorf("%s EvictionCount = %d, want 0 (still resident)", id, got)
+		}
+	}
+}
+
+// TestResidentAdapterSet_MixedBaseAndAdapterTraffic verifies that, on a LoRA-enabled
+// instance, base-model requests (empty Adapter) interleaved with adapter requests
+// produce no resident-set events: they never enter the resident set, never appear in
+// the adapters block, and never perturb the adapter load/eviction counts.
+func TestResidentAdapterSet_MixedBaseAndAdapterTraffic(t *testing.T) {
+	capVal := 4
+	cfg := newTestSimConfig()
+	cfg.LoRAConfig = LoRAConfig{
+		AdapterCapacity: &capVal,
+		Adapters:        []AdapterSpec{{ID: "adapter_0", Rank: 8}},
+	}
+	sim := mustNewSimulator(t, cfg)
+
+	// Interleave: base, adapter_0, base, adapter_0, base.
+	adapters := []string{"", "adapter_0", "", "adapter_0", ""}
+	for i, a := range adapters {
+		req := newTestRequest(fmt.Sprintf("r%d", i), int64(i), 8, 4)
+		req.Adapter = a
+		sim.InjectArrival(req)
+	}
+	sim.Run()
+
+	out := sim.Metrics.BuildOutput("test-instance", nil)
+	// Only adapter_0 surfaces; the base ("") requests form no adapter entry.
+	if _, ok := out.Adapters[""]; ok {
+		t.Fatal("base-model (empty adapter) requests must not form an adapter entry")
+	}
+	if len(out.Adapters) != 1 {
+		t.Fatalf("expected exactly 1 adapter entry (adapter_0), got %d: %v", len(out.Adapters), out.Adapters)
+	}
+	a0 := out.Adapters["adapter_0"]
+	if a0.LoadCount != 1 {
+		t.Errorf("adapter_0 LoadCount = %d, want 1 (cold-loaded once; second use is warm)", a0.LoadCount)
+	}
+	if a0.EvictionCount != 0 {
+		t.Errorf("adapter_0 EvictionCount = %d, want 0 (capacity 4, single adapter)", a0.EvictionCount)
+	}
+	if got := sim.residentAdapters.Len(); got != 1 {
+		t.Errorf("resident set size = %d, want 1 (only adapter_0; base traffic adds nothing)", got)
+	}
+}
+
+// TestNewSimulator_InvalidAdapterCapacity verifies NewSimulator returns an error
+// (not a panic) when adapters are declared with a non-positive capacity — the
+// library-boundary defense-in-depth for a caller that bypasses the CLI's
+// LoRAConfig.Validate (R6: library code must not terminate on user input).
+func TestNewSimulator_InvalidAdapterCapacity(t *testing.T) {
+	for _, capVal := range []int{0, -1} {
+		cfg := newTestSimConfig()
+		c := capVal
+		cfg.LoRAConfig = LoRAConfig{
+			AdapterCapacity: &c,
+			Adapters:        []AdapterSpec{{ID: "adapter_0", Rank: 8}},
+		}
+		kvStore := MustNewKVStoreFromConfig(cfg.KVCacheConfig)
+		latencyModel, err := MustNewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig)
+		if err != nil {
+			t.Fatalf("MustNewLatencyModel: %v", err)
+		}
+		if _, err := NewSimulator(cfg, kvStore, latencyModel); err == nil {
+			t.Fatalf("capacity %d: expected error, got nil", capVal)
+		}
+	}
+}
+
+// TestResidentAdapterSet_InertWhenNoLoRA verifies the no-op default: with no
+// LoRA config, the resident set is not constructed and no adapter metrics are
+// emitted (INV-6, SC-001). Requests without an adapter run exactly as before.
+func TestResidentAdapterSet_InertWhenNoLoRA(t *testing.T) {
+	cfg := newTestSimConfig() // no LoRAConfig
+	sim := mustNewSimulator(t, cfg)
+	if sim.residentAdapters != nil {
+		t.Fatal("residentAdapters must be nil when no adapters are configured")
+	}
+
+	for i := 0; i < 3; i++ {
+		sim.InjectArrival(newTestRequest(fmt.Sprintf("r%d", i), int64(i), 8, 4))
+	}
+	sim.Run()
+
+	out := sim.Metrics.BuildOutput("test-instance", nil)
+	if out.Adapters != nil {
+		t.Fatalf("adapter-blind run emitted adapters block: %v", out.Adapters)
+	}
+}

--- a/sim/resident_adapter_wiring_test.go
+++ b/sim/resident_adapter_wiring_test.go
@@ -132,6 +132,94 @@ func TestResidentAdapterSet_MixedBaseAndAdapterTraffic(t *testing.T) {
 	}
 }
 
+// TestResidentAdapterSet_PreemptionDoesNotDoubleCountLoad verifies that a request
+// preempted and rescheduled does not double-count its adapter's cold load. When the
+// request re-enters the running batch its adapter is still resident, so
+// recordAdapterResidency takes the warm (Touch) path — LoadCount stays 1.
+//
+// Scenario mirrors TestSimulator_TotalOutputTokens_NoDoubleCountAfterPreemption:
+// 4 KV blocks × 16 tokens. B (32 input, base model) is injected first and sits at
+// the batch head; A (16 input, adapter "a") is injected second at the tail and is
+// the eviction victim. A is preempted, re-queued, re-prefills, and completes. With
+// capacity 2 and a single adapter, "a" is never evicted from the resident set, so
+// A's reschedule is a warm Touch, not a second cold load.
+func TestResidentAdapterSet_PreemptionDoesNotDoubleCountLoad(t *testing.T) {
+	capVal := 2
+	cfg := SimConfig{
+		Horizon:             1_000_000_000,
+		Seed:                42,
+		KVCacheConfig:       NewKVCacheConfig(4, 16, 0, 0, 0, 0),
+		BatchConfig:         NewBatchConfig(10, 10_000, 16),
+		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 1, 0}, []float64{0, 0, 0}),
+		ModelHardwareConfig: NewModelHardwareConfig(rooflineModelConfig(), rooflineHWCalib(), "test", "H100", 1, 1, false, "", "roofline", 0),
+		LoRAConfig:          LoRAConfig{AdapterCapacity: &capVal, Adapters: []AdapterSpec{{ID: "a", Rank: 8}}},
+	}
+	s := mustNewSimulator(t, cfg)
+	if s.residentAdapters == nil {
+		t.Fatal("residentAdapters is nil: LoRA subsystem not wired")
+	}
+
+	// Distinct non-zero token slices prevent prefix-cache sharing between A and B.
+	bInput := make([]TokenID, 32)
+	for i := range bInput {
+		bInput[i] = TokenID(i + 1)
+	}
+	aInput := make([]TokenID, 16)
+	for i := range aInput {
+		aInput[i] = TokenID(1000 + i)
+	}
+
+	// B first → batch head (never evicted, base model). A second → tail, adapter "a".
+	s.InjectArrival(&Request{ID: "B", ArrivalTime: 0, InputTokens: bInput, OutputTokens: make([]TokenID, 5)})
+	s.InjectArrival(&Request{ID: "A", ArrivalTime: 0, InputTokens: aInput, OutputTokens: make([]TokenID, 5), Adapter: "a"})
+
+	s.Run()
+
+	// Precondition: the scenario must actually exercise a preemption, else it proves nothing.
+	if s.Metrics.PreemptionCount == 0 {
+		t.Fatal("precondition violated: expected at least one preemption, got 0")
+	}
+
+	out := s.Metrics.BuildOutput("test-instance", nil)
+	if got := out.Adapters["a"].LoadCount; got != 1 {
+		t.Errorf("adapter \"a\" LoadCount = %d, want 1 (preempt+reschedule must not re-count a resident adapter)", got)
+	}
+	if got := out.Adapters["a"].EvictionCount; got != 0 {
+		t.Errorf("adapter \"a\" EvictionCount = %d, want 0 (single adapter, never evicted)", got)
+	}
+}
+
+// TestNewSimulator_AdaptersWithoutCapacity verifies the silent-inert-with-warning
+// path: a caller that declares adapters but leaves AdapterCapacity nil gets a
+// successful construction (no error, no panic) with the resident set left nil, so
+// residency events never fire and per-adapter LoadCount/EvictionCount stay 0. This
+// guards the logrus.Warnf branch in NewSimulator against a regression that turns it
+// into a Fatalf or removes the nil-capacity handling.
+func TestNewSimulator_AdaptersWithoutCapacity(t *testing.T) {
+	cfg := newTestSimConfig()
+	cfg.LoRAConfig = LoRAConfig{Adapters: []AdapterSpec{{ID: "a", Rank: 8}}} // AdapterCapacity nil
+	sim := mustNewSimulator(t, cfg)
+	if sim.residentAdapters != nil {
+		t.Fatal("residentAdapters must be nil when adapter_capacity is unset")
+	}
+
+	for i := 0; i < 3; i++ {
+		req := newTestRequest(fmt.Sprintf("r%d", i), int64(i), 8, 4)
+		req.Adapter = "a"
+		sim.InjectArrival(req)
+	}
+	sim.Run()
+
+	// The adapter may still surface via PR1's per-adapter TTFT/throughput metrics,
+	// but no cold loads or evictions are ever recorded without a resident set.
+	out := sim.Metrics.BuildOutput("test-instance", nil)
+	for id, am := range out.Adapters {
+		if am.LoadCount != 0 || am.EvictionCount != 0 {
+			t.Errorf("adapter %q: LoadCount=%d EvictionCount=%d, want 0/0 (resident set inert)", id, am.LoadCount, am.EvictionCount)
+		}
+	}
+}
+
 // TestNewSimulator_InvalidAdapterCapacity verifies NewSimulator returns an error
 // (not a panic) when adapters are declared with a non-positive capacity — the
 // library-boundary defense-in-depth for a caller that bypasses the CLI's

--- a/sim/resident_adapter_wiring_test.go
+++ b/sim/resident_adapter_wiring_test.go
@@ -180,6 +180,13 @@ func TestResidentAdapterSet_PreemptionDoesNotDoubleCountLoad(t *testing.T) {
 		t.Fatal("precondition violated: expected at least one preemption, got 0")
 	}
 
+	// Positive confirmation the warm path was reachable: "a" stayed resident through
+	// the preemption, so the reschedule took Touch (not a skipped recordAdapterResidency,
+	// which would also leave LoadCount == 1 and mask a regression).
+	if !s.residentAdapters.IsResident("a") {
+		t.Error("adapter \"a\" not resident after run: warm Touch path on reschedule was not exercised")
+	}
+
 	out := s.Metrics.BuildOutput("test-instance", nil)
 	if got := out.Adapters["a"].LoadCount; got != 1 {
 		t.Errorf("adapter \"a\" LoadCount = %d, want 1 (preempt+reschedule must not re-count a resident adapter)", got)

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -118,6 +118,12 @@ type Simulator struct {
 	sloMap *SLOPriorityMap // vLLM-convention priority mapping for instance-level scheduling
 	scheduler      InstanceScheduler
 	latencyModel           LatencyModel
+	// residentAdapters tracks this instance's finite resident LoRA adapter slots
+	// (capacity-bounded LRU). nil when the LoRA subsystem is inert (no adapters /
+	// capacity configured, or sim/lora not imported), in which case adapter handling
+	// is a no-op and output is byte-identical to a pre-feature build (INV-6). State
+	// only in this PR — updating it has no latency effect yet (#1465).
+	residentAdapters ResidentAdapterSet
 	seqCounter             int64 // monotonic counter for event queue seqID (deterministic ordering)
 	// OnRequestDone is an optional callback invoked when a request reaches a terminal
 	// state (completed, length-capped, or timed out). Returns follow-up requests to inject.
@@ -189,6 +195,21 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	}
 	s.rng = NewPartitionedRNG(NewSimulationKey(cfg.Seed))
 	s.scheduler = NewScheduler(cfg.Scheduler)
+
+	// Defense-in-depth: reject a non-positive adapter capacity here rather than
+	// letting it reach newResidentSet as a panic. cmd/ validates via LoRAConfig.Validate,
+	// but NewSimulator is library code and must return an error, not terminate, for a
+	// caller that bypasses the CLI (R6). Mirrors the BatchConfig re-validation above.
+	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && *cfg.AdapterCapacity <= 0 {
+		return nil, fmt.Errorf("NewSimulator: adapter_capacity must be > 0 when adapters are declared, got %d", *cfg.AdapterCapacity)
+	}
+	// Wire the per-instance resident-adapter set only when the LoRA subsystem is
+	// active — adapters declared with a positive capacity — and sim/lora is linked
+	// (NewResidentAdapterSetFunc registered). Otherwise it stays nil and adapter
+	// handling is a no-op (INV-6).
+	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc != nil {
+		s.residentAdapters = NewResidentAdapterSetFunc(*cfg.AdapterCapacity)
+	}
 
 	return s, nil
 }
@@ -725,10 +746,45 @@ func (sim *Simulator) scheduleBatch(now int64) {
 			Request: s.Request,
 		})
 		sim.Metrics.RequestSchedulingDelays[s.Request.ID] = now - s.Request.ArrivalTime
+		sim.recordAdapterResidency(s.Request)
 	}
 
 	// Record queue depth observations after batch formation
 	sim.recordQueueSnapshots()
+}
+
+// recordAdapterResidency updates the per-instance resident-adapter set when a
+// request is scheduled onto the running batch: a warm adapter is moved to
+// most-recently-used, a cold adapter is loaded (evicting the LRU non-pinned entry
+// when at capacity, and counting the load / eviction). It is a no-op when the LoRA
+// subsystem is inert or the request targets the base model (empty Adapter), so an
+// adapter-blind run is byte-identical to a pre-feature build (INV-6).
+//
+// Recording residency at running-batch entry matches the design's "in use from the
+// moment a request enters the running batch" semantics. State only: residency has no
+// latency or gating effect here — a cold request still runs immediately. This PR
+// (#1465) wires the resident-set state and metrics; the cold-load pre-admission gate
+// that consumes them is a follow-up PR.
+func (sim *Simulator) recordAdapterResidency(req *Request) {
+	if sim.residentAdapters == nil || req.Adapter == "" {
+		return
+	}
+	if sim.residentAdapters.IsResident(req.Adapter) {
+		sim.residentAdapters.Touch(req.Adapter) // warm reference
+		return
+	}
+	// Cold: load the adapter (may evict the LRU non-pinned entry at capacity).
+	evicted, admitted := sim.residentAdapters.Store(req.Adapter)
+	if !admitted {
+		// Set full and every resident adapter pinned: nothing was loaded, so don't
+		// record a phantom load. Unreachable in this PR (pinning is not wired yet);
+		// the guard keeps the accounting correct once the cold-load gate lands.
+		return
+	}
+	sim.Metrics.AdapterLoadCounts[req.Adapter]++
+	if evicted != "" {
+		sim.Metrics.AdapterEvictionCounts[evicted]++
+	}
 }
 
 // executeBatchStep handles Phase 2: model execution (prefill + decode) for all requests

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -121,8 +121,7 @@ type Simulator struct {
 	// residentAdapters tracks this instance's finite resident LoRA adapter slots
 	// (capacity-bounded LRU). nil when the LoRA subsystem is inert (no adapters /
 	// capacity configured, or sim/lora not imported), in which case adapter handling
-	// is a no-op and output is byte-identical to a pre-feature build (INV-6). State
-	// only in this PR — updating it has no latency effect yet (#1465).
+	// is a no-op and output is byte-identical to a pre-feature build (INV-6).
 	residentAdapters ResidentAdapterSet
 	seqCounter             int64 // monotonic counter for event queue seqID (deterministic ordering)
 	// OnRequestDone is an optional callback invoked when a request reaches a terminal
@@ -209,6 +208,17 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	// handling is a no-op (INV-6).
 	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc != nil {
 		s.residentAdapters = NewResidentAdapterSetFunc(*cfg.AdapterCapacity)
+	} else if cfg.HasAdapters() && cfg.AdapterCapacity == nil {
+		// Adapters declared but no capacity: the resident set stays inert and every
+		// adapter metric reports zero. Warn rather than fail silently (R1) — a run
+		// that completes with zeroed adapter counts is otherwise indistinguishable
+		// from a working one.
+		logrus.Warnf("adapters declared but adapter_capacity is not set; per-instance resident-adapter tracking is disabled and adapter metrics will be zero")
+	} else if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc == nil {
+		// Adapters + capacity configured but sim/lora was never linked, so the seam
+		// factory is unregistered. Only reachable from a non-CLI caller (cmd/root.go
+		// imports sim/lora); warn so that path does not silently drop adapter tracking.
+		logrus.Warnf("adapters and adapter_capacity are configured but sim/lora is not linked (NewResidentAdapterSetFunc unregistered); resident-adapter tracking is disabled and adapter metrics will be zero")
 	}
 
 	return s, nil
@@ -764,7 +774,7 @@ func (sim *Simulator) scheduleBatch(now int64) {
 // moment a request enters the running batch" semantics. State only: residency has no
 // latency or gating effect here — a cold request still runs immediately. This PR
 // (#1465) wires the resident-set state and metrics; the cold-load pre-admission gate
-// that consumes them is a follow-up PR.
+// that consumes them is tracked under #1464.
 func (sim *Simulator) recordAdapterResidency(req *Request) {
 	if sim.residentAdapters == nil || req.Adapter == "" {
 		return

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -207,7 +207,15 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	// (NewResidentAdapterSetFunc registered). Otherwise it stays nil and adapter
 	// handling is a no-op (INV-6).
 	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc != nil {
-		s.residentAdapters = NewResidentAdapterSetFunc(*cfg.AdapterCapacity)
+		// Guard against a factory that returns a nil interface value: the concrete
+		// sim/lora set never does (it returns a valid set or panics on bad capacity),
+		// but a test double or future implementation might, and a typed-nil interface
+		// would slip past the sim.residentAdapters == nil guard and panic on first use.
+		rs := NewResidentAdapterSetFunc(*cfg.AdapterCapacity)
+		if rs == nil {
+			return nil, fmt.Errorf("NewSimulator: NewResidentAdapterSetFunc returned nil for capacity %d", *cfg.AdapterCapacity)
+		}
+		s.residentAdapters = rs
 	} else if cfg.HasAdapters() && cfg.AdapterCapacity == nil {
 		// Adapters declared but no capacity: the resident set stays inert and every
 		// adapter metric reports zero. Warn rather than fail silently (R1) — a run
@@ -218,6 +226,9 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 		// Adapters + capacity configured but sim/lora was never linked, so the seam
 		// factory is unregistered. Only reachable from a non-CLI caller (cmd/root.go
 		// imports sim/lora); warn so that path does not silently drop adapter tracking.
+		// This branch is not unit-testable from within package sim: the blank import in
+		// lora_import_test.go always registers the factory, so there is no way to
+		// observe NewResidentAdapterSetFunc == nil in a sim test.
 		logrus.Warnf("adapters and adapter_capacity are configured but sim/lora is not linked (NewResidentAdapterSetFunc unregistered); resident-adapter tracking is disabled and adapter metrics will be zero")
 	}
 
@@ -785,12 +796,13 @@ func (sim *Simulator) recordAdapterResidency(req *Request) {
 	evicted, admitted := sim.residentAdapters.Store(req.Adapter)
 	if !admitted {
 		// Set full and every resident adapter pinned: nothing was loaded, so don't
-		// record a phantom load. Unreachable in this PR (pinning is not wired yet);
-		// the guard keeps the accounting correct once the cold-load gate lands. Warn
-		// so that, once pinning is wired, a failed cold load surfaces as a logged
-		// event rather than silently missing adapter metrics (R1).
-		logrus.Warnf("recordAdapterResidency: adapter %q could not be loaded "+
-			"(resident set full, all slots pinned); no load counted", req.Adapter)
+		// record a phantom load. Unreachable until pin/unpin are wired (LoRA cold-load
+		// gate); the guard keeps the accounting correct once that lands. Warn so that,
+		// once pinning is wired, a failed cold load surfaces as a logged event rather
+		// than silently missing adapter metrics (R1). Include req.ID so a multi-instance
+		// cluster trace can correlate which request hit the all-pinned condition.
+		logrus.Warnf("recordAdapterResidency: adapter %q (req %s) could not be loaded "+
+			"(resident set full, all slots pinned); no load counted", req.Adapter, req.ID)
 		return
 	}
 	sim.Metrics.AdapterLoadCounts[req.Adapter]++

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -772,9 +772,7 @@ func (sim *Simulator) scheduleBatch(now int64) {
 //
 // Recording residency at running-batch entry matches the design's "in use from the
 // moment a request enters the running batch" semantics. State only: residency has no
-// latency or gating effect here — a cold request still runs immediately. This PR
-// (#1465) wires the resident-set state and metrics; the cold-load pre-admission gate
-// that consumes them is tracked under #1464.
+// latency or gating effect here — a cold request still runs immediately.
 func (sim *Simulator) recordAdapterResidency(req *Request) {
 	if sim.residentAdapters == nil || req.Adapter == "" {
 		return
@@ -788,7 +786,11 @@ func (sim *Simulator) recordAdapterResidency(req *Request) {
 	if !admitted {
 		// Set full and every resident adapter pinned: nothing was loaded, so don't
 		// record a phantom load. Unreachable in this PR (pinning is not wired yet);
-		// the guard keeps the accounting correct once the cold-load gate lands.
+		// the guard keeps the accounting correct once the cold-load gate lands. Warn
+		// so that, once pinning is wired, a failed cold load surfaces as a logged
+		// event rather than silently missing adapter metrics (R1).
+		logrus.Warnf("recordAdapterResidency: adapter %q could not be loaded "+
+			"(resident set full, all slots pinned); no load counted", req.Adapter)
 		return
 	}
 	sim.Metrics.AdapterLoadCounts[req.Adapter]++


### PR DESCRIPTION
## Summary

PR2 of the LoRA control-plane subsystem (epic #1464). Adds the **per-instance resident-adapter set** (User Story 2): a capacity-bounded LRU over adapter ids, wired into the core `Simulator`, plus per-adapter load/eviction metrics.

**State-only:** residency has no latency or gating effect yet — a cold request still runs immediately. The cold-load pre-admission gate that consumes this state is a follow-up PR.

> ✅ **PR1 (#1472) merged to `main` (2026-07-23); this branch has been rebased onto merged `main`.** The stale PR1 commits it previously carried are gone — the diff now shows the single PR2 commit alone. Part of the LoRA control-plane stack (epic #1464); PR3–PR7 follow and will rebase onto this once it lands.

Closes #1465.

## What it does

- **`sim/lora/resident_set.go`** — capacity-bounded LRU reusing the `cpuTier` hash + doubly-linked-list pattern (`store`/`touch`/`unlink`/`appendToTail`), with reference-counted pinning (`Pin`/`Unpin`/`EvictLRU` proven now so the follow-up gate inherits a tested primitive). Deterministic, no RNG (INV-6).
- **`sim/resident_adapter_set.go`** — `ResidentAdapterSet` seam interface + `NewResidentAdapterSetFunc`, registered by `sim/lora`'s `init()` (mirrors `NewAdapterRegistryFunc` / `NewLatencyModelFunc`; no reverse import). Interface is intentionally minimal (`IsResident`/`Touch`/`Store`/`Len`); `Pin`/`Unpin`/`EvictLRU` join it when the gate consumes them (R13).
- **`sim/simulator.go`** — `Simulator.residentAdapters`, wired in `NewSimulator` when adapters + capacity are configured (capacity validated `> 0`, returns an **error** not a panic — R6); `recordAdapterResidency` hook off the existing `NewlyScheduled` loop (cold → `Store`, warm → `Touch`).
- **`sim/metrics.go` / `metrics_utils.go`** — `AdapterLoadCounts`/`AdapterEvictionCounts`, surfaced through `buildAdapterMetrics` (sorted-id; returns nil for adapter-blind runs).
- **`sim/cluster/cluster.go`** — `aggregateMetrics` sums the per-adapter counts across instances (adapter ids legitimately recur across instances, unlike globally-unique request ids → sum, not merge-and-warn).

## Invariants

- **New:** `resident ≤ capacity` (structural, unit- and run-level tested).
- **INV-6:** adapter-blind runs are byte-identical to a pre-feature build (nil resident set + nil adapters block); the no-op golden holds.
- **INV-4:** no KV reservation in this PR (deferred to a later PR).
- **Run/replay parity:** both drive the shared `sim.Simulator`, so residency is wired for both automatically; `observe` (real HTTP) has no DES/resident set — correct scope boundary.

## Testing

`go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean. Coverage: 8 LRU unit tests, run-level capacity-bound + inert-when-no-LoRA + mixed base/adapter integration tests, cluster aggregation (direct-input unit + end-to-end 2-instance), and metrics-surfacing tests. Determinism verified.

A detailed review report (convergence review + blis-pr-review) is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
