### PR TITLE
feat(lora): PR5 — static adapter HBM accounting in CalculateKVBlocks (#1464)

### DIFF
--- a/cmd/lora_cli_test.go
+++ b/cmd/lora_cli_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/inference-sim/inference-sim/sim"
 	"github.com/spf13/cobra"
 )
 
@@ -156,5 +157,231 @@ func TestLoRAConfig_ZeroCapacityWithAdaptersRejected(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "adapter_capacity") {
 		t.Errorf("fatal message must mention adapter_capacity; output:\n%s", out)
+	}
+}
+
+// TestAdapterReservedBytesFor covers the config→bytes resolution seam that production
+// actually uses (both runCmd and replayCmd call it to set loraReservedBytesForKV). The
+// resolveLatencyConfig tests set that package var directly, so without this a
+// regression that made adapterReservedBytesFor return 0 — silently disabling the
+// reservation for every real run/replay — would pass the suite green.
+func TestAdapterReservedBytesFor(t *testing.T) {
+	// Inert config (no adapters / no capacity): BuildAdapterCost returns nil ⇒ 0,
+	// leaving KV byte-identical (INV-6).
+	if got := adapterReservedBytesFor(sim.LoRAConfig{}); got != 0 {
+		t.Errorf("inert config: adapterReservedBytesFor = %d, want 0", got)
+	}
+
+	// Populated config: equals the cost model's capacity × maxRank × footprint.
+	fp := func(v float64) *float64 { return &v }
+	capacity := 4
+	cfg := sim.LoRAConfig{
+		AdapterCapacity:       &capacity,
+		LoadBaseLatencyUs:     fp(1000.0),
+		LoadBandwidthBytesUs:  fp(2.0e6),
+		FootprintBytesPerRank: fp(2.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K6: fp(0.02), K7: fp(1.0)}},
+		Adapters: []sim.AdapterSpec{
+			{ID: "a8", Rank: 8},
+			{ID: "a16", Rank: 16},
+			{ID: "a32", Rank: 32}, // max rank sizes the per-slot footprint
+		},
+	}
+	if got, want := adapterReservedBytesFor(cfg), int64(4*32*2.0e6); got != want {
+		t.Errorf("adapterReservedBytesFor = %d, want %d (capacity × maxRank × footprint_per_rank)", got, want)
+	}
+}
+
+// TestResolveLatencyConfig_AppliesAdapterHBMReservation is the cmd-level end-to-end
+// check that the static LoRA HBM reservation threads into the auto-derived KV
+// capacity (PR5). resolveLatencyConfig is the shared auto-calc chokepoint for BOTH
+// run and replay, so exercising it pins the main-path INV-13 parity too: the same
+// reservation reduces the same block count regardless of command. It resolves an
+// identical fixture WITHOUT --total-kv-blocks (so the auto-capacity path runs) at
+// reservation 0 vs a non-zero reservation and asserts the block count shrinks.
+func TestResolveLatencyConfig_AppliesAdapterHBMReservation(t *testing.T) {
+	dir := t.TempDir()
+	mcDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(mcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Dense Llama-like fixture: the auto-capacity path needs vocab_size + realistic
+	// dims so the derived block count is comfortably positive on an 80 GiB GPU.
+	configJSON := `{
+  "architectures": ["LlamaForCausalLM"],
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "hidden_size": 4096,
+  "intermediate_size": 14336,
+  "num_key_value_heads": 8,
+  "vocab_size": 32000,
+  "hidden_act": "silu",
+  "torch_dtype": "float16",
+  "max_position_embeddings": 4096
+}`
+	if err := os.WriteFile(filepath.Join(mcDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	hwPath := filepath.Join(dir, "hw.json")
+	if err := os.WriteFile(hwPath, []byte(`{"H100": {"MemoryGiB": 80.0, "TFlopsPeak": 989.5, "BwPeakTBs": 3.35}}`), 0644); err != nil {
+		t.Fatalf("write hw: %v", err)
+	}
+
+	// Full isolation: this test mutates several cmd-level package vars, so save and
+	// restore ALL of them to avoid leaking state into other cmd tests.
+	// captureCmdLevelVars covers most (model, backend, gpu, tp, totalKVBlocks,
+	// modelConfigFolder, hwConfigPath, defaultsFilePath, blockSizeTokens,
+	// maxModelLen, ...); save the few it does not, including the new
+	// loraReservedBytesForKV.
+	orig := captureCmdLevelVars()
+	origDP, origEP, origMoE := dataParallelism, enableExpertParallel, moeCommBackend
+	origUtil, origReserved := gpuMemoryUtilization, loraReservedBytesForKV
+	defer func() {
+		orig.restore()
+		dataParallelism, enableExpertParallel, moeCommBackend = origDP, origEP, origMoE
+		gpuMemoryUtilization, loraReservedBytesForKV = origUtil, origReserved
+	}()
+
+	resolve := func(reserved int64) int64 {
+		// Reset the package-level vars resolveLatencyConfig reads.
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		gpu = "H100"
+		tensorParallelism = 1
+		dataParallelism = 1
+		enableExpertParallel = false
+		moeCommBackend = ""
+		totalKVBlocks = 0 // auto-derive
+		blockSizeTokens = 16
+		maxModelLen = 0
+		gpuMemoryUtilization = 0.9
+		modelConfigFolder = mcDir
+		hwConfigPath = hwPath
+		defaultsFilePath = "../defaults.yaml"
+		loraReservedBytesForKV = reserved
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		// No --total-kv-blocks, so Changed("total-kv-blocks") is false and the
+		// auto-capacity path (which passes WithAdapterReservedBytes) runs.
+		args := []string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--hardware", "H100", "--tp", "1",
+			"--model-config-folder", mcDir, "--hardware-config", hwPath,
+			"--defaults-filepath", "../defaults.yaml",
+		}
+		if err := testCmd.ParseFlags(args); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		resolveLatencyConfig(testCmd)
+		return totalKVBlocks
+	}
+
+	base := resolve(0)
+	withRes := resolve(8 << 30)   // 8 GiB reservation
+	withRes2 := resolve(16 << 30) // 16 GiB reservation (double)
+	if base <= 0 {
+		t.Fatalf("baseline auto-derived blocks must be positive, got %d", base)
+	}
+	if withRes >= base {
+		t.Errorf("adapter HBM reservation not applied via resolveLatencyConfig: base=%d withReservation=%d (expected fewer)", base, withRes)
+	}
+	// Magnitude law, not just direction: block loss must be LINEAR in the reserved
+	// bytes (the reservation is subtracted as GiB from a fixed overhead, then blocks =
+	// floor(remaining / per_block)), so doubling the reservation must remove ~twice
+	// the blocks. This ratio catches a wiring bug that threads the value through with a
+	// constant/fixed offset or otherwise non-linearly — it would still shrink the count
+	// and pass a direction-only check, but breaks the 2× ratio. It intentionally does
+	// NOT probe dp/tp scaling: at dp=tp=1 a dp/tp-scale error multiplies by 1 and a
+	// uniform coefficient error preserves the ratio, so both are invisible here; the
+	// per-DP-rank scaling law is pinned separately by the library test
+	// TestCalculateKVBlocks_AdapterReservationPerDPRankScaling. Slack absorbs floor()
+	// truncation at each of the two subtractions.
+	lost1, lost2 := base-withRes, base-withRes2
+	if lost1 <= 0 {
+		t.Fatalf("8 GiB reservation removed no blocks: base=%d withReservation=%d", base, withRes)
+	}
+	if lost2 <= lost1 {
+		t.Errorf("16 GiB reservation must remove more blocks than 8 GiB: lost(8GiB)=%d lost(16GiB)=%d", lost1, lost2)
+	}
+	if diff := lost2 - 2*lost1; diff < -2 || diff > 2 {
+		t.Errorf("block loss must scale linearly with the reservation: lost(8GiB)=%d, lost(16GiB)=%d, want lost(16GiB) ≈ 2×lost(8GiB) (±2 blocks truncation slack)", lost1, lost2)
+	}
+}
+
+// TestResolveLatencyConfig_ExplicitTotalKVBlocksBypassesReservation pins the scope
+// boundary documented in the --lora-config flag help: when --total-kv-blocks is set
+// explicitly, the auto-calc path does NOT run, so the static LoRA HBM reservation is
+// NOT subtracted — the explicit value is used as-is. Guards against a future refactor
+// that accidentally applies the reservation to an explicit block count.
+func TestResolveLatencyConfig_ExplicitTotalKVBlocksBypassesReservation(t *testing.T) {
+	dir := t.TempDir()
+	mcDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(mcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configJSON := `{
+  "architectures": ["LlamaForCausalLM"],
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "hidden_size": 4096,
+  "intermediate_size": 14336,
+  "num_key_value_heads": 8,
+  "vocab_size": 32000,
+  "hidden_act": "silu",
+  "torch_dtype": "float16",
+  "max_position_embeddings": 4096
+}`
+	if err := os.WriteFile(filepath.Join(mcDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	hwPath := filepath.Join(dir, "hw.json")
+	if err := os.WriteFile(hwPath, []byte(`{"H100": {"MemoryGiB": 80.0, "TFlopsPeak": 989.5, "BwPeakTBs": 3.35}}`), 0644); err != nil {
+		t.Fatalf("write hw: %v", err)
+	}
+
+	orig := captureCmdLevelVars()
+	origDP, origEP, origMoE := dataParallelism, enableExpertParallel, moeCommBackend
+	origUtil, origReserved := gpuMemoryUtilization, loraReservedBytesForKV
+	defer func() {
+		orig.restore()
+		dataParallelism, enableExpertParallel, moeCommBackend = origDP, origEP, origMoE
+		gpuMemoryUtilization, loraReservedBytesForKV = origUtil, origReserved
+	}()
+
+	model = "test-model"
+	latencyModelBackend = "trained-physics"
+	gpu = "H100"
+	tensorParallelism = 1
+	dataParallelism = 1
+	enableExpertParallel = false
+	moeCommBackend = ""
+	blockSizeTokens = 16
+	maxModelLen = 0
+	gpuMemoryUtilization = 0.9
+	modelConfigFolder = mcDir
+	hwConfigPath = hwPath
+	defaultsFilePath = "../defaults.yaml"
+	loraReservedBytesForKV = 8 << 30 // a reservation IS configured...
+
+	const explicit = int64(5000)
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	// ...but --total-kv-blocks is set explicitly, so Changed("total-kv-blocks") is
+	// true and the auto-calc path (which would subtract the reservation) is skipped.
+	args := []string{
+		"--model", "test-model", "--latency-model", "trained-physics",
+		"--hardware", "H100", "--tp", "1",
+		"--model-config-folder", mcDir, "--hardware-config", hwPath,
+		"--defaults-filepath", "../defaults.yaml",
+		"--total-kv-blocks", "5000",
+	}
+	if err := testCmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	resolveLatencyConfig(testCmd)
+
+	if totalKVBlocks != explicit {
+		t.Errorf("explicit --total-kv-blocks must be used as-is (reservation NOT applied), got %d, want %d", totalKVBlocks, explicit)
 	}
 }

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -159,6 +159,14 @@ Example:
 		}
 		logrus.Infof("Simulation horizon: %d ticks", replayHorizon)
 
+		// LoRA control-plane (#1464): resolve ONCE (R4) so the KV auto-capacity path
+		// (resolveLatencyConfig + per-pool calc) subtracts the same static HBM
+		// reservation runCmd does (PR5 / INV-13 parity) and the SimConfig below reuses
+		// it. Reservation is 0 when the subsystem is inert (INV-6). Set before
+		// resolveLatencyConfig.
+		loraCfg := resolveLoRAConfig(cmd)
+		loraReservedBytesForKV = adapterReservedBytesFor(loraCfg)
+
 		// Resolve latency backend configuration (single code path shared with runCmd).
 		lr := resolveLatencyConfig(cmd)
 
@@ -318,7 +326,8 @@ Example:
 						} else {
 							// Per-pool TP but GLOBAL dp: per-pool DP is out of scope (#1420);
 							// --dp applies uniformly to all pools. Mirrors run (cmd/root.go).
-							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolPrefillTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool)
+							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolPrefillTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool,
+								latency.WithAdapterReservedBytes(loraReservedBytesForKV))
 							if calcErr != nil {
 								logrus.Fatalf("--prefill-tp/--prefill-hardware: KV capacity auto-calculation failed for prefill pool: %v", calcErr)
 							} else {
@@ -353,7 +362,8 @@ Example:
 							logrus.Warnf("--decode-hardware: GPU memory capacity not available for %q in hardware config; decode pool will use global total-kv-blocks=%d", poolDecodeGPU, totalKVBlocks)
 						} else {
 							// Per-pool TP, global dp (see prefill-pool note above; #1420).
-							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolDecodeTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool)
+							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolDecodeTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool,
+								latency.WithAdapterReservedBytes(loraReservedBytesForKV))
 							if calcErr != nil {
 								logrus.Fatalf("--decode-tp/--decode-hardware: KV capacity auto-calculation failed for decode pool: %v", calcErr)
 							} else {
@@ -467,7 +477,7 @@ Example:
 				LatencyCoeffs:        sim.NewLatencyCoeffs(lr.BetaCoeffs, lr.AlphaCoeffs),
 				ModelHardwareConfig:  sim.NewModelHardwareConfig(lr.ModelConfig, lr.HWConfig, model, gpu, tensorParallelism, dataParallelism, enableExpertParallel, moeCommBackend, lr.Backend, maxModelLen),
 				PolicyConfig:         sim.NewPolicyConfig(scheduler, preemptionPolicy),
-				LoRAConfig:           resolveLoRAConfig(cmd),
+				LoRAConfig:           loraCfg,
 				SLOPriorityOverrides: sloPriorityOverrides,
 			},
 			NumInstances:                    numInstances,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,13 @@ var (
 	loraLoadBandwidthBytesUs  float64 // --lora-load-bandwidth-bytes-us
 	loraFootprintBytesPerRank float64 // --lora-footprint-bytes-per-rank
 
+	// loraReservedBytesForKV carries the resolved static LoRA HBM reservation
+	// (bytes) into KV auto-capacity, mirroring how totalKVBlocks is threaded as a
+	// package var. Set once per command RunE from the single resolveLoRAConfig call
+	// (BEFORE resolveLatencyConfig, which reads it at the main auto-calc); 0 when the
+	// subsystem is inert, keeping KV capacity byte-identical to today (INV-6/PR5).
+	loraReservedBytesForKV int64
+
 	// Fitness evaluation config (PR9)
 	fitnessWeights string // Fitness weights string "key:val,key:val"
 
@@ -619,14 +626,17 @@ func resolveLatencyConfig(cmd *cobra.Command) latencyResolution {
 			if kvParamsErr != nil {
 				logrus.Warnf("--latency-model: could not extract KV capacity params: %v. "+
 					"Using total-kv-blocks=%d. Set --total-kv-blocks explicitly to override", kvParamsErr, totalKVBlocks)
+				logAdapterHBMReservationNotApplied()
 			} else if hwConfig.MemoryGiB <= 0 {
 				logrus.Warnf("--latency-model: GPU memory capacity not available in hardware config; "+
 					"using current total-kv-blocks=%d. Add MemoryGiB to hardware_config.json or pass --total-kv-blocks explicitly", totalKVBlocks)
+				logAdapterHBMReservationNotApplied()
 			} else {
 				if kvParams.HiddenAct == "" {
 					logrus.Infof("--latency-model: hidden_act not set in config.json; assuming SwiGLU (3-matrix MLP) for weight estimation")
 				}
-				autoBlocks, calcErr := latency.CalculateKVBlocks(modelConfig, hwConfig, tensorParallelism, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParams)
+				autoBlocks, calcErr := latency.CalculateKVBlocks(modelConfig, hwConfig, tensorParallelism, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParams,
+					latency.WithAdapterReservedBytes(loraReservedBytesForKV))
 				if calcErr != nil {
 					logrus.Fatalf("--latency-model: KV capacity auto-calculation failed: %v", calcErr)
 				}
@@ -634,7 +644,17 @@ func resolveLatencyConfig(cmd *cobra.Command) latencyResolution {
 				logrus.Infof("--gpu-memory-utilization: %.2f used for KV block auto-calculation", gpuMemoryUtilization)
 				logrus.Infof("--latency-model: auto-calculated total-kv-blocks=%d (GPU=%.0f GiB, TP=%d, DP=%d, block_size=%d, MoE=%v)",
 					totalKVBlocks, hwConfig.MemoryGiB, tensorParallelism, dataParallelism, blockSizeTokens, kvParams.IsMoE)
+				logAdapterHBMReservation("--latency-model")
 			}
+		} else if loraReservedBytesForKV > 0 {
+			// Explicit --total-kv-blocks bypasses the global auto-calc, so the static
+			// LoRA HBM reservation is NOT subtracted from that global count (it applies
+			// only on an auto-calc path). Surface this so a user who configured adapters
+			// is not surprised that usable KV did not shrink (matches the --lora-config
+			// flag help). Note: any per-pool auto-calc (--prefill-tp/--decode-tp etc.)
+			// still applies the reservation to its own pool block count.
+			logrus.Warnf("--total-kv-blocks set explicitly (%d blocks); the static LoRA adapter HBM reservation (%.2f GiB) is NOT applied to that explicit global block count (per-pool auto-calc, if any, still applies it) — omit --total-kv-blocks to let auto-calc subtract it",
+				totalKVBlocks, float64(loraReservedBytesForKV)/float64(1<<30))
 		}
 
 		// Auto-derive --max-model-len from HF config's max_position_embeddings.
@@ -1154,7 +1174,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	// and per-rank step_overhead_tiers are config-file only (--lora-config); a scalar
 	// flag cannot express a per-rank map. Scalar coefficient flags compose with and
 	// override the file / defaults.yaml (R18: applied only when Changed).
-	cmd.Flags().StringVar(&loraConfigPath, "lora-config", "", "Path to YAML file with a top-level lora: block (adapter registry, capacity, cost coefficients). Absent => LoRA subsystem inert.")
+	cmd.Flags().StringVar(&loraConfigPath, "lora-config", "", "Path to YAML file with a top-level lora: block (adapter registry, capacity, cost coefficients). The static adapter HBM reservation is subtracted from KV capacity only on the auto-calc path; an explicit --total-kv-blocks is used as-is (reservation not applied). Absent => LoRA subsystem inert.")
 	cmd.Flags().IntVar(&loraAdapterCapacity, "lora-adapter-capacity", 0, "Per-instance resident adapter slots (0 with adapters declared => error). Applied only when set.")
 	cmd.Flags().Float64Var(&loraLoadBaseLatencyUs, "lora-load-base-latency-us", 0, "Cold adapter-load fixed latency in µs. Applied only when set; else --lora-config / defaults.yaml.")
 	cmd.Flags().Float64Var(&loraLoadBandwidthBytesUs, "lora-load-bandwidth-bytes-us", 0, "Cold adapter-load bandwidth in bytes/µs (>0). Applied only when set; else --lora-config / defaults.yaml.")
@@ -1251,6 +1271,79 @@ func resolveLoRAConfig(cmd *cobra.Command) sim.LoRAConfig {
 	return cfg
 }
 
+// adapterReservedBytesFor returns the static LoRA HBM reservation (bytes) to carve
+// out of the KV budget for a resolved config, obtained through the sim/lora cost
+// model's pure AdapterReservedBytes() query (design boundary #4 — the memory path
+// never reaches into sim/lora internals). It routes through sim.BuildAdapterCost so
+// the activation condition matches NewSimulator's resident-set/cost wiring exactly
+// (R4): 0 when the subsystem is inert (no adapters, no capacity, or sim/lora not
+// linked), leaving KV capacity byte-identical to today (INV-6). A malformed cost
+// config aborts at the CLI boundary (Principle V), the same check NewSimulator makes.
+//
+// This deliberately builds an adapter-cost model that sim.NewSimulator (the
+// cold-load gate) and sim/cluster.NewInstanceSimulator (the latency backends,
+// #1467) each also build from the same config via sim.BuildAdapterCost. The model
+// is a pure, stateless value object, so independent builds from one config are
+// behaviorally identical — the extra one-time O(adapters) construction at startup is
+// the established BuildAdapterCost pattern, not a caching bug.
+func adapterReservedBytesFor(cfg sim.LoRAConfig) int64 {
+	ac, err := sim.BuildAdapterCost(sim.SimConfig{LoRAConfig: cfg})
+	if err != nil {
+		logrus.Fatalf("Invalid LoRA configuration (HBM reservation): %v", err)
+	}
+	if ac == nil {
+		return 0
+	}
+	// Defense in depth: NewCostModel already rejects a non-finite reservation and
+	// caps it below maxReservedBytes (< math.MaxInt64), so this conversion is exact
+	// and non-negative for any model built through it. Guard the CLI boundary
+	// explicitly anyway — so a future construction path that bypasses that check can
+	// never silently truncate a huge/±Inf float64 to a garbage int64 (Go's
+	// out-of-range float→int conversion is implementation-defined). Principle V:
+	// fail at the CLI boundary, not deep in the KV-capacity library.
+	//
+	// int64(x) is well-defined and exact for every representable float64 strictly
+	// below 2^63. The trap is float64(math.MaxInt64): MaxInt64 (2^63-1) is not
+	// representable in float64 and rounds UP to 2^63, so it must NOT be used as the
+	// bound (int64(2^63) overflows). We reject at the comfortably-conservative,
+	// exactly-representable 2^62 (≈4.6e18) — far above any real reservation (the cost
+	// model caps at 1e18) — so the cast is provably safe without relying on the exact
+	// 2^63 edge.
+	const maxSafeReservedBytes = float64(int64(1) << 62)
+	reserved := ac.AdapterReservedBytes()
+	if math.IsNaN(reserved) || math.IsInf(reserved, 0) || reserved < 0 || reserved >= maxSafeReservedBytes {
+		logrus.Fatalf("Invalid LoRA configuration (HBM reservation): %v bytes is outside the representable range", reserved)
+	}
+	return int64(reserved)
+}
+
+// logAdapterHBMReservation surfaces the static LoRA HBM reservation once, on the
+// main auto-calculated KV-block path, so a user can see WHY usable KV shrank (the
+// success-path counterpart to the reservation term in CalculateKVBlocks'
+// insufficient-memory / infeasibility error). The reservation is a single per-instance constant applied identically to
+// every KV auto-calc (global and any per-pool), so logging it once conveys the full
+// picture without repetition. No-op when the subsystem is inert (reservation 0), so
+// non-LoRA runs log nothing new (INV-6). scope labels the originating flag/path.
+func logAdapterHBMReservation(scope string) {
+	if loraReservedBytesForKV > 0 {
+		logrus.Infof("%s: reserved %.2f GiB GPU HBM for LoRA adapters (static capacity × per-slot footprint); usable KV blocks reduced accordingly",
+			scope, float64(loraReservedBytesForKV)/float64(1<<30))
+	}
+}
+
+// logAdapterHBMReservationNotApplied warns that a configured LoRA HBM reservation
+// was NOT subtracted because auto-calc was abandoned (KV params unextractable or no
+// GPU-memory figure) and total-kv-blocks fell back to its default. Without this, a
+// user who configured adapters would see only the generic "couldn't auto-derive
+// capacity" warning and no LoRA-specific signal that the reservation was dropped
+// (silent-LoRA-misconfig class). No-op when the subsystem is inert (INV-6).
+func logAdapterHBMReservationNotApplied() {
+	if loraReservedBytesForKV > 0 {
+		logrus.Warnf("--lora-config: KV auto-calculation was skipped, so the static LoRA adapter HBM reservation (%.2f GiB) is NOT applied to the fallback total-kv-blocks=%d — fix the model/hardware config or set --total-kv-blocks with headroom for adapters",
+			float64(loraReservedBytesForKV)/float64(1<<30), totalKVBlocks)
+	}
+}
+
 // applyTimeoutToSpec sets ClientSpec.Timeout and CohortSpec.Timeout on every entry in spec.
 // timeoutSecs>0 converts to µs and sets a deadline; timeoutSecs<=0 sets an explicit *int64(0)
 // (disabled). Explicit zero is required so computeDeadline does not fall back to the 300s
@@ -1308,6 +1401,14 @@ var runCmd = &cobra.Command{
 		if model == "" { // model not provided, exit
 			logrus.Fatalf("LLM name not provided. Exiting simulation.")
 		}
+
+		// LoRA control-plane (#1464): resolve the config ONCE here (R4 single site) so
+		// both the KV auto-capacity path — resolveLatencyConfig and the per-pool calc
+		// below read the resulting static HBM reservation (PR5) — and the SimConfig
+		// literal further down share one resolution. The reservation is 0 (KV
+		// unaffected) when the subsystem is inert (INV-6). Set before resolveLatencyConfig.
+		loraCfg := resolveLoRAConfig(cmd)
+		loraReservedBytesForKV = adapterReservedBytesFor(loraCfg)
 
 		// Resolve latency backend configuration (single code path shared with replayCmd).
 		lr := resolveLatencyConfig(cmd)
@@ -1376,7 +1477,8 @@ var runCmd = &cobra.Command{
 						} else {
 							// Per-pool TP but GLOBAL dp: per-pool DP is out of scope (#1420);
 							// --dp applies uniformly to all pools. Not a bug — see issue #1420.
-							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolPrefillTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool)
+							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolPrefillTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool,
+								latency.WithAdapterReservedBytes(loraReservedBytesForKV))
 							if calcErr != nil {
 								logrus.Fatalf("--prefill-tp/--prefill-hardware: KV capacity auto-calculation failed for prefill pool: %v", calcErr)
 							} else {
@@ -1411,7 +1513,8 @@ var runCmd = &cobra.Command{
 							logrus.Warnf("--decode-hardware: GPU memory capacity not available for %q in hardware config; decode pool will use global total-kv-blocks=%d", poolDecodeGPU, totalKVBlocks)
 						} else {
 							// Per-pool TP, global dp (see prefill-pool note above; #1420).
-							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolDecodeTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool)
+							poolBlocks, calcErr := latency.CalculateKVBlocks(lr.ModelConfig, poolHC, poolDecodeTP, dataParallelism, blockSizeTokens, gpuMemoryUtilization, kvParamsPool,
+								latency.WithAdapterReservedBytes(loraReservedBytesForKV))
 							if calcErr != nil {
 								logrus.Fatalf("--decode-tp/--decode-hardware: KV capacity auto-calculation failed for decode pool: %v", calcErr)
 							} else {
@@ -1866,11 +1969,11 @@ var runCmd = &cobra.Command{
 		logrus.Infof("Starting simulation with %d KV blocks, horizon=%dticks, alphaCoeffs=%v, betaCoeffs=%v",
 			totalKVBlocks, simulationHorizon, lr.AlphaCoeffs, lr.BetaCoeffs)
 
-		// LoRA control-plane (#1464). Resolve once, then cross-validate every workload
-		// adapter reference against the declared registry (unknown id / base-model
-		// mismatch => Fatalf, never a silent no-op). With no adapters and no workload
-		// adapter references this is inert (INV-6).
-		loraCfg := resolveLoRAConfig(cmd)
+		// LoRA control-plane (#1464). loraCfg was resolved once at the top of RunE (for
+		// the KV HBM reservation); here we cross-validate every workload adapter
+		// reference against the declared registry (unknown id / base-model mismatch =>
+		// Fatalf, never a silent no-op). With no adapters and no workload adapter
+		// references this is inert (INV-6).
 		var loraRegistry sim.AdapterRegistry
 		if loraCfg.HasAdapters() {
 			r, regErr := sim.NewAdapterRegistryFunc(loraCfg.Adapters)

--- a/sim/adapter_cost.go
+++ b/sim/adapter_cost.go
@@ -7,9 +7,8 @@ package sim
 // NewAdapterCostFunc, mirroring NewAdapterRegistryFunc / NewResidentAdapterSetFunc.
 //
 // The interface is scoped to what its consumers read today (R13): LoadLatency for
-// the cold-load gate (#1466) and StepOverheadFactor for the latency backends
-// (#1467). The concrete cost model additionally derives the HBM footprint; that
-// enters this interface when the memory PR consumes it.
+// the cold-load gate (#1466), StepOverheadFactor for the latency backends
+// (#1467), and AdapterReservedBytes for the KV-capacity module (#1468).
 type AdapterCost interface {
 	// LoadLatency returns the one-time cold-load latency of an adapter id in µs
 	// (>= 0). An empty (base-model) or unregistered id returns 0 — it never gates.
@@ -20,6 +19,13 @@ type AdapterCost interface {
 	// (R23). It is exactly 1.0 when the batch carries no adapter ids, so a
 	// no-adapter step is byte-identical to a pre-feature build (INV-6).
 	StepOverheadFactor(batch []*Request) float64
+
+	// AdapterReservedBytes returns the fixed, capacity-based HBM reservation in
+	// bytes (>= 0): adapter_capacity × per-slot footprint (sized from the max
+	// declared rank). Constant for the model's lifetime (static reservation,
+	// D2/INV-L4) — the KV-capacity module subtracts it once at startup. Returns 0
+	// when no adapters or no capacity are configured (INV-6 no-op).
+	AdapterReservedBytes() float64
 }
 
 // NewAdapterCostFunc builds an AdapterCost from a LoRAConfig (rank registry +

--- a/sim/latency/adapter_overhead_test.go
+++ b/sim/latency/adapter_overhead_test.go
@@ -28,6 +28,7 @@ type fakeAdapterCost struct{ factor float64 }
 
 func (f fakeAdapterCost) LoadLatency(string) float64                { return 0 }
 func (f fakeAdapterCost) StepOverheadFactor([]*sim.Request) float64 { return f.factor }
+func (f fakeAdapterCost) AdapterReservedBytes() float64             { return 0 }
 
 // newAdapterCost builds a real *lora.CostModel (satisfying sim.AdapterCost) with
 // the given rank tiers and adapter registry. Load-cost coefficients are inert

--- a/sim/latency/kv_capacity.go
+++ b/sim/latency/kv_capacity.go
@@ -118,10 +118,31 @@ func KVBytesPerToken(mc sim.ModelConfig, tp int) (float64, error) {
 	return perTokenKVBytesPerGPUF, nil
 }
 
+// kvCapacityOptions accumulates optional inputs to CalculateKVBlocks. Zero value
+// ⇒ no adapter reservation, so the block count is byte-identical to a pre-LoRA
+// build (INV-6). A variadic Option (mirroring latency.Option for NewLatencyModel,
+// #1467) keeps the existing positional call sites unchanged.
+type kvCapacityOptions struct {
+	adapterReservedBytes int64
+}
+
+// KVCapacityOption customizes CalculateKVBlocks.
+type KVCapacityOption func(*kvCapacityOptions)
+
+// WithAdapterReservedBytes reserves a fixed, capacity-based block of GPU HBM for
+// resident LoRA adapters, subtracted once at startup beside model weights (the
+// static memory model, design D2 / INV-L4). The value is the sim/lora cost model's
+// pure AdapterReservedBytes() query (capacity × per-slot footprint); 0 (or the
+// option absent) leaves KV capacity unchanged (INV-6 no-op). A negative value is
+// rejected by CalculateKVBlocks.
+func WithAdapterReservedBytes(bytes int64) KVCapacityOption {
+	return func(o *kvCapacityOptions) { o.adapterReservedBytes = bytes }
+}
+
 // CalculateKVBlocks computes the maximum number of KV cache blocks that fit
-// in GPU memory after accounting for model weights, activations, and
-// non-PyTorch overhead. The formula matches the llm-d-benchmark
-// capacity_planner.py reference.
+// in GPU memory after accounting for model weights, activations, non-PyTorch
+// overhead, and (optionally) the static LoRA adapter HBM reservation. The base
+// formula matches the llm-d-benchmark capacity_planner.py reference.
 //
 // Parameters:
 //
@@ -155,10 +176,18 @@ func KVBytesPerToken(mc sim.ModelConfig, tp int) (float64, error) {
 //
 // Returns the number of blocks, or an error if inputs are invalid or memory
 // budget is insufficient.
-func CalculateKVBlocks(mc sim.ModelConfig, hc sim.HardwareCalib, tp int, dp int, blockSize int64, gpuMemoryUtilization float64, params KVCapacityParams) (int64, error) {
+func CalculateKVBlocks(mc sim.ModelConfig, hc sim.HardwareCalib, tp int, dp int, blockSize int64, gpuMemoryUtilization float64, params KVCapacityParams, options ...KVCapacityOption) (int64, error) {
+	var opts kvCapacityOptions
+	for _, o := range options {
+		o(&opts)
+	}
+
 	// --- Input validation (R3, R11) ---
 	if gpuMemoryUtilization <= 0 || gpuMemoryUtilization > 1.0 || math.IsNaN(gpuMemoryUtilization) || math.IsInf(gpuMemoryUtilization, 0) {
 		return 0, fmt.Errorf("CalculateKVBlocks: gpuMemoryUtilization must be in (0, 1.0], got %v", gpuMemoryUtilization)
+	}
+	if opts.adapterReservedBytes < 0 {
+		return 0, fmt.Errorf("CalculateKVBlocks: adapterReservedBytes must be >= 0, got %d", opts.adapterReservedBytes)
 	}
 	if blockSize <= 0 {
 		return 0, fmt.Errorf("CalculateKVBlocks: block size must be > 0, got %d", blockSize)
@@ -232,12 +261,27 @@ func CalculateKVBlocks(mc sim.ModelConfig, hc sim.HardwareCalib, tp int, dp int,
 	}
 	nonTorchGiB := nonTorchPerGPU * float64(tp)
 
-	overheadGiB := modelWeightGiB + activationGiB + nonTorchGiB
+	// Static LoRA adapter HBM reservation (D2 / INV-L4): a fixed, capacity-based
+	// block of memory reserved once beside model weights. Treated EXACTLY like
+	// model weights: a per-DP-rank overhead that is NOT multiplied by dp here. Each
+	// DP rank is an independent EngineCore on its own GPUs that reserves its own
+	// adapter slots, so the per-rank budget subtracts the reservation once; the
+	// dp block-count scaling below then aggregates per-rank budgets into the
+	// instance total (multiplying the reservation by dp here as well would
+	// double-count it — same reasoning that keeps modelWeightGiB per-rank). The
+	// reservation is also TP-independent (a total across the rank's TP GPUs, since
+	// the adapter A/B matrices are sharded like weights). Zero when no
+	// adapters/capacity are configured (INV-6).
+	adapterReservedGiB := float64(opts.adapterReservedBytes) / float64(gibToBytes)
+
+	overheadGiB := modelWeightGiB + activationGiB + nonTorchGiB + adapterReservedGiB
 	if overheadGiB >= totalAvailableGiB {
 		perGPUAvailable := hc.MemoryGiB * gpuMemoryUtilization
 
-		// Calculate minimum TP needed: use TP-independent overhead (weights + activation)
-		// and subtract per-GPU non-torch overhead from available capacity.
+		// Calculate minimum TP needed: use TP-independent overhead (weights +
+		// activation + adapter reservation) and subtract per-GPU non-torch overhead
+		// from available capacity. The static adapter reservation is TP-independent
+		// (sharded like weights, total constant), so it raises the minimum TP.
 		// For TP>1, use nonTorchMemoryTPMultiGiB (0.6 GiB/GPU) to account for NCCL/CUDA overhead.
 		nonTorchPerGPUForMinTP := nonTorchMemoryTPMultiGiB
 		perGPUCapacity := perGPUAvailable - nonTorchPerGPUForMinTP
@@ -249,14 +293,14 @@ func CalculateKVBlocks(mc sim.ModelConfig, hc sim.HardwareCalib, tp int, dp int,
 				perGPUAvailable, nonTorchPerGPUForMinTP, perGPUCapacity)
 		}
 
-		tpIndependentOverhead := modelWeightGiB + activationGiB
+		tpIndependentOverhead := modelWeightGiB + activationGiB + adapterReservedGiB
 		minTP := int(math.Ceil(tpIndependentOverhead / perGPUCapacity))
 
 		return 0, fmt.Errorf(
-			"CalculateKVBlocks: model overhead (%.2f GiB = %.2f weights + %.2f activation + %.2f non-torch) "+
+			"CalculateKVBlocks: model overhead (%.2f GiB = %.2f weights + %.2f activation + %.2f non-torch + %.2f lora-adapter-reservation) "+
 				"exceeds available GPU memory (%.2f GiB = %.1f GiB × %.0f%% util × %d GPUs). "+
 				"Minimum GPUs required per instance: %d",
-			overheadGiB, modelWeightGiB, activationGiB, nonTorchGiB,
+			overheadGiB, modelWeightGiB, activationGiB, nonTorchGiB, adapterReservedGiB,
 			totalAvailableGiB, hc.MemoryGiB, gpuMemoryUtilization*100, tp, minTP)
 	}
 

--- a/sim/latency/kv_capacity_test.go
+++ b/sim/latency/kv_capacity_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inference-sim/inference-sim/sim"
 	"github.com/inference-sim/inference-sim/sim/latency"
+	"github.com/inference-sim/inference-sim/sim/lora"
 )
 
 // --- Test helpers ---
@@ -1483,5 +1484,195 @@ func TestCalculateKVBlocks_RejectsInvalidDP(t *testing.T) {
 		if _, err := latency.CalculateKVBlocks(mc, hc, 2, dp, 16, 0.9, params); err == nil {
 			t.Errorf("dp=%d must be rejected, got nil error", dp)
 		}
+	}
+}
+
+// --- LoRA static HBM reservation (PR5, T033) ---
+//
+// The KV-capacity module subtracts a fixed, capacity-based adapter reservation
+// (capacity × per-slot footprint, sized from the max declared rank) once at
+// startup beside model weights — the static memory model (design D2 / INV-L4).
+// These tests assert the observable laws: usable KV shrinks by the reservation,
+// memory is conserved, the reservation is the fixed capacity/max-rank amount (not
+// a dynamic per-adapter sum), an infeasible reservation is rejected at startup
+// (R22), and the zero reservation is byte-identical to the pre-feature result
+// (INV-6).
+
+// perBlockBytesFor mirrors CalculateKVBlocks' per-block byte computation so tests
+// can reason about block-count deltas.
+func perBlockBytesFor(t *testing.T, mc sim.ModelConfig, tp int, blockSize int64) int64 {
+	t.Helper()
+	perTok, err := latency.KVBytesPerToken(mc, tp)
+	if err != nil {
+		t.Fatalf("KVBytesPerToken: %v", err)
+	}
+	return int64(perTok * float64(blockSize))
+}
+
+// TestCalculateKVBlocks_AdapterReservationShrinksAndConserves verifies a non-zero
+// reservation shrinks usable KV blocks and that memory is conserved: the block
+// count lost equals the reserved bytes divided by the per-block size
+// (allocated + free + adapter_reserved = total, INV-4/INV-L4), within one block
+// of truncation.
+func TestCalculateKVBlocks_AdapterReservationShrinksAndConserves(t *testing.T) {
+	mc, hc, params := validDenseModelConfig(), validHWConfig(), validDenseKVParams()
+	tp, dp, blockSize, util := 1, 1, int64(16), 0.9
+
+	base, err := latency.CalculateKVBlocks(mc, hc, tp, dp, blockSize, util, params)
+	if err != nil {
+		t.Fatalf("baseline (no reservation): %v", err)
+	}
+
+	reserved := int64(2) << 30 // 2 GiB
+	withRes, err := latency.CalculateKVBlocks(mc, hc, tp, dp, blockSize, util, params,
+		latency.WithAdapterReservedBytes(reserved))
+	if err != nil {
+		t.Fatalf("with reservation: %v", err)
+	}
+
+	if withRes >= base {
+		t.Fatalf("reservation did not shrink usable KV blocks: base=%d withReservation=%d", base, withRes)
+	}
+
+	// Conservation: the bytes carved out (lost blocks × per-block) equal the
+	// reservation, within one block of int64 truncation.
+	perBlock := perBlockBytesFor(t, mc, tp, blockSize)
+	lostBlocks := base - withRes
+	expectedLost := reserved / perBlock
+	if lostBlocks < expectedLost-1 || lostBlocks > expectedLost+1 {
+		t.Errorf("lost %d blocks, want ≈ reserved/perBlock = %d (±1); reserved=%d perBlock=%d",
+			lostBlocks, expectedLost, reserved, perBlock)
+	}
+}
+
+// TestCalculateKVBlocks_ReservationUsesFixedCapacityMaxRank drives the reservation
+// through the real sim/lora cost model (the pure query behind the sim.AdapterCost
+// seam) and confirms the value fed to CalculateKVBlocks is the fixed
+// capacity × maxRank amount — NOT a sum over declared/resident adapters. This
+// guards against the rejected dynamic running-sum model: because the reservation
+// is capacity-provisioned at the max rank, it is invariant to which adapters are
+// resident (adapters churn within the pre-reserved slots; INV-L4).
+func TestCalculateKVBlocks_ReservationUsesFixedCapacityMaxRank(t *testing.T) {
+	capacity := 4
+	fp := func(v float64) *float64 { return &v }
+	cfg := sim.LoRAConfig{
+		AdapterCapacity:       &capacity,
+		LoadBaseLatencyUs:     fp(1000.0),
+		LoadBandwidthBytesUs:  fp(2.0e6),
+		FootprintBytesPerRank: fp(2.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K6: fp(0.02), K7: fp(1.0)}},
+		Adapters: []sim.AdapterSpec{
+			{ID: "a8", Rank: 8},
+			{ID: "a16", Rank: 16},
+			{ID: "a32", Rank: 32}, // max rank sizes the per-slot footprint
+		},
+	}
+	cm, err := lora.NewCostModel(cfg)
+	if err != nil {
+		t.Fatalf("lora.NewCostModel: %v", err)
+	}
+
+	// The exact formula (capacity × maxRank × footprint, and that it is NOT a
+	// per-adapter sum) is the cost model's own contract, verified in
+	// TestCostModel_AdapterReservedBytes. Here we treat AdapterReservedBytes() as a
+	// black box and confirm the real cost model's value flows through
+	// CalculateKVBlocks and shrinks usable KV (the integration this test owns).
+	reserved := int64(cm.AdapterReservedBytes())
+	if reserved <= 0 {
+		t.Fatalf("cost model reservation must be positive, got %d", reserved)
+	}
+
+	mc, hc, params := validDenseModelConfig(), validHWConfig(), validDenseKVParams()
+	base, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params)
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	withRes, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params,
+		latency.WithAdapterReservedBytes(reserved))
+	if err != nil {
+		t.Fatalf("with reservation: %v", err)
+	}
+	if withRes >= base {
+		t.Errorf("cost-model reservation did not shrink usable KV blocks: base=%d withReservation=%d", base, withRes)
+	}
+}
+
+// TestCalculateKVBlocks_AdapterReservationPerDPRankScaling verifies the reservation
+// is a per-DP-rank overhead (treated like model weights), NOT dp-scaled itself. For
+// an MoE model at dp>1 the per-rank block count is multiplied by dp to aggregate the
+// instance total, so the TOTAL blocks lost to the reservation is dp × (reserved /
+// per-block) — each rank independently reserves its own slots. This locks the DP
+// semantics: a reduction of only reserved/per-block would mean dp was ignored; a
+// reduction of dp² × (...) would mean the reservation was itself wrongly dp-scaled.
+func TestCalculateKVBlocks_AdapterReservationPerDPRankScaling(t *testing.T) {
+	mc, hc, params := validMoEModelConfig(), validHWConfig(), validMoEKVParams()
+	tp, dp, blockSize, util := 2, 2, int64(16), 0.9
+
+	base, err := latency.CalculateKVBlocks(mc, hc, tp, dp, blockSize, util, params)
+	if err != nil {
+		t.Fatalf("baseline MoE dp=2: %v", err)
+	}
+
+	reserved := int64(2) << 30 // 2 GiB, per DP rank
+	withRes, err := latency.CalculateKVBlocks(mc, hc, tp, dp, blockSize, util, params,
+		latency.WithAdapterReservedBytes(reserved))
+	if err != nil {
+		t.Fatalf("MoE dp=2 with reservation: %v", err)
+	}
+	if withRes >= base {
+		t.Fatalf("reservation did not shrink MoE dp=2 blocks: base=%d withReservation=%d", base, withRes)
+	}
+
+	perBlock := perBlockBytesFor(t, mc, tp, blockSize)
+	lostBlocks := base - withRes
+	expectedLost := int64(dp) * (reserved / perBlock) // per-rank loss, aggregated across dp ranks
+	// Tolerance ±dp: one block of int64 truncation per DP rank.
+	if lostBlocks < expectedLost-int64(dp) || lostBlocks > expectedLost+int64(dp) {
+		t.Errorf("MoE dp=%d lost %d blocks, want ≈ dp×(reserved/perBlock) = %d (±%d); reserved=%d perBlock=%d",
+			dp, lostBlocks, expectedLost, dp, reserved, perBlock)
+	}
+}
+
+// TestCalculateKVBlocks_InfeasibleReservationRejectedAtStartup verifies an adapter
+// reservation that cannot fit alongside weights + activation + minimum KV is
+// rejected at startup (returns an error the CLI maps to Fatalf), never a silent
+// runtime KV drop (R22 / INV-L4).
+func TestCalculateKVBlocks_InfeasibleReservationRejectedAtStartup(t *testing.T) {
+	mc, hc, params := validDenseModelConfig(), validHWConfig(), validDenseKVParams()
+	reserved := int64(1000) << 30 // 1000 GiB — far exceeds the 80 GiB budget
+	_, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params,
+		latency.WithAdapterReservedBytes(reserved))
+	if err == nil {
+		t.Fatal("expected startup error for an infeasible adapter reservation (R22), got nil")
+	}
+	// Pin that the adapter reservation caused the rejection, not some unrelated
+	// capacity error — the error breakdown names the reservation term.
+	if !strings.Contains(err.Error(), "lora-adapter-reservation") {
+		t.Errorf("infeasibility error must name the adapter reservation term, got: %v", err)
+	}
+}
+
+// TestCalculateKVBlocks_ZeroReservationByteIdentical verifies the no-op default:
+// omitting the option, or passing zero, yields the exact pre-feature block count
+// (INV-6). A negative reservation is rejected (guard).
+func TestCalculateKVBlocks_ZeroReservationByteIdentical(t *testing.T) {
+	mc, hc, params := validDenseModelConfig(), validHWConfig(), validDenseKVParams()
+
+	base, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params)
+	if err != nil {
+		t.Fatalf("no option: %v", err)
+	}
+	zero, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params,
+		latency.WithAdapterReservedBytes(0))
+	if err != nil {
+		t.Fatalf("zero option: %v", err)
+	}
+	if zero != base {
+		t.Errorf("WithAdapterReservedBytes(0) = %d, want %d (INV-6 byte-identical no-op)", zero, base)
+	}
+
+	if _, err := latency.CalculateKVBlocks(mc, hc, 1, 1, 16, 0.9, params,
+		latency.WithAdapterReservedBytes(-1)); err == nil {
+		t.Error("negative adapter reservation must be rejected, got nil error")
 	}
 }

--- a/sim/lora/cost_model.go
+++ b/sim/lora/cost_model.go
@@ -16,23 +16,36 @@ import (
 //     pre-admission gate (PR3): base + ceil(footprint(rank)/bandwidth).
 //   - StepOverheadFactor(b)  — multiplicative per-step compute overhead >= 1.0,
 //     1 + (K6(r_max)/K7(r_max))·A_B, applied by both latency backends (PR4).
-//   - FootprintBytes(id)     — per-adapter HBM footprint, summed into the KV
-//     reservation (PR5).
+//   - FootprintBytes(id)     — per-adapter HBM footprint (footprint_bytes_per_rank
+//     · rank); an input to LoadLatency, not itself a KV-reservation term.
+//   - AdapterReservedBytes() — the FIXED, capacity-based static HBM reservation
+//     (adapter_capacity × per-slot footprint, sized from the max declared rank)
+//     subtracted from the KV budget once at startup (PR5). A constant, NOT a
+//     running sum over currently-resident adapters (D2 / INV-L4).
 //
 // All methods are pure queries (Principle III): they never mutate the model and
 // return identical results for identical inputs (INV-6, no RNG — R7). Ranks are
 // resolved from the pre-declared registry built once at construction; requests
 // carry only the adapter id.
 //
-// It satisfies sim.AdapterCost (via the LoadLatency method); the type stays
-// exported so PR4/PR5 can consume StepOverheadFactor / FootprintBytes directly
-// while the sim/ seam interface grows only as each term is wired (R13).
+// It satisfies sim.AdapterCost; the type stays exported so the latency backends
+// consume StepOverheadFactor and the KV-capacity path consumes AdapterReservedBytes
+// through that seam (each term wired as its PR landed — PR3/PR4/PR5; R13).
 type CostModel struct {
 	loadBaseLatencyUs     float64
 	loadBandwidthBytesUs  float64 // > 0, divisor guard enforced at construction (R11)
 	footprintBytesPerRank float64
 
 	ranks map[string]int // adapter id -> declared rank (registry projection)
+
+	// adapterCapacity and maxRank size the static HBM reservation (PR5): the
+	// resident-slot count and the largest declared rank, resolved once at
+	// construction. per-slot footprint = footprintBytesPerRank · maxRank, so the
+	// reservation (capacity × per-slot) is a constant regardless of which adapters
+	// are resident (D2 / INV-L4). Both are 0 when no capacity / no adapters are
+	// declared, making the reservation 0 (INV-6 no-op).
+	adapterCapacity int
+	maxRank         int
 
 	// tiers holds the per-rank compute-overhead coefficients; tierRanks is the
 	// sorted key list used to clamp an out-of-envelope max rank to the nearest
@@ -70,11 +83,23 @@ func NewCostModel(cfg sim.LoRAConfig) (*CostModel, error) {
 	}
 
 	ranks := make(map[string]int, len(cfg.Adapters))
+	maxRank := 0
 	for _, a := range cfg.Adapters {
 		if a.ID == "" || a.Rank <= 0 {
 			return nil, fmt.Errorf("lora.NewCostModel: adapter %q must have non-empty id and rank > 0", a.ID)
 		}
 		ranks[a.ID] = a.Rank
+		if a.Rank > maxRank {
+			maxRank = a.Rank
+		}
+	}
+
+	// AdapterCapacity may be nil when adapters are absent (the config is inert);
+	// the reservation is 0 in that case. A declared-but-non-positive capacity is
+	// rejected by LoRAConfig.Validate upstream, so a set value is > 0 here.
+	adapterCapacity := 0
+	if cfg.AdapterCapacity != nil {
+		adapterCapacity = *cfg.AdapterCapacity
 	}
 
 	tiers := make(map[int]tierCoeff, len(cfg.StepOverheadTiers))
@@ -109,6 +134,8 @@ func NewCostModel(cfg sim.LoRAConfig) (*CostModel, error) {
 		loadBandwidthBytesUs:  *cfg.LoadBandwidthBytesUs,
 		footprintBytesPerRank: *cfg.FootprintBytesPerRank,
 		ranks:                 ranks,
+		adapterCapacity:       adapterCapacity,
+		maxRank:               maxRank,
 		tiers:                 tiers,
 		tierRanks:             tierRanks,
 	}
@@ -127,8 +154,26 @@ func NewCostModel(cfg sim.LoRAConfig) (*CostModel, error) {
 		}
 	}
 
+	// Fail fast if the static HBM reservation (capacity × footprint × maxRank) is
+	// non-finite (±Inf from a huge footprint/rank) or too large to convert to an
+	// int64 byte count. Its three factors are each individually bounded > 0 but
+	// their product is unbounded (R3/R20 — capacity and rank are unbounded ints).
+	// int64(x) for x ≥ 2^63 or ±Inf is implementation-defined (a garbage/negative
+	// value on some platforms), which would corrupt the KV-capacity subtraction
+	// rather than fail cleanly. maxReservedBytes bounds it below MaxInt64 with
+	// generous headroom, mirroring the maxLoadLatencyUs guard above.
+	if reserved := cm.AdapterReservedBytes(); !isFinite(reserved) || reserved > maxReservedBytes {
+		return nil, fmt.Errorf("lora.NewCostModel: static HBM reservation (capacity %d × footprint_bytes_per_rank %g × max rank %d = %v bytes) is unusable — reduce adapter_capacity, footprint_bytes_per_rank, or the maximum declared rank", adapterCapacity, cm.footprintBytesPerRank, maxRank, reserved)
+	}
+
 	return cm, nil
 }
+
+// maxReservedBytes caps the static adapter HBM reservation well below
+// math.MaxInt64 so the float64→int64 conversion at the KV-capacity boundary is
+// always exact and non-negative. 1e18 bytes = 1 exabyte — orders of magnitude
+// beyond any real GPU HBM, so any config exceeding it is degenerate.
+const maxReservedBytes = 1e18
 
 // maxLoadLatencyUs caps a single adapter load latency well below math.MaxInt64
 // ticks (µs), leaving headroom so now+loadTicks cannot overflow int64 for any
@@ -150,6 +195,19 @@ func (c *CostModel) FootprintBytes(id string) float64 {
 		return 0
 	}
 	return c.footprintBytesPerRank * float64(rank)
+}
+
+// AdapterReservedBytes returns the fixed, capacity-based HBM reservation in bytes
+// (>= 0): adapter_capacity × per-slot footprint, where the per-slot footprint is
+// sized from the MAX declared rank (footprintBytesPerRank · maxRank) so any adapter
+// fits any slot. This is the static memory model (design D2 / INV-L4): the value is
+// a constant for the model's lifetime — adapters load and evict WITHIN the
+// pre-reserved slots without changing it — as opposed to a dynamic running sum over
+// currently-resident adapters. Returns 0 when no capacity or no adapters are
+// configured (INV-6 / INV-L1 no-op). The KV-capacity module subtracts this once at
+// startup beside model weights (PR5). Pure and deterministic (R7).
+func (c *CostModel) AdapterReservedBytes() float64 {
+	return float64(c.adapterCapacity) * c.footprintBytesPerRank * float64(c.maxRank)
 }
 
 // LoadLatency returns the one-time cold-load latency of an adapter id in µs (>= 0):

--- a/sim/lora/cost_model_test.go
+++ b/sim/lora/cost_model_test.go
@@ -2,6 +2,7 @@ package lora
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -249,5 +250,97 @@ func TestNewCostModel_RejectsMalformedConfig(t *testing.T) {
 				t.Errorf("NewCostModel(%s): expected error, got nil", tt.name)
 			}
 		})
+	}
+}
+
+// TestCostModel_AdapterReservedBytes verifies the static HBM reservation (PR5,
+// consumed by the KV-capacity module via the sim.AdapterCost seam) is the FIXED
+// capacity-based amount — adapter_capacity × per-slot footprint, where the
+// per-slot footprint is sized from the MAX declared rank
+// (footprint_bytes_per_rank × max_rank). It is a constant, NOT a running sum over
+// currently-resident adapters: this is the static model (design D2 / INV-L4), and
+// asserting the max-rank/full-capacity form guards against the rejected dynamic
+// running-sum model (which would nominally satisfy a laxer "shrinks KV" test).
+func TestCostModel_AdapterReservedBytes(t *testing.T) {
+	capacity := 4
+	cfg := sim.LoRAConfig{
+		AdapterCapacity:       &capacity,
+		LoadBaseLatencyUs:     fptr(1000.0),
+		LoadBandwidthBytesUs:  fptr(2.0e6),
+		FootprintBytesPerRank: fptr(2.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K6: fptr(0.02), K7: fptr(1.0)}},
+		Adapters: []sim.AdapterSpec{
+			{ID: "a8", Rank: 8},
+			{ID: "a16", Rank: 16},
+			{ID: "a32", Rank: 32}, // max rank sizes the per-slot footprint
+		},
+	}
+	cm, err := NewCostModel(cfg)
+	if err != nil {
+		t.Fatalf("NewCostModel: unexpected error: %v", err)
+	}
+
+	// reservation = capacity(4) × per-slot(maxRank 32 × 2e6 B/rank) = 2.56e8 bytes.
+	want := 4.0 * 32.0 * 2.0e6
+	if got := cm.AdapterReservedBytes(); got != want {
+		t.Errorf("AdapterReservedBytes = %v, want %v (capacity × maxRank × footprint_per_rank)", got, want)
+	}
+
+	// It is NOT the sum over declared adapter ranks ((8+16+32)×2e6 = 1.12e8) — the
+	// slots are provisioned uniformly at the largest declared rank so any adapter
+	// fits, so the reservation stays constant as adapters load/evict within slots.
+	sumOverAdapters := (8.0 + 16.0 + 32.0) * 2.0e6
+	if got := cm.AdapterReservedBytes(); got == sumOverAdapters {
+		t.Errorf("AdapterReservedBytes = %v = sum-over-adapter-ranks; expected the fixed capacity × maxRank reservation (not a per-adapter sum)", got)
+	}
+
+	// Purity: the reservation is a constant — repeated calls agree (no RNG, no
+	// dependence on mutable state; INV-6, R7).
+	if a, b := cm.AdapterReservedBytes(), cm.AdapterReservedBytes(); a != b {
+		t.Errorf("AdapterReservedBytes not constant across calls: %v vs %v", a, b)
+	}
+}
+
+// TestCostModel_AdapterReservedBytes_InertWhenNoCapacity verifies the reservation
+// is 0 when no capacity is configured, keeping KV capacity unaffected (INV-6 /
+// INV-L1 no-op default). testCostModel declares adapters but no AdapterCapacity.
+func TestCostModel_AdapterReservedBytes_InertWhenNoCapacity(t *testing.T) {
+	if got := testCostModel(t).AdapterReservedBytes(); got != 0 {
+		t.Errorf("AdapterReservedBytes with no capacity = %v, want 0 (inert)", got)
+	}
+}
+
+// TestCostModel_RejectsOverflowingReservation verifies a config whose static HBM
+// reservation (capacity × footprint × maxRank) is non-finite or exceeds the int64
+// conversion cap is rejected at construction (R3/R20 fail-fast), not silently
+// truncated at the KV-capacity boundary. The three factors are individually valid
+// (> 0) but their product overflows — this guards the float64→int64 conversion,
+// mirroring the maxLoadLatencyUs guard for LoadLatency.
+func TestCostModel_RejectsOverflowingReservation(t *testing.T) {
+	// capacity multiplies the reservation but NOT LoadLatency, so a huge capacity
+	// overflows the reservation while LoadLatency (base + footprint·rank/bandwidth)
+	// stays well under maxLoadLatencyUs — isolating the new reservation guard from
+	// the pre-existing LoadLatency guard.
+	hugeCapacity := 1 << 40 // ≈1.1e12
+	cfg := sim.LoRAConfig{
+		AdapterCapacity:       &hugeCapacity,
+		LoadBaseLatencyUs:     fptr(1000.0),
+		LoadBandwidthBytesUs:  fptr(1.0e6),
+		FootprintBytesPerRank: fptr(1.0e6),
+		StepOverheadTiers:     map[int]sim.StepOverheadTier{8: {K6: fptr(0.02), K7: fptr(1.0)}},
+		Adapters: []sim.AdapterSpec{
+			// LoadLatency = 1000 + ceil(1e6·2^20 / 1e6) ≈ 1.05e6 µs (< maxLoadLatencyUs);
+			// reservation = 2^40 · 1e6 · 2^20 ≈ 1.2e24 bytes (≫ maxReservedBytes).
+			{ID: "a", Rank: 1 << 20},
+		},
+	}
+	_, err := NewCostModel(cfg)
+	if err == nil {
+		t.Fatal("NewCostModel: expected error for an overflowing static HBM reservation, got nil")
+	}
+	// Pin that the RESERVATION guard fired, not the (earlier) LoadLatency guard —
+	// isolation is otherwise guaranteed only by the fixture's magnitudes.
+	if !strings.Contains(err.Error(), "HBM reservation") {
+		t.Errorf("error must identify the HBM reservation guard, got: %v", err)
 	}
 }

--- a/specs/007-lora-control-plane/tasks.md
+++ b/specs/007-lora-control-plane/tasks.md
@@ -135,8 +135,8 @@ rank → longer step; usable KV shrinks with resident adapters, total conserved.
 
 ### HBM accounting (PR5, static)
 
-- [ ] T033 [P] [US3] Write HBM contract test in `sim/latency/kv_capacity_test.go`: usable KV blocks shrink by the **fixed `capacity × per-slot footprint` (max declared rank)** reservation set once at startup; `allocated + free + adapter_reserved = total` (INV-4/INV-L4); and **`adapter_reserved` stays numerically invariant across adapter load/evict churn** (guards against the rejected dynamic running-sum model, which would nominally satisfy a laxer test); an infeasible reservation is rejected at startup (R22), not a runtime drop (fail first)
-- [ ] T034 [US3] Subtract the **fixed capacity-based reservation** (`capacity × per-slot footprint`, from max declared rank) in `CalculateKVBlocks` (`sim/latency/kv_capacity.go`), once at startup beside model weights, to pass T033
+- [X] T033 [P] [US3] Write HBM contract test in `sim/latency/kv_capacity_test.go`: usable KV blocks shrink by the **fixed `capacity × per-slot footprint` (max declared rank)** reservation set once at startup; `allocated + free + adapter_reserved = total` (INV-4/INV-L4); and **`adapter_reserved` stays numerically invariant across adapter load/evict churn** (guards against the rejected dynamic running-sum model, which would nominally satisfy a laxer test); an infeasible reservation is rejected at startup (R22), not a runtime drop (fail first)
+- [X] T034 [US3] Subtract the **fixed capacity-based reservation** (`capacity × per-slot footprint`, from max declared rank) in `CalculateKVBlocks` (`sim/latency/kv_capacity.go`), once at startup beside model weights, to pass T033
 
 **Checkpoint**: All three cost terms live; TTFT/throughput/memory physically meaningful; INV-4 extended and holds.
 


### PR DESCRIPTION
## Summary

PR5 of the LoRA control-plane subsystem (epic #1464). **Closes #1468.**

Subtracts a fixed, capacity-based LoRA adapter HBM reservation from KV auto-capacity once at startup, beside model weights (design **D2 / INV-L4** static memory model): `adapter_capacity × per-slot footprint`, where the per-slot footprint is sized from the **max declared rank**. The value is a **constant** regardless of which adapters are resident — deliberately **not** a running sum over the resident set. This consumes the third Digital-Twin cost term (T033–T034); PR3 built `FootprintBytes`/`AdapterReservedBytes`, PR5 wires the reservation into the KV budget.

### Changes
- **sim/lora** — `CostModel.AdapterReservedBytes()` (= `capacity × footprint_bytes_per_rank × maxRank`); construction fail-fast on a non-finite or `>1e18` reservation (R3/R20).
- **sim** — `AdapterCost.AdapterReservedBytes()` seam method, scoped to the KV-capacity consumer (R13), mirroring the PR3/PR4 term-by-term wiring.
- **sim/latency** — variadic `WithAdapterReservedBytes` option on `CalculateKVBlocks`; the reservation is folded into `overheadGiB` **per-DP-rank** and **TP-independent** (treated exactly like model weights); an infeasible reservation is rejected at startup with the `lora-adapter-reservation` term named in the error (R22); a zero reservation is **byte-identical** to a pre-LoRA build (INV-6).
- **cmd** — wired through **run and replay** at all KV auto-calc sites (global + per-pool prefill/decode) for **INV-13 parity**; a CLI-boundary `float64→int64` overflow guard; and warnings whenever the reservation is *not* applied (explicit `--total-kv-blocks`, or an auto-calc fallback where KV params / GPU memory are unavailable).

### Invariants
INV-4 (KV conservation, extended with the adapter-reserved term), INV-6 (determinism / byte-identical no-op), INV-13 (run/replay parity), R22 (fail-fast), R3/R20 (overflow guards) — all verified by tests.

## Rebased onto merged `main`

PR1–PR4 (#1472/#1473/#1474/#1475) have **all merged**. This PR is now a **single commit `136b4fda`** on top of `main` — the diff is PR5 only (10 files, +765/−32). Rebased `--onto` merged main; the auto-merge into PR4's landed files (`sim/adapter_cost.go`, `sim/lora/cost_model.go`, `sim/latency/adapter_overhead_test.go`) was clean and PR4's review additions are intact. Fixed 5 pre-existing `QF1001` (De Morgan) lint failures in the new test files (`kv_capacity_test.go`, `lora_cli_test.go`) that had CI red pre-rebase; the `test (workload & cmd)` failure was a stale-base artifact and is resolved by the rebase. `go build/test/lint ./...` all clean; MERGEABLE.

## Review (pre-rebase cycle)
- **convergence-review** (`pr-code`, 10 perspectives): converged — 0 genuine Critical/Important.
- **blis-pr-review** (5 pr-review-toolkit agents): all approve / READY TO MERGE; 4 IMPORTANT findings applied (stale header comment, silent reservation-drop on auto-calc fallback, `[2^62,2^63)` precision comment accuracy, direct `adapterReservedBytesFor` test) plus R22 error-term test hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
