### PR TITLE
feat(lora): PR7 — DT fidelity comparison + adapter trace round-trip (#1470)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ __pycache__/*
 !model_configs/*/config.json
 !hardware_config.json
 !specs/**/testdata/*.json
+!cmd/testdata/**/*.json
 data/
 *.txt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,15 @@ go build -o blis main.go
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
   --slo-ttft "critical=100ms" --slo-e2e "critical=5s" --report calibration.json
 
+# Compare LoRA adapter-cost fidelity vs a Digital Twin reference (#1470, US5).
+# Standalone mode: BLIS aggregate (from blis run --metrics-path) vs a committed DT
+# reference (per-config adapter_aware/adapter_blind), per-metric MAPE on TTFT +
+# throughput. --sim-metrics-blind enables the delta-normalized (aware/blind)
+# diagnostic that isolates the ported adapter physics. Does not use --trace-*.
+./blis calibrate --adapter-reference dt-ref.json \
+  --sim-metrics aware.json --sim-metrics-blind blind.json \
+  --adapter-mape-threshold 0.20 --report adapter-fidelity.json
+
 # Run with lazy request generation (alpha, #1441). Streams requests from the
 # workload generator into the cluster instead of pre-generating the full
 # slice — reduces peak generator memory from O(total_requests) to the
@@ -320,7 +329,9 @@ Full details: see [`docs/contributing/standards/principles.md`](docs/contributin
 
 ### Current Implementation Focus
 
-Composable Scorer Framework completed: PR17 (scorer framework + stateless scorers) and PR18 (prefix-affinity scorer + router-side cache). Default weighted routing profile: `precise-prefix-cache:2,queue-depth:1,kv-utilization:1` (llm-d parity). Precise prefix scoring (#883): `precise-prefix-cache` scorer queries actual instance KV cache state with min-max normalization (llm-d production parity); `no-hit-lru` scorer distributes cold requests to least-recently-used endpoints. Valid scorer names: `prefix-affinity`, `precise-prefix-cache`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`, `active-requests`, `running-requests`, `load-aware`, `vllm-dp`.
+Composable Scorer Framework completed: PR17 (scorer framework + stateless scorers) and PR18 (prefix-affinity scorer + router-side cache). Default weighted routing profile: `precise-prefix-cache:2,queue-depth:1,kv-utilization:1` (llm-d parity). Precise prefix scoring (#883): `precise-prefix-cache` scorer queries actual instance KV cache state with min-max normalization (llm-d production parity); `no-hit-lru` scorer distributes cold requests to least-recently-used endpoints. Valid scorer names: `prefix-affinity`, `precise-prefix-cache`, `no-hit-lru`, `queue-depth`, `kv-utilization`, `load-balance`, `active-requests`, `running-requests`, `load-aware`, `vllm-dp`, `lora-affinity` (#1469, off by default; scores instances with the request's adapter already resident higher, min-max normalized).
+
+LoRA control-plane subsystem (#1464, epic PRs 1–7): adapter identity + pre-declared `id→rank` registry, per-instance resident set (capacity-bounded LRU), three DT-derived cost terms (cold-load latency, per-step compute overhead, static HBM reservation), the `lora-affinity` scorer, and per-adapter metrics. No-op by default (`lora:` absent ⇒ byte-identical output, INV-6). Adapter ids round-trip through TraceV2 (trailing conditional `adapter` column) for run/replay parity (INV-13). Fidelity vs the Agullo Digital Twin (#1470, `blis calibrate --adapter-reference`): the compute-overhead (throughput) term validates ≤20% MAPE for both calibrated configs (Llama-3.1-8B-Instruct, Qwen-2.5-7B-Instruct); the absolute-TTFT leg is bounded but unsupported (BLIS ports adapter *deltas* onto its own separately-calibrated base, which differs from the DT's H100 base fit) — reported honestly, never silently passed.
 
 Phase 0 workload unification complete (see issue #420): W0-1 (spec v2 schema + SLO tiers), W0-2 (binary rename + converters), W0-3 (cohort population dynamics), W0-4 (legacy retirement). All workload generation now flows through `sim/workload/GenerateRequests()`. SLO tiers: critical, standard, sheddable, batch, background. Arrival processes: poisson, gamma, weibull, constant. CLI binary renamed from `simulation_worker` to `blis`.
 

--- a/cmd/calibrate.go
+++ b/cmd/calibrate.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"sort"
 
+	"github.com/inference-sim/inference-sim/sim"
 	"github.com/inference-sim/inference-sim/sim/workload"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -25,6 +27,13 @@ var (
 	calibrateGoodputSLOTTFT string
 	calibrateGoodputSLOITL  string
 	calibrateGoodputSLOE2E  string
+	// Adapter-cost fidelity comparison vs the Digital Twin (US5, #1470). When
+	// --adapter-reference is set, calibrate runs a standalone per-config DT
+	// comparison (BLIS aggregate vs DT reference) instead of the real-vs-sim flow.
+	calibrateAdapterReference  string
+	calibrateSimMetrics        string
+	calibrateSimMetricsBlind   string
+	calibrateAdapterMAPEThresh float64
 )
 
 var calibrateCmd = &cobra.Command{
@@ -49,6 +58,13 @@ Example:
   blis calibrate --trace-header t.yaml --trace-data d.csv \
     --sim-results results.json --report calibration.json`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Adapter-cost fidelity comparison mode (US5, #1470): BLIS aggregate vs DT
+		// reference, per config. Standalone — does not use the real-vs-sim flow.
+		if calibrateAdapterReference != "" {
+			runAdapterReferenceComparison()
+			return
+		}
+
 		if calibrateTraceHeaderPath == "" {
 			logrus.Fatalf("--trace-header is required")
 		}
@@ -327,6 +343,99 @@ Example:
 	},
 }
 
+// loadBLISAggregate reads a BLIS MetricsOutput JSON file (from blis run/replay
+// --metrics-path) and distills the aggregate TTFT + output throughput needed for
+// the DT comparison. Output throughput = total_output_tokens / estimated duration.
+func loadBLISAggregate(path string) workload.BLISAggregate {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		logrus.Fatalf("Failed to read sim metrics from %s: %v", path, err)
+	}
+	var m sim.MetricsOutput
+	if err := json.Unmarshal(data, &m); err != nil {
+		logrus.Fatalf("Failed to parse sim metrics JSON from %s: %v", path, err)
+	}
+	if m.VllmDurationSec <= 0 {
+		logrus.Fatalf("sim metrics %s: vllm_estimated_duration_s must be > 0 to compute throughput, got %v", path, m.VllmDurationSec)
+	}
+	return workload.BLISAggregate{
+		TTFTMs:           m.TTFTMeanMs,
+		OutputThroughput: float64(m.TotalOutputTokens) / m.VllmDurationSec,
+	}
+}
+
+// runAdapterReferenceComparison implements the US5 (#1470) DT fidelity comparison:
+// BLIS aggregate (from --sim-metrics) vs a committed DT reference (--adapter-reference),
+// per config, on TTFT and output throughput. Writes the report JSON and logs a
+// per-metric pass/fail against --adapter-mape-threshold. Configs exceeding the bound
+// are reported honestly (never a silent pass); the mechanism ships regardless of the
+// empirical outcome (design §15).
+func runAdapterReferenceComparison() {
+	if calibrateSimMetrics == "" {
+		logrus.Fatalf("--sim-metrics is required with --adapter-reference (BLIS aggregate MetricsOutput from run/replay --metrics-path)")
+	}
+	if calibrateReportPath == "" {
+		logrus.Fatalf("--report is required")
+	}
+	if math.IsNaN(calibrateAdapterMAPEThresh) || math.IsInf(calibrateAdapterMAPEThresh, 0) || calibrateAdapterMAPEThresh <= 0 {
+		logrus.Fatalf("--adapter-mape-threshold must be a finite number > 0, got %v", calibrateAdapterMAPEThresh)
+	}
+
+	ref, err := workload.LoadDTReference(calibrateAdapterReference)
+	if err != nil {
+		logrus.Fatalf("%v", err)
+	}
+	aware := loadBLISAggregate(calibrateSimMetrics)
+	var blind *workload.BLISAggregate
+	if calibrateSimMetricsBlind != "" {
+		b := loadBLISAggregate(calibrateSimMetricsBlind)
+		blind = &b
+	}
+
+	report := workload.CompareAdapterReference(ref, aware, blind, calibrateAdapterMAPEThresh)
+
+	reportData, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		logrus.Fatalf("Failed to marshal adapter-reference report: %v", err)
+	}
+	if err := os.WriteFile(calibrateReportPath, reportData, 0644); err != nil {
+		logrus.Fatalf("Failed to write adapter-reference report to %s: %v", calibrateReportPath, err)
+	}
+
+	logrus.Infof("Adapter-reference comparison (%s) written to %s (MAPE threshold %.0f%%)",
+		report.Model, calibrateReportPath, report.Threshold*100)
+	for _, m := range report.Metrics {
+		verdict := "WITHIN"
+		if !m.Within {
+			verdict = "EXCEEDS"
+		}
+		line := fmt.Sprintf("  %-11s BLIS=%.2f DT=%.2f MAPE=%.1f%% [%s]",
+			m.Metric, m.BLISValue, m.DTValue, m.MAPE*100, verdict)
+		if m.DeltaMAPE != nil {
+			line += fmt.Sprintf(" delta-normalized MAPE=%.1f%%", *m.DeltaMAPE*100)
+		}
+		if m.Within {
+			logrus.Info(line)
+		} else {
+			logrus.Warn(line)
+		}
+	}
+	// Surface silent degradation (R1): the user asked for the delta-normalized
+	// diagnostic (--sim-metrics-blind) but a zero blind denominator on either side
+	// prevented computing it for a metric.
+	if calibrateSimMetricsBlind != "" {
+		for _, m := range report.Metrics {
+			if m.DeltaMAPE == nil {
+				logrus.Warnf("delta-normalized diagnostic skipped for %q: the DT reference's adapter_blind %s is zero or the BLIS blind aggregate is zero (aware/blind ratio undefined).", m.Metric, m.Metric)
+			}
+		}
+	}
+	if !report.AllWithin {
+		logrus.Warnf("SC-007 not satisfied on all metrics for %s at MAPE<=%.0f%% — that dimension's fidelity claim is unsupported for this config (design §15 falsification path). The comparison mechanism succeeded; the bound was not met.",
+			report.Model, report.Threshold*100)
+	}
+}
+
 func init() {
 	calibrateCmd.Flags().StringVar(&calibrateTraceHeaderPath, "trace-header", "", "Path to TraceV2 header YAML file (from blis observe; required)")
 	calibrateCmd.Flags().StringVar(&calibrateTraceDataPath, "trace-data", "", "Path to TraceV2 data CSV file (from blis observe; required)")
@@ -339,5 +448,10 @@ func init() {
 	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOTTFT, "slo-ttft", "", "Per-class TTFT goodput thresholds (e.g. \"critical=100ms,standard=500ms\"). Precedence: CLI > trace header.")
 	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOITL, "slo-itl", "", "Per-class mean ITL goodput thresholds. Skipped with a warning when ITL data is absent on either side.")
 	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
+	// Adapter-cost fidelity comparison vs the Digital Twin (US5, #1470).
+	calibrateCmd.Flags().StringVar(&calibrateAdapterReference, "adapter-reference", "", "Path to a DT reference JSON (per-config adapter_aware/adapter_blind aggregates). Enables standalone BLIS-vs-DT fidelity comparison; --trace-header/--trace-data/--sim-results are not used in this mode.")
+	calibrateCmd.Flags().StringVar(&calibrateSimMetrics, "sim-metrics", "", "Path to a BLIS aggregate MetricsOutput JSON (from blis run/replay --metrics-path) for the adapter-aware run. Required with --adapter-reference.")
+	calibrateCmd.Flags().StringVar(&calibrateSimMetricsBlind, "sim-metrics-blind", "", "Optional BLIS MetricsOutput JSON for the adapter-blind baseline run; enables the delta-normalized (aware/blind) diagnostic that isolates the ported adapter physics.")
+	calibrateCmd.Flags().Float64Var(&calibrateAdapterMAPEThresh, "adapter-mape-threshold", 0.20, "MAPE bound (fraction) for the adapter-reference comparison (SC-007 target 0.20).")
 	rootCmd.AddCommand(calibrateCmd)
 }

--- a/cmd/calibrate_adapter_reference_test.go
+++ b/cmd/calibrate_adapter_reference_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// T043 (US5, SC-007, #1470): fixture-based validation of the BLIS-vs-DT adapter
+// fidelity comparison for the two calibrated reference configs. The fixtures under
+// testdata/dt-reference/ are real: DT simulate() aggregates (from the GPULLM fork)
+// and BLIS `replay --metrics-path` aggregates over the identical seeded arrival
+// stream (see testdata/dt-reference/README.md).
+//
+// Honest-scoping outcome (design §15 falsification path — the *mechanism* is the
+// deliverable, the bound is an empirical result):
+//   - THROUGHPUT (the compute-overhead term, D4) lands WITHIN 20% MAPE for both
+//     configs → SC-007 throughput leg validated.
+//   - TTFT lands FAR outside 20% because BLIS ports adapter deltas onto its own
+//     separately-calibrated base (§6), which is ~100× faster than the DT's H100
+//     base fit; the DT's large absolute TTFT is queueing amplification BLIS's
+//     faster base never enters. TTFT is also the DT's own weakest axis (§15). This
+//     leg is therefore marked UNSUPPORTED — asserted here as > 20%, never a silent
+//     pass.
+//
+// Caveat documented in README: the canonical DT workload does not saturate BLIS,
+// so the throughput agreement partly reflects both tracking offered load; a
+// saturating-workload D4 validation is future work.
+func TestSC007_AdapterFidelity_Fixtures(t *testing.T) {
+	const threshold = 0.20
+	dir := "testdata/dt-reference"
+	configs := []string{"qwen-2.5-7b-instruct", "llama-3.1-8b-instruct"}
+
+	for _, cfg := range configs {
+		t.Run(cfg, func(t *testing.T) {
+			ref, err := workload.LoadDTReference(filepath.Join(dir, cfg+".dt.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			aware := loadBLISAggregate(filepath.Join(dir, cfg+".blis-aware.json"))
+			blind := loadBLISAggregate(filepath.Join(dir, cfg+".blis-blind.json"))
+			rep := workload.CompareAdapterReference(ref, aware, &blind, threshold)
+
+			byName := map[string]workload.AdapterMetricComparison{}
+			for _, m := range rep.Metrics {
+				byName[m.Metric] = m
+			}
+
+			// SC-007 throughput leg: WITHIN 20% for both configs (validated).
+			tput := byName["throughput"]
+			if !tput.Within {
+				t.Errorf("%s throughput MAPE = %.1f%% exceeds %.0f%% — SC-007 throughput leg regressed",
+					cfg, tput.MAPE*100, threshold*100)
+			}
+			// Delta-normalized throughput diagnostic present and within bound.
+			if tput.DeltaMAPE == nil {
+				t.Errorf("%s throughput delta-normalized MAPE missing (blind fixture should enable it)", cfg)
+			} else if *tput.DeltaMAPE > threshold {
+				t.Errorf("%s throughput delta-normalized MAPE = %.1f%% exceeds %.0f%%", cfg, *tput.DeltaMAPE*100, threshold*100)
+			}
+
+			// TTFT leg: UNSUPPORTED — must be reported as exceeding the bound, not
+			// silently within it (base/queueing-regime mismatch, §15).
+			ttft := byName["ttft"]
+			if ttft.Within {
+				t.Errorf("%s ttft MAPE = %.1f%% is within %.0f%% — unexpected; the TTFT leg is documented UNSUPPORTED and must be flagged, not silently passed",
+					cfg, ttft.MAPE*100, threshold*100)
+			}
+
+			// Because the TTFT leg exceeds, the config is not fully within threshold.
+			if rep.AllWithin {
+				t.Errorf("%s AllWithin=true but the TTFT leg is unsupported — no silent pass", cfg)
+			}
+		})
+	}
+}

--- a/cmd/testdata/dt-reference/README.md
+++ b/cmd/testdata/dt-reference/README.md
@@ -1,0 +1,68 @@
+# DT adapter-fidelity reference fixtures (PR7 / #1470)
+
+Committed fixtures for the BLIS-vs-Digital-Twin adapter-cost fidelity comparison
+(`blis calibrate --adapter-reference`) and the SC-007 test
+(`TestSC007_AdapterFidelity_Fixtures`).
+
+Per config (`qwen-2.5-7b-instruct`, `llama-3.1-8b-instruct`):
+
+| File | Source |
+|---|---|
+| `<config>.dt.json` | Agullo Digital Twin `simulate()` aggregates (adapter-aware + adapter-blind), from the `GPULLMAdapterOptimization` fork (arXiv:2508.08343) via `lora-control/experiments/export_dt_reference.py`. |
+| `<config>.blis-aware.json` | BLIS aggregate MetricsOutput, adapter physics ON (`--lora-config`). |
+| `<config>.blis-blind.json` | BLIS aggregate MetricsOutput, adapters inert (no `--lora-config`), same arrivals. |
+
+## Workload
+
+Both sides run the **identical** seeded arrival stream (the DT's canonical
+`dt_driver.py` workload: 16 adapters, ranks {8,16,32}, 8 slots, 0.5 req/s each,
+60 s, `np.random.default_rng(0)`). BLIS replays the DT's exact arrivals via a
+TraceV2 built from the exported stream, so any error is attributable to model /
+scheduler / adapter-physics differences, not to re-drawn arrivals. The DT
+loading + overhead coefficients are mapped to `LoRAConfig` (`k6/k7 =
+slope/intercept`, rank-blind, matching the DT `_small` overhead variant).
+
+## Regenerate
+
+```bash
+# 1. DT references (needs the fork; GPULLM_REPO points at it)
+GPULLM_REPO=/path/to/GPULLMAdapterOptimization \
+  python3 lora-control/experiments/export_dt_reference.py /tmp/dt-ref-out
+# 2. Build a BLIS TraceV2 + LoRAConfig from the exported arrival stream, then
+#    replay it twice (aware = with --lora-config, blind = without) and capture the
+#    aggregate MetricsOutput. `blis replay` intentionally exposes only
+#    --results-path (BC-2), so read the "=== Simulation Metrics ===" JSON block
+#    from replay's stdout and trim to the aggregate fields above.
+```
+
+## Producing `--sim-metrics` yourself
+
+The general user flow for the comparison uses `blis run`, which writes a clean
+aggregate MetricsOutput via `--metrics-path`:
+
+```bash
+blis run --model qwen2.5-7b-instruct --hardware H100 --tp 1 \
+  --workload-spec <your-adapter-workload>.yaml --lora-config <dt-coeffs>.yaml \
+  --metrics-path aware.json
+blis calibrate --adapter-reference qwen-2.5-7b-instruct.dt.json \
+  --sim-metrics aware.json --report report.json
+```
+
+## Finding (SC-007, design §15 falsification path)
+
+| Metric | qwen absMAPE | llama absMAPE | ≤ 20%? |
+|---|--:|--:|:--:|
+| **throughput** (compute-overhead term, D4) | 14.2% | 14.4% | ✅ validated |
+| **TTFT** | 98.5% | 97.2% | ❌ **unsupported** |
+
+TTFT diverges because BLIS ports adapter *deltas* onto its own separately-calibrated
+base (design §6), which is ~100× faster than the DT's H100 base fit (BLIS blind
+TTFT ≈26 ms vs DT ≈3250 ms); the DT's large absolute TTFT is queueing amplification
+BLIS's faster base never enters. TTFT is also the DT's own weakest axis (~17–21%
+SMAPE vs real; throughput ~5%, §15). The comparison mechanism ships regardless; the
+TTFT fidelity claim is withheld, not silently passed.
+
+**Caveat:** the canonical DT workload does not saturate BLIS, so the throughput
+agreement partly reflects both systems tracking offered load (BLIS aware/blind
+throughput ratio ≈0.999 vs DT ≈0.90). A saturating-workload validation of the D4
+compute-overhead term is future work.

--- a/cmd/testdata/dt-reference/README.md
+++ b/cmd/testdata/dt-reference/README.md
@@ -62,7 +62,17 @@ BLIS's faster base never enters. TTFT is also the DT's own weakest axis (~17–2
 SMAPE vs real; throughput ~5%, §15). The comparison mechanism ships regardless; the
 TTFT fidelity claim is withheld, not silently passed.
 
-**Caveat:** the canonical DT workload does not saturate BLIS, so the throughput
-agreement partly reflects both systems tracking offered load (BLIS aware/blind
-throughput ratio ≈0.999 vs DT ≈0.90). A saturating-workload validation of the D4
-compute-overhead term is future work.
+**Caveat (workload):** the canonical DT workload does not saturate BLIS, so the
+throughput agreement partly reflects both systems tracking offered load (BLIS
+aware/blind throughput ratio ≈0.999 vs DT ≈0.90). A saturating-workload validation
+of the D4 compute-overhead term is future work.
+
+**Caveat (rank-blind coefficients):** the DT overhead fit used here
+(`predictor_latency_overhead_small`) is linear in the unique-adapter count and
+**ignores rank**, so the LoRAConfig coefficients are mapped rank-blind
+(`k6/k7 = slope/intercept`, identical across the {8,16,32} rank tiers). This
+comparison therefore does **not** exercise BLIS's rank-tiered overhead
+(FR-009 / D4's max-rank-in-batch term) — with a single rank per adapter the tier
+key is fixed. Validating the rank dependence would require a rank-dependent DT fit
+(the `_small` variant's commented-out sigmoid, or a re-profile); BLIS's rank
+tiering is instead covered by the PR4 rank/uniqueness-sensitivity unit test.

--- a/cmd/testdata/dt-reference/llama-3.1-8b-instruct.blis-aware.json
+++ b/cmd/testdata/dt-reference/llama-3.1-8b-instruct.blis-aware.json
@@ -1,0 +1,9 @@
+{
+  "completed_requests": 451,
+  "injected_requests": 451,
+  "tokens_per_sec": 1175.3226181997816,
+  "total_input_tokens": 146521,
+  "total_output_tokens": 72234,
+  "ttft_mean_ms": 310.9935742793792,
+  "vllm_estimated_duration_s": 61.45887
+}

--- a/cmd/testdata/dt-reference/llama-3.1-8b-instruct.blis-blind.json
+++ b/cmd/testdata/dt-reference/llama-3.1-8b-instruct.blis-blind.json
@@ -1,0 +1,9 @@
+{
+  "completed_requests": 451,
+  "injected_requests": 451,
+  "tokens_per_sec": 1180.2598091143723,
+  "total_input_tokens": 146521,
+  "total_output_tokens": 72234,
+  "ttft_mean_ms": 27.130450110864746,
+  "vllm_estimated_duration_s": 61.201779
+}

--- a/cmd/testdata/dt-reference/llama-3.1-8b-instruct.dt.json
+++ b/cmd/testdata/dt-reference/llama-3.1-8b-instruct.dt.json
@@ -1,0 +1,19 @@
+{
+  "adapter_aware": {
+    "output_throughput": 1027.2812777956847,
+    "total_throughput": 3119.2128503879776,
+    "ttft": 11224.791002375703
+  },
+  "adapter_blind": {
+    "output_throughput": 1148.340927242921,
+    "total_throughput": 3471.949005631099,
+    "ttft": 3086.5379769266524
+  },
+  "model": "llama-3.1-8b-instruct",
+  "provenance": {
+    "arxiv": "2508.08343",
+    "generator": "lora-control/experiments/export_dt_reference.py (seed 0, 16 adapters, 8 slots, 60s)",
+    "note": "DT simulate() workload-aggregate ttft(ms) + throughput(tok/s). H100/vLLM. adapter_blind = both DT overhead models off.",
+    "source_repo": "FerranAgulloLopez/GPULLMAdapterOptimization"
+  }
+}

--- a/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.blis-aware.json
+++ b/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.blis-aware.json
@@ -1,0 +1,9 @@
+{
+  "completed_requests": 451,
+  "injected_requests": 451,
+  "tokens_per_sec": 1181.4224339843784,
+  "total_input_tokens": 146521,
+  "total_output_tokens": 72234,
+  "ttft_mean_ms": 163.7778514412417,
+  "vllm_estimated_duration_s": 61.141551
+}

--- a/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.blis-blind.json
+++ b/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.blis-blind.json
@@ -1,0 +1,9 @@
+{
+  "completed_requests": 451,
+  "injected_requests": 451,
+  "tokens_per_sec": 1182.163074972532,
+  "total_input_tokens": 146521,
+  "total_output_tokens": 72234,
+  "ttft_mean_ms": 25.83650110864745,
+  "vllm_estimated_duration_s": 61.103245
+}

--- a/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.dt.json
+++ b/cmd/testdata/dt-reference/qwen-2.5-7b-instruct.dt.json
@@ -1,0 +1,19 @@
+{
+  "adapter_aware": {
+    "output_throughput": 1034.4976392657245,
+    "total_throughput": 3142.878699410052,
+    "ttft": 10696.262264198787
+  },
+  "adapter_blind": {
+    "output_throughput": 1144.6457211251018,
+    "total_throughput": 3463.765010593822,
+    "ttft": 3251.7368498961196
+  },
+  "model": "qwen-2.5-7b-instruct",
+  "provenance": {
+    "arxiv": "2508.08343",
+    "generator": "lora-control/experiments/export_dt_reference.py (seed 0, 16 adapters, 8 slots, 60s)",
+    "note": "DT simulate() workload-aggregate ttft(ms) + throughput(tok/s). H100/vLLM. adapter_blind = both DT overhead models off.",
+    "source_repo": "FerranAgulloLopez/GPULLMAdapterOptimization"
+  }
+}

--- a/model_configs/llama-3.1-8b-instruct/config.json
+++ b/model_configs/llama-3.1-8b-instruct/config.json
@@ -1,0 +1,26 @@
+{
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 128000,
+  "eos_token_id": 128009,
+  "hidden_act": "silu",
+  "hidden_size": 4096,
+  "initializer_range": 0.02,
+  "intermediate_size": 14336,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "num_key_value_heads": 8,
+  "rms_norm_eps": 1e-05,
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.43.0",
+  "use_cache": true,
+  "vocab_size": 128256
+}

--- a/sim/resident_adapter_wiring_test.go
+++ b/sim/resident_adapter_wiring_test.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -262,6 +263,67 @@ func TestNewSimulator_InvalidAdapterCapacity(t *testing.T) {
 		if _, err := NewSimulator(cfg, kvStore, latencyModel); err == nil {
 			t.Fatalf("capacity %d: expected error, got nil", capVal)
 		}
+	}
+}
+
+// TestResidentAdapterSet_ActiveRun_Deterministic (#1470, T045, INV-6/SC-006)
+// asserts byte-identical output across two runs of an *active* adapter workload
+// (adapters loading and evicting, M > N) with the same seed — deliberately
+// including co-arriving requests (same arrival tick) and a repeated adapter to
+// exercise simultaneous-touch and same-timestamp tie conditions. LRU ties are
+// broken by insertion order; any map-iteration-order nondeterminism leaking into
+// output would diverge the two JSON blobs.
+func TestResidentAdapterSet_ActiveRun_Deterministic(t *testing.T) {
+	const (
+		capacity    = 2
+		numAdapters = 5 // M > N → active load/evict churn
+	)
+	build := func() string {
+		cfg := newTestSimConfig()
+		capVal := capacity
+		adapters := make([]AdapterSpec, numAdapters)
+		for i := range adapters {
+			adapters[i] = AdapterSpec{ID: fmt.Sprintf("adapter_%d", i), Rank: 8}
+		}
+		cfg.LoRAConfig = LoRAConfig{
+			AdapterCapacity:       &capVal,
+			LoadBaseLatencyUs:     fptrGate(1000.0),
+			LoadBandwidthBytesUs:  fptrGate(2.0e6),
+			FootprintBytesPerRank: fptrGate(2.0e6),
+			Adapters:              adapters,
+		}
+		s := mustNewSimulator(t, cfg)
+		// Co-arriving requests (same tick 0) + a repeated adapter to hit tie paths.
+		arrivals := []struct {
+			id      string
+			t       int64
+			adapter string
+		}{
+			{"r0", 0, "adapter_0"},
+			{"r1", 0, "adapter_1"}, // co-arrival tie with r0
+			{"r2", 0, "adapter_0"}, // same adapter, same tick (coalesce/touch tie)
+			{"r3", 10, "adapter_2"},
+			{"r4", 10, "adapter_3"}, // co-arrival tie
+			{"r5", 20, "adapter_4"},
+		}
+		for _, a := range arrivals {
+			req := newTestRequest(a.id, a.t, 8, 4)
+			req.Adapter = a.adapter
+			s.InjectArrival(req)
+		}
+		s.Run()
+		out := s.Metrics.BuildOutput("test-instance", nil)
+		b, err := json.Marshal(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+
+	first := build()
+	second := build()
+	if first != second {
+		t.Errorf("active-adapter run output not byte-identical across two runs (INV-6/SC-006 determinism)\nfirst:  %s\nsecond: %s", first, second)
 	}
 }
 

--- a/sim/routing_scorers_test.go
+++ b/sim/routing_scorers_test.go
@@ -385,7 +385,7 @@ func TestScoreLoadAware_ScoreRange_MaxIsHalf(t *testing.T) {
 
 func TestAllScorers_ReturnScoreForEveryInstance(t *testing.T) {
 	snapshots := []RoutingSnapshot{
-		{ID: "a", QueueDepth: 1, KVUtilization: 0.3},
+		{ID: "a", QueueDepth: 1, KVUtilization: 0.3, ResidentAdapters: map[string]bool{"x": true}},
 		{ID: "b", QueueDepth: 2, KVUtilization: 0.7},
 		{ID: "c", QueueDepth: 0, KVUtilization: 0.0},
 	}
@@ -409,8 +409,12 @@ func TestAllScorers_ReturnScoreForEveryInstance(t *testing.T) {
 		{"vllm-dp", scoreVLLMDP},
 		{"precise-prefix-cache", precisePrefixScorer},
 		{"no-hit-lru", noHitLRUScorer},
+		{"lora-affinity", scoreLoRAAffinity},
 	}
-	req := &Request{ID: "r1", InputTokens:  []TokenID{1, 2, 3}}
+	// req carries an adapter resident only on "a" so lora-affinity exercises its
+	// min-max normalization branch (warm vs cold), not just the neutral path.
+	// Other scorers ignore Adapter/ResidentAdapters, so the shared fixture is unaffected.
+	req := &Request{ID: "r1", InputTokens: []TokenID{1, 2, 3}, Adapter: "x"}
 	for _, sf := range scorerFns {
 		t.Run(sf.name, func(t *testing.T) {
 			scores := sf.fn(req, snapshots)

--- a/sim/workload/adapter_reference.go
+++ b/sim/workload/adapter_reference.go
@@ -1,0 +1,136 @@
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+)
+
+// Adapter-cost fidelity comparison vs the Agullo Digital Twin (DT) reference
+// (US5, #1470). The DT's simulate() emits workload-AGGREGATE ttft (mean, ms) and
+// throughput (tokens/s) — not per-adapter — so the comparison is per reference
+// CONFIG (Llama-3.1-8B-Instruct, Qwen-2.5-7B-Instruct), matching what the DT
+// actually reports.
+//
+// Fidelity is bounded, not ground truth (design §15): the DT itself is ~17–21%
+// SMAPE on TTFT vs a real H100 but only ~5% on throughput, and BLIS ports the DT
+// adapter *deltas* onto its own separately-calibrated base — so absolute TTFT is
+// expected to diverge (base + queueing-regime mismatch) while the throughput term
+// (the compute-overhead physics, D4) is the leg the DT calibrates most tightly.
+// The report therefore also carries a delta-normalized (aware ÷ blind) diagnostic
+// that cancels the base and isolates the ported adapter physics.
+
+// DTAggregate is one side (adapter-aware or adapter-blind) of a DT simulate()
+// result. Field names match the DT driver's output dict.
+type DTAggregate struct {
+	TTFTMs           float64 `json:"ttft"`              // mean TTFT in milliseconds
+	OutputThroughput float64 `json:"output_throughput"` // completed output tokens/s
+	TotalThroughput  float64 `json:"total_throughput"`  // (input+output) tokens/s
+}
+
+// DTReference is a committed DT reference fixture for one config, holding the
+// adapter-aware run and the adapter-blind baseline (both physics models off).
+type DTReference struct {
+	Model        string      `json:"model"`
+	AdapterAware DTAggregate `json:"adapter_aware"`
+	AdapterBlind DTAggregate `json:"adapter_blind"`
+}
+
+// LoadDTReference reads a DT reference JSON fixture (produced offline by
+// lora-control/experiments/export_dt_reference.py).
+func LoadDTReference(path string) (*DTReference, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading adapter reference %s: %w", path, err)
+	}
+	var ref DTReference
+	if err := json.Unmarshal(data, &ref); err != nil {
+		return nil, fmt.Errorf("parsing adapter reference %s: %w", path, err)
+	}
+	if ref.AdapterAware.TTFTMs <= 0 || ref.AdapterAware.OutputThroughput <= 0 {
+		return nil, fmt.Errorf("adapter reference %s: adapter_aware ttft/output_throughput must be positive (got ttft=%v tput=%v)",
+			path, ref.AdapterAware.TTFTMs, ref.AdapterAware.OutputThroughput)
+	}
+	return &ref, nil
+}
+
+// BLISAggregate is the BLIS side of the comparison, distilled from a MetricsOutput.
+type BLISAggregate struct {
+	TTFTMs           float64 // ttft_mean_ms
+	OutputThroughput float64 // total_output_tokens / vllm_estimated_duration_s
+}
+
+// AdapterMetricComparison is one metric's BLIS-vs-DT error for a single config.
+type AdapterMetricComparison struct {
+	Metric    string   `json:"metric"` // "ttft" | "throughput"
+	DTValue   float64  `json:"dt_value"`
+	BLISValue float64  `json:"blis_value"`
+	MAPE      float64  `json:"mape"`             // |blis-dt|/|dt| (fraction; single-config APE)
+	Within    bool     `json:"within_threshold"` // MAPE <= threshold
+	DeltaMAPE *float64 `json:"delta_mape,omitempty"`
+}
+
+// AdapterReferenceReport is the per-config comparison result.
+type AdapterReferenceReport struct {
+	Model     string                    `json:"model"`
+	Threshold float64                   `json:"mape_threshold"`
+	Metrics   []AdapterMetricComparison `json:"metrics"`
+	AllWithin bool                      `json:"all_within_threshold"`
+}
+
+// ape returns the absolute percentage error |a-b|/|b| as a fraction, or +Inf if
+// the reference b is zero (undefined — surfaced rather than silently zero). In
+// practice LoadDTReference validates the aware TTFT/throughput denominators are
+// > 0, so the +Inf path is unreachable at the primary call sites; it exists as a
+// defensive guard rather than a silently-zero MAPE.
+func ape(blis, dt float64) float64 {
+	if dt == 0 {
+		return math.Inf(1)
+	}
+	return math.Abs(blis-dt) / math.Abs(dt)
+}
+
+// CompareAdapterReference compares BLIS aggregate metrics against a DT reference
+// config on TTFT and (output) throughput. When blind is non-nil it also computes
+// the delta-normalized (aware ÷ blind) ratio error, which cancels the base-latency
+// mismatch and isolates the ported adapter physics. threshold is the MAPE bound
+// (SC-007 target 0.20). A metric with a zero DT denominator yields MAPE=+Inf and
+// is reported as out-of-threshold (never a silent pass).
+func CompareAdapterReference(ref *DTReference, aware BLISAggregate, blind *BLISAggregate, threshold float64) *AdapterReferenceReport {
+	rep := &AdapterReferenceReport{Model: ref.Model, Threshold: threshold, AllWithin: true}
+
+	type spec struct {
+		name     string
+		dt, blis float64
+		dtBase   float64  // blind DT value (for delta ratio)
+		blisBase *float64 // blind BLIS value (for delta ratio)
+	}
+	var blisTTFTBase, blisTputBase *float64
+	if blind != nil {
+		blisTTFTBase = &blind.TTFTMs
+		blisTputBase = &blind.OutputThroughput
+	}
+	specs := []spec{
+		{"ttft", ref.AdapterAware.TTFTMs, aware.TTFTMs, ref.AdapterBlind.TTFTMs, blisTTFTBase},
+		{"throughput", ref.AdapterAware.OutputThroughput, aware.OutputThroughput, ref.AdapterBlind.OutputThroughput, blisTputBase},
+	}
+
+	for _, s := range specs {
+		m := AdapterMetricComparison{Metric: s.name, DTValue: s.dt, BLISValue: s.blis}
+		m.MAPE = ape(s.blis, s.dt)
+		m.Within = m.MAPE <= threshold
+		// Delta-normalized: compare aware/blind ratios (base cancels).
+		if s.blisBase != nil && s.dtBase != 0 && *s.blisBase != 0 {
+			dtRatio := s.dt / s.dtBase
+			blisRatio := s.blis / *s.blisBase
+			d := ape(blisRatio, dtRatio)
+			m.DeltaMAPE = &d
+		}
+		if !m.Within {
+			rep.AllWithin = false
+		}
+		rep.Metrics = append(rep.Metrics, m)
+	}
+	return rep
+}

--- a/sim/workload/adapter_reference_test.go
+++ b/sim/workload/adapter_reference_test.go
@@ -1,0 +1,114 @@
+package workload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// T041 (US5, #1470): DT rank-table/reference import + per-config TTFT and
+// throughput comparison report with an error metric (MAPE). Fail-first contract
+// test — defines the API before implementation.
+
+func TestLoadDTReference_ParsesAggregates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ref.json")
+	// Minimal DT reference: adapter_aware + adapter_blind aggregate blocks.
+	json := `{
+	  "model": "qwen-2.5-7b-instruct",
+	  "adapter_aware": {"ttft": 10696.3, "output_throughput": 1034.5, "total_throughput": 3142.9},
+	  "adapter_blind": {"ttft": 3251.7, "output_throughput": 1144.6, "total_throughput": 3463.8}
+	}`
+	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ref, err := LoadDTReference(path)
+	if err != nil {
+		t.Fatalf("LoadDTReference: %v", err)
+	}
+	if ref.Model != "qwen-2.5-7b-instruct" {
+		t.Errorf("model = %q, want qwen-2.5-7b-instruct", ref.Model)
+	}
+	if ref.AdapterAware.TTFTMs != 10696.3 {
+		t.Errorf("aware ttft = %v, want 10696.3", ref.AdapterAware.TTFTMs)
+	}
+	if ref.AdapterBlind.OutputThroughput != 1144.6 {
+		t.Errorf("blind output_throughput = %v, want 1144.6", ref.AdapterBlind.OutputThroughput)
+	}
+}
+
+func TestCompareAdapterReference_ProducesPerMetricMAPE(t *testing.T) {
+	ref := &DTReference{
+		Model:        "m",
+		AdapterAware: DTAggregate{TTFTMs: 1000, OutputThroughput: 100},
+		AdapterBlind: DTAggregate{TTFTMs: 500, OutputThroughput: 110},
+	}
+	// BLIS aware exactly matches DT aware → 0% MAPE on both metrics.
+	aware := BLISAggregate{TTFTMs: 1000, OutputThroughput: 100}
+	rep := CompareAdapterReference(ref, aware, nil, 0.20)
+	if rep == nil {
+		t.Fatal("nil report")
+	}
+	if len(rep.Metrics) != 2 {
+		t.Fatalf("expected ttft+throughput metrics, got %d", len(rep.Metrics))
+	}
+	for _, m := range rep.Metrics {
+		if m.MAPE != 0 {
+			t.Errorf("metric %s MAPE = %v, want 0 (exact match)", m.Metric, m.MAPE)
+		}
+		if !m.Within {
+			t.Errorf("metric %s should be within threshold at 0 MAPE", m.Metric)
+		}
+	}
+	if !rep.AllWithin {
+		t.Error("AllWithin should be true when every metric is within threshold")
+	}
+}
+
+func TestCompareAdapterReference_FlagsExceedances(t *testing.T) {
+	ref := &DTReference{
+		Model:        "m",
+		AdapterAware: DTAggregate{TTFTMs: 10000, OutputThroughput: 1000},
+		AdapterBlind: DTAggregate{TTFTMs: 3000, OutputThroughput: 1100},
+	}
+	// BLIS TTFT wildly off (base mismatch), throughput close — mirrors the real
+	// PR7 finding. Threshold 20%.
+	aware := BLISAggregate{TTFTMs: 160, OutputThroughput: 1150}
+	rep := CompareAdapterReference(ref, aware, nil, 0.20)
+	byName := map[string]AdapterMetricComparison{}
+	for _, m := range rep.Metrics {
+		byName[m.Metric] = m
+	}
+	if byName["ttft"].Within {
+		t.Errorf("ttft MAPE %.3f should exceed 0.20 (base mismatch)", byName["ttft"].MAPE)
+	}
+	if !byName["throughput"].Within {
+		t.Errorf("throughput MAPE %.3f should be within 0.20", byName["throughput"].MAPE)
+	}
+	if rep.AllWithin {
+		t.Error("AllWithin must be false when ttft exceeds threshold (no silent pass)")
+	}
+}
+
+func TestCompareAdapterReference_DeltaNormalizedDiagnostic(t *testing.T) {
+	ref := &DTReference{
+		Model:        "m",
+		AdapterAware: DTAggregate{TTFTMs: 1000, OutputThroughput: 90},
+		AdapterBlind: DTAggregate{TTFTMs: 500, OutputThroughput: 100}, // DT tput ratio 0.90
+	}
+	aware := BLISAggregate{TTFTMs: 200, OutputThroughput: 90}
+	blind := &BLISAggregate{TTFTMs: 100, OutputThroughput: 100} // BLIS tput ratio 0.90 → delta 0%
+	rep := CompareAdapterReference(ref, aware, blind, 0.20)
+	var tput AdapterMetricComparison
+	for _, m := range rep.Metrics {
+		if m.Metric == "throughput" {
+			tput = m
+		}
+	}
+	if tput.DeltaMAPE == nil {
+		t.Fatal("delta-normalized MAPE should be populated when blind aggregate is provided")
+	}
+	if *tput.DeltaMAPE > 1e-9 {
+		t.Errorf("throughput delta MAPE = %v, want ~0 (both ratios 0.90)", *tput.DeltaMAPE)
+	}
+}

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -3,6 +3,8 @@ package workload
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
 )
 
 func TestLoadTraceV2Requests_CorrectTokenCounts(t *testing.T) {
@@ -56,6 +58,62 @@ func TestLoadTraceV2Requests_CorrectTokenCounts(t *testing.T) {
 	}
 	if requests[1].MaxOutputLen != len(requests[1].OutputTokens) {
 		t.Errorf("request 1 MaxOutputLen = %d, want %d", requests[1].MaxOutputLen, len(requests[1].OutputTokens))
+	}
+}
+
+// TestRunReplayParity_Adapter_INV13 (#1470, T044) verifies the full run→replay
+// adapter round-trip that INV-13 (per-adapter metric parity) rests on: a request's
+// adapter id survives Request → RequestsToTraceRecords → Export/Load →
+// LoadTraceV2Requests unchanged. Without adapter round-tripping through TraceV2, an
+// adapter-blind replay of a LoRA trace would silently attribute those requests to
+// the base model and per-adapter metrics would diverge.
+func TestRunReplayParity_Adapter_INV13(t *testing.T) {
+	// Build requests as `blis run` would produce them, carrying adapter ids.
+	orig := []*sim.Request{
+		{ID: "request_0", ArrivalTime: 0, InputTokens: make([]sim.TokenID, 100),
+			OutputTokens: make([]sim.TokenID, 50), State: sim.StateCompleted, Adapter: "adapter_0"},
+		{ID: "request_1", ArrivalTime: 1000, InputTokens: make([]sim.TokenID, 80),
+			OutputTokens: make([]sim.TokenID, 40), State: sim.StateCompleted, Adapter: ""},
+		{ID: "request_2", ArrivalTime: 2000, InputTokens: make([]sim.TokenID, 120),
+			OutputTokens: make([]sim.TokenID, 60), State: sim.StateCompleted, Adapter: "adapter_7"},
+	}
+	// Mark TTFT so timing fields are emitted (mimics a completed run).
+	for _, r := range orig {
+		r.TTFTSet = true
+		r.FirstTokenTime = 500
+		r.ITL = []int64{10, 10}
+	}
+
+	records := RequestsToTraceRecords(orig)
+	for i, want := range []string{"adapter_0", "", "adapter_7"} {
+		if records[i].Adapter != want {
+			t.Fatalf("record %d Adapter = %q, want %q (request→record mapping)", i, records[i].Adapter, want)
+		}
+	}
+
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+	header := &TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "generated"}
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	trace, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := LoadTraceV2Requests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(replayed) != len(orig) {
+		t.Fatalf("replayed %d requests, want %d", len(replayed), len(orig))
+	}
+	// INV-13 mechanism: adapter id survives the full cycle for every request.
+	for i, r := range replayed {
+		if r.Adapter != orig[i].Adapter {
+			t.Errorf("request %d Adapter = %q after replay, want %q (INV-13 adapter round-trip)", i, r.Adapter, orig[i].Adapter)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1470. US5 + Phase-8 polish — the final PR in the LoRA control-plane stack (epic #1464). **Rebased onto merged `main`** (PR6/#1481 merged): the branch is now two clean commits (`53045dea` feature + `f7ef8e7c` docs) with no lower-stack noise.

Also folds in one orphaned PR6 review-completeness change that landed after #1481 had already merged: `TestAllScorers_ReturnScoreForEveryInstance` now includes the `lora-affinity` scorer in its coverage table, with a `ResidentAdapters` fixture + adapter-carrying request so the scorer's min-max normalization branch is exercised alongside the others (`sim/routing_scorers_test.go`, +8/-3; behavior unchanged, test-only).

## What

**Fidelity comparison vs the Agullo Digital Twin (T041–T043).** `blis calibrate --adapter-reference <dt.json>` runs a standalone per-config BLIS-vs-DT comparison on **TTFT and output throughput**, reporting per-metric MAPE against `--adapter-mape-threshold` (default 0.20). `--sim-metrics` is the BLIS aggregate (`blis run --metrics-path`); optional `--sim-metrics-blind` adds a delta-normalized (aware ÷ blind) diagnostic that cancels the base and isolates the ported adapter physics. Pure loader + comparator in `sim/workload/adapter_reference.go`; a zero DT denominator yields MAPE=+∞ (out-of-threshold, never a silent pass). Real DT fixtures (from the GPULLM fork) + BLIS aggregate fixtures are committed under `cmd/testdata/dt-reference/`, both over the **identical seeded arrival stream**.

**Adapter trace round-trip (T044, INV-13).** `TraceRecord` gains a trailing conditional `adapter` CSV column (absent for adapter-free traces → byte-identical to the pre-LoRA format, INV-6), threaded through `RequestsToTraceRecords`, `LoadTraceV2`, and all replay request builders. This was previously missing, so run→replay silently dropped per-request adapter ids.

**Determinism (T045, INV-6/SC-006):** byte-identity across two runs of an active adapter workload (M>N, co-arrivals + repeated adapter to exercise tie paths).

Also: `model_configs/llama-3.1-8b-instruct/config.json` (trained-physics is cross-model, no per-model calibration); CLAUDE.md valid-scorer list (+`lora-affinity`) and LoRA/fidelity notes; `.gitignore` negation for the committed fixtures.

## Finding (honest scoping, design §15 falsification path)

| Metric | qwen-2.5-7b | llama-3.1-8b | SC-007 (≤20%) |
|---|--:|--:|:--:|
| **throughput** (compute-overhead term, D4) | 14.2% | 14.4% | ✅ validated |
| **TTFT** | 98.5% | 97.2% | ❌ **unsupported** |

TTFT diverges exactly as the "port deltas onto a *separately-calibrated* base" premise (§6) predicts: BLIS's trained-physics base is ~100× faster than the DT's H100 base fit (BLIS blind TTFT ≈26 ms vs DT ≈3250 ms), and the DT's large absolute TTFT is queueing amplification BLIS's faster base never enters. TTFT is also the DT's own weakest axis (~17–21% SMAPE vs real; throughput ~5%). The **mechanism ships regardless**; the TTFT fidelity claim is withheld, not silently passed. **Caveat:** the canonical DT workload does not saturate BLIS, so the throughput agreement partly reflects both tracking offered load — a saturating-workload D4 validation is future work.

## Test / gate

`go build ./...`, `go test ./...` (exit 0), and `golangci-lint run` on the changed files: all clean. Reviewed with the adversarial code-review pass (no correctness bugs; one silent-degradation finding fixed — warn when the delta-normalized diagnostic can't be computed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
