### PR TITLE
feat(workload): session_context_growth header drives accumulate replay (PR-A of #1477)

### DIFF
--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -185,6 +185,9 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	var requests []*sim.Request
 	var blueprints []SessionBlueprint
 
+	// Growth mode from header (design §5): "accumulate" → strict growing prefix.
+	contextGrowth := trace.Header.SessionContextGrowth
+
 	for _, sessionID := range sessionOrder {
 		sr := sessionMap[sessionID]
 		rounds := sr.records
@@ -268,6 +271,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			SessionID:        sessionID,
 			ClientID:         r0.ClientID,
 			MaxRounds:        len(rounds),
+			ContextGrowth:    contextGrowth,
 			ThinkTimeSampler: sessionThinkTimeSampler,
 			Horizon:          horizon,
 			InputSampler:     &SequenceSampler{values: inputSeq[1:]},  // rounds 1..N

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -118,6 +118,14 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 // carries a recorded think_time_us (#1478). Round 0 has no predecessor, so its think
 // time is meaningless and ignored. When true, closed-loop replay prefers the recorded
 // per-round think time over arrival-gap derivation.
+//
+// LOSSY SENTINEL (F1, #1484 review): a value of 0 means "not recorded", so a session
+// whose every round has a genuinely-zero recorded think time (real for Weka's
+// overlap-clamped rounds) reads as false here and falls back to the arrival-gap path
+// — which bundles service time into the gap (see the gap-derivation note below), the
+// very effect think_time_us exists to avoid. The impact is bounded (a ~0 recorded
+// think replaced by the recorded arrival gap); a non-lossy encoding is deferred to the
+// Weka converter (#1604). Pinned by TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap.
 func sessionHasRecordedThinkTime(rounds []TraceRecord) bool {
 	for i := 1; i < len(rounds); i++ {
 		if rounds[i].ThinkTimeUs != 0 {

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -200,7 +200,13 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	var blueprints []SessionBlueprint
 
 	// Growth mode from header (design §5): "accumulate" → strict growing prefix.
+	// Validate up front: an unrecognized value (e.g. a typo like "Accumulate") would
+	// otherwise fall through to the non-accumulate branch silently, disabling the
+	// feature with no feedback — an operator footgun. Fail loudly instead (R1).
 	contextGrowth := trace.Header.SessionContextGrowth
+	if contextGrowth != "" && contextGrowth != "accumulate" {
+		return nil, nil, fmt.Errorf("session_context_growth: unknown value %q (valid: \"accumulate\" or empty)", contextGrowth)
+	}
 
 	for _, sessionID := range sessionOrder {
 		sr := sessionMap[sessionID]

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -114,6 +114,19 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 	return requests, nil
 }
 
+// sessionHasRecordedThinkTime reports whether any non-round-0 record in a session
+// carries a recorded think_time_us (#1478). Round 0 has no predecessor, so its think
+// time is meaningless and ignored. When true, closed-loop replay prefers the recorded
+// per-round think time over arrival-gap derivation.
+func sessionHasRecordedThinkTime(rounds []TraceRecord) bool {
+	for i := 1; i < len(rounds); i++ {
+		if rounds[i].ThinkTimeUs != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // LoadTraceV2SessionBlueprints groups trace records by session and builds
 // SessionBlueprints with SequenceSamplers for deterministic token replay.
 // Returns round-0 requests (plus all non-session requests) for initial injection,
@@ -204,11 +217,29 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			outputSeq[i] = rec.OutputTokens
 		}
 
-		// Build think time: use provided sampler or derive from inter-round arrival gaps.
+		// Build think time. Precedence (#1478):
+		//   1. caller-provided sampler (CLI --think-time-dist / --think-time-ms)
+		//   2. recorded per-round think_time_us column (set by agentic-trace converters):
+		//      pure client think time, decoupled from inference — preferred over the
+		//      arrival-gap derivation, which bundles service time into the gap
+		//   3. inter-round arrival gaps (existing default; NOT pure client think time)
 		var sessionThinkTimeSampler LengthSampler
-		if thinkTimeSampler != nil {
+		switch {
+		case thinkTimeSampler != nil:
 			sessionThinkTimeSampler = thinkTimeSampler // stateless: safe to share across sessions
-		} else if len(rounds) > 1 {
+		case sessionHasRecordedThinkTime(rounds):
+			// think_time_us on round i is the recorded gap BEFORE round i (from round
+			// i-1's end). Round 0 carries no think; rounds 1..N supply the sequence.
+			thinkTimes := make([]int, len(rounds)-1)
+			for i := 1; i < len(rounds); i++ {
+				t := rounds[i].ThinkTimeUs
+				if t < 0 {
+					t = 0 // defensive; LoadTraceV2 already rejects negatives (INV-3)
+				}
+				thinkTimes[i-1] = int(t)
+			}
+			sessionThinkTimeSampler = &SequenceSampler{values: thinkTimes}
+		case len(rounds) > 1:
 			thinkTimes := make([]int, len(rounds)-1)
 			for i := 1; i < len(rounds); i++ {
 				gap := rounds[i].ArrivalTimeUs - rounds[i-1].ArrivalTimeUs

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -186,6 +186,9 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	var requests []*sim.Request
 	var blueprints []SessionBlueprint
 
+	// Growth mode from header (design §5): "accumulate" → strict growing prefix.
+	contextGrowth := trace.Header.SessionContextGrowth
+
 	for _, sessionID := range sessionOrder {
 		sr := sessionMap[sessionID]
 		rounds := sr.records
@@ -270,6 +273,7 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			SessionID:        sessionID,
 			ClientID:         r0.ClientID,
 			MaxRounds:        len(rounds),
+			ContextGrowth:    contextGrowth,
 			ThinkTimeSampler: sessionThinkTimeSampler,
 			Horizon:          horizon,
 			InputSampler:     &SequenceSampler{values: inputSeq[1:]},  // rounds 1..N

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -3,6 +3,8 @@ package workload
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
 )
 
 func TestLoadTraceV2Requests_CorrectTokenCounts(t *testing.T) {
@@ -805,5 +807,87 @@ func TestLoadTraceV2SessionBlueprints_NegativeSendTime(t *testing.T) {
 	// Non-session: must use ArrivalTimeUs (20000), not SendTimeUs (-100).
 	if nonSessionArrival != 20000 {
 		t.Errorf("non-session: ArrivalTime = %d, want 20000 (negative send_time must fall back)", nonSessionArrival)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_AccumulateFromHeader(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(bps) != 1 {
+		t.Fatalf("got %d blueprints, want 1", len(bps))
+	}
+	if bps[0].ContextGrowth != "accumulate" {
+		t.Errorf("ContextGrowth = %q, want accumulate", bps[0].ContextGrowth)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_DefaultNoAccumulate(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}, // no growth field
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if bps[0].ContextGrowth != "" {
+		t.Errorf("ContextGrowth = %q, want empty (unchanged default)", bps[0].ContextGrowth)
+	}
+}
+
+func TestAccumulateReplay_StrictPrefixIdentity(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sm := NewSessionManager(bps)
+
+	// Round 0 input = 100 tokens (no prefix group).
+	round0 := r0[0]
+	if round0.InputLen() != 100 {
+		t.Fatalf("round0 input len = %d, want 100", round0.InputLen())
+	}
+	// Simulate round 0 completing: mark completed with full output generated so
+	// ProgressIndex - InputLen == actual output (accumulate uses actual output).
+	round0.State = sim.StateCompleted
+	round0.ProgressIndex = int64(round0.InputLen()) + 10 // 10 output tokens generated
+
+	// Capture round 0's input token IDs before follow-up assembly.
+	prefix := append([]sim.TokenID{}, round0.FullInputTokens()...)
+
+	followUps := sm.OnComplete(round0, 8_000_000)
+	if len(followUps) != 1 {
+		t.Fatalf("got %d follow-ups, want 1", len(followUps))
+	}
+	round1 := followUps[0]
+	// Round 1 total input = round0(100) + round0 output(10) + delta(40) = 150.
+	if round1.InputLen() != 150 {
+		t.Fatalf("round1 input len = %d, want 150", round1.InputLen())
+	}
+	// STRICT prefix identity: round1's first 100 tokens are byte-identical to round0's input.
+	got := round1.FullInputTokens()
+	for i := 0; i < 100; i++ {
+		if got[i] != prefix[i] {
+			t.Fatalf("round1 token[%d]=%d != round0 token[%d]=%d — prefix not strictly identical", i, got[i], i, prefix[i])
+		}
 	}
 }

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -312,6 +312,56 @@ func TestLoadTraceV2SessionBlueprints_OverrideThinkTime(t *testing.T) {
 	}
 }
 
+func TestLoadTraceV2SessionBlueprints_PrefersRecordedThinkTime(t *testing.T) {
+	// GIVEN a 3-round session whose recorded think_time_us (300, 400) DIFFERS from
+	// its inter-round arrival gaps (5000, 7000)
+	// WHEN blueprints are built with no caller sampler
+	// THEN the think sampler yields the RECORDED think times, not the arrival gaps
+	// (#1478: recorded per-round think time is pure client think, preferred over the
+	// gap derivation which bundles service time).
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: 300},
+			{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 300, OutputTokens: 90, ArrivalTimeUs: 12000, ThinkTimeUs: 400},
+		},
+	}
+
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bp := blueprints[0]
+	if bp.ThinkTimeSampler == nil {
+		t.Fatal("expected ThinkTimeSampler to be set")
+	}
+	got1 := bp.ThinkTimeSampler.Sample(nil)
+	got2 := bp.ThinkTimeSampler.Sample(nil)
+	if got1 != 300 || got2 != 400 {
+		t.Errorf("think times = [%d, %d], want recorded [300, 400] (not arrival gaps [5000, 7000])", got1, got2)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_RecordedThinkTime_CLIOverrides(t *testing.T) {
+	// GIVEN a session with recorded think_time_us AND a caller-provided sampler
+	// WHEN blueprints are built
+	// THEN the caller sampler wins (#1478 precedence: CLI > recorded > gap).
+	trace := &TraceV2{
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: 300},
+		},
+	}
+	sampler := &ConstantSampler{value: 500_000}
+	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, sampler, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := blueprints[0].ThinkTimeSampler.Sample(nil); got != 500_000 {
+		t.Errorf("ThinkTimeSampler.Sample() = %d, want 500000 (CLI sampler overrides recorded think_time_us)", got)
+	}
+}
+
 func TestLoadTraceV2SessionBlueprints_NonMonotoneGapClamped(t *testing.T) {
 	// GIVEN a 2-round session where round-1 has an earlier arrival than round-0
 	// (clock skew in observed trace), THEN ThinkTimeSampler returns 0 (not negative),
@@ -358,11 +408,11 @@ func TestLoadTraceV2SessionBlueprints_NonConsecutiveRoundIndex_Error(t *testing.
 
 func TestEffectiveInputTokenCount(t *testing.T) {
 	cases := []struct {
-		name             string
-		inputTokens      int
-		serverTokens     int
-		prefixGroup      string
-		want             int
+		name         string
+		inputTokens  int
+		serverTokens int
+		prefixGroup  string
+		want         int
 	}{
 		// Server > client, no prefix: use server (chat-template overhead case)
 		{"server_overrides_client", 512, 530, "", 530},
@@ -436,7 +486,7 @@ func TestLoadTraceV2Requests_ServerInputTokens_PrefixGroup_FallsBackToInputToken
 		Records: []TraceRecord{
 			{RequestID: 0, InputTokens: 100, PrefixGroup: "shared", PrefixLength: 128,
 				ServerInputTokens: 246, // = PrefixLength(128) + InputTokens(100) + overhead(18)
-				OutputTokens: 32, ArrivalTimeUs: 0, Status: "ok"},
+				OutputTokens:      32, ArrivalTimeUs: 0, Status: "ok"},
 		},
 	}
 	requests, err := LoadTraceV2Requests(trace, 42)
@@ -569,7 +619,7 @@ func TestLoadTraceV2SessionBlueprints_ServerInputTokens_Sampler_PrefixGroup_Fall
 			{RequestID: 2, SessionID: "A", RoundIndex: 1,
 				InputTokens: 50, PrefixGroup: "shared", PrefixLength: 64,
 				ServerInputTokens: 132, // = PrefixLength(64) + InputTokens(50) + overhead(18)
-				OutputTokens: 16, ArrivalTimeUs: 5000},
+				OutputTokens:      16, ArrivalTimeUs: 5000},
 		},
 	}
 	_, blueprints, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
@@ -626,8 +676,8 @@ func TestLoadTraceV2Requests_ModelAndDeadline(t *testing.T) {
 		},
 		{
 			RequestID:         1,
-			Model:             "",  // BC-6: empty = default model
-			DeadlineUs:        0,   // BC-5: no timeout
+			Model:             "", // BC-6: empty = default model
+			DeadlineUs:        0,  // BC-5: no timeout
 			ServerInputTokens: 0,
 			InputTokens:       50,
 			OutputTokens:      25,

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -865,3 +865,85 @@ func TestLoadTraceV2SessionBlueprints_NegativeSendTime(t *testing.T) {
 		t.Errorf("non-session: ArrivalTime = %d, want 20000 (negative send_time must fall back)", nonSessionArrival)
 	}
 }
+
+func TestLoadTraceV2SessionBlueprints_AccumulateFromHeader(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(bps) != 1 {
+		t.Fatalf("got %d blueprints, want 1", len(bps))
+	}
+	if bps[0].ContextGrowth != "accumulate" {
+		t.Errorf("ContextGrowth = %q, want accumulate", bps[0].ContextGrowth)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_DefaultNoAccumulate(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}, // no growth field
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if bps[0].ContextGrowth != "" {
+		t.Errorf("ContextGrowth = %q, want empty (unchanged default)", bps[0].ContextGrowth)
+	}
+}
+
+func TestAccumulateReplay_StrictPrefixIdentity(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 8_000_000},
+		},
+	}
+	r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sm := NewSessionManager(bps)
+
+	// Round 0 input = 100 tokens (no prefix group).
+	round0 := r0[0]
+	if round0.InputLen() != 100 {
+		t.Fatalf("round0 input len = %d, want 100", round0.InputLen())
+	}
+	// Simulate round 0 completing: mark completed with full output generated so
+	// ProgressIndex - InputLen == actual output (accumulate uses actual output).
+	round0.State = sim.StateCompleted
+	round0.ProgressIndex = int64(round0.InputLen()) + 10 // 10 output tokens generated
+
+	// Capture round 0's input token IDs before follow-up assembly.
+	prefix := append([]sim.TokenID{}, round0.FullInputTokens()...)
+
+	followUps := sm.OnComplete(round0, 8_000_000)
+	if len(followUps) != 1 {
+		t.Fatalf("got %d follow-ups, want 1", len(followUps))
+	}
+	round1 := followUps[0]
+	// Round 1 total input = round0(100) + round0 output(10) + delta(40) = 150.
+	if round1.InputLen() != 150 {
+		t.Fatalf("round1 input len = %d, want 150", round1.InputLen())
+	}
+	// STRICT prefix identity: round1's first 100 tokens are byte-identical to round0's input.
+	got := round1.FullInputTokens()
+	for i := 0; i < 100; i++ {
+		if got[i] != prefix[i] {
+			t.Fatalf("round1 token[%d]=%d != round0 token[%d]=%d — prefix not strictly identical", i, got[i], i, prefix[i])
+		}
+	}
+}

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -913,6 +914,22 @@ func TestLoadTraceV2SessionBlueprints_NegativeSendTime(t *testing.T) {
 	// Non-session: must use ArrivalTimeUs (20000), not SendTimeUs (-100).
 	if nonSessionArrival != 20000 {
 		t.Errorf("non-session: ArrivalTime = %d, want 20000 (negative send_time must fall back)", nonSessionArrival)
+	}
+}
+
+func TestLoadTraceV2SessionBlueprints_UnknownContextGrowth_Errors(t *testing.T) {
+	// A typo'd session_context_growth (e.g. wrong case) must fail loudly rather than
+	// silently falling through to the non-accumulate branch and disabling the feature.
+	trace := &TraceV2{
+		Header: TraceHeader{SessionContextGrowth: "Accumulate"}, // wrong case
+		Records: []TraceRecord{
+			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40},
+		},
+	}
+	_, _, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "session_context_growth") {
+		t.Errorf("expected error for unknown session_context_growth, got %v", err)
 	}
 }
 

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -1014,3 +1014,120 @@ func TestAccumulateReplay_StrictPrefixIdentity(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap pins the
+// F1 lossy-sentinel behavior (#1484 review): a session whose every round records
+// think_time_us == 0 (real for Weka's overlap-clamped rounds) is indistinguishable
+// from an absent column, so it falls back to arrival-gap derivation.
+func TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap(t *testing.T) {
+	trace := &TraceV2{Records: []TraceRecord{
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: 0},
+		{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ArrivalTimeUs: 12000, ThinkTimeUs: 0},
+	}}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s := bps[0].ThinkTimeSampler
+	if s == nil {
+		t.Fatal("expected a think sampler for a multi-round session")
+	}
+	// Falls back to arrival gaps [5000, 7000], NOT the recorded zeros.
+	if g1, g2 := s.Sample(nil), s.Sample(nil); g1 != 5000 || g2 != 7000 {
+		t.Errorf("all-zero recorded think: sampler = [%d, %d], want arrival gaps [5000, 7000] (documented lossy-sentinel fallback)", g1, g2)
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_MixedThinkSessions covers F4 (#1484 review): the
+// export gate (includeThinkTime) is global, but think-time selection is per-session,
+// so a trace mixing a recorded-think session with an all-zero one must select each
+// independently — A uses its recorded think, B falls back to arrival gaps.
+func TestLoadTraceV2SessionBlueprints_MixedThinkSessions(t *testing.T) {
+	trace := &TraceV2{Records: []TraceRecord{
+		// A: recorded think 300; arrival gap (9999) deliberately differs so the two are distinguishable.
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 9999, ThinkTimeUs: 300},
+		// B: all-zero recorded think; arrival gap 5000.
+		{RequestID: 4, SessionID: "B", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
+		{RequestID: 5, SessionID: "B", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: 0},
+	}}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	byID := map[string]*SessionBlueprint{}
+	for i := range bps {
+		byID[bps[i].SessionID] = &bps[i]
+	}
+	if got := byID["A"].ThinkTimeSampler.Sample(nil); got != 300 {
+		t.Errorf("session A think = %d, want recorded 300", got)
+	}
+	if got := byID["B"].ThinkTimeSampler.Sample(nil); got != 5000 {
+		t.Errorf("session B think = %d, want arrival gap 5000 (all-zero fallback)", got)
+	}
+}
+
+// TestAccumulateReplay_TransitivityAndLengthCap covers F3 (#1484 review): 3+ round
+// transitivity — round 2's prefix is byte-identical to round 1's FULL input as the
+// accumulate buffer keeps growing (which also verifies round 1's interior segment
+// flows forward unchanged) — plus the length-capped path (actual output < recorded
+// output shrinks the appended segment).
+func TestAccumulateReplay_TransitivityAndLengthCap(t *testing.T) {
+	mk := func() (*sim.Request, *SessionManager) {
+		trace := &TraceV2{
+			Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+			Records: []TraceRecord{
+				{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+				{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 1_000_000},
+				{RequestID: 2, SessionID: "s", RoundIndex: 2, InputTokens: 25, OutputTokens: 5, ArrivalTimeUs: 2_000_000},
+			},
+		}
+		r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		return r0[0], NewSessionManager(bps)
+	}
+	next := func(sm *SessionManager, req *sim.Request, tick int64) *sim.Request {
+		fu := sm.OnComplete(req, tick)
+		if len(fu) != 1 {
+			t.Fatalf("expected 1 follow-up, got %d", len(fu))
+		}
+		return fu[0]
+	}
+
+	t.Run("full-output transitivity", func(t *testing.T) {
+		round0, sm := mk()
+		round0.State = sim.StateCompleted
+		round0.ProgressIndex = int64(round0.InputLen()) + 10 // full 10 output tokens
+		round1 := next(sm, round0, 1_000_000)
+		if round1.InputLen() != 150 { // 100 + 10 output + 40 delta
+			t.Fatalf("round1 len = %d, want 150", round1.InputLen())
+		}
+		round1In := append([]sim.TokenID{}, round1.FullInputTokens()...)
+		round1.State = sim.StateCompleted
+		round1.ProgressIndex = int64(round1.InputLen()) + 20
+		round2 := next(sm, round1, 2_000_000)
+		if round2.InputLen() != 195 { // 150 + 20 output + 25 delta
+			t.Fatalf("round2 len = %d, want 195", round2.InputLen())
+		}
+		r2 := round2.FullInputTokens()
+		for i := 0; i < 150; i++ {
+			if r2[i] != round1In[i] {
+				t.Fatalf("round2 token[%d] diverged from round1 full input — transitivity/interior broken", i)
+			}
+		}
+	})
+
+	t.Run("length-capped output", func(t *testing.T) {
+		round0, sm := mk()
+		round0.State = sim.StateCompleted
+		round0.ProgressIndex = int64(round0.InputLen()) + 5 // only 5 of the 10 output tokens generated
+		round1 := next(sm, round0, 1_000_000)
+		// Appended segment tracks ACTUAL output, not the recorded count: 100 + 5 + 40 = 145.
+		if round1.InputLen() != 145 {
+			t.Errorf("length-capped round1 len = %d, want 145 (100 + actual-output 5 + delta 40)", round1.InputLen())
+		}
+	})
+}

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -28,6 +28,14 @@ type TraceHeader struct {
 	//   - empty (omitted) when distribution synthesis or concurrency mode is used
 	WorkloadSpec   string `yaml:"workload_spec,omitempty"`
 
+	// SessionContextGrowth controls per-round input assembly in closed-loop
+	// replay. "accumulate" makes each session reuse a single growing token
+	// buffer so round N+1's input is byte-identical to round N's plus new
+	// tokens (strict prefix reuse for KV-cache modeling; see design §5).
+	// Empty (default) = each round's input is generated independently
+	// (pre-existing behavior). Set by `blis convert otel`.
+	SessionContextGrowth string `yaml:"session_context_growth,omitempty"`
+
 	Server  *TraceServerConfig  `yaml:"server,omitempty"`
 	Network *TraceNetworkConfig `yaml:"network,omitempty"`
 	// GoodputSLOTargets: per-SLO-class TTFT/ITL/E2E thresholds for goodput

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -185,7 +185,7 @@ type TraceRecord struct {
 	FinishReason      string // server-reported finish_reason ("stop", "length", "abort", etc.); empty = not recorded
 	XRequestID        string // client-generated UUID sent as x-request-id header (real-mode only); empty = not recorded
 	Adapter           string // LoRA adapter id serving this request (registry key; #1464); empty = base-model-only
-	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end); 0 = not recorded. Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay.
+	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end). Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay. NOTE: 0 is a LOSSY SENTINEL for "not recorded" — a genuinely-zero recorded think time (e.g. Weka's overlap-clamped rounds) is indistinguishable from an absent column, so an all-zero session falls back to arrival-gap derivation. A non-lossy encoding (distinguishing recorded-0 from absent) is deferred to the Weka converter work (#1604).
 }
 
 // TraceV2 combines header and records for a complete trace.
@@ -473,8 +473,9 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 
 // parseTraceRecord parses a CSV row. Handles optional columns vllm_priority
 // (after slo_class), slo_target_us (after deadline_us), and the trailing
-// columns x_request_id and adapter. xRequestIDIdx and adapterIdx are absolute
-// column indices in the row, or -1 if the respective column is absent.
+// columns x_request_id, adapter, and think_time_us. xRequestIDIdx, adapterIdx,
+// and thinkTimeUsIdx are absolute column indices in the row, or -1 if the
+// respective column is absent.
 func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx, adapterIdx, thinkTimeUsIdx int) (*TraceRecord, error) {
 	// Column offset: optional columns shift subsequent indices.
 	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -26,7 +26,7 @@ type TraceHeader struct {
 	//   - a file path when --workload-spec is used (e.g. "workload.yaml")
 	//   - "preset:<name>" when --workload is used (e.g. "preset:chatbot")
 	//   - empty (omitted) when distribution synthesis or concurrency mode is used
-	WorkloadSpec   string `yaml:"workload_spec,omitempty"`
+	WorkloadSpec string `yaml:"workload_spec,omitempty"`
 
 	// SessionContextGrowth controls per-round input assembly in closed-loop
 	// replay. "accumulate" makes each session reuse a single growing token
@@ -138,13 +138,13 @@ type TraceKVOffloadTier struct {
 
 // TraceServerConfig captures server configuration in trace header.
 type TraceServerConfig struct {
-	Type                  string  `yaml:"type,omitempty"`
-	Model                 string  `yaml:"model,omitempty"`
-	TensorParallel        int     `yaml:"tensor_parallel,omitempty"`
-	MaxNumSeqs            int     `yaml:"max_num_seqs,omitempty"`
-	BlockSize             int     `yaml:"block_size,omitempty"`
-	GPUMemoryUtilization  float64 `yaml:"gpu_memory_utilization,omitempty"`
-	MaxModelLen           int64   `yaml:"max_model_len,omitempty"`
+	Type                 string  `yaml:"type,omitempty"`
+	Model                string  `yaml:"model,omitempty"`
+	TensorParallel       int     `yaml:"tensor_parallel,omitempty"`
+	MaxNumSeqs           int     `yaml:"max_num_seqs,omitempty"`
+	BlockSize            int     `yaml:"block_size,omitempty"`
+	GPUMemoryUtilization float64 `yaml:"gpu_memory_utilization,omitempty"`
+	MaxModelLen          int64   `yaml:"max_model_len,omitempty"`
 }
 
 // TraceNetworkConfig captures network configuration in trace header.
@@ -158,7 +158,7 @@ type TraceRecord struct {
 	ClientID          string
 	TenantID          string
 	SLOClass          string
-	VLLMPriority      int    // vLLM priority value (0=highest urgency, higher=lower urgency); 0 when not set
+	VLLMPriority      int // vLLM priority value (0=highest urgency, higher=lower urgency); 0 when not set
 	SessionID         string
 	RoundIndex        int
 	PrefixGroup       string
@@ -185,6 +185,7 @@ type TraceRecord struct {
 	FinishReason      string // server-reported finish_reason ("stop", "length", "abort", etc.); empty = not recorded
 	XRequestID        string // client-generated UUID sent as x-request-id header (real-mode only); empty = not recorded
 	Adapter           string // LoRA adapter id serving this request (registry key; #1464); empty = base-model-only
+	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end); 0 = not recorded. Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay.
 }
 
 // TraceV2 combines header and records for a complete trace.
@@ -260,6 +261,18 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		}
 	}
 
+	// Conditionally include think_time_us column (#1478): present iff any record carries
+	// a non-zero recorded think time. Trailing position (like x_request_id / adapter) keeps
+	// the positional parser's index math untouched. Omitted when no record has it, so
+	// existing traces (e.g. observe, generated) add no column (INV-6 byte-identity).
+	includeThinkTime := false
+	for _, r := range records {
+		if r.ThinkTimeUs != 0 {
+			includeThinkTime = true
+			break
+		}
+	}
+
 	// Conditionally include vllm_priority column: present iff priority was actually computed.
 	// Include when either:
 	// 1. Any record has non-zero priority (batch, standard, sheddable, background from observe)
@@ -295,6 +308,10 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 	// Append adapter at end (#1464): also trailing; parsed by header-position lookup.
 	if includeAdapter {
 		columns = append(columns, "adapter")
+	}
+	// Append think_time_us at end (#1478): also trailing; parsed by header-position lookup.
+	if includeThinkTime {
+		columns = append(columns, "think_time_us")
 	}
 
 	// Write header row
@@ -336,7 +353,7 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		}
 		row = append(row,
 			strconv.Itoa(r.ServerInputTokens),
-			strconv.FormatInt(r.ArrivalTimeUs, 10),   // integer format
+			strconv.FormatInt(r.ArrivalTimeUs, 10),    // integer format
 			strconv.FormatInt(r.SendTimeUs, 10),       // integer format
 			strconv.FormatInt(r.FirstChunkTimeUs, 10), // integer format
 			strconv.FormatInt(r.LastChunkTimeUs, 10),  // integer format
@@ -352,6 +369,10 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		// Append adapter at end (#1464).
 		if includeAdapter {
 			row = append(row, r.Adapter)
+		}
+		// Append think_time_us at end (#1478).
+		if includeThinkTime {
+			row = append(row, strconv.FormatInt(r.ThinkTimeUs, 10))
 		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("writing CSV row %d: %w", r.RequestID, err)
@@ -393,8 +414,9 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 	// Detect optional columns from header
 	hasVLLMPriority := false
 	hasSLOTarget := false
-	xRequestIDIdx := -1 // header-position lookup; -1 = absent (issue #1428)
-	adapterIdx := -1    // header-position lookup; -1 = absent (#1464)
+	xRequestIDIdx := -1  // header-position lookup; -1 = absent (issue #1428)
+	adapterIdx := -1     // header-position lookup; -1 = absent (#1464)
+	thinkTimeUsIdx := -1 // header-position lookup; -1 = absent (#1478)
 	for i, col := range headerRow {
 		switch col {
 		case "vllm_priority":
@@ -405,6 +427,8 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 			xRequestIDIdx = i
 		case "adapter":
 			adapterIdx = i
+		case "think_time_us":
+			thinkTimeUsIdx = i
 		}
 	}
 
@@ -430,11 +454,14 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 		if adapterIdx >= 0 {
 			minCols++
 		}
+		if thinkTimeUsIdx >= 0 {
+			minCols++
+		}
 		if len(row) < minCols {
 			return nil, fmt.Errorf("CSV row has %d columns, expected at least %d", len(row), minCols)
 		}
 
-		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget, xRequestIDIdx, adapterIdx)
+		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget, xRequestIDIdx, adapterIdx, thinkTimeUsIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -448,7 +475,7 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 // (after slo_class), slo_target_us (after deadline_us), and the trailing
 // columns x_request_id and adapter. xRequestIDIdx and adapterIdx are absolute
 // column indices in the row, or -1 if the respective column is absent.
-func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx, adapterIdx int) (*TraceRecord, error) {
+func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx, adapterIdx, thinkTimeUsIdx int) (*TraceRecord, error) {
 	// Column offset: optional columns shift subsequent indices.
 	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.
 	// slo_target_us appears after deadline_us → shifts everything after by +1.
@@ -613,6 +640,22 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequest
 		adapter = strings.TrimSpace(row[adapterIdx])
 	}
 
+	// Optional think_time_us at trailing column (#1478): looked up by absolute header
+	// position so the positional index math above is unaffected. Negative values are
+	// rejected — recorded think time cannot be negative (INV-3).
+	var thinkTimeUs int64
+	if thinkTimeUsIdx >= 0 && thinkTimeUsIdx < len(row) {
+		if v := strings.TrimSpace(row[thinkTimeUsIdx]); v != "" {
+			thinkTimeUs, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing think_time_us %q: %w", v, err)
+			}
+			if thinkTimeUs < 0 {
+				return nil, fmt.Errorf("parsing think_time_us: negative value %d not allowed", thinkTimeUs)
+			}
+		}
+	}
+
 	return &TraceRecord{
 		RequestID:         requestID,
 		ClientID:          row[1],
@@ -645,6 +688,7 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequest
 		FinishReason:      finishReason,
 		XRequestID:        xRequestID,
 		Adapter:           adapter,
+		ThinkTimeUs:       thinkTimeUs,
 	}, nil
 }
 
@@ -706,7 +750,7 @@ func RequestsToTraceRecords(requests []*sim.Request) []TraceRecord {
 			PrefixGroup:      req.PrefixGroup,
 			PrefixLength:     prefixLen,
 			Streaming:        req.Streaming,
-			InputTokens:      inputTokens,      // suffix-only: total - PrefixLength
+			InputTokens:      inputTokens,           // suffix-only: total - PrefixLength
 			OutputTokens:     len(req.OutputTokens), // pre-determined count for replay fidelity
 			TextTokens:       req.TextTokenCount,
 			ImageTokens:      req.ImageTokenCount,

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -313,7 +313,7 @@ func TestParseTraceRecord_InvalidInteger_ReturnsError(t *testing.T) {
 	}
 
 	// WHEN parsing
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -332,7 +332,7 @@ func TestParseTraceRecord_InvalidDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "not_a_number" // deadline_us column (shifted +1 by prefix_length)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric deadline_us, got nil")
@@ -350,7 +350,7 @@ func TestParseTraceRecord_InvalidServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "not_a_number" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric server_input_tokens, got nil")
@@ -370,7 +370,7 @@ func TestParseTraceRecord_InvalidVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "not_a_number" // vllm_priority column (index 4)
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false, -1, -1)
+	_, err := parseTraceRecord(row, true, false, -1, -1, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -391,7 +391,7 @@ func TestParseTraceRecord_NegativeVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "-1" // negative vllm_priority
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false, -1, -1)
+	_, err := parseTraceRecord(row, true, false, -1, -1, -1)
 
 	// THEN error about negative value
 	if err == nil {
@@ -413,7 +413,7 @@ func TestParseTraceRecord_NegativeDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "-1" // negative deadline_us (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative deadline_us, got nil")
@@ -432,7 +432,7 @@ func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[9] = "-1" // input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative input_tokens, got nil")
@@ -451,7 +451,7 @@ func TestParseTraceRecord_NegativeOutputTokens_ReturnsError(t *testing.T) {
 	}
 	row[10] = "-1" // output_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative output_tokens, got nil")
@@ -470,7 +470,7 @@ func TestParseTraceRecord_NegativeServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "-1" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative server_input_tokens, got nil")
@@ -490,7 +490,7 @@ func TestParseTraceRecord_DeadlineBeforeArrival_ReturnsError(t *testing.T) {
 	row[17] = "1000" // deadline_us = 1000 (shifted +1)
 	row[19] = "5000" // arrival_time_us = 5000 (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for deadline before arrival, got nil")
@@ -519,7 +519,7 @@ func TestParseTraceRecord_InvalidReasonRatio_ReturnsError(t *testing.T) {
 		}
 		row[15] = tc.value // reason_ratio column (shifted +1)
 
-		_, err := parseTraceRecord(row, false, false, -1, -1)
+		_, err := parseTraceRecord(row, false, false, -1, -1, -1)
 
 		if err == nil {
 			t.Errorf("reason_ratio=%q: expected error, got nil", tc.value)
@@ -619,8 +619,8 @@ func TestRequestMetadataFields(t *testing.T) {
 	req := &sim.Request{
 		ID:             "request_0",
 		State:          sim.StateCompleted,
-		InputTokens:  []sim.TokenID{1, 2, 3},
-		OutputTokens: []sim.TokenID{4, 5},
+		InputTokens:    []sim.TokenID{1, 2, 3},
+		OutputTokens:   []sim.TokenID{4, 5},
 		ArrivalTime:    1000,
 		TTFTSet:        true,
 		FirstTokenTime: 500,
@@ -1129,6 +1129,81 @@ func TestTraceRecord_VLLMPriority_FieldExists(t *testing.T) {
 	}
 }
 
+func TestTraceV2_ThinkTimeUs_RoundTrip(t *testing.T) {
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+
+	t.Run("present: value round-trips and column is emitted", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: 0},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ThinkTimeUs: 5000},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		data, _ := os.ReadFile(dataPath)
+		if !strings.Contains(string(data), "think_time_us") {
+			t.Error("think_time_us column missing from CSV when a record carries it")
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[0].ThinkTimeUs != 0 || loaded.Records[1].ThinkTimeUs != 5000 {
+			t.Errorf("ThinkTimeUs round-trip = [%d, %d], want [0, 5000]", loaded.Records[0].ThinkTimeUs, loaded.Records[1].ThinkTimeUs)
+		}
+	})
+
+	t.Run("absent: no column when no record carries it (INV-6 byte-identity)", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		data, _ := os.ReadFile(dataPath)
+		if strings.Contains(string(data), "think_time_us") {
+			t.Error("think_time_us column emitted when no record carries it (must be omitted, INV-6)")
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[1].ThinkTimeUs != 0 {
+			t.Errorf("absent column: ThinkTimeUs = %d, want 0", loaded.Records[1].ThinkTimeUs)
+		}
+	})
+}
+
+func TestParseTraceRecord_NegativeThinkTime_Errors(t *testing.T) {
+	// A think_time_us column carrying a negative value must be rejected (INV-3:
+	// recorded client think time cannot be negative).
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: 5000},
+	}
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+	data, _ := os.ReadFile(dataPath)
+	corrupt := strings.Replace(string(data), "5000", "-5000", 1)
+	if err := os.WriteFile(dataPath, []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadTraceV2(headerPath, dataPath); err == nil || !strings.Contains(err.Error(), "think_time_us") {
+		t.Errorf("expected negative think_time_us to error, got %v", err)
+	}
+}
+
 func TestExportTraceV2_VLLMPriority_ConditionalColumn(t *testing.T) {
 	// BC-3: vllm_priority column included only when priority was actually computed.
 	// Distinguishes between:
@@ -1544,46 +1619,46 @@ func TestTraceV2_SLOTargetUs_WithVLLMPriority_DoubleOffset(t *testing.T) {
 func TestTraceRecordsToRequestMetrics_UnitsAndFiltering(t *testing.T) {
 	records := []TraceRecord{
 		{
-			RequestID:        1,
-			Status:           "ok",
-			ArrivalTimeUs:    1000000, // 1 second in microseconds
-			SendTimeUs:       1000000,
-			LastChunkTimeUs:  1150000, // E2E = 150ms
+			RequestID:       1,
+			Status:          "ok",
+			ArrivalTimeUs:   1000000, // 1 second in microseconds
+			SendTimeUs:      1000000,
+			LastChunkTimeUs: 1150000, // E2E = 150ms
 		},
 		{
-			RequestID:        2,
-			Status:           "timeout",
-			ArrivalTimeUs:    2000000,
-			SendTimeUs:       2000000,
-			LastChunkTimeUs:  2100000,
+			RequestID:       2,
+			Status:          "timeout",
+			ArrivalTimeUs:   2000000,
+			SendTimeUs:      2000000,
+			LastChunkTimeUs: 2100000,
 		},
 		{
-			RequestID:        3,
-			Status:           "ok",
-			ArrivalTimeUs:    3000000, // 3 seconds in microseconds
-			SendTimeUs:       3000000,
-			LastChunkTimeUs:  3200000, // E2E = 200ms
+			RequestID:       3,
+			Status:          "ok",
+			ArrivalTimeUs:   3000000, // 3 seconds in microseconds
+			SendTimeUs:      3000000,
+			LastChunkTimeUs: 3200000, // E2E = 200ms
 		},
 		{
-			RequestID:        4,
-			Status:           "error",
-			ArrivalTimeUs:    4000000,
-			SendTimeUs:       4000000,
-			LastChunkTimeUs:  4050000,
+			RequestID:       4,
+			Status:          "error",
+			ArrivalTimeUs:   4000000,
+			SendTimeUs:      4000000,
+			LastChunkTimeUs: 4050000,
 		},
 		{
-			RequestID:        5,
-			Status:           "ok",
-			ArrivalTimeUs:    5000000,
-			SendTimeUs:       5000000,
-			LastChunkTimeUs:  5000000, // E2E = 0 (clock skew or malformed)
+			RequestID:       5,
+			Status:          "ok",
+			ArrivalTimeUs:   5000000,
+			SendTimeUs:      5000000,
+			LastChunkTimeUs: 5000000, // E2E = 0 (clock skew or malformed)
 		},
 		{
-			RequestID:        6,
-			Status:           "ok",
-			ArrivalTimeUs:    6000000,
-			SendTimeUs:       6100000,
-			LastChunkTimeUs:  6050000, // E2E < 0 (clock skew)
+			RequestID:       6,
+			Status:          "ok",
+			ArrivalTimeUs:   6000000,
+			SendTimeUs:      6100000,
+			LastChunkTimeUs: 6050000, // E2E < 0 (clock skew)
 		},
 	}
 
@@ -1658,12 +1733,12 @@ func TestTraceRecordsToRequestMetrics_RateDeficitSemantics(t *testing.T) {
 	// The rate_deficit formula depends on this distinction:
 	// rate_deficit = 1 - (completions / totalArrivals)
 	// If caller passes len(metrics) instead of len(records), the deficit is understated.
-	completions := len(metrics)             // 2
-	totalArrivalsCorrect := len(records)    // 4
-	totalArrivalsWrong := len(metrics)      // 2
+	completions := len(metrics)          // 2
+	totalArrivalsCorrect := len(records) // 4
+	totalArrivalsWrong := len(metrics)   // 2
 
-	rateDeficitCorrect := 1.0 - float64(completions)/float64(totalArrivalsCorrect)   // 1 - 2/4 = 0.5
-	rateDeficitWrong := 1.0 - float64(completions)/float64(totalArrivalsWrong)       // 1 - 2/2 = 0.0
+	rateDeficitCorrect := 1.0 - float64(completions)/float64(totalArrivalsCorrect) // 1 - 2/4 = 0.5
+	rateDeficitWrong := 1.0 - float64(completions)/float64(totalArrivalsWrong)     // 1 - 2/2 = 0.0
 
 	if rateDeficitCorrect != 0.5 {
 		t.Errorf("With totalArrivals=4: rate_deficit = %f, want 0.5", rateDeficitCorrect)
@@ -1955,7 +2030,7 @@ func TestTraceV2_RoundTrip_WithKVOffload(t *testing.T) {
 					Type: "fs", RootDir: "/mnt/kv-cache",
 					NReadThreads: 16, NWriteThreads: 16,
 					Locality: "LOCAL", EnableKVEvents: false, DirectIO: true,
-					DeviceClass: "nvme_gen4",
+					DeviceClass:   "nvme_gen4",
 					ReadBandwidth: 7000, WriteBandwidth: 5000, BaseLatency: 80,
 				},
 			},

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -1204,6 +1204,69 @@ func TestParseTraceRecord_NegativeThinkTime_Errors(t *testing.T) {
 	}
 }
 
+func TestTraceV2_SessionContextGrowth_HeaderRoundTrip(t *testing.T) {
+	t.Run("accumulate survives export→load", func(t *testing.T) {
+		dir := t.TempDir()
+		hp := filepath.Join(dir, "h.yaml")
+		dp := filepath.Join(dir, "d.csv")
+		h := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
+		if err := ExportTraceV2(h, nil, hp, dp); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		loaded, err := LoadTraceV2(hp, dp)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Header.SessionContextGrowth != "accumulate" {
+			t.Errorf("SessionContextGrowth = %q, want %q", loaded.Header.SessionContextGrowth, "accumulate")
+		}
+	})
+	t.Run("absent → empty (omitempty)", func(t *testing.T) {
+		dir := t.TempDir()
+		hp := filepath.Join(dir, "h.yaml")
+		dp := filepath.Join(dir, "d.csv")
+		h := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+		if err := ExportTraceV2(h, nil, hp, dp); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		loaded, err := LoadTraceV2(hp, dp)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Header.SessionContextGrowth != "" {
+			t.Errorf("SessionContextGrowth = %q, want empty", loaded.Header.SessionContextGrowth)
+		}
+	})
+}
+
+func TestExportTraceV2_ThinkTimeUs_CoexistsWithAdapterAndXRequestID(t *testing.T) {
+	// think_time_us is appended after the adapter and x_request_id trailing columns;
+	// verify all three optional trailing columns round-trip together with correct
+	// values (guards the column-ordering / index math when they coexist).
+	dir := t.TempDir()
+	hp := filepath.Join(dir, "h.yaml")
+	dp := filepath.Join(dir, "d.csv")
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "real"} // real → x_request_id emitted
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, Adapter: "sql-lora", XRequestID: "uuid-0", ThinkTimeUs: 0},
+		{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, Adapter: "sql-lora", XRequestID: "uuid-1", ThinkTimeUs: 7000},
+	}
+	if err := ExportTraceV2(header, records, hp, dp); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+	loaded, err := LoadTraceV2(hp, dp)
+	if err != nil {
+		t.Fatalf("LoadTraceV2: %v", err)
+	}
+	r := loaded.Records[1]
+	if r.Adapter != "sql-lora" || r.XRequestID != "uuid-1" || r.ThinkTimeUs != 7000 {
+		t.Errorf("coexistence round-trip: adapter=%q xreq=%q think=%d; want sql-lora/uuid-1/7000", r.Adapter, r.XRequestID, r.ThinkTimeUs)
+	}
+	if loaded.Records[0].ThinkTimeUs != 0 {
+		t.Errorf("record 0 think_time_us = %d, want 0", loaded.Records[0].ThinkTimeUs)
+	}
+}
+
 func TestExportTraceV2_VLLMPriority_ConditionalColumn(t *testing.T) {
 	// BC-3: vllm_priority column included only when priority was actually computed.
 	// Distinguishes between:


### PR DESCRIPTION
> **Draft — part of the OTel agentic trace replay stack (#1477). PR-A of 3.**

Closes #1478.

## What this adds

A `session_context_growth` field on `TraceHeader`. When set to `accumulate`, closed-loop replay routes each session's per-round input through the existing accumulate token buffer, so round N+1's input is **byte-identical** to round N's plus the newly-added tokens (a strictly-growing shared prefix → realistic KV-cache reuse). Default (empty) preserves today's behavior exactly.

- `SessionContextGrowth string` with `yaml:"session_context_growth,omitempty"` — absent field decodes to `""`, so existing traces are unaffected (strict-YAML safe, no version bump).
- `LoadTraceV2SessionBlueprints` propagates the header value to each blueprint's `ContextGrowth`.

## Invariants

- **INV-13 (run/replay parity):** field is replay-only and additive; `blis run` uses the separate spec-level `context_growth`. Default path byte-for-byte unchanged.
- **INV-6 (determinism):** no new randomness.

## Stack

This is the base of a 3-PR stack (all based on `main`):

1. **PR-A (this)** — accumulate replay fidelity → #1478
2. **PR-B** — `blis convert otel` → #1479
3. **PR-C** — `--concurrent-sessions` / `--total-sessions` pool replay → #1480

## Tests

`go test ./...` green; the load-bearing check is the strict-prefix-identity test (round 1's first N tokens == round 0's input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
