### PR TITLE
feat(lora): PR3 — adapter cold-load latency via pre-admission gate (#1466)

### DIFF
--- a/sim/adapter_cost.go
+++ b/sim/adapter_cost.go
@@ -1,0 +1,24 @@
+package sim
+
+// AdapterCost is the read-only query bridge over the LoRA adapter cost model. It
+// is owned by sim/ so the cold-load pre-admission gate can charge load latency
+// without importing sim/lora (Principle I: no reverse import); the concrete
+// model (rank-derived cost terms) lives in sim/lora and is wired in via
+// NewAdapterCostFunc, mirroring NewAdapterRegistryFunc / NewResidentAdapterSetFunc.
+//
+// The interface is intentionally scoped to what the gate consumes today (R13):
+// only LoadLatency. The concrete cost model additionally derives the per-step
+// compute-overhead factor and the HBM footprint; those enter this interface when
+// the latency and memory PRs consume them.
+type AdapterCost interface {
+	// LoadLatency returns the one-time cold-load latency of an adapter id in µs
+	// (>= 0). An empty (base-model) or unregistered id returns 0 — it never gates.
+	LoadLatency(id string) float64
+}
+
+// NewAdapterCostFunc builds an AdapterCost from a LoRAConfig (rank registry +
+// cost coefficients). Registered by sim/lora's init() (import sim/lora to wire
+// it); nil until then, in which case the Simulator leaves cold-load gating inert
+// (INV-6). Returns an error for a malformed config (missing/non-positive divisor
+// coefficients), which the caller maps to fatality.
+var NewAdapterCostFunc func(cfg LoRAConfig) (AdapterCost, error)

--- a/sim/batch_formation.go
+++ b/sim/batch_formation.go
@@ -31,6 +31,14 @@ type BatchContext struct {
 	Now                   int64
 	StepCount             int
 	ComputedTokens        map[string]int64
+
+	// AdapterResident is the cold-load pre-admission gate predicate (#1466): it
+	// reports whether a request's LoRA adapter is currently resident on the
+	// instance. A new prefill request whose adapter is NOT resident is held out of
+	// the batch (blocking model: it also stalls the requests behind it) until the
+	// kernel-scheduled adapter load completes. nil ⇒ no LoRA gating; admission is
+	// byte-identical to a pre-feature build (INV-6).
+	AdapterResident func(id string) bool
 }
 
 // ScheduledRequest carries metadata about a newly scheduled request.
@@ -157,6 +165,17 @@ func (v *VLLMBatchFormation) FormBatch(ctx BatchContext) BatchResult {
 	// Phase 2: Dequeue new requests from wait queue
 	for len(result.RunningBatch.Requests) < int(ctx.MaxRunningReqs) && ctx.WaitQ.Len() > 0 && tokenBudget > 0 && !result.PreemptionHappened {
 		next := ctx.WaitQ.Peek()
+
+		// Cold-load pre-admission gate (LoRA, #1466): a new prefill request whose
+		// adapter is not yet resident on this instance is held out of the batch
+		// until its adapter load completes (FR-007, §7). Because Phase 2 inspects
+		// only the queue head and breaks on the first non-admittable request, this
+		// realizes the DT-faithful blocking model — a gated head stalls the warm
+		// requests behind it for the load duration. Decode sub-requests (PD) are
+		// already past the gate (their prefill ran with the adapter resident).
+		if ctx.AdapterResident != nil && !next.IsDecodeSubRequest && next.Adapter != "" && !ctx.AdapterResident(next.Adapter) {
+			break
+		}
 
 		// Handle decode-only requests (PD disaggregation: KV pre-allocated by transfer).
 		// IsDecodeSubRequest is set exclusively by KVTransferStartedEvent when it

--- a/sim/cluster/adapter_metrics_aggregation_test.go
+++ b/sim/cluster/adapter_metrics_aggregation_test.go
@@ -17,9 +17,15 @@ func TestClusterSimulator_AdapterMetrics_AggregatedAcrossInstances_E2E(t *testin
 	config := newTestDeploymentConfig(2)
 	config.RoutingPolicy = "round-robin"
 	capVal := 8 // capacity >> 1 adapter, so no evictions
+	// Cost coefficients are required once the cold-load gate consumes them (#1466);
+	// production fills them from defaults.yaml when adapters are configured.
+	base, bw, fp := 1000.0, 2.0e6, 2.0e6
 	config.LoRAConfig = sim.LoRAConfig{
-		AdapterCapacity: &capVal,
-		Adapters:        []sim.AdapterSpec{{ID: "adapter_shared", Rank: 8}},
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     &base,
+		LoadBandwidthBytesUs:  &bw,
+		FootprintBytesPerRank: &fp,
+		Adapters:              []sim.AdapterSpec{{ID: "adapter_shared", Rank: 8}},
 	}
 
 	requests := newTestRequests(6)

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -477,6 +477,10 @@ func (i *InstanceSimulator) DrainWaitQueue() []*sim.Request {
 func (i *InstanceSimulator) EvictRequest(req *sim.Request) bool {
 	if i.sim.WaitQ.Remove(req) {
 		i.sim.KVCache.ReleaseKVBlocks(req)
+		// Release the LoRA adapter pin (#1466): a queued request is not pinned, so
+		// this is a no-op here, but calling it keeps eviction symmetric with the
+		// running-batch branch below and robust if pinning semantics change.
+		i.sim.ReleaseAdapterPin(req)
 		req.State = sim.StateCompleted
 		return true
 	}
@@ -488,6 +492,11 @@ func (i *InstanceSimulator) EvictRequest(req *sim.Request) bool {
 					i.sim.RunningBatch.Requests[idx+1:]...,
 				)
 				i.sim.KVCache.ReleaseKVBlocks(req)
+				// Release the LoRA adapter pin (#1466): a running request WAS pinned
+				// on batch entry, and this gateway eviction is a terminal path outside
+				// completion/timeout, so it must free the slot or the pin leaks and
+				// eventually stalls all cold loads on this instance (INV-L5).
+				i.sim.ReleaseAdapterPin(req)
 				req.State = sim.StateCompleted
 				if len(i.sim.RunningBatch.Requests) == 0 {
 					i.sim.RunningBatch = nil

--- a/sim/cluster/instance_test.go
+++ b/sim/cluster/instance_test.go
@@ -637,3 +637,58 @@ func TestInstanceSimulator_MaxBatchSize_ReturnsConstructorValue(t *testing.T) {
 		t.Errorf("MaxBatchSize() = %d, want 128", got)
 	}
 }
+
+// TestInstanceSimulator_EvictRequest_ReleasesAdapterPin is a regression for the
+// cold-load gate pin leak (#1466): gateway in-flight eviction of a RUNNING adapter
+// request is a terminal path outside completion/timeout, so it must release the
+// request's adapter pin — otherwise the slot stays falsely pinned for the rest of
+// the run and blocks every future cold load on the instance (INV-L5). Capacity 1
+// makes the leak observable: after evicting a running a1, a cold a2 can only load
+// if a1's slot was unpinned (so EvictLRU can reclaim it).
+func TestInstanceSimulator_EvictRequest_ReleasesAdapterPin(t *testing.T) {
+	cfg := newTestSimConfig()
+	cfg.Horizon = 100_000_000 // bounded so a regression fails cleanly instead of spinning forever
+	capVal := 1
+	base, bw, fp := 1000.0, 2.0e6, 2.0e6
+	cfg.LoRAConfig = sim.LoRAConfig{
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     &base,
+		LoadBandwidthBytesUs:  &bw,
+		FootprintBytesPerRank: &fp,
+		Adapters:              []sim.AdapterSpec{{ID: "a1", Rank: 8}, {ID: "a2", Rank: 8}},
+	}
+	inst := NewInstanceSimulator(InstanceID("evict-pin"), cfg)
+
+	// a1 has a long output so it is still running (pinned) when we evict it.
+	a1 := &sim.Request{ID: "a1req", Adapter: "a1", ArrivalTime: 0, State: sim.StateQueued,
+		InputTokens: make([]sim.TokenID, 8), OutputTokens: make([]sim.TokenID, 100), MaxOutputLen: 100}
+	inst.InjectRequest(a1)
+
+	// Step until a1 is admitted to the running batch (past its cold load): now pinned.
+	for i := 0; i < 100000 && inst.BatchSize() == 0 && inst.HasPendingEvents(); i++ {
+		inst.ProcessNextEvent()
+	}
+	require.GreaterOrEqual(t, inst.BatchSize(), 1, "a1 should be running (pinned) before eviction")
+
+	// Gateway in-flight eviction of the running (pinned) a1.
+	if !inst.EvictRequest(a1) {
+		t.Fatal("EvictRequest(a1) returned false; expected the running request to be found")
+	}
+
+	// A cold a2 now arrives; with capacity 1 it must evict a1's freed slot to load.
+	a2 := &sim.Request{ID: "a2req", Adapter: "a2", ArrivalTime: inst.Clock(), State: sim.StateQueued,
+		InputTokens: make([]sim.TokenID, 8), OutputTokens: make([]sim.TokenID, 4), MaxOutputLen: 4}
+	inst.InjectRequest(a2)
+
+	// Drain (bounded): if the pin leaked, EvictLRU stays stuck and a2 never loads,
+	// so this loop hits the cap and the assertion below fails cleanly.
+	for i := 0; i < 500000 && inst.HasPendingEvents(); i++ {
+		inst.ProcessNextEvent()
+	}
+
+	out := inst.Metrics().BuildOutput("evict-pin", nil)
+	if lc := out.Adapters["a2"].LoadCount; lc != 1 {
+		t.Errorf("adapter a2 LoadCount = %d, want 1 — cold a2 could not load after a1 was evicted; "+
+			"the eviction leaked a1's adapter pin (EvictLRU stuck)", lc)
+	}
+}

--- a/sim/cold_load_gate_test.go
+++ b/sim/cold_load_gate_test.go
@@ -1,0 +1,273 @@
+package sim
+
+import (
+	"testing"
+)
+
+// The cold-load pre-admission gate charges a one-time adapter load latency when a
+// request's adapter is not yet resident on the instance (FR-007, US3 scenario 1,
+// SC-004). A cold request is held out of the running batch until its adapter load
+// completes; a warm request is admitted immediately with no load latency. Adapter
+// loads on an instance are serialized. These are the T027 contract tests and the
+// T029 companion invariant tests; they observe behavior through per-request TTFT
+// and the exported adapter metrics, independent of the gate's internal mechanism.
+
+// gateTestConfig returns a LoRA-enabled SimConfig with a single ranked adapter
+// and simple cost coefficients so the load latency is an exact, predictable value.
+// base=1000µs, bandwidth=2e6 B/µs, footprint=2e6 B/rank ⇒ LoadLatency(rank 8) =
+// 1000 + ceil(1.6e7/2e6) = 1008µs.
+func gateTestConfig(capacity int, adapters ...AdapterSpec) SimConfig {
+	cfg := newTestSimConfig()
+	c := capacity
+	cfg.LoRAConfig = LoRAConfig{
+		AdapterCapacity:       &c,
+		LoadBaseLatencyUs:     fptrGate(1000.0),
+		LoadBandwidthBytesUs:  fptrGate(2.0e6),
+		FootprintBytesPerRank: fptrGate(2.0e6),
+		Adapters:              adapters,
+	}
+	return cfg
+}
+
+func fptrGate(v float64) *float64 { return &v }
+
+const gateLoadLatencyRank8 = 1008 // base 1000 + ceil(footprint/bw) 8
+
+// runSingleTTFT drives a one-request simulation and returns the request's TTFT
+// (FirstTokenTime, measured relative to arrival). The request pointer is mutated
+// in place by the run, so its FirstTokenTime is readable afterward.
+func runSingleTTFT(t *testing.T, cfg SimConfig, adapter string) int64 {
+	t.Helper()
+	req := newTestRequest("solo", 0, 8, 4)
+	req.Adapter = adapter
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(req)
+	s.Run()
+	if !req.TTFTSet {
+		t.Fatalf("request never produced a first token (adapter=%q)", adapter)
+	}
+	return req.FirstTokenTime
+}
+
+// TestColdLoadGate_ColdAddsLoadLatencyToTTFT is the core T027 contract: a cold
+// adapter request's TTFT exceeds an otherwise-identical base-model request's TTFT
+// by exactly the modeled load latency (US3 scenario 1, SC-004).
+func TestColdLoadGate_ColdAddsLoadLatencyToTTFT(t *testing.T) {
+	adapter := AdapterSpec{ID: "a8", Rank: 8}
+
+	// Base-model request on a LoRA-enabled instance (empty adapter never gates).
+	base := runSingleTTFT(t, gateTestConfig(2, adapter), "")
+	// Cold adapter request: identical shape, adapter not yet resident.
+	cold := runSingleTTFT(t, gateTestConfig(2, adapter), "a8")
+
+	if got := cold - base; got != gateLoadLatencyRank8 {
+		t.Errorf("cold TTFT excess over base = %d, want %d (one load latency); base=%d cold=%d",
+			got, gateLoadLatencyRank8, base, cold)
+	}
+}
+
+// TestColdLoadGate_WarmIncursNoLoadLatency is the T027 warm case: once an adapter
+// is resident, a subsequent request for it incurs zero load latency — its TTFT
+// equals the base-model TTFT (US3 scenario 1). The second request arrives long
+// after the first completes so it does not queue behind it.
+func TestColdLoadGate_WarmIncursNoLoadLatency(t *testing.T) {
+	adapter := AdapterSpec{ID: "a8", Rank: 8}
+	cfg := gateTestConfig(2, adapter)
+
+	baseTTFT := runSingleTTFT(t, gateTestConfig(2, adapter), "")
+
+	r1 := newTestRequest("cold", 0, 8, 4)
+	r1.Adapter = "a8"
+	r2 := newTestRequest("warm", 5_000_000, 8, 4) // arrives well after r1 completes
+	r2.Adapter = "a8"
+
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(r1)
+	s.InjectArrival(r2)
+	s.Run()
+
+	if !r1.TTFTSet || !r2.TTFTSet {
+		t.Fatalf("requests did not both complete: r1.set=%v r2.set=%v", r1.TTFTSet, r2.TTFTSet)
+	}
+	// r1 cold: pays the load; r2 warm: pays nothing (TTFT == base).
+	if got := r1.FirstTokenTime - baseTTFT; got != gateLoadLatencyRank8 {
+		t.Errorf("cold r1 TTFT excess = %d, want %d", got, gateLoadLatencyRank8)
+	}
+	if r2.FirstTokenTime != baseTTFT {
+		t.Errorf("warm r2 TTFT = %d, want %d (base, no load latency)", r2.FirstTokenTime, baseTTFT)
+	}
+
+	// The adapter is cold-loaded exactly once across both requests (INV-L3).
+	out := s.Metrics.BuildOutput("test-instance", nil)
+	if lc := out.Adapters["a8"].LoadCount; lc != 1 {
+		t.Errorf("adapter a8 LoadCount = %d, want 1 (charged once; second use warm)", lc)
+	}
+}
+
+// TestColdLoadGate_LoadsSerializePerInstance is the T027 serialization contract:
+// two distinct cold adapters arriving together cannot load concurrently — the
+// second request is gated behind the first load (blocking model), so its TTFT is
+// strictly greater, and each adapter loads exactly once.
+func TestColdLoadGate_LoadsSerializePerInstance(t *testing.T) {
+	cfg := gateTestConfig(2, AdapterSpec{ID: "a8", Rank: 8}, AdapterSpec{ID: "b8", Rank: 8})
+
+	r1 := newTestRequest("r1", 0, 8, 4)
+	r1.Adapter = "a8"
+	r2 := newTestRequest("r2", 0, 8, 4)
+	r2.Adapter = "b8"
+
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(r1)
+	s.InjectArrival(r2)
+	s.Run()
+
+	if !r1.TTFTSet || !r2.TTFTSet {
+		t.Fatalf("requests did not both complete")
+	}
+	// Serialized + blocking: the second-admitted request waited behind the first
+	// load, so the two TTFTs cannot be equal.
+	if r1.FirstTokenTime == r2.FirstTokenTime {
+		t.Errorf("both requests share TTFT %d: loads did not serialize (blocking model)", r1.FirstTokenTime)
+	}
+
+	out := s.Metrics.BuildOutput("test-instance", nil)
+	for _, id := range []string{"a8", "b8"} {
+		if lc := out.Adapters[id].LoadCount; lc != 1 {
+			t.Errorf("adapter %s LoadCount = %d, want 1", id, lc)
+		}
+	}
+}
+
+// TestColdLoadGate_SameAdapterCoalesces verifies INV-L3: two requests for the
+// SAME cold adapter arriving together share a single load — the adapter is loaded
+// exactly once and no second load is charged (same-adapter coalescing, §7). The
+// second request finds the adapter resident after the first load completes.
+func TestColdLoadGate_SameAdapterCoalesces(t *testing.T) {
+	cfg := gateTestConfig(2, AdapterSpec{ID: "a8", Rank: 8})
+
+	r1 := newTestRequest("r1", 0, 8, 4)
+	r1.Adapter = "a8"
+	r2 := newTestRequest("r2", 0, 8, 4) // same adapter, arrives together
+	r2.Adapter = "a8"
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(r1)
+	s.InjectArrival(r2)
+	s.Run()
+
+	if !r1.TTFTSet || !r2.TTFTSet {
+		t.Fatalf("requests did not both complete")
+	}
+	if s.Metrics.CompletedRequests != 2 {
+		t.Errorf("CompletedRequests = %d, want 2", s.Metrics.CompletedRequests)
+	}
+	out := s.Metrics.BuildOutput("test-instance", nil)
+	if lc := out.Adapters["a8"].LoadCount; lc != 1 {
+		t.Errorf("adapter a8 LoadCount = %d, want 1 (both requests coalesce onto one load, INV-L3)", lc)
+	}
+	if ev := out.Adapters["a8"].EvictionCount; ev != 0 {
+		t.Errorf("adapter a8 EvictionCount = %d, want 0 (single adapter, capacity 2)", ev)
+	}
+}
+
+// TestAdapterLoadEventPriorityOrdering pins the §7 ordering contract as an
+// explicit invariant: an adapter-load completion MUST fire ahead of a co-timed
+// step (so the newly-resident adapter's request is batch-eligible that tick) and
+// after queueing. A future renumbering that breaks this would silently delay
+// gated admissions; this guards against it.
+func TestAdapterLoadEventPriorityOrdering(t *testing.T) {
+	if PriorityQueued >= PriorityAdapterLoad || PriorityAdapterLoad >= PriorityStep {
+		t.Fatalf("priority ordering broken: want Queued(%d) < AdapterLoad(%d) < Step(%d)",
+			PriorityQueued, PriorityAdapterLoad, PriorityStep)
+	}
+}
+
+// --- T029: companion invariant tests ---
+
+// TestColdLoadGate_INV6_NoOpByteIdentity verifies that a run with no adapters
+// configured is unaffected by the gate machinery: an adapter-blind workload on a
+// non-LoRA config produces the same per-request TTFT as before (INV-6, SC-001).
+// (Cross-checked against the golden baseline in the package's no-op test; here we
+// assert the gate never perturbs a base-model request even when LoRA is enabled.)
+func TestColdLoadGate_INV6_BaseRequestUnaffectedByLoRAConfig(t *testing.T) {
+	adapter := AdapterSpec{ID: "a8", Rank: 8}
+	// Same base-model request, once on a plain config and once on a LoRA-enabled
+	// config: the empty adapter must never gate, so TTFT is identical.
+	plain := runSingleTTFT(t, newTestSimConfig(), "")
+	loraEnabled := runSingleTTFT(t, gateTestConfig(2, adapter), "")
+	if plain != loraEnabled {
+		t.Errorf("base-model TTFT differs with LoRA enabled: plain=%d lora=%d (INV-6)", plain, loraEnabled)
+	}
+}
+
+// TestColdLoadGate_INV5_Causality verifies the gate delays scheduling, not
+// arrival/enqueue: for a cold request, the scheduling delay (queued→running)
+// absorbs the full load latency, so schedule_time > enqueue_time ≥ arrival_time
+// (INV-5). Observed via RequestSchedulingDelays, which is (schedule − arrival).
+func TestColdLoadGate_INV5_GateDelaysSchedule(t *testing.T) {
+	cfg := gateTestConfig(2, AdapterSpec{ID: "a8", Rank: 8})
+	req := newTestRequest("cold", 0, 8, 4)
+	req.Adapter = "a8"
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(req)
+	s.Run()
+
+	delay, ok := s.Metrics.RequestSchedulingDelays["cold"]
+	if !ok {
+		t.Fatal("no scheduling delay recorded for cold request")
+	}
+	// The cold request cannot be scheduled before its adapter finishes loading, so
+	// its schedule delay is at least the load latency (INV-5: arrival ≤ schedule).
+	if delay < gateLoadLatencyRank8 {
+		t.Errorf("cold scheduling delay = %d, want >= %d (adapter load precedes schedule)", delay, gateLoadLatencyRank8)
+	}
+}
+
+// TestColdLoadGate_INV8_NoDeadlockUnderCapacityPressure verifies the gate never
+// strands a request (INV-8 work-conserving, INV-11 completeness): with capacity 1
+// and two distinct cold adapters, the second load cannot start until the first
+// request completes and unpins its slot (its adapter is the only eviction victim
+// and is pinned while in use, INV-L5). The run must still fully drain — both
+// requests complete and each adapter loads exactly once.
+func TestColdLoadGate_INV8_NoDeadlockUnderCapacityPressure(t *testing.T) {
+	cfg := gateTestConfig(1, AdapterSpec{ID: "a8", Rank: 8}, AdapterSpec{ID: "b8", Rank: 8})
+
+	r1 := newTestRequest("r1", 0, 8, 4)
+	r1.Adapter = "a8"
+	r2 := newTestRequest("r2", 0, 8, 4)
+	r2.Adapter = "b8"
+	s := mustNewSimulator(t, cfg)
+	s.InjectArrival(r1)
+	s.InjectArrival(r2)
+	s.Run()
+
+	if !r1.TTFTSet || !r2.TTFTSet {
+		t.Fatalf("gate stranded a request under capacity pressure: r1.set=%v r2.set=%v", r1.TTFTSet, r2.TTFTSet)
+	}
+	if s.Metrics.CompletedRequests != 2 {
+		t.Errorf("CompletedRequests = %d, want 2 (both drain, INV-11)", s.Metrics.CompletedRequests)
+	}
+	out := s.Metrics.BuildOutput("test-instance", nil)
+	for _, id := range []string{"a8", "b8"} {
+		if lc := out.Adapters[id].LoadCount; lc != 1 {
+			t.Errorf("adapter %s LoadCount = %d, want 1", id, lc)
+		}
+	}
+	// Capacity 1 with two distinct adapters forces exactly one eviction (the first
+	// adapter is evicted to make room for the second once its request completes).
+	if ev := out.Adapters["a8"].EvictionCount; ev != 1 {
+		t.Errorf("adapter a8 EvictionCount = %d, want 1 (evicted for b8 after r1 completes)", ev)
+	}
+}
+
+// TestColdLoadGate_INV3_LoadCompletionInFuture verifies determinism and that the
+// gate never stalls the simulator (INV-8: a gated request's load is scheduled
+// work, so the run always drains). Two identical seeds produce identical TTFT
+// (INV-6 determinism, no RNG in the cost path — R7).
+func TestColdLoadGate_Determinism(t *testing.T) {
+	run := func() int64 {
+		return runSingleTTFT(t, gateTestConfig(2, AdapterSpec{ID: "a8", Rank: 8}), "a8")
+	}
+	if a, b := run(), run(); a != b {
+		t.Errorf("cold-load gate not deterministic: run1=%d run2=%d", a, b)
+	}
+}

--- a/sim/cold_load_gate_test.go
+++ b/sim/cold_load_gate_test.go
@@ -259,10 +259,10 @@ func TestColdLoadGate_INV8_NoDeadlockUnderCapacityPressure(t *testing.T) {
 	}
 }
 
-// TestColdLoadGate_INV3_LoadCompletionInFuture verifies determinism and that the
-// gate never stalls the simulator (INV-8: a gated request's load is scheduled
-// work, so the run always drains). Two identical seeds produce identical TTFT
-// (INV-6 determinism, no RNG in the cost path — R7).
+// TestColdLoadGate_Determinism verifies determinism and that the gate never stalls
+// the simulator (INV-8: a gated request's load is scheduled work, so the run always
+// drains). Two identical seeds produce identical TTFT (INV-6 determinism, no RNG in
+// the cost path — R7).
 func TestColdLoadGate_Determinism(t *testing.T) {
 	run := func() int64 {
 		return runSingleTTFT(t, gateTestConfig(2, AdapterSpec{ID: "a8", Rank: 8}), "a8")

--- a/sim/config.go
+++ b/sim/config.go
@@ -313,15 +313,17 @@ func (c LoRAConfig) Validate() error {
 	}
 
 	// Cost coefficients (validated whenever set, even absent adapters, so a malformed
-	// coefficient is caught at declaration time).
-	if c.LoadBaseLatencyUs != nil && *c.LoadBaseLatencyUs < 0 {
-		return fmt.Errorf("LoRAConfig: load_base_latency_us must be >= 0, got %v", *c.LoadBaseLatencyUs)
+	// coefficient is caught at declaration time). Non-finite values (NaN/±Inf) slip
+	// past the ordering guards below — NaN comparisons are always false and +Inf
+	// passes > 0 — and later poison the cost model's arithmetic, so reject them (R3/R20).
+	if c.LoadBaseLatencyUs != nil && (math.IsNaN(*c.LoadBaseLatencyUs) || math.IsInf(*c.LoadBaseLatencyUs, 0) || *c.LoadBaseLatencyUs < 0) {
+		return fmt.Errorf("LoRAConfig: load_base_latency_us must be finite and >= 0, got %v", *c.LoadBaseLatencyUs)
 	}
-	if c.LoadBandwidthBytesUs != nil && *c.LoadBandwidthBytesUs <= 0 {
-		return fmt.Errorf("LoRAConfig: load_bandwidth_bytes_us must be > 0 (divisor guard), got %v", *c.LoadBandwidthBytesUs)
+	if c.LoadBandwidthBytesUs != nil && (math.IsNaN(*c.LoadBandwidthBytesUs) || math.IsInf(*c.LoadBandwidthBytesUs, 0) || *c.LoadBandwidthBytesUs <= 0) {
+		return fmt.Errorf("LoRAConfig: load_bandwidth_bytes_us must be finite and > 0 (divisor guard), got %v", *c.LoadBandwidthBytesUs)
 	}
-	if c.FootprintBytesPerRank != nil && *c.FootprintBytesPerRank <= 0 {
-		return fmt.Errorf("LoRAConfig: footprint_bytes_per_rank must be > 0, got %v", *c.FootprintBytesPerRank)
+	if c.FootprintBytesPerRank != nil && (math.IsNaN(*c.FootprintBytesPerRank) || math.IsInf(*c.FootprintBytesPerRank, 0) || *c.FootprintBytesPerRank <= 0) {
+		return fmt.Errorf("LoRAConfig: footprint_bytes_per_rank must be finite and > 0, got %v", *c.FootprintBytesPerRank)
 	}
 
 	// Step-overhead tiers: rank key > 0, K6 >= 0, K7 > 0 (divisor).
@@ -329,11 +331,25 @@ func (c LoRAConfig) Validate() error {
 		if rank <= 0 {
 			return fmt.Errorf("LoRAConfig: step_overhead_tiers rank key must be > 0, got %d", rank)
 		}
-		if tier.K6 != nil && *tier.K6 < 0 {
-			return fmt.Errorf("LoRAConfig: step_overhead_tiers[%d].k6 must be >= 0, got %v", rank, *tier.K6)
+		if tier.K6 != nil && (math.IsNaN(*tier.K6) || math.IsInf(*tier.K6, 0) || *tier.K6 < 0) {
+			return fmt.Errorf("LoRAConfig: step_overhead_tiers[%d].k6 must be finite and >= 0, got %v", rank, *tier.K6)
 		}
-		if tier.K7 == nil || *tier.K7 <= 0 {
-			return fmt.Errorf("LoRAConfig: step_overhead_tiers[%d].k7 must be > 0 (divisor guard)", rank)
+		if tier.K7 == nil || math.IsNaN(*tier.K7) || math.IsInf(*tier.K7, 0) || *tier.K7 <= 0 {
+			return fmt.Errorf("LoRAConfig: step_overhead_tiers[%d].k7 must be finite and > 0 (divisor guard)", rank)
+		}
+	}
+
+	// Cost coefficients are REQUIRED once the subsystem is active (adapters declared
+	// with a positive capacity): the cold-load gate consumes them via the cost model
+	// (#1466), and NewSimulator hard-fails without them. Require them here so the CLI
+	// catches the gap at its validation gate with a clear message rather than
+	// surfacing a confusing constructor error later. The CLI backfills these from
+	// defaults.yaml before validating (resolveLoRAConfig), so a config that reaches
+	// here still missing them declared adapters with no cost source at all. Checked
+	// last so a malformed-but-present coefficient reports its own specific error first.
+	if c.HasAdapters() && c.AdapterCapacity != nil && *c.AdapterCapacity > 0 {
+		if c.LoadBaseLatencyUs == nil || c.LoadBandwidthBytesUs == nil || c.FootprintBytesPerRank == nil {
+			return fmt.Errorf("LoRAConfig: load_base_latency_us, load_bandwidth_bytes_us, and footprint_bytes_per_rank must all be set when adapters are declared with a positive capacity")
 		}
 	}
 

--- a/sim/config_test.go
+++ b/sim/config_test.go
@@ -515,6 +515,14 @@ func TestLoRAConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "adapters and positive capacity but no cost coefficients",
+			cfg: LoRAConfig{
+				AdapterCapacity: loraIntPtr(4),
+				Adapters:        []AdapterSpec{{ID: "adapter_0", Rank: 8}},
+			},
+			wantErr: true, // gate consumes cost coefficients; CLI must catch the gap here (#1466)
+		},
+		{
 			name: "adapters present but zero capacity",
 			cfg: LoRAConfig{
 				AdapterCapacity: loraIntPtr(0),

--- a/sim/event.go
+++ b/sim/event.go
@@ -8,12 +8,16 @@ import (
 // This ensures deterministic same-tick ordering (INV-6 improvement over
 // timestamp-only heap). Matches cluster event queue's (timestamp, priority, seqID) scheme.
 const (
-	PriorityArrival      = 0 // External input enters system first
-	PriorityQueued       = 1 // Request enters queue after arrival processing
-	PriorityStep         = 2 // Batch processing (may complete requests)
-	PriorityScheduled    = 3 // Observational (no state mutation)
-	PriorityRequestLeft  = 4 // Observational (no state mutation)
-	PriorityTimeout      = 5 // Client-side cancellation fires last (BC-12: completion wins)
+	PriorityArrival     = 0 // External input enters system first
+	PriorityQueued      = 1 // Request enters queue after arrival processing
+	PriorityAdapterLoad = 2 // LoRA adapter-load completion: makes a gated adapter resident
+	//                        BEFORE a co-timed step forms its batch (§7 ordering
+	//                        contract), so the newly-loaded adapter's request is
+	//                        batch-eligible that same tick.
+	PriorityStep        = 3 // Batch processing (may complete requests)
+	PriorityScheduled   = 4 // Observational (no state mutation)
+	PriorityRequestLeft = 5 // Observational (no state mutation)
+	PriorityTimeout     = 6 // Client-side cancellation fires last (BC-12: completion wins)
 )
 
 // Event defines the interface for all simulation events.
@@ -120,6 +124,29 @@ func (e *StepEvent) Execute(sim *Simulator) {
 	sim.Step(e.time)
 }
 
+// AdapterLoadCompletionEvent fires when a per-instance LoRA adapter load finishes.
+// It is endogenous — the cold-load pre-admission gate schedules it at
+// now + LoadLatency when a cold request reaches the wait-queue head (§7). On
+// completion the adapter becomes resident and the gated request(s) become
+// batch-eligible; the event is ordered ahead of a co-timed StepEvent
+// (PriorityAdapterLoad < PriorityStep) so the request is admitted that same tick.
+// Loads serialize per instance: the gate starts at most one at a time.
+type AdapterLoadCompletionEvent struct {
+	time    int64  // Scheduled completion time (in ticks) = load-start + LoadLatency
+	Adapter string // Adapter id being loaded
+}
+
+func (e *AdapterLoadCompletionEvent) Timestamp() int64 { return e.time }
+func (e *AdapterLoadCompletionEvent) Priority() int    { return PriorityAdapterLoad }
+
+// Execute makes the loaded adapter resident, charges the one-time load (INV-L3),
+// clears the in-flight-load marker so the next serialized load can start, and
+// ensures a step forms so the gated request is admitted (INV-8).
+func (e *AdapterLoadCompletionEvent) Execute(sim *Simulator) {
+	logrus.Debugf("<< AdapterLoadCompletion: %s at %d ticks", e.Adapter, e.time)
+	sim.completeAdapterLoad(e.time, e.Adapter)
+}
+
 // TimeoutEvent models client-side request cancellation at the deadline tick.
 // Classification: mixed exogenous/endogenous (round-0 exogenous, follow-up endogenous).
 // Priority 5: fires after all other event types at equal timestamps (BC-12).
@@ -143,6 +170,11 @@ func (e *TimeoutEvent) Execute(sim *Simulator) {
 	wasRunning := e.Request.State == StateRunning
 	e.Request.State = StateTimedOut
 	sim.Metrics.TimedOutRequests++
+
+	// Release the adapter pin (cold-load gate, #1466) for a request cancelled while
+	// running: it no longer uses its adapter. A queued/gated request never pinned,
+	// so releaseAdapterPin is a no-op there (guarded by the per-request flag).
+	sim.releaseAdapterPin(e.Request)
 
 	// Release KV blocks (safe for zero-block queued requests per BC-15)
 	sim.KVCache.ReleaseKVBlocks(e.Request)

--- a/sim/lora/cost_model.go
+++ b/sim/lora/cost_model.go
@@ -1,0 +1,222 @@
+package lora
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// CostModel derives the three Digital-Twin adapter cost terms as pure,
+// deterministic deltas onto BLIS's calibrated base (data-model.md "Adapter Cost
+// Model", contracts/latency-model.md):
+//
+//   - LoadLatency(id)        — one-time cold-load latency (µs), charged by the
+//     pre-admission gate (PR3): base + ceil(footprint(rank)/bandwidth).
+//   - StepOverheadFactor(b)  — multiplicative per-step compute overhead >= 1.0,
+//     1 + (K6(r_max)/K7(r_max))·A_B, applied by both latency backends (PR4).
+//   - FootprintBytes(id)     — per-adapter HBM footprint, summed into the KV
+//     reservation (PR5).
+//
+// All methods are pure queries (Principle III): they never mutate the model and
+// return identical results for identical inputs (INV-6, no RNG — R7). Ranks are
+// resolved from the pre-declared registry built once at construction; requests
+// carry only the adapter id.
+//
+// It satisfies sim.AdapterCost (via the LoadLatency method); the type stays
+// exported so PR4/PR5 can consume StepOverheadFactor / FootprintBytes directly
+// while the sim/ seam interface grows only as each term is wired (R13).
+type CostModel struct {
+	loadBaseLatencyUs     float64
+	loadBandwidthBytesUs  float64 // > 0, divisor guard enforced at construction (R11)
+	footprintBytesPerRank float64
+
+	ranks map[string]int // adapter id -> declared rank (registry projection)
+
+	// tiers holds the per-rank compute-overhead coefficients; tierRanks is the
+	// sorted key list used to clamp an out-of-envelope max rank to the nearest
+	// calibrated tier (contracts/latency-model.md). Consumed by PR4.
+	tiers     map[int]tierCoeff
+	tierRanks []int
+}
+
+// tierCoeff is the resolved (non-pointer) per-tier coefficient pair.
+type tierCoeff struct {
+	k6 float64
+	k7 float64 // > 0, per-tier normalization denominator (divisor guard)
+}
+
+// NewCostModel builds a CostModel from a validated LoRAConfig. It re-checks the
+// cost coefficients (R3 non-negativity, R11 divisor guards) so a model built
+// directly is as safe as one from a validated config, returning an error the
+// caller maps to fatality (cmd/ -> logrus.Fatalf; sim/ factory -> panic).
+func NewCostModel(cfg sim.LoRAConfig) (*CostModel, error) {
+	// NaN/Inf slip past ordering guards (NaN <= 0 and NaN < 0 are both false; +Inf
+	// passes > 0), then poison LoadLatency (int64(ceil(NaN/Inf)) is garbage and can
+	// violate INV-3). Reject non-finite coefficients up front (R3/R20 degenerate
+	// input). A finite base + finite positive divisor keeps LoadLatency finite.
+	if cfg.LoadBaseLatencyUs == nil {
+		return nil, fmt.Errorf("lora.NewCostModel: load_base_latency_us must be set")
+	}
+	if !isFinite(*cfg.LoadBaseLatencyUs) || *cfg.LoadBaseLatencyUs < 0 {
+		return nil, fmt.Errorf("lora.NewCostModel: load_base_latency_us must be finite and >= 0, got %v", *cfg.LoadBaseLatencyUs)
+	}
+	if cfg.LoadBandwidthBytesUs == nil || !isFinite(*cfg.LoadBandwidthBytesUs) || *cfg.LoadBandwidthBytesUs <= 0 {
+		return nil, fmt.Errorf("lora.NewCostModel: load_bandwidth_bytes_us must be finite and > 0 (divisor guard), got %v", cfg.LoadBandwidthBytesUs)
+	}
+	if cfg.FootprintBytesPerRank == nil || !isFinite(*cfg.FootprintBytesPerRank) || *cfg.FootprintBytesPerRank <= 0 {
+		return nil, fmt.Errorf("lora.NewCostModel: footprint_bytes_per_rank must be finite and > 0, got %v", cfg.FootprintBytesPerRank)
+	}
+
+	ranks := make(map[string]int, len(cfg.Adapters))
+	for _, a := range cfg.Adapters {
+		if a.ID == "" || a.Rank <= 0 {
+			return nil, fmt.Errorf("lora.NewCostModel: adapter %q must have non-empty id and rank > 0", a.ID)
+		}
+		ranks[a.ID] = a.Rank
+	}
+
+	tiers := make(map[int]tierCoeff, len(cfg.StepOverheadTiers))
+	tierRanks := make([]int, 0, len(cfg.StepOverheadTiers))
+	for rank, t := range cfg.StepOverheadTiers {
+		if rank <= 0 {
+			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers rank key must be > 0, got %d", rank)
+		}
+		if t.K6 == nil || !isFinite(*t.K6) || *t.K6 < 0 {
+			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers[%d].k6 must be finite and >= 0", rank)
+		}
+		if t.K7 == nil || !isFinite(*t.K7) || *t.K7 <= 0 {
+			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers[%d].k7 must be finite and > 0 (divisor guard)", rank)
+		}
+		tiers[rank] = tierCoeff{k6: *t.K6, k7: *t.K7}
+		tierRanks = append(tierRanks, rank)
+	}
+	sort.Ints(tierRanks) // deterministic clamp lookup (R2)
+
+	cm := &CostModel{
+		loadBaseLatencyUs:     *cfg.LoadBaseLatencyUs,
+		loadBandwidthBytesUs:  *cfg.LoadBandwidthBytesUs,
+		footprintBytesPerRank: *cfg.FootprintBytesPerRank,
+		ranks:                 ranks,
+		tiers:                 tiers,
+		tierRanks:             tierRanks,
+	}
+
+	// Fail fast if any declared adapter's rank is large enough that its load latency
+	// is non-finite (±Inf) OR too large to convert to an int64 tick count. Left
+	// unchecked, int64(math.Ceil(x)) for x ≥ 2^63 saturates to MaxInt64, and the
+	// gate's now+loadTicks then wraps to a negative timestamp, violating INV-3
+	// (R3/R20 — unbounded numeric input; rank is an unbounded int). maxLoadLatencyUs
+	// bounds a single load below MaxInt64 with generous headroom for now+loadTicks.
+	// Iterate the declared slice for a deterministic error (R2).
+	for _, a := range cfg.Adapters {
+		ll := cm.LoadLatency(a.ID)
+		if !isFinite(ll) || ll > maxLoadLatencyUs {
+			return nil, fmt.Errorf("lora.NewCostModel: adapter %q rank %d yields an unusable load latency (%v µs) — reduce rank or footprint_bytes_per_rank", a.ID, a.Rank, ll)
+		}
+	}
+
+	return cm, nil
+}
+
+// maxLoadLatencyUs caps a single adapter load latency well below math.MaxInt64
+// ticks (µs), leaving headroom so now+loadTicks cannot overflow int64 for any
+// realistic clock. 1e15 µs ≈ 31.7 years — any config exceeding it is degenerate.
+const maxLoadLatencyUs = 1e15
+
+// RankOf returns the declared rank of an adapter id and whether it is registered.
+// An empty id (base-model request) is not registered.
+func (c *CostModel) RankOf(id string) (int, bool) {
+	r, ok := c.ranks[id]
+	return r, ok
+}
+
+// FootprintBytes returns the HBM footprint of an adapter id in bytes (>= 0):
+// footprint_bytes_per_rank · rank. An empty or unregistered id has zero footprint.
+func (c *CostModel) FootprintBytes(id string) float64 {
+	rank, ok := c.ranks[id]
+	if !ok {
+		return 0
+	}
+	return c.footprintBytesPerRank * float64(rank)
+}
+
+// LoadLatency returns the one-time cold-load latency of an adapter id in µs (>= 0):
+// load_base_latency_us + ceil(FootprintBytes(rank) / load_bandwidth_bytes_us). An
+// empty or unregistered id carries no load cost (0) — a base-model request never
+// gates. Pure and deterministic (R7).
+func (c *CostModel) LoadLatency(id string) float64 {
+	rank, ok := c.ranks[id]
+	if !ok {
+		return 0
+	}
+	footprint := c.footprintBytesPerRank * float64(rank)
+	return c.loadBaseLatencyUs + math.Ceil(footprint/c.loadBandwidthBytesUs)
+}
+
+// StepOverheadFactor returns the multiplicative per-step compute-overhead factor
+// for a batch (>= 1.0): 1 + (K6(r_max)/K7(r_max))·A_B, where A_B is the count of
+// DISTINCT non-empty adapter ids in the batch and r_max is their maximum rank.
+// The K6/K7 coefficients are selected by r_max's tier (rank enters here — FR-009),
+// clamped to the nearest calibrated tier when out of envelope. Normalized so the
+// factor is exactly 1.0 when A_B==0 for any fitted K7 (INV-6). Consumed by the
+// latency backends in a later PR.
+func (c *CostModel) StepOverheadFactor(batch []*sim.Request) float64 {
+	seen := make(map[string]struct{}, len(batch))
+	maxRank := 0
+	for _, req := range batch {
+		if req == nil || req.Adapter == "" {
+			continue
+		}
+		if _, dup := seen[req.Adapter]; dup {
+			continue
+		}
+		seen[req.Adapter] = struct{}{}
+		if rank, ok := c.ranks[req.Adapter]; ok && rank > maxRank {
+			maxRank = rank
+		}
+	}
+	aB := len(seen)
+	if aB == 0 {
+		return 1.0 // no adapters: byte-identical no-op (INV-6)
+	}
+	tier, ok := c.tierForRank(maxRank)
+	if !ok {
+		return 1.0 // no calibrated tiers: no modeled overhead
+	}
+	return 1.0 + (tier.k6/tier.k7)*float64(aB)
+}
+
+// tierForRank returns the coefficients for a rank, clamping to the nearest
+// calibrated tier when rank falls outside the fitted envelope (below the smallest
+// or above the largest calibrated rank, or between tiers). Ties in distance
+// resolve to the lower calibrated rank for determinism (R2). Returns ok=false
+// only when no tiers are configured.
+func (c *CostModel) tierForRank(rank int) (tierCoeff, bool) {
+	if len(c.tierRanks) == 0 {
+		return tierCoeff{}, false
+	}
+	if t, exact := c.tiers[rank]; exact {
+		return t, true
+	}
+	best := c.tierRanks[0]
+	bestDist := abs(rank - best)
+	for _, r := range c.tierRanks[1:] {
+		if d := abs(rank - r); d < bestDist {
+			best, bestDist = r, d
+		}
+	}
+	return c.tiers[best], true
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// isFinite reports whether x is a finite float64 (not NaN, not ±Inf). Used to
+// reject degenerate cost coefficients that would slip past ordering guards.
+func isFinite(x float64) bool { return !math.IsNaN(x) && !math.IsInf(x, 0) }

--- a/sim/lora/cost_model.go
+++ b/sim/lora/cost_model.go
@@ -83,13 +83,23 @@ func NewCostModel(cfg sim.LoRAConfig) (*CostModel, error) {
 		if rank <= 0 {
 			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers rank key must be > 0, got %d", rank)
 		}
-		if t.K6 == nil || !isFinite(*t.K6) || *t.K6 < 0 {
-			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers[%d].k6 must be finite and >= 0", rank)
+		// K6 (the numerator coefficient) is optional and defaults to 0 — a tier with
+		// no K6 contributes no per-step overhead (factor stays 1.0). This mirrors
+		// LoRAConfig.Validate, which requires K7 (the divisor) but only validates K6
+		// when present, so any config that passes the CLI gate also builds here
+		// rather than surfacing a confusing constructor error. When present, K6 must
+		// be finite and >= 0.
+		k6 := 0.0
+		if t.K6 != nil {
+			if !isFinite(*t.K6) || *t.K6 < 0 {
+				return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers[%d].k6 must be finite and >= 0", rank)
+			}
+			k6 = *t.K6
 		}
 		if t.K7 == nil || !isFinite(*t.K7) || *t.K7 <= 0 {
 			return nil, fmt.Errorf("lora.NewCostModel: step_overhead_tiers[%d].k7 must be finite and > 0 (divisor guard)", rank)
 		}
-		tiers[rank] = tierCoeff{k6: *t.K6, k7: *t.K7}
+		tiers[rank] = tierCoeff{k6: k6, k7: *t.K7}
 		tierRanks = append(tierRanks, rank)
 	}
 	sort.Ints(tierRanks) // deterministic clamp lookup (R2)

--- a/sim/lora/cost_model_test.go
+++ b/sim/lora/cost_model_test.go
@@ -1,0 +1,207 @@
+package lora
+
+import (
+	"math"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// The adapter cost model derives the three Digital-Twin cost terms — cold-load
+// latency, per-step compute-overhead factor, and HBM footprint — as pure,
+// deterministic functions of adapter rank plus configured coefficients
+// (data-model.md "Adapter Cost Model"). These contract tests assert the
+// observable laws (non-negativity, monotonicity in rank, the no-adapter
+// normalization, purity) independent of the internal representation.
+
+// fptr is a small helper for building the pointer-typed LoRAConfig cost fields.
+func fptr(v float64) *float64 { return &v }
+
+// testCostModel builds a cost model over three ranked adapters (8/16/32) with
+// simple, well-conditioned coefficients. base=1000µs, bandwidth=2e6 B/µs,
+// footprint=2e6 B/rank.
+func testCostModel(t *testing.T) *CostModel {
+	t.Helper()
+	cfg := sim.LoRAConfig{
+		LoadBaseLatencyUs:     fptr(1000.0),
+		LoadBandwidthBytesUs:  fptr(2.0e6),
+		FootprintBytesPerRank: fptr(2.0e6),
+		StepOverheadTiers: map[int]sim.StepOverheadTier{
+			8:  {K6: fptr(0.02), K7: fptr(1.0)},
+			16: {K6: fptr(0.04), K7: fptr(1.0)},
+			32: {K6: fptr(0.06), K7: fptr(1.0)},
+		},
+		Adapters: []sim.AdapterSpec{
+			{ID: "a8", Rank: 8},
+			{ID: "a16", Rank: 16},
+			{ID: "a32", Rank: 32},
+		},
+	}
+	cm, err := NewCostModel(cfg)
+	if err != nil {
+		t.Fatalf("NewCostModel: unexpected error: %v", err)
+	}
+	return cm
+}
+
+// TestCostModel_LoadLatencyNonNegativeAndCharged verifies load latency is >= 0
+// for every registered adapter and 0 for a base-model (empty id) or unknown id
+// (SC-004 charge shape; T025).
+func TestCostModel_LoadLatencyNonNegative(t *testing.T) {
+	cm := testCostModel(t)
+
+	for _, id := range []string{"a8", "a16", "a32"} {
+		if got := cm.LoadLatency(id); got < 0 {
+			t.Errorf("LoadLatency(%q) = %v, want >= 0", id, got)
+		}
+	}
+	// base-model (empty) and unregistered ids carry no load cost.
+	if got := cm.LoadLatency(""); got != 0 {
+		t.Errorf("LoadLatency(\"\") = %v, want 0 (base model)", got)
+	}
+	if got := cm.LoadLatency("ghost"); got != 0 {
+		t.Errorf("LoadLatency(ghost) = %v, want 0 (unregistered)", got)
+	}
+
+	// Exact value: base + ceil(footprint(rank)/bandwidth). rank=8 => footprint=1.6e7,
+	// /2e6 = 8 => 1000 + 8 = 1008.
+	if got, want := cm.LoadLatency("a8"), 1008.0; got != want {
+		t.Errorf("LoadLatency(a8) = %v, want %v", got, want)
+	}
+}
+
+// TestCostModel_LoadLatencyMonotonicInRank verifies a higher-rank adapter costs
+// at least as much to load as a lower-rank one (footprint grows with rank).
+func TestCostModel_LoadLatencyMonotonicInRank(t *testing.T) {
+	cm := testCostModel(t)
+	if !(cm.LoadLatency("a8") <= cm.LoadLatency("a16") && cm.LoadLatency("a16") <= cm.LoadLatency("a32")) {
+		t.Errorf("LoadLatency not monotonic in rank: a8=%v a16=%v a32=%v",
+			cm.LoadLatency("a8"), cm.LoadLatency("a16"), cm.LoadLatency("a32"))
+	}
+}
+
+// TestCostModel_FootprintMonotonicInRank verifies footprint is >= 0 and strictly
+// increases with rank (data-model.md; T025).
+func TestCostModel_FootprintMonotonicInRank(t *testing.T) {
+	cm := testCostModel(t)
+	f8, f16, f32 := cm.FootprintBytes("a8"), cm.FootprintBytes("a16"), cm.FootprintBytes("a32")
+	if f8 < 0 || f16 < 0 || f32 < 0 {
+		t.Fatalf("footprint must be >= 0: a8=%v a16=%v a32=%v", f8, f16, f32)
+	}
+	if !(f8 < f16 && f16 < f32) {
+		t.Errorf("footprint not strictly increasing in rank: a8=%v a16=%v a32=%v", f8, f16, f32)
+	}
+	if got := cm.FootprintBytes(""); got != 0 {
+		t.Errorf("FootprintBytes(\"\") = %v, want 0", got)
+	}
+}
+
+// TestCostModel_StepOverheadUnitWhenNoAdapters verifies the compute-overhead
+// factor is exactly 1.0 for a batch with no adapters (INV-6 no-op), for any
+// fitted K7 — a batch of base-model requests or an empty batch both normalize to
+// 1.0 (T025).
+func TestCostModel_StepOverheadUnitWhenNoAdapters(t *testing.T) {
+	cm := testCostModel(t)
+
+	if got := cm.StepOverheadFactor(nil); got != 1.0 {
+		t.Errorf("StepOverheadFactor(nil) = %v, want 1.0", got)
+	}
+	baseOnly := []*sim.Request{{ID: "r1"}, {ID: "r2"}} // Adapter == "" for both
+	if got := cm.StepOverheadFactor(baseOnly); got != 1.0 {
+		t.Errorf("StepOverheadFactor(base-only batch) = %v, want 1.0", got)
+	}
+
+	// Non-unit K7 must still normalize to exactly 1.0 at A_B==0 (guards the no-op
+	// regression: the factor is (K7 + K6*A_B)/K7, = 1.0 for any K7 when A_B==0).
+	cfg := sim.LoRAConfig{
+		LoadBaseLatencyUs:     fptr(1000.0),
+		LoadBandwidthBytesUs:  fptr(2.0e6),
+		FootprintBytesPerRank: fptr(2.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K6: fptr(0.5), K7: fptr(3.7)}},
+		Adapters:              []sim.AdapterSpec{{ID: "a8", Rank: 8}},
+	}
+	cm2, err := NewCostModel(cfg)
+	if err != nil {
+		t.Fatalf("NewCostModel: %v", err)
+	}
+	if got := cm2.StepOverheadFactor(baseOnly); got != 1.0 {
+		t.Errorf("StepOverheadFactor with non-unit K7, no adapters = %v, want 1.0", got)
+	}
+}
+
+// TestCostModel_StepOverheadGrowsWithAdapters verifies the factor is >= 1.0 and
+// increases with the count of distinct adapters, counting a repeated adapter
+// once (spec edge case; T025 / US3 scenario 2 precondition).
+func TestCostModel_StepOverheadGrowsWithAdapters(t *testing.T) {
+	cm := testCostModel(t)
+
+	one := []*sim.Request{{ID: "r1", Adapter: "a8"}}
+	// Same adapter twice => counted once => same factor as one.
+	dup := []*sim.Request{{ID: "r1", Adapter: "a8"}, {ID: "r2", Adapter: "a8"}}
+	two := []*sim.Request{{ID: "r1", Adapter: "a8"}, {ID: "r2", Adapter: "a16"}}
+
+	fOne, fDup, fTwo := cm.StepOverheadFactor(one), cm.StepOverheadFactor(dup), cm.StepOverheadFactor(two)
+	if fOne < 1.0 {
+		t.Errorf("factor for one adapter = %v, want >= 1.0", fOne)
+	}
+	if fDup != fOne {
+		t.Errorf("duplicate adapter counted more than once: dup=%v one=%v", fDup, fOne)
+	}
+	if !(fTwo > fOne) {
+		t.Errorf("factor did not grow with distinct adapters: two=%v one=%v", fTwo, fOne)
+	}
+}
+
+// TestCostModel_Deterministic verifies the queries are pure: repeated calls with
+// the same inputs return identical results and do not mutate the model (INV-6, R7).
+func TestCostModel_Deterministic(t *testing.T) {
+	cm := testCostModel(t)
+	batch := []*sim.Request{{ID: "r1", Adapter: "a8"}, {ID: "r2", Adapter: "a32"}}
+	for i := 0; i < 3; i++ {
+		if cm.LoadLatency("a16") != cm.LoadLatency("a16") ||
+			cm.FootprintBytes("a16") != cm.FootprintBytes("a16") ||
+			cm.StepOverheadFactor(batch) != cm.StepOverheadFactor(batch) {
+			t.Fatalf("cost model not deterministic on iteration %d", i)
+		}
+	}
+}
+
+// TestNewCostModel_RejectsMalformedConfig verifies the constructor guards missing
+// or non-positive divisor coefficients (R3/R11), mirroring LoRAConfig.Validate so
+// a directly-built model is as safe as one from a validated config.
+func TestNewCostModel_RejectsMalformedConfig(t *testing.T) {
+	base := func() sim.LoRAConfig {
+		return sim.LoRAConfig{
+			LoadBaseLatencyUs:     fptr(1000.0),
+			LoadBandwidthBytesUs:  fptr(2.0e6),
+			FootprintBytesPerRank: fptr(2.0e6),
+			Adapters:              []sim.AdapterSpec{{ID: "a8", Rank: 8}},
+		}
+	}
+	tests := []struct {
+		name  string
+		mutate func(*sim.LoRAConfig)
+	}{
+		{"nil load base latency", func(c *sim.LoRAConfig) { c.LoadBaseLatencyUs = nil }},
+		{"nil bandwidth (divisor)", func(c *sim.LoRAConfig) { c.LoadBandwidthBytesUs = nil }},
+		{"zero bandwidth (divisor)", func(c *sim.LoRAConfig) { c.LoadBandwidthBytesUs = fptr(0) }},
+		{"nil footprint", func(c *sim.LoRAConfig) { c.FootprintBytesPerRank = nil }},
+		{"negative base latency", func(c *sim.LoRAConfig) { c.LoadBaseLatencyUs = fptr(-1) }},
+		{"NaN base latency", func(c *sim.LoRAConfig) { c.LoadBaseLatencyUs = fptr(math.NaN()) }},
+		{"Inf bandwidth", func(c *sim.LoRAConfig) { c.LoadBandwidthBytesUs = fptr(math.Inf(1)) }},
+		{"NaN footprint", func(c *sim.LoRAConfig) { c.FootprintBytesPerRank = fptr(math.NaN()) }},
+		{"rank overflows footprint to Inf", func(c *sim.LoRAConfig) {
+			c.FootprintBytesPerRank = fptr(math.MaxFloat64)
+			c.Adapters = []sim.AdapterSpec{{ID: "a8", Rank: 1 << 40}} // huge rank ⇒ footprint = Inf
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(&cfg)
+			if _, err := NewCostModel(cfg); err == nil {
+				t.Errorf("NewCostModel(%s): expected error, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/sim/lora/cost_model_test.go
+++ b/sim/lora/cost_model_test.go
@@ -166,6 +166,31 @@ func TestCostModel_Deterministic(t *testing.T) {
 	}
 }
 
+// TestNewCostModel_NilK6DefaultsToZero verifies the constructor accepts a tier
+// with K7 set but K6 omitted (nil), mirroring LoRAConfig.Validate — which requires
+// K7 but leaves K6 optional. A config that passes the CLI validation gate must also
+// build here rather than failing with a confusing constructor error. A nil K6
+// defaults to 0, so the tier contributes no per-step overhead: the factor stays
+// exactly 1.0 for any batch, distinct adapters included.
+func TestNewCostModel_NilK6DefaultsToZero(t *testing.T) {
+	cfg := sim.LoRAConfig{
+		LoadBaseLatencyUs:     fptr(1000.0),
+		LoadBandwidthBytesUs:  fptr(2.0e6),
+		FootprintBytesPerRank: fptr(2.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K7: fptr(1.0)}}, // K6 omitted
+		Adapters:              []sim.AdapterSpec{{ID: "a8", Rank: 8}},
+	}
+	cm, err := NewCostModel(cfg)
+	if err != nil {
+		t.Fatalf("NewCostModel with nil K6: unexpected error %v (must match Validate, which permits nil K6)", err)
+	}
+	// K6==0 ⇒ 1 + (0/K7)·A_B == 1.0 even with a distinct adapter in the batch.
+	batch := []*sim.Request{{ID: "r1", Adapter: "a8"}}
+	if got := cm.StepOverheadFactor(batch); got != 1.0 {
+		t.Errorf("StepOverheadFactor with nil (=0) K6 = %v, want 1.0 (no overhead contribution)", got)
+	}
+}
+
 // TestNewCostModel_RejectsMalformedConfig verifies the constructor guards missing
 // or non-positive divisor coefficients (R3/R11), mirroring LoRAConfig.Validate so
 // a directly-built model is as safe as one from a validated config.

--- a/sim/lora/register.go
+++ b/sim/lora/register.go
@@ -13,4 +13,7 @@ func init() {
 	sim.NewResidentAdapterSetFunc = func(capacity int) sim.ResidentAdapterSet {
 		return newResidentSet(capacity)
 	}
+	sim.NewAdapterCostFunc = func(cfg sim.LoRAConfig) (sim.AdapterCost, error) {
+		return NewCostModel(cfg)
+	}
 }

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -52,6 +52,10 @@ func newResidentSet(capacity int) *residentSet {
 // Len reports the number of currently resident adapters.
 func (s *residentSet) Len() int { return len(s.entries) }
 
+// AtCapacity reports whether every slot is occupied (Len == capacity). The
+// cold-load gate uses it to decide whether a slot must be freed before a load.
+func (s *residentSet) AtCapacity() bool { return len(s.entries) >= s.capacity }
+
 // IsResident reports whether id currently occupies a slot.
 func (s *residentSet) IsResident(id string) bool {
 	_, ok := s.entries[id]

--- a/sim/request.go
+++ b/sim/request.go
@@ -89,6 +89,14 @@ type Request struct {
 	// generation). Set from the owning client/cohort's Adapter during generation.
 	Adapter string
 
+	// adapterPinned tracks whether this request currently holds a pin on its
+	// adapter's resident slot (cold-load gate, #1466). Set once when the request
+	// enters the running batch and cleared once at a terminal state, so a
+	// preempted-then-re-admitted request pins exactly once (the pin persists
+	// through preemption, INV-L5) rather than double-counting. Zero value (false)
+	// is correct for base-model requests and adapter-blind runs.
+	adapterPinned bool
+
 	// Client timeout: absolute tick by which request must complete (0 = no timeout).
 	// Computed during workload generation as ArrivalTime + timeout.
 	Deadline int64

--- a/sim/resident_adapter_set.go
+++ b/sim/resident_adapter_set.go
@@ -8,9 +8,10 @@ package sim
 // so sim/ can own the state without importing sim/lora (Principle I: no reverse
 // import).
 //
-// The interface is intentionally scoped to what the scheduling hook needs (R13).
-// The concrete set additionally supports pin/unpin and explicit eviction; those
-// enter this interface when the LoRA cold-load gate consumes them.
+// The interface is scoped to what the scheduling hook and the cold-load
+// pre-admission gate consume (R13). The gate (#1466) added AtCapacity / EvictLRU
+// (to commit an eviction victim and reserve a slot at load-start) and Pin / Unpin
+// (to protect an adapter in use by an in-flight request from eviction, INV-L5).
 type ResidentAdapterSet interface {
 	// IsResident reports whether id currently occupies a slot.
 	IsResident(id string) bool
@@ -24,6 +25,20 @@ type ResidentAdapterSet interface {
 	Store(id string) (evicted string, admitted bool)
 	// Len returns the number of resident adapters (always ≤ capacity).
 	Len() int
+
+	// AtCapacity reports whether every slot is occupied (Len == capacity). The
+	// cold-load gate uses it to decide whether a slot must be freed before a load.
+	AtCapacity() bool
+	// EvictLRU removes the least-recently-used non-pinned adapter and returns its id
+	// and true, or ("", false) if the set is empty or every entry is pinned. The gate
+	// calls it at load-start to commit the eviction victim and reserve a slot (§7).
+	EvictLRU() (string, bool)
+	// Pin protects id from eviction while an in-flight request references it
+	// (reference-counted). No-op if id is absent.
+	Pin(id string)
+	// Unpin releases one reference; id becomes evictable once no in-flight request
+	// references it. No-op if id is absent or its count is already zero.
+	Unpin(id string)
 }
 
 // NewResidentAdapterSetFunc builds a ResidentAdapterSet with the given per-instance

--- a/sim/resident_adapter_wiring_test.go
+++ b/sim/resident_adapter_wiring_test.go
@@ -30,7 +30,13 @@ func TestResidentAdapterSet_CapacityBoundAcrossRun(t *testing.T) {
 	for i := range adapters {
 		adapters[i] = AdapterSpec{ID: fmt.Sprintf("adapter_%d", i), Rank: 8}
 	}
-	cfg.LoRAConfig = LoRAConfig{AdapterCapacity: &capVal, Adapters: adapters}
+	cfg.LoRAConfig = LoRAConfig{
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     fptrGate(1000.0),
+		LoadBandwidthBytesUs:  fptrGate(2.0e6),
+		FootprintBytesPerRank: fptrGate(2.0e6),
+		Adapters:              adapters,
+	}
 
 	sim := mustNewSimulator(t, cfg)
 	if sim.residentAdapters == nil {
@@ -98,8 +104,11 @@ func TestResidentAdapterSet_MixedBaseAndAdapterTraffic(t *testing.T) {
 	capVal := 4
 	cfg := newTestSimConfig()
 	cfg.LoRAConfig = LoRAConfig{
-		AdapterCapacity: &capVal,
-		Adapters:        []AdapterSpec{{ID: "adapter_0", Rank: 8}},
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     fptrGate(1000.0),
+		LoadBandwidthBytesUs:  fptrGate(2.0e6),
+		FootprintBytesPerRank: fptrGate(2.0e6),
+		Adapters:              []AdapterSpec{{ID: "adapter_0", Rank: 8}},
 	}
 	sim := mustNewSimulator(t, cfg)
 
@@ -152,7 +161,13 @@ func TestResidentAdapterSet_PreemptionDoesNotDoubleCountLoad(t *testing.T) {
 		BatchConfig:         NewBatchConfig(10, 10_000, 16),
 		LatencyCoeffs:       NewLatencyCoeffs([]float64{0, 1, 0}, []float64{0, 0, 0}),
 		ModelHardwareConfig: NewModelHardwareConfig(rooflineModelConfig(), rooflineHWCalib(), "test", "H100", 1, 1, false, "", "roofline", 0),
-		LoRAConfig:          LoRAConfig{AdapterCapacity: &capVal, Adapters: []AdapterSpec{{ID: "a", Rank: 8}}},
+		LoRAConfig: LoRAConfig{
+			AdapterCapacity:       &capVal,
+			LoadBaseLatencyUs:     fptrGate(1000.0),
+			LoadBandwidthBytesUs:  fptrGate(2.0e6),
+			FootprintBytesPerRank: fptrGate(2.0e6),
+			Adapters:              []AdapterSpec{{ID: "a", Rank: 8}},
+		},
 	}
 	s := mustNewSimulator(t, cfg)
 	if s.residentAdapters == nil {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -123,6 +123,14 @@ type Simulator struct {
 	// capacity configured, or sim/lora not imported), in which case adapter handling
 	// is a no-op and output is byte-identical to a pre-feature build (INV-6).
 	residentAdapters ResidentAdapterSet
+	// adapterCost derives the cold-load latency charged by the pre-admission gate
+	// (#1466). Non-nil exactly when residentAdapters is (both wired together from
+	// the same sim/lora registration); nil ⇒ no gating.
+	adapterCost AdapterCost
+	// loadingAdapter is the id of the adapter whose load is currently in flight on
+	// this instance, or "" when none. Loads serialize per instance: the gate starts
+	// a new load only when this is "" (§7 serialization).
+	loadingAdapter string
 	seqCounter             int64 // monotonic counter for event queue seqID (deterministic ordering)
 	// OnRequestDone is an optional callback invoked when a request reaches a terminal
 	// state (completed, length-capped, or timed out). Returns follow-up requests to inject.
@@ -206,7 +214,18 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 	// active — adapters declared with a positive capacity — and sim/lora is linked
 	// (NewResidentAdapterSetFunc registered). Otherwise it stays nil and adapter
 	// handling is a no-op (INV-6).
-	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc != nil {
+	// Wire the resident set AND the cost model together (both from sim/lora's single
+	// init, so both registration funcs are non-nil or both nil). Requiring both here
+	// guarantees the invariant the gate relies on: whenever residentAdapters != nil,
+	// adapterCost != nil too. If only the resident set were wired, FormBatch would
+	// gate cold requests (AdapterResident predicate set) but maybeStartAdapterLoad
+	// could never start a load (adapterCost nil) — stranding them. A malformed cost
+	// config is a library-boundary error (R6), not a panic.
+	if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc != nil && NewAdapterCostFunc != nil {
+		ac, err := NewAdapterCostFunc(cfg.LoRAConfig)
+		if err != nil {
+			return nil, fmt.Errorf("NewSimulator: adapter cost model: %w", err)
+		}
 		// Guard against a factory that returns a nil interface value: the concrete
 		// sim/lora set never does (it returns a valid set or panics on bad capacity),
 		// but a test double or future implementation might, and a typed-nil interface
@@ -216,20 +235,21 @@ func NewSimulator(cfg SimConfig, kvStore KVStore, latencyModel LatencyModel) (*S
 			return nil, fmt.Errorf("NewSimulator: NewResidentAdapterSetFunc returned nil for capacity %d", *cfg.AdapterCapacity)
 		}
 		s.residentAdapters = rs
+		s.adapterCost = ac
 	} else if cfg.HasAdapters() && cfg.AdapterCapacity == nil {
 		// Adapters declared but no capacity: the resident set stays inert and every
 		// adapter metric reports zero. Warn rather than fail silently (R1) — a run
 		// that completes with zeroed adapter counts is otherwise indistinguishable
 		// from a working one.
 		logrus.Warnf("adapters declared but adapter_capacity is not set; per-instance resident-adapter tracking is disabled and adapter metrics will be zero")
-	} else if cfg.HasAdapters() && cfg.AdapterCapacity != nil && NewResidentAdapterSetFunc == nil {
+	} else if cfg.HasAdapters() && cfg.AdapterCapacity != nil && (NewResidentAdapterSetFunc == nil || NewAdapterCostFunc == nil) {
 		// Adapters + capacity configured but sim/lora was never linked, so the seam
-		// factory is unregistered. Only reachable from a non-CLI caller (cmd/root.go
+		// factories are unregistered. Only reachable from a non-CLI caller (cmd/root.go
 		// imports sim/lora); warn so that path does not silently drop adapter tracking.
 		// This branch is not unit-testable from within package sim: the blank import in
-		// lora_import_test.go always registers the factory, so there is no way to
-		// observe NewResidentAdapterSetFunc == nil in a sim test.
-		logrus.Warnf("adapters and adapter_capacity are configured but sim/lora is not linked (NewResidentAdapterSetFunc unregistered); resident-adapter tracking is disabled and adapter metrics will be zero")
+		// lora_import_test.go always registers the factories, so there is no way to
+		// observe them nil in a sim test.
+		logrus.Warnf("adapters and adapter_capacity are configured but sim/lora is not linked (NewResidentAdapterSetFunc/NewAdapterCostFunc unregistered); resident-adapter tracking is disabled and adapter metrics will be zero")
 	}
 
 	return s, nil
@@ -639,6 +659,12 @@ func (sim *Simulator) recordKVUsageMetrics(stepDuration int64) {
 // response serialization) is non-blocking but still contributes to client-perceived latency.
 // For trained-physics, PostDecodeFixedOverhead adds ~777µs to E2E; for other backends it's 0.
 func (sim *Simulator) recordRequestCompletion(req *Request) {
+	// Release this request's adapter pin (cold-load gate, #1466): a completed
+	// request no longer uses its adapter, so the slot becomes evictable. Covers the
+	// normal and length-capped completion paths (both funnel through here); the
+	// running-request timeout path releases separately. No-op when inert (INV-6).
+	sim.releaseAdapterPin(req)
+
 	// INV-1 conservation: Always increment CompletedRequests.
 	// For redirected requests: the source instance drained the request from its WaitQ
 	// (StillQueued=0 at end), so source contributes 0 to InjectedRequests.
@@ -735,6 +761,14 @@ func (sim *Simulator) scheduleBatch(now int64) {
 		sim.scheduler.OrderQueue(reqs, now)
 	})
 
+	// Cold-load pre-admission gate (LoRA, #1466): if the wait-queue head is a cold
+	// adapter request and no load is in flight, start a serialized per-instance
+	// adapter load now (committing an eviction victim and scheduling the load
+	// completion). FormBatch then holds any not-yet-resident adapter out of the
+	// batch via the AdapterResident predicate below. No-op when the subsystem is
+	// inert (INV-6).
+	sim.maybeStartAdapterLoad(now)
+
 	// Delegate batch composition to the pluggable BatchFormation strategy.
 	// Event scheduling and metrics recording happen after FormBatch returns (kernel concerns).
 	batchCtx := BatchContext{
@@ -748,6 +782,9 @@ func (sim *Simulator) scheduleBatch(now int64) {
 		Now:                   now,
 		StepCount:             sim.stepCount,
 		ComputedTokens:        sim.reqNumComputedTokens,
+	}
+	if sim.residentAdapters != nil {
+		batchCtx.AdapterResident = sim.residentAdapters.IsResident
 	}
 	batchResult := sim.batchFormation.FormBatch(batchCtx)
 
@@ -775,40 +812,105 @@ func (sim *Simulator) scheduleBatch(now int64) {
 }
 
 // recordAdapterResidency updates the per-instance resident-adapter set when a
-// request is scheduled onto the running batch: a warm adapter is moved to
-// most-recently-used, a cold adapter is loaded (evicting the LRU non-pinned entry
-// when at capacity, and counting the load / eviction). It is a no-op when the LoRA
-// subsystem is inert or the request targets the base model (empty Adapter), so an
-// adapter-blind run is byte-identical to a pre-feature build (INV-6).
-//
-// Recording residency at running-batch entry matches the design's "in use from the
-// moment a request enters the running batch" semantics. State only: residency has no
-// latency or gating effect here — a cold request still runs immediately.
+// request enters the running batch. Under the cold-load gate (#1466) a request is
+// admitted only once its adapter is resident (a cold request is held out of the
+// batch until its load completes), so here the adapter is always resident: touch
+// it to most-recently-used and pin it for the request's in-flight lifetime so it
+// cannot be evicted while in use (INV-L5). The pin is taken exactly once per
+// request (a preempted-then-re-admitted request keeps its existing pin) and
+// released at a terminal state by releaseAdapterPin. No-op when the LoRA subsystem
+// is inert or the request targets the base model, preserving byte-identity (INV-6).
 func (sim *Simulator) recordAdapterResidency(req *Request) {
 	if sim.residentAdapters == nil || req.Adapter == "" {
 		return
 	}
-	if sim.residentAdapters.IsResident(req.Adapter) {
-		sim.residentAdapters.Touch(req.Adapter) // warm reference
+	sim.residentAdapters.Touch(req.Adapter)
+	if !req.adapterPinned {
+		sim.residentAdapters.Pin(req.Adapter)
+		req.adapterPinned = true
+	}
+}
+
+// ReleaseAdapterPin releases req's adapter pin if it holds one. Exported for the
+// cluster layer's gateway-eviction / drain paths (InstanceSimulator.EvictRequest),
+// which remove a running request from this instance outside the normal
+// completion/timeout terminal paths and must still free its pinned adapter slot —
+// otherwise the pin leaks and eventually blocks all future cold loads (INV-L5,
+// #1466). Idempotent and a no-op for unpinned (e.g. queued) or base-model requests.
+func (sim *Simulator) ReleaseAdapterPin(req *Request) {
+	sim.releaseAdapterPin(req)
+}
+
+// releaseAdapterPin drops this request's pin on its adapter when it reaches a
+// terminal state (completed, length-capped, or timed-out while running), letting
+// the adapter become evictable once no in-flight request references it. Idempotent
+// via the per-request adapterPinned flag; no-op when inert or base-model (INV-6).
+func (sim *Simulator) releaseAdapterPin(req *Request) {
+	if sim.residentAdapters == nil || req.Adapter == "" || !req.adapterPinned {
 		return
 	}
-	// Cold: load the adapter (may evict the LRU non-pinned entry at capacity).
-	evicted, admitted := sim.residentAdapters.Store(req.Adapter)
-	if !admitted {
-		// Set full and every resident adapter pinned: nothing was loaded, so don't
-		// record a phantom load. Unreachable until pin/unpin are wired (LoRA cold-load
-		// gate); the guard keeps the accounting correct once that lands. Warn so that,
-		// once pinning is wired, a failed cold load surfaces as a logged event rather
-		// than silently missing adapter metrics (R1). Include req.ID so a multi-instance
-		// cluster trace can correlate which request hit the all-pinned condition.
-		logrus.Warnf("recordAdapterResidency: adapter %q (req %s) could not be loaded "+
-			"(resident set full, all slots pinned); no load counted", req.Adapter, req.ID)
+	sim.residentAdapters.Unpin(req.Adapter)
+	req.adapterPinned = false
+}
+
+// maybeStartAdapterLoad begins a serialized cold-adapter load when the wait-queue
+// head is a new prefill request whose adapter is not yet resident (§7). It runs
+// before batch formation each step. Loads serialize per instance: it starts at
+// most one at a time (guarded by loadingAdapter). At load-start it commits the
+// eviction victim and reserves a slot (EvictLRU when at capacity), then schedules
+// an AdapterLoadCompletionEvent at now + LoadLatency; residency is committed at
+// completion, so the gate keeps holding the request until then. No-op when the
+// subsystem is inert (INV-6).
+func (sim *Simulator) maybeStartAdapterLoad(now int64) {
+	if sim.residentAdapters == nil || sim.adapterCost == nil || sim.loadingAdapter != "" {
 		return
 	}
-	sim.Metrics.AdapterLoadCounts[req.Adapter]++
-	if evicted != "" {
+	head := sim.WaitQ.Peek()
+	if head == nil || head.IsDecodeSubRequest || head.Adapter == "" || sim.residentAdapters.IsResident(head.Adapter) {
+		return
+	}
+	// Cold head: reserve a slot by committing the LRU non-pinned victim now (§7).
+	if sim.residentAdapters.AtCapacity() {
+		evicted, ok := sim.residentAdapters.EvictLRU()
+		if !ok {
+			// Every slot is pinned by an in-flight request; cannot start a load this
+			// step. A running request will complete and unpin, and the INV-8 guard
+			// will re-form a step to retry. (Guaranteed reachable: pins come from
+			// running requests, which make progress.)
+			return
+		}
 		sim.Metrics.AdapterEvictionCounts[evicted]++
 	}
+	sim.loadingAdapter = head.Adapter
+	loadTicks := max(1, int64(math.Ceil(sim.adapterCost.LoadLatency(head.Adapter))))
+	sim.Schedule(&AdapterLoadCompletionEvent{time: now + loadTicks, Adapter: head.Adapter})
+}
+
+// completeAdapterLoad finishes a cold-adapter load: it makes the adapter resident
+// (a slot was reserved at load-start, so Store adds without further eviction),
+// charges the one-time load (INV-L3 — exactly once per cold (adapter, instance)
+// transition), clears the in-flight marker so the next serialized load can begin,
+// and ensures a step forms so the gated request is admitted this tick (INV-8; the
+// completion is ordered ahead of a co-timed step by PriorityAdapterLoad).
+func (sim *Simulator) completeAdapterLoad(now int64, adapter string) {
+	if sim.residentAdapters == nil {
+		return
+	}
+	// A slot was reserved at load-start (EvictLRU when at capacity), so Store adds
+	// the adapter without further eviction and must succeed. A false result would
+	// mean the set filled and fully pinned during the load — impossible under the
+	// blocking model (no admissions occur mid-load) — so surface it loudly (R1)
+	// rather than silently dropping the load accounting.
+	if _, admitted := sim.residentAdapters.Store(adapter); admitted {
+		sim.Metrics.AdapterLoadCounts[adapter]++ // charged once per cold transition (INV-L3)
+	} else {
+		logrus.Errorf("[tick %07d] adapter %q load completed but could not be made resident (set full and fully pinned) — resident-set accounting bug", now, adapter)
+	}
+	// Clear the in-flight marker and ensure a step forms REGARDLESS of the Store
+	// outcome, so the gated request is retried and the simulator never wedges with
+	// queued work and no pending step (INV-8) — even on the unreachable error path.
+	sim.loadingAdapter = ""
+	sim.ScheduleStepIfIdle(now)
 }
 
 // executeBatchStep handles Phase 2: model execution (prefill + decode) for all requests
@@ -1009,7 +1111,15 @@ func (sim *Simulator) scheduleNextStep(now, currStepAdvance int64, remaining []*
 		// queued requests are stranded until the next arrival event
 		// triggers a QueuedEvent — violating the work-conserving
 		// property that real vLLM maintains.
-		if sim.WaitQ.Len() > 0 {
+		//
+		// Exception (cold-load gate, #1466): when a per-instance adapter load is in
+		// flight, the wait-queue head is gated (held out of the batch) for the load
+		// duration and nothing else can be admitted (blocking model). The scheduled
+		// work IS the load, so INV-8 is satisfied by the pending
+		// AdapterLoadCompletionEvent — which re-forms a step on completion via
+		// ScheduleStepIfIdle. Scheduling an empty step here instead would spin one
+		// step per tick for the whole load. Inert when no LoRA (loadingAdapter == "").
+		if sim.WaitQ.Len() > 0 && sim.loadingAdapter == "" {
 			pbe := StepEvent{time: now + currStepAdvance}
 			sim.Schedule(&pbe)
 			sim.stepEvent = &pbe

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -900,7 +900,10 @@ func (sim *Simulator) completeAdapterLoad(now int64, adapter string) {
 	// the adapter without further eviction and must succeed. A false result would
 	// mean the set filled and fully pinned during the load — impossible under the
 	// blocking model (no admissions occur mid-load) — so surface it loudly (R1)
-	// rather than silently dropping the load accounting.
+	// rather than silently dropping the load accounting. Store's evicted-id return
+	// is intentionally discarded: the eviction (and its AdapterEvictionCounts
+	// increment) already happened at load-start, so it is always "" here; any future
+	// path that calls Store at capacity would need to account for that eviction.
 	if _, admitted := sim.residentAdapters.Store(adapter); admitted {
 		sim.Metrics.AdapterLoadCounts[adapter]++ // charged once per cold transition (INV-L3)
 	} else {

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -1114,7 +1114,9 @@ func (sim *Simulator) scheduleNextStep(now, currStepAdvance int64, remaining []*
 		//
 		// Exception (cold-load gate, #1466): when a per-instance adapter load is in
 		// flight, the wait-queue head is gated (held out of the batch) for the load
-		// duration and nothing else can be admitted (blocking model). The scheduled
+		// duration and nothing else can be admitted (blocking model) — including any
+		// warm-adapter or base-model requests queued behind it (intentional
+		// head-of-line blocking, DT-faithful; design §7/D1). The scheduled
 		// work IS the load, so INV-8 is satisfied by the pending
 		// AdapterLoadCompletionEvent — which re-forms a step on completion via
 		// ScheduleStepIfIdle. Scheduling an empty step here instead would spin one


### PR DESCRIPTION
## Summary

PR3 of the LoRA control-plane epic (#1464). Implements US3's cold-load part: a **serialized per-instance cold-load pre-admission gate** plus the **shared adapter cost-model core**. Closes #1466.

> **✅ Rebased onto merged `main` (2026-07-23).** PR1 (#1472) and PR2 (#1473) have merged, so this PR is now a **single clean commit** (`78fe5d01`) on top of `main` — the diff is PR3 only. PR2's review-round hardening was carried across the rebase (see the two `NewSimulator`/`recordAdapterResidency` conflict resolutions: the cost-model wiring now sits inside PR2's factory-nil guard + warning branches).

## What's in it

**Cost model** — `sim/lora/cost_model.go` (T025/T026)
- Pure, deterministic queries: `LoadLatency(id) = base + ceil(footprint/bw)`, `FootprintBytes(id)`, `StepOverheadFactor(batch) = 1 + (K6(r_max)/K7(r_max))·A_B`. `StepOverheadFactor`/`FootprintBytes` are built now but consumed by PR4/PR5.
- Fail-fast construction rejects nil / non-positive / non-finite (NaN, ±Inf) coefficients and any declared rank whose load latency would overflow a safe int64 bound (R3/R20, protects INV-3).
- Exposed to `sim/` via the new `sim.AdapterCost` seam (`LoadLatency` only — R13-minimal), registered by `sim/lora` `init()`.

**Cold-load gate** — `sim/simulator.go` + `sim/batch_formation.go` (T027/T028)
- `maybeStartAdapterLoad`: cold wait-queue head with no in-flight load → commit the LRU eviction victim (reserve a slot) and schedule an `AdapterLoadCompletionEvent` at `now + LoadLatency`; serialized per instance.
- `FormBatch` holds any not-yet-resident adapter out of the batch via `BatchContext.AdapterResident` (DT-faithful **blocking model**: the gated head stalls requests behind it for the load duration, design §7).
- New `AdapterLoadCompletionEvent`, priority-ordered ahead of a co-timed `StepEvent` (`PriorityAdapterLoad` inserted between `Queued` and `Step`; all existing relative orderings preserved ⇒ INV-6 byte-identity holds for adapter-blind runs).
- Completion makes the adapter resident, charges the load once (INV-L3), clears the in-flight marker, and ensures a step forms (INV-8) on **every** path.
- **Pinning (INV-L5)**: pin on running-batch entry (once per request via `Request.adapterPinned`, persists through preemption), released at every terminal path — completion, timeout, and **gateway in-flight eviction** (new exported `ReleaseAdapterPin`, called from cluster `EvictRequest`). `scheduleNextStep` suppresses empty-step spinning while a load is in flight.
- `ResidentAdapterSet` interface gains `AtCapacity`/`EvictLRU`/`Pin`/`Unpin` (consumed by the gate).

**Config** — `LoRAConfig.Validate` now requires the cost coefficients when adapters are declared with a positive capacity, so the CLI catches the gap at its validation gate rather than failing later in `NewSimulator`.

## Tests (T029)
Cold-vs-warm TTFT gap, load serialization, same-adapter coalescing, INV-5/INV-8/INV-6/determinism, no-deadlock under capacity pressure, cost-model laws (monotonicity, no-op normalization, malformed-config rejection incl. NaN/Inf/overflow), and a **cluster eviction pin-release regression** (provably fails without the fix). The PR2-inherited `TestResidentAdapterSet_PreemptionDoesNotDoubleCountLoad` was updated to supply cost coefficients (PR3 now requires them) and still asserts LoadCount==1 + `IsResident` across a preemption. Full `go test ./...` + `golangci-lint run ./...` clean; no-op byte-identity golden holds.

## Invariants
INV-3 (clock monotonicity — load completion `> now`, overflow-guarded), INV-5 (gate delays schedule not arrival), INV-6 (byte-identity when inert), INV-8 (work-conserving across the load), INV-L3 (load charged once per cold transition), INV-L5 (pinned adapters never evicted; pin released on all terminal paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)