### PR TITLE
feat(lora): PR6 — LoRA-aware routing scorer (lora-affinity) (#1464)

### DIFF
--- a/cmd/lora_scorer_weight_test.go
+++ b/cmd/lora_scorer_weight_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+
+	sim "github.com/inference-sim/inference-sim/sim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposeLoRAScorer_AppendsToDefaultProfile verifies that with no explicit
+// profile the lora-affinity scorer is composed onto the default dimensions rather
+// than replacing them (#1469, T039).
+func TestComposeLoRAScorer_AppendsToDefaultProfile(t *testing.T) {
+	got, err := composeLoRAScorer(nil, 2.0)
+	require.NoError(t, err)
+
+	want := append(sim.DefaultScorerConfigs(), sim.ScorerConfig{Name: "lora-affinity", Weight: 2.0})
+	assert.Equal(t, want, got, "empty base ⇒ default profile + lora-affinity")
+}
+
+// TestComposeLoRAScorer_AppendsToExplicitProfile verifies composition onto a
+// user-supplied --routing-scorers profile preserves the existing dimensions.
+func TestComposeLoRAScorer_AppendsToExplicitProfile(t *testing.T) {
+	base := []sim.ScorerConfig{{Name: "queue-depth", Weight: 1.0}}
+	got, err := composeLoRAScorer(base, 3.0)
+	require.NoError(t, err)
+
+	assert.Equal(t, []sim.ScorerConfig{
+		{Name: "queue-depth", Weight: 1.0},
+		{Name: "lora-affinity", Weight: 3.0},
+	}, got)
+	// The base slice must not be mutated (no aliasing of its backing array).
+	assert.Equal(t, []sim.ScorerConfig{{Name: "queue-depth", Weight: 1.0}}, base,
+		"composeLoRAScorer must not mutate the caller's base slice")
+}
+
+// TestComposeLoRAScorer_RejectsInvalidWeight enforces the finite-positive contract.
+func TestComposeLoRAScorer_RejectsInvalidWeight(t *testing.T) {
+	for _, w := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		_, err := composeLoRAScorer(nil, w)
+		assert.Errorf(t, err, "weight %v must be rejected", w)
+	}
+}
+
+// TestComposeLoRAScorer_RejectsDoubleSpecification guards against declaring
+// lora-affinity via both --routing-scorers and --lora-scorer-weight.
+func TestComposeLoRAScorer_RejectsDoubleSpecification(t *testing.T) {
+	base := []sim.ScorerConfig{{Name: "lora-affinity", Weight: 1.0}}
+	_, err := composeLoRAScorer(base, 2.0)
+	assert.Error(t, err, "lora-affinity already in profile must be rejected")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,8 +108,9 @@ var (
 	gaieKVThreshold       float64            // GAIE-legacy KV cache utilization threshold (default 0.8)
 
 	// routing policy config (PR 6, evolved in PR17)
-	routingPolicy  string // Routing policy name
-	routingScorers string // Comma-separated name:weight pairs for weighted routing
+	routingPolicy    string  // Routing policy name
+	routingScorers   string  // Comma-separated name:weight pairs for weighted routing
+	loraScorerWeight float64 // Weight of the lora-affinity scorer; 0 (default) ⇒ off (#1469)
 
 	// Scheduler and preemption config
 	scheduler        string // Scheduler name
@@ -779,6 +780,31 @@ func resolveLatencyConfig(cmd *cobra.Command) latencyResolution {
 	}
 }
 
+// composeLoRAScorer appends the lora-affinity scorer at the given weight to the
+// effective weighted-routing profile (#1469). When base is empty (no explicit
+// --routing-scorers or bundle), it materializes the default profile first so the
+// LoRA scorer composes alongside the standard dimensions rather than replacing
+// them. Returns an error for a non-finite/non-positive weight or when base already
+// declares lora-affinity (double-specification via both --routing-scorers and
+// --lora-scorer-weight). The returned slice never aliases base's backing array.
+func composeLoRAScorer(base []sim.ScorerConfig, weight float64) ([]sim.ScorerConfig, error) {
+	if weight <= 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {
+		return nil, fmt.Errorf("weight must be a finite positive number, got %v", weight)
+	}
+	if len(base) == 0 {
+		base = sim.DefaultScorerConfigs()
+	}
+	for _, sc := range base {
+		if sc.Name == "lora-affinity" {
+			return nil, fmt.Errorf("lora-affinity already present in the scorer profile; set its weight via --routing-scorers OR --lora-scorer-weight, not both")
+		}
+	}
+	composed := make([]sim.ScorerConfig, 0, len(base)+1)
+	composed = append(composed, base...)
+	composed = append(composed, sim.ScorerConfig{Name: "lora-affinity", Weight: weight})
+	return composed, nil
+}
+
 // resolvePolicies resolves admission/routing/priority/scheduler policy configuration
 // from CLI flags and an optional policy bundle YAML file. It is called by both runCmd
 // and replayCmd to ensure a single validation code path (R23: code path parity).
@@ -1037,6 +1063,19 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 		} else if len(bundleScorerConfigs) > 0 {
 			parsedScorerConfigs = bundleScorerConfigs
 		}
+		// Compose the lora-affinity scorer (#1469). Left unset the flag is inert, so
+		// routing is byte-identical to today (INV-6). When set (to a positive weight;
+		// an explicit non-positive value is rejected by composeLoRAScorer), append it
+		// to the effective profile — materializing the default base when no explicit
+		// --routing-scorers/bundle profile was given — so the LoRA scorer participates
+		// alongside the existing dimensions.
+		if cmd.Flags().Changed("lora-scorer-weight") {
+			composed, err := composeLoRAScorer(parsedScorerConfigs, loraScorerWeight)
+			if err != nil {
+				logrus.Fatalf("Invalid --lora-scorer-weight: %v", err)
+			}
+			parsedScorerConfigs = composed
+		}
 		activeScorerConfigs := parsedScorerConfigs
 		if len(activeScorerConfigs) == 0 {
 			activeScorerConfigs = sim.DefaultScorerConfigs()
@@ -1049,6 +1088,9 @@ func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle)
 	}
 	if routingPolicy != "weighted" && routingScorers != "" {
 		logrus.Warnf("--routing-scorers has no effect when routing policy is %q (only applies to 'weighted')", routingPolicy)
+	}
+	if routingPolicy != "weighted" && cmd.Flags().Changed("lora-scorer-weight") {
+		logrus.Warnf("--lora-scorer-weight has no effect when routing policy is %q (only applies to 'weighted')", routingPolicy)
 	}
 	if admissionPolicy == "token-bucket" {
 		logrus.Infof("Token bucket: capacity=%.0f, refill-rate=%.0f", tokenBucketCapacity, tokenBucketRefillRate)
@@ -1100,6 +1142,7 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	// Routing policy config
 	cmd.Flags().StringVar(&routingPolicy, "routing-policy", "round-robin", "Routing policy: round-robin, least-loaded, weighted, always-busiest")
 	cmd.Flags().StringVar(&routingScorers, "routing-scorers", "", "Scorer weights for weighted routing (e.g., queue-depth:2,kv-utilization:2,load-balance:1). Default: precise-prefix-cache:2,queue-depth:1,kv-utilization:1")
+	cmd.Flags().Float64Var(&loraScorerWeight, "lora-scorer-weight", 0, "Weight of the lora-affinity routing scorer, composed into the weighted profile. Leave unset to keep routing unchanged; must be a finite positive number when set. Requires --routing-policy weighted (#1469)")
 
 	// Scheduler and preemption config
 	cmd.Flags().StringVar(&scheduler, "scheduler", "fcfs", "Instance scheduler: fcfs, priority-fcfs, sjf, reverse-priority")

--- a/cmd/simconfig_shared_test.go
+++ b/cmd/simconfig_shared_test.go
@@ -105,7 +105,7 @@ func TestResolvePolicies_InvalidAdmissionPolicy_Fatal(t *testing.T) {
 func TestResolvePolicies_PolicyFlagsRegisteredInBothCommands(t *testing.T) {
 	policyFlags := []string{
 		"admission-policy", "routing-policy", "scheduler", "preemption-policy",
-		"routing-scorers", "token-bucket-capacity", "token-bucket-refill-rate",
+		"routing-scorers", "lora-scorer-weight", "token-bucket-capacity", "token-bucket-refill-rate",
 		"kv-cpu-blocks", "kv-offload-threshold", "kv-transfer-bandwidth",
 		"kv-transfer-base-latency", "snapshot-refresh-interval",
 		"admission-latency", "routing-latency", "trace-level",
@@ -157,7 +157,7 @@ func TestBothCommands_SimConfigFlagsHaveIdenticalDefaults(t *testing.T) {
 		"total-kv-blocks", "block-size-in-tokens", "max-model-len",
 		"gpu-memory-utilization", "model-config-folder", "hardware-config",
 		"admission-policy", "routing-policy", "scheduler", "preemption-policy",
-		"routing-scorers", "token-bucket-capacity", "token-bucket-refill-rate",
+		"routing-scorers", "lora-scorer-weight", "token-bucket-capacity", "token-bucket-refill-rate",
 		"kv-cpu-blocks", "kv-offload-threshold", "kv-transfer-bandwidth",
 		"kv-transfer-base-latency", "snapshot-refresh-interval",
 		"admission-latency", "routing-latency", "trace-level",

--- a/sim/cluster/adapter_metrics_aggregation_test.go
+++ b/sim/cluster/adapter_metrics_aggregation_test.go
@@ -47,6 +47,54 @@ func TestClusterSimulator_AdapterMetrics_AggregatedAcrossInstances_E2E(t *testin
 	}
 }
 
+// TestBuildRouterState_PopulatesResidentAdapters verifies T037: after an adapter
+// is loaded on an instance, buildRouterState's snapshot for that instance reports
+// it in ResidentAdapters (the signal the lora-affinity scorer consumes). Under the
+// default Immediate freshness (SnapshotRefreshInterval unset ⇒ 0), the snapshot
+// reflects live resident state at build time.
+func TestBuildRouterState_PopulatesResidentAdapters(t *testing.T) {
+	config := newTestDeploymentConfig(1)
+	config.RoutingPolicy = "round-robin"
+	capVal := 8
+	base, bw, fp := 1000.0, 2.0e6, 2.0e6
+	config.LoRAConfig = sim.LoRAConfig{
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     &base,
+		LoadBandwidthBytesUs:  &bw,
+		FootprintBytesPerRank: &fp,
+		Adapters:              []sim.AdapterSpec{{ID: "adapter_x", Rank: 8}},
+	}
+	requests := newTestRequests(3)
+	for _, r := range requests {
+		r.Adapter = "adapter_x"
+	}
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
+	mustRun(t, cs)
+
+	// After the run the adapter remains resident (capacity 8, never evicted).
+	state := buildRouterState(cs, nil)
+	if len(state.Snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(state.Snapshots))
+	}
+	if !state.Snapshots[0].ResidentAdapters["adapter_x"] {
+		t.Errorf("ResidentAdapters = %v, want it to contain adapter_x", state.Snapshots[0].ResidentAdapters)
+	}
+}
+
+// TestBuildRouterState_ResidentAdaptersNilWhenInert verifies the no-op default:
+// with no LoRA configured, ResidentAdapters stays nil so the lora-affinity scorer
+// is neutral and routing is byte-identical to a pre-feature build (INV-6).
+func TestBuildRouterState_ResidentAdaptersNilWhenInert(t *testing.T) {
+	cs := NewClusterSimulator(newTestDeploymentConfig(2), NewSliceRequestSource(newTestRequests(2)), nil)
+	mustRun(t, cs)
+	state := buildRouterState(cs, nil)
+	for _, snap := range state.Snapshots {
+		if snap.ResidentAdapters != nil {
+			t.Errorf("instance %s: ResidentAdapters = %v, want nil when LoRA inert", snap.ID, snap.ResidentAdapters)
+		}
+	}
+}
+
 // TestAggregateMetrics_AdapterCountsSummedAcrossInstances verifies that per-adapter
 // resident-set load/eviction counts (#1465) are summed across instances during
 // cluster aggregation. The same adapter can be resident on multiple instances, so

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -167,6 +167,16 @@ func (i *InstanceSimulator) BatchSize() int {
 	return i.sim.BatchSize()
 }
 
+// ResidentAdapterIDs returns the ids of LoRA adapters currently resident on this
+// instance, or nil when the LoRA subsystem is inert. Read by the snapshot provider
+// to populate RoutingSnapshot.ResidentAdapters for the lora-affinity scorer (#1469).
+func (i *InstanceSimulator) ResidentAdapterIDs() []string {
+	if i.sim == nil {
+		return nil
+	}
+	return i.sim.ResidentAdapterIDs()
+}
+
 // KVUtilization returns the fraction of KV cache blocks in use.
 // Returns 0 when TotalCapacity is 0 to avoid division by zero (R11 defensive guard).
 func (i *InstanceSimulator) KVUtilization() float64 {

--- a/sim/cluster/lora_affinity_routing_e2e_test.go
+++ b/sim/cluster/lora_affinity_routing_e2e_test.go
@@ -1,0 +1,104 @@
+package cluster
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// loraAffinityTestConfig builds a LoRA-enabled multi-instance deployment with a
+// small per-instance adapter capacity, so distinct adapters compete for slots and
+// routing choices drive the total cold-load count. cost coefficients are required
+// once the cold-load gate consumes them (#1466).
+func loraAffinityTestConfig(numInstances, capacity int, adapters []string) DeploymentConfig {
+	config := newTestDeploymentConfig(numInstances)
+	capVal := capacity
+	base, bw, fp := 1000.0, 2.0e6, 2.0e6
+	specs := make([]sim.AdapterSpec, len(adapters))
+	for i, id := range adapters {
+		specs[i] = sim.AdapterSpec{ID: id, Rank: 8}
+	}
+	config.LoRAConfig = sim.LoRAConfig{
+		AdapterCapacity:       &capVal,
+		LoadBaseLatencyUs:     &base,
+		LoadBandwidthBytesUs:  &bw,
+		FootprintBytesPerRank: &fp,
+		Adapters:              specs,
+	}
+	return config
+}
+
+// zipfianAdapterRequests builds n deterministic test requests and assigns each a
+// LoRA adapter drawn from a fixed Zipfian distribution over adapters (a few
+// adapters dominate the traffic — the popularity skew LoRA serving exhibits in
+// practice, spec SC-005). The request sequence and the adapter draw are both
+// seeded, so two calls with the same arguments produce byte-identical workloads —
+// essential for an apples-to-apples routing comparison.
+func zipfianAdapterRequests(n int, adapters []string) []*sim.Request {
+	reqs := newTestRequests(n)
+	z := rand.NewZipf(rand.New(rand.NewSource(7)), 1.3, 1.0, uint64(len(adapters)-1))
+	for _, r := range reqs {
+		r.Adapter = adapters[z.Uint64()]
+	}
+	return reqs
+}
+
+// totalAdapterLoads sums cold-load counts across all adapters — the metric SC-005
+// targets. Fewer total loads means the router kept more requests on instances that
+// already held their adapter.
+func totalAdapterLoads(m *sim.Metrics) int64 {
+	var sum int64
+	for _, c := range m.AdapterLoadCounts {
+		sum += c
+	}
+	return sum
+}
+
+// TestLoRAAffinity_SkewedPopularity_FewerLoadsThanLeastLoaded is the SC-005
+// integration payoff (spec US4 scenario 2, T040): under a skewed adapter-popularity
+// workload, weighted routing with the lora-affinity scorer keeps repeat requests on
+// the instance that already holds their adapter, so the cluster performs
+// substantially fewer total cold loads than adapter-oblivious least-loaded routing.
+//
+// The two runs share an identical workload (same requests, same adapter draw) and
+// differ only in routing policy, isolating the scorer as the cause of the delta.
+func TestLoRAAffinity_SkewedPopularity_FewerLoadsThanLeastLoaded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SC-005 skewed-popularity e2e test in short mode (-short flag)")
+	}
+	const (
+		numInstances = 4
+		capacity     = 2 // << number of adapters ⇒ eviction pressure
+		numRequests  = 200
+	)
+	adapters := []string{"a0", "a1", "a2", "a3", "a4", "a5"}
+
+	// Baseline: adapter-oblivious least-loaded routing.
+	baseCfg := loraAffinityTestConfig(numInstances, capacity, adapters)
+	baseCfg.RoutingPolicy = "least-loaded"
+	baseCS := NewClusterSimulator(baseCfg, NewSliceRequestSource(zipfianAdapterRequests(numRequests, adapters)), nil)
+	mustRun(t, baseCS)
+	baselineLoads := totalAdapterLoads(baseCS.AggregatedMetrics())
+
+	// Treatment: weighted routing with the lora-affinity scorer.
+	loraCfg := loraAffinityTestConfig(numInstances, capacity, adapters)
+	loraCfg.RoutingPolicy = "weighted"
+	loraCfg.RoutingScorerConfigs = []sim.ScorerConfig{{Name: "lora-affinity", Weight: 1.0}}
+	loraCS := NewClusterSimulator(loraCfg, NewSliceRequestSource(zipfianAdapterRequests(numRequests, adapters)), nil)
+	mustRun(t, loraCS)
+	loraLoads := totalAdapterLoads(loraCS.AggregatedMetrics())
+
+	if baselineLoads == 0 || loraLoads == 0 {
+		t.Fatalf("expected non-zero cold loads in both runs, got baseline=%d lora=%d", baselineLoads, loraLoads)
+	}
+	// SC-005 target: at least 30% fewer total adapter loads with the scorer.
+	maxAllowed := 0.70 * float64(baselineLoads)
+	reduction := 1.0 - float64(loraLoads)/float64(baselineLoads)
+	t.Logf("total adapter loads: least-loaded=%d, lora-affinity=%d (%.1f%% fewer)",
+		baselineLoads, loraLoads, reduction*100)
+	if float64(loraLoads) > maxAllowed {
+		t.Errorf("lora-affinity loads=%d exceed SC-005 target (≤%.0f, ≥30%% fewer than baseline=%d); reduction=%.1f%%",
+			loraLoads, maxAllowed, baselineLoads, reduction*100)
+	}
+}

--- a/sim/cluster/snapshot.go
+++ b/sim/cluster/snapshot.go
@@ -25,21 +25,23 @@ type FieldConfig struct {
 
 // ObservabilityConfig configures refresh behavior for all snapshot fields.
 type ObservabilityConfig struct {
-	QueueDepth      FieldConfig
-	BatchSize       FieldConfig
-	KVUtilization   FieldConfig
-	CacheBlocks     FieldConfig // cache block hash map staleness (precise-prefix-cache, no-hit-lru)
-	PreemptionCount FieldConfig
+	QueueDepth       FieldConfig
+	BatchSize        FieldConfig
+	KVUtilization    FieldConfig
+	CacheBlocks      FieldConfig // cache block hash map staleness (precise-prefix-cache, no-hit-lru)
+	PreemptionCount  FieldConfig
+	ResidentAdapters FieldConfig // resident LoRA adapter set staleness (lora-affinity scorer, #1469)
 }
 
 // DefaultObservabilityConfig returns a config where all fields use Immediate mode.
 func DefaultObservabilityConfig() ObservabilityConfig {
 	return ObservabilityConfig{
-		QueueDepth:      FieldConfig{Mode: Immediate},
-		BatchSize:       FieldConfig{Mode: Immediate},
-		KVUtilization:   FieldConfig{Mode: Immediate},
-		CacheBlocks:     FieldConfig{Mode: Immediate},
-		PreemptionCount: FieldConfig{Mode: Immediate},
+		QueueDepth:       FieldConfig{Mode: Immediate},
+		BatchSize:        FieldConfig{Mode: Immediate},
+		KVUtilization:    FieldConfig{Mode: Immediate},
+		CacheBlocks:      FieldConfig{Mode: Immediate},
+		PreemptionCount:  FieldConfig{Mode: Immediate},
+		ResidentAdapters: FieldConfig{Mode: Immediate},
 	}
 }
 
@@ -54,6 +56,7 @@ func newObservabilityConfig(refreshInterval int64, cacheDelay int64) Observabili
 		config.BatchSize = periodic
 		config.KVUtilization = periodic
 		config.PreemptionCount = periodic
+		config.ResidentAdapters = periodic
 	}
 	if cacheDelay > 0 {
 		config.CacheBlocks = FieldConfig{Mode: Periodic, Interval: cacheDelay}
@@ -72,10 +75,11 @@ type SnapshotProvider interface {
 
 // fieldTimestamps tracks the last refresh time per field per instance.
 type fieldTimestamps struct {
-	QueueDepth      int64
-	BatchSize       int64
-	KVUtilization   int64
-	PreemptionCount int64
+	QueueDepth       int64
+	BatchSize        int64
+	KVUtilization    int64
+	PreemptionCount  int64
+	ResidentAdapters int64
 }
 
 // cacheEntry holds a live instance reference and its current stale snapshot closure.
@@ -165,10 +169,31 @@ func (p *CachedSnapshotProvider) Snapshot(id InstanceID, clock int64) sim.Routin
 		snap.KvTokensInUse = inst.KvTokensInUse()
 		lr.KVUtilization = clock
 	}
+	if p.shouldRefresh(p.config.ResidentAdapters, lr.ResidentAdapters, clock) {
+		snap.ResidentAdapters = residentAdapterSet(inst)
+		lr.ResidentAdapters = clock
+	}
 
 	p.cache[id] = snap
 	p.lastRefresh[id] = lr
 	return snap
+}
+
+// residentAdapterSet builds a membership set of the instance's resident LoRA
+// adapter ids for RoutingSnapshot.ResidentAdapters. Returns nil when no adapter is
+// resident (LoRA inert or empty set), keeping the snapshot's ResidentAdapters nil
+// so the lora-affinity scorer is neutral (INV-6). Each refresh builds a fresh map
+// so the cached snapshot holds a frozen view (correct Periodic staleness).
+func residentAdapterSet(inst *InstanceSimulator) map[string]bool {
+	ids := inst.ResidentAdapterIDs()
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
 }
 
 // RefreshAll refreshes all fields for all instances regardless of mode.
@@ -183,12 +208,14 @@ func (p *CachedSnapshotProvider) RefreshAll(clock int64) {
 		snap.CacheHitRate = inst.CacheHitRate()
 		snap.TotalKvCapacityTokens = inst.TotalKvCapacityTokens()
 		snap.KvTokensInUse = inst.KvTokensInUse()
+		snap.ResidentAdapters = residentAdapterSet(inst)
 		p.cache[id] = snap
 		p.lastRefresh[id] = fieldTimestamps{
-			PreemptionCount: clock,
-			QueueDepth:      clock,
-			BatchSize:       clock,
-			KVUtilization:   clock,
+			PreemptionCount:  clock,
+			QueueDepth:       clock,
+			BatchSize:        clock,
+			KVUtilization:    clock,
+			ResidentAdapters: clock,
 		}
 	}
 }

--- a/sim/cluster/snapshot_test.go
+++ b/sim/cluster/snapshot_test.go
@@ -185,6 +185,7 @@ func TestSnapshotProvider_DefaultConfig_AllImmediate(t *testing.T) {
 		{"KVUtilization", config.KVUtilization},
 		{"CacheBlocks", config.CacheBlocks},
 		{"PreemptionCount", config.PreemptionCount},
+		{"ResidentAdapters", config.ResidentAdapters},
 	}
 
 	for _, tc := range tests {
@@ -213,6 +214,7 @@ func TestNewObservabilityConfig_ZeroAndNegativeInterval_AllImmediate(t *testing.
 				{"KVUtilization", config.KVUtilization},
 				{"CacheBlocks", config.CacheBlocks},
 				{"PreemptionCount", config.PreemptionCount},
+				{"ResidentAdapters", config.ResidentAdapters},
 			} {
 				if f.fc.Mode != Immediate {
 					t.Errorf("%s: Mode = %d, want Immediate (%d)", f.name, f.fc.Mode, Immediate)
@@ -238,6 +240,7 @@ func TestNewObservabilityConfig_NonZeroInterval_AllFieldsPeriodic(t *testing.T) 
 		{"BatchSize", config.BatchSize},
 		{"KVUtilization", config.KVUtilization},
 		{"PreemptionCount", config.PreemptionCount},
+		{"ResidentAdapters", config.ResidentAdapters},
 	}
 	for _, f := range fields {
 		t.Run(f.name, func(t *testing.T) {

--- a/sim/lora/resident_set.go
+++ b/sim/lora/resident_set.go
@@ -56,6 +56,20 @@ func (s *residentSet) Len() int { return len(s.entries) }
 // cold-load gate uses it to decide whether a slot must be freed before a load.
 func (s *residentSet) AtCapacity() bool { return len(s.entries) >= s.capacity }
 
+// ResidentIDs returns the resident adapter ids in LRU→MRU order by walking the
+// doubly-linked list from head to tail. The list order is a pure function of the
+// access sequence, so the result is deterministic (INV-6). Returns nil when empty.
+func (s *residentSet) ResidentIDs() []string {
+	if len(s.entries) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(s.entries))
+	for e := s.lruHead; e != nil; e = e.next {
+		ids = append(ids, e.id)
+	}
+	return ids
+}
+
 // IsResident reports whether id currently occupies a slot.
 func (s *residentSet) IsResident(id string) bool {
 	_, ok := s.entries[id]

--- a/sim/resident_adapter_set.go
+++ b/sim/resident_adapter_set.go
@@ -25,6 +25,13 @@ type ResidentAdapterSet interface {
 	Store(id string) (evicted string, admitted bool)
 	// Len returns the number of resident adapters (always ≤ capacity).
 	Len() int
+	// ResidentIDs returns the ids currently resident. The order is stable and
+	// deterministic (LRU→MRU — INV-6); the current sole consumer (the snapshot
+	// provider, which collapses the result into RoutingSnapshot.ResidentAdapters as a
+	// membership set for the lora-affinity scorer, #1469) does not depend on order,
+	// so implementations must not be constrained to preserve it beyond determinism.
+	// Returns nil when empty.
+	ResidentIDs() []string
 
 	// AtCapacity reports whether every slot is occupied (Len == capacity). The
 	// cold-load gate uses it to decide whether a slot must be freed before a load.

--- a/sim/routing.go
+++ b/sim/routing.go
@@ -32,6 +32,13 @@ type RoutingSnapshot struct {
 	AvgInTokens           float64 // average input tokens per completed request; 0 if not yet available
 	AvgOutTokens          float64 // average output tokens per completed request; 0 if not yet available
 	MaxBatchSize          float64 // server-configured max batch size; 0 if not yet available
+	// ResidentAdapters is the set of LoRA adapter ids currently resident on this
+	// instance (membership set; #1469, PR6). Consumed by the lora-affinity scorer
+	// for placement affinity. Freshness (R17, INV-7): Periodic — refreshed by
+	// CachedSnapshotProvider at --snapshot-refresh-interval (default 50ms), Immediate
+	// when the interval is 0. Zero value (nil) ⇒ no adapter resident ⇒ scorer neutral,
+	// preserving byte-identical routing when the LoRA subsystem is inert (INV-6).
+	ResidentAdapters map[string]bool
 }
 
 // EffectiveLoad returns the total effective load on this instance:

--- a/sim/routing_scorers.go
+++ b/sim/routing_scorers.go
@@ -84,6 +84,7 @@ var validScorerNames = map[string]bool{
 	"running-requests":     true,
 	"load-aware":           true,
 	"vllm-dp":              true,
+	"lora-affinity":        true,
 }
 
 // IsValidScorer returns true if name is a recognized scorer.
@@ -180,6 +181,8 @@ func newScorerWithObserver(name string, blockSize int, cacheFn cacheQueryFn) (sc
 		return scoreLoadAware, nil
 	case "vllm-dp":
 		return scoreVLLMDP, nil
+	case "lora-affinity":
+		return scoreLoRAAffinity, nil
 	default:
 		panic(fmt.Sprintf("unknown scorer %q", name))
 	}
@@ -331,6 +334,65 @@ func scoreLoadAware(_ *Request, snapshots []RoutingSnapshot) map[string]float64 
 			}
 			scores[snap.ID] = 0.5 * (1.0 - float64(clamped)/float64(loadAwareQueueThreshold))
 		}
+	}
+	return scores
+}
+
+// scoreLoRAAffinity computes per-instance scores favoring instances that already
+// hold the request's LoRA adapter resident, avoiding a cold-load elsewhere (#1469,
+// spec US4). Raw score is 1.0 when req.Adapter is resident on the instance, else
+// 0.0; raw scores are then min-max normalized (llm-d parity), so with a mix of
+// warm and cold candidates warm instances score 1.0 and cold instances 0.0.
+//
+// Neutral (all instances score 1.0, no routing bias) whenever raw scores are
+// uniform: an empty req.Adapter (base-model request), no instance holding the
+// adapter (all cold), every instance holding it (all warm), or a single candidate.
+// This keeps base-model traffic and inert-LoRA deployments byte-identical to
+// today (INV-6).
+//
+// INV-9 (oracle knowledge boundary): reads only req.Adapter and
+// snapshot.ResidentAdapters — never the request's oracle output length.
+//
+// Signal freshness (R17, INV-7):
+//
+//	Reads: ResidentAdapters (Periodic when --snapshot-refresh-interval>0, else Immediate).
+func scoreLoRAAffinity(req *Request, snapshots []RoutingSnapshot) map[string]float64 {
+	scores := make(map[string]float64, len(snapshots))
+	adapter := ""
+	if req != nil {
+		adapter = req.Adapter
+	}
+	// Empty adapter (base-model request) ⇒ neutral: every instance scores 1.0.
+	if adapter == "" {
+		for _, snap := range snapshots {
+			scores[snap.ID] = 1.0
+		}
+		return scores
+	}
+	raw := make(map[string]float64, len(snapshots))
+	minRaw, maxRaw := 1.0, 0.0
+	for _, snap := range snapshots {
+		r := 0.0
+		if snap.ResidentAdapters[adapter] {
+			r = 1.0
+		}
+		raw[snap.ID] = r
+		if r < minRaw {
+			minRaw = r
+		}
+		if r > maxRaw {
+			maxRaw = r
+		}
+	}
+	// Uniform raw (all warm, all cold, or single instance) ⇒ neutral: all 1.0.
+	if maxRaw == minRaw {
+		for _, snap := range snapshots {
+			scores[snap.ID] = 1.0
+		}
+		return scores
+	}
+	for _, snap := range snapshots {
+		scores[snap.ID] = (raw[snap.ID] - minRaw) / (maxRaw - minRaw)
 	}
 	return scores
 }

--- a/sim/routing_scorers_test.go
+++ b/sim/routing_scorers_test.go
@@ -574,3 +574,127 @@ func TestScoreVLLMDP_PileOnInPeriodicMode(t *testing.T) {
 		// see incremented counts and potentially route to "b" or "c".
 	}
 }
+
+// --- lora-affinity scorer (PR6, #1469) -------------------------------------
+//
+// Contract (contracts/routing-snapshot.md, spec US4):
+//   raw(instance)   = 1.0 if req.Adapter ∈ instance.ResidentAdapters else 0.0
+//   score(instance) = minMaxNormalize(raw over candidate instances)  (llm-d parity)
+
+func residentSetOf(ids ...string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// TestScoreLoRAAffinity_WarmScoresHigherThanCold is US4 scenario 1: an instance
+// that already holds req.Adapter must outscore one that does not, all else equal.
+func TestScoreLoRAAffinity_WarmScoresHigherThanCold(t *testing.T) {
+	req := &Request{Adapter: "sql-lora"}
+	snapshots := []RoutingSnapshot{
+		{ID: "warm", ResidentAdapters: residentSetOf("sql-lora", "other")},
+		{ID: "cold", ResidentAdapters: residentSetOf("other")},
+	}
+	scores := scoreLoRAAffinity(req, snapshots)
+	assert.Greater(t, scores["warm"], scores["cold"], "warm instance must outscore cold")
+	// min-max over {1.0, 0.0}: warm→1.0, cold→0.0.
+	assert.Equal(t, 1.0, scores["warm"])
+	assert.Equal(t, 0.0, scores["cold"])
+}
+
+// TestScoreLoRAAffinity_EmptyAdapterNeutral: base-model requests (no adapter)
+// must not bias routing — every instance scores equally (neutral).
+func TestScoreLoRAAffinity_EmptyAdapterNeutral(t *testing.T) {
+	req := &Request{Adapter: ""}
+	snapshots := []RoutingSnapshot{
+		{ID: "a", ResidentAdapters: residentSetOf("sql-lora")},
+		{ID: "b", ResidentAdapters: residentSetOf("other")},
+		{ID: "c"}, // nil ResidentAdapters
+	}
+	scores := scoreLoRAAffinity(req, snapshots)
+	assert.Equal(t, 1.0, scores["a"])
+	assert.Equal(t, 1.0, scores["b"])
+	assert.Equal(t, 1.0, scores["c"])
+}
+
+// TestScoreLoRAAffinity_NilResidentAdaptersNeutral: the zero value (nil set) on
+// every instance yields all-cold ⇒ min-max of all-equal ⇒ all score 1.0. This is
+// the no-op default that keeps routing unchanged when the LoRA subsystem is inert.
+func TestScoreLoRAAffinity_NilResidentAdaptersNeutral(t *testing.T) {
+	req := &Request{Adapter: "sql-lora"}
+	snapshots := []RoutingSnapshot{{ID: "a"}, {ID: "b"}}
+	scores := scoreLoRAAffinity(req, snapshots)
+	assert.Equal(t, 1.0, scores["a"], "all-cold ⇒ neutral")
+	assert.Equal(t, 1.0, scores["b"], "all-cold ⇒ neutral")
+}
+
+// TestScoreLoRAAffinity_AllWarmNeutral: when every candidate already holds the
+// adapter, min-max of all-equal raw scores ⇒ all 1.0 (no differentiation).
+func TestScoreLoRAAffinity_AllWarmNeutral(t *testing.T) {
+	req := &Request{Adapter: "sql-lora"}
+	snapshots := []RoutingSnapshot{
+		{ID: "a", ResidentAdapters: residentSetOf("sql-lora")},
+		{ID: "b", ResidentAdapters: residentSetOf("sql-lora")},
+	}
+	scores := scoreLoRAAffinity(req, snapshots)
+	assert.Equal(t, 1.0, scores["a"])
+	assert.Equal(t, 1.0, scores["b"])
+}
+
+// TestScoreLoRAAffinity_SingleInstance always scores 1.0 (min == max).
+func TestScoreLoRAAffinity_SingleInstance(t *testing.T) {
+	req := &Request{Adapter: "sql-lora"}
+	scores := scoreLoRAAffinity(req, []RoutingSnapshot{{ID: "a"}})
+	assert.Equal(t, 1.0, scores["a"], "single instance always scores 1.0")
+}
+
+// TestScoreLoRAAffinity_IgnoresOutputTokens enforces INV-9 (oracle knowledge
+// boundary): the scorer reads only Adapter/ResidentAdapters, never OutputTokens.
+// Scores must be identical whether OutputTokens is set or zero.
+func TestScoreLoRAAffinity_IgnoresOutputTokens(t *testing.T) {
+	snapshots := []RoutingSnapshot{
+		{ID: "warm", ResidentAdapters: residentSetOf("sql-lora")},
+		{ID: "cold"},
+	}
+	base := scoreLoRAAffinity(&Request{Adapter: "sql-lora"}, snapshots)
+	withOut := scoreLoRAAffinity(&Request{Adapter: "sql-lora", OutputTokens: make([]TokenID, 4096)}, snapshots)
+	assert.Equal(t, base, withOut, "OutputTokens must not influence routing scores (INV-9)")
+}
+
+// TestLoRAAffinity_Registered verifies the scorer is a recognized name (R8) and
+// resolves to a stateless scorerFunc (nil observer) via newScorerWithObserver.
+func TestLoRAAffinity_Registered(t *testing.T) {
+	assert.True(t, IsValidScorer("lora-affinity"), "lora-affinity must be a valid scorer name")
+	assert.Contains(t, ValidScorerNames(), "lora-affinity")
+	scorer, observer := newScorerWithObserver("lora-affinity", 16, nil)
+	require.NotNil(t, scorer, "lora-affinity must resolve to a scorerFunc")
+	assert.Nil(t, observer, "lora-affinity is stateless (no observer)")
+}
+
+// TestLoRAAffinity_NotInProfile_RoutingUnchanged is US4 scenario 3 / INV-6: with
+// the scorer absent from the weighted profile, an adapter request routes exactly
+// as it would with no LoRA awareness. We assert the composite decision is
+// identical with and without ResidentAdapters populated, because the default
+// profile never consults them.
+func TestLoRAAffinity_NotInProfile_RoutingUnchanged(t *testing.T) {
+	configs := DefaultScorerConfigs() // precise-prefix-cache, queue-depth, kv-utilization
+	policyWithout := NewRoutingPolicy("weighted", configs, 16, nil)
+	req := &Request{Adapter: "sql-lora", InputTokens: make([]TokenID, 32)}
+
+	// Two snapshot sets identical except for ResidentAdapters (which the default
+	// profile ignores). Same routing decision proves the adapter field is inert.
+	bare := []RoutingSnapshot{
+		{ID: "a", QueueDepth: 5, KVUtilization: 0.5},
+		{ID: "b", QueueDepth: 1, KVUtilization: 0.1},
+	}
+	withResident := []RoutingSnapshot{
+		{ID: "a", QueueDepth: 5, KVUtilization: 0.5, ResidentAdapters: residentSetOf("sql-lora")},
+		{ID: "b", QueueDepth: 1, KVUtilization: 0.1},
+	}
+	dBare := policyWithout.Route(req, &RouterState{Snapshots: bare})
+	dResident := policyWithout.Route(req, &RouterState{Snapshots: withResident})
+	assert.Equal(t, dBare.TargetInstance, dResident.TargetInstance,
+		"default profile must ignore ResidentAdapters (INV-6)")
+}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -424,6 +424,19 @@ func (sim *Simulator) buildInstanceSnapshot() InstanceSnapshot {
 // QueueDepth returns the number of requests in the wait queue.
 func (sim *Simulator) QueueDepth() int { return sim.WaitQ.Len() }
 
+// ResidentAdapterIDs returns the ids of LoRA adapters currently resident on this
+// instance, in a deterministic order (INV-6). Returns nil when the LoRA subsystem
+// is inert (no adapters/capacity configured, or sim/lora not imported), so the
+// snapshot's ResidentAdapters stays nil and the lora-affinity scorer is neutral
+// (INV-6). Read by the cluster snapshot provider to populate
+// RoutingSnapshot.ResidentAdapters (#1469).
+func (sim *Simulator) ResidentAdapterIDs() []string {
+	if sim.residentAdapters == nil {
+		return nil
+	}
+	return sim.residentAdapters.ResidentIDs()
+}
+
 // DrainWaitQueue removes and returns all requests currently in the wait queue.
 // Used by DrainRedirect policy to re-inject queued requests into the cluster router.
 // After this call, WaitQ.Len() == 0.


### PR DESCRIPTION
## Summary

PR6 of the LoRA control-plane subsystem (epic #1464). Adds the **`lora-affinity`** weighted-routing scorer (spec **US4**, Policy Template), **off by default**, so requests prefer instances that already hold their LoRA adapter — reducing cold loads under skewed adapter popularity.

Closes #1469.

> ✅ **Rebased onto merged `main` 2026-07-24.** PR1–PR5 (#1472/#1473/#1474/#1475/#1476) have merged; this PR is now a **single clean commit `afdf7d84`** on `main` (no stale stack commits). Zero-conflict rebase.

## Tasks (TDD, T035–T040)

- **T035** scorer contract tests (`sim/routing_scorers_test.go`): warm>cold; empty-adapter neutral; not-in-profile ⇒ routing unchanged (INV-6); reads only `Adapter`/`ResidentAdapters`, never oracle output length (INV-9).
- **T036** `RoutingSnapshot.ResidentAdapters map[string]bool` — membership set; nil zero value ⇒ scorer neutral (INV-6).
- **T037** populated via `CachedSnapshotProvider` at **Periodic** freshness (Immediate when `--snapshot-refresh-interval 0`). Adds `ResidentIDs()` to the `ResidentAdapterSet` interface + concrete LRU, plus `Simulator`/`InstanceSimulator` accessors.
- **T038** `scoreLoRAAffinity`: `raw = 1.0 if resident else 0.0`, min-max normalized (llm-d parity); neutral for empty-adapter/all-warm/all-cold/single-instance. Registered in `validScorerNames` (R8) + `newScorerWithObserver`.
- **T039** `--lora-scorer-weight` flag + `composeLoRAScorer` helper wired into the shared `resolvePolicies` (run + replay, R23 parity); `Flags().Changed` guard (R18); rejects non-finite/non-positive weight and double-specification with `--routing-scorers`.
- **T040** SC-005 integration test: Zipfian adapter popularity ⇒ **~92% fewer** total adapter loads with `lora-affinity` vs least-loaded (target ≥30%).

## Invariants / rules

INV-6 (default routing byte-identical — no-op golden holds), INV-7 + R17 (freshness declared in the scorer doc comment), INV-9 (oracle boundary — grep guard passes), R8, R13, R18, R23.

## Deliberate deviation (flag for review)

T037's literal text said "populate in `buildRouterState()`", but I populated in `CachedSnapshotProvider.Snapshot()` — the only site whose "Immediate when `--snapshot-refresh-interval 0`" semantics match the stated Periodic/INV-7 contract. `buildRouterState` has no interval logic; populating there would be unconditionally Immediate, violating the contract.

## Cross-path parity

Scorer + flag apply to `blis run` and `blis replay` (shared `resolvePolicies` + weighted routing). `blis observe` dispatches to a real server and performs no DES routing, so scorer parity does not apply there.

## Follow-up (out of scope)

`--lora-scorer-weight` set while no adapters are configured leaves the scorer inert (neutral) with no warning — a diagnostic would require plumbing `LoRAConfig` into `resolvePolicies`. Consistent with the codebase's warn-on-no-effect pattern; deferred to avoid a layering change here.

## Verification

`go build ./...` and full `go test ./...` green; INV-6 no-op byte-identity golden holds; INV-9 control-plane grep guard passes; no gofmt churn on changed files; assembled `lora-integration` stack builds + tests clean.

## Review

5-agent pr-review-toolkit self-review dispatched (read-only, pristine-diff snapshotted per prior-PR incident lesson): comment-analyzer and type-design-analyzer completed — types rated sound (membership map correct; `ResidentIDs` justified by real consumer, R13 satisfied; `composeLoRAScorer` strong encapsulation). Three agents hit an infrastructure watchdog timeout; their scope (correctness/invariants, silent-failure, test-coverage) was reviewed directly. Applied fixes: reworded `--lora-scorer-weight` help + comment (explicit-0 rejects, not no-op); softened `ResidentIDs` order-guarantee doc; added `ResidentAdapters` freshness assertions to the ObservabilityConfig tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

