### PR TITLE
docs: mark docs/plans/ as local-only and fix dangling archive references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,8 +491,8 @@ Request processing pipeline: Arrival → Admission → Routing → WaitQueue →
 
 ### Per-Feature Plans
 
-- **Active plans:** `docs/plans/` (implementation plans for in-progress work)
-- **Archived design docs:** `docs/plans/archive/` (completed design docs for architectural reference)
+- **Active plans:** `docs/plans/` (design and implementation plans for in-progress work). **Gitignored since #1322 — never commit these.** They are local scratch artifacts; `git add` of a path there requires `-f`, and once a file is force-added `git check-ignore` goes silent on it forever (use `git check-ignore -v --no-index <path>` to see the real rule).
+- **Committed feature artifacts:** `specs/<NNN>-<feature>/` (spec, plan, research, data-model, contracts, quickstart, checklists). This is the tracked home for anything that must survive in the repo.
 - **PR history:** Use `git log --oneline main` for the definitive commit history
 
 ## Active Technologies

--- a/docs/contributing/extension-recipes.md
+++ b/docs/contributing/extension-recipes.md
@@ -61,7 +61,7 @@ To add a new KV tier (e.g., NVMe offloading for 3-tier GPU+CPU+NVMe):
 Examples:
 - See `TieredKVCache` in `sim/kv/tiered.go` for 2-tier GPU+CPU composition
 - See `KVCacheState` in `sim/kv/cache.go` for single-tier baseline (also implements `KVStore`)
-- See `docs/plans/archive/pr12-architectural-predesign.md` for the design decisions behind the tiered architecture
+- For the design decisions behind the tiered architecture, see the PR12 architectural pre-design doc in git history: `git show d25e1935:docs/plans/pr12-architectural-predesign.md` (removed from the tree by #1322, which gitignored `docs/plans/`)
 
 ## Adding New Trace Record Types
 

--- a/docs/contributing/templates/design-guidelines.md
+++ b/docs/contributing/templates/design-guidelines.md
@@ -474,5 +474,5 @@ If a design doc follows this principle, its content stays durable, its modules s
 1. Banks, J., Carson, J. S., Nelson, B. L., & Nicol, D. M. *Discrete-Event System Simulation* (5th ed.). Pearson. — Foundational text on DES methodology, model scoping, input modeling, output analysis, V&V.
 2. Misra, J. "Distributed Discrete-Event Simulation." *Computing Surveys*, Vol. 18, No. 1, March 1986. — Formal correctness proofs for DES, causal ordering, simulation as formal property.
 3. BLIS Issue #183 — Golden dataset encoded a silently-dropped request. Conservation invariant test would have caught it on day one.
-4. BLIS PR12 Pre-Design (`docs/plans/archive/pr12-architectural-predesign.md`) — Gold standard for decision records: 9 decisions, each with trade-off analysis.
-5. BLIS Hardening Design (`docs/plans/archive/2026-02-18-hardening-antipattern-refactoring-design.md`) — Extension scenario analysis identifying friction points for autoscaling, LMCache, heterogeneous HW, new engines.
+4. BLIS PR12 Pre-Design — Gold standard for decision records: 9 decisions, each with trade-off analysis. Read via `git show d25e1935:docs/plans/pr12-architectural-predesign.md` (removed from the tree by #1322, which gitignored `docs/plans/`).
+5. BLIS Hardening Design — Extension scenario analysis identifying friction points for autoscaling, LMCache, heterogeneous HW, new engines. Read via `git show bd84b21a:docs/plans/2026-02-18-hardening-antipattern-refactoring-design.md` (same removal).

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -151,8 +151,10 @@ inference-sim/
 │   │       ├── micro-plan.md         # Single-PR template (human-readable)
 │   │       ├── micro-plan-prompt.md  # Agent preamble for writing-plans skill
 │   │       └── hypothesis.md         # Experiment FINDINGS.md template
-│   └── plans/                 # Active implementation plans (excluded from MkDocs)
-│       └── archive/           # Completed design docs (architectural reference)
+│   └── plans/                 # Local-only scratch: design/implementation plans.
+│                              # GITIGNORED since #1322 — never committed. Excluded
+│                              # from MkDocs. Committed feature artifacts belong in
+│                              # specs/<NNN>-<feature>/ instead.
 ├── CONTRIBUTING.md            # Contributor guide (references docs/contributing/standards/)
 └── mkdocs.yml                 # MkDocs Material site configuration
 ```


### PR DESCRIPTION
## Problem

`docs/plans/` has been gitignored since **#1322** (`46e327ba`), which in the same commit deleted 22+ previously-committed plan and design docs; **#1352** purged two stragglers. But the documentation never caught up:

- `docs/reference/project-structure.md` still listed `docs/plans/` as a repo location and described a `docs/plans/archive/` subdirectory that **exists on no current ref**.
- `CLAUDE.md` still said "**Active plans:** `docs/plans/` (implementation plans for in-progress work)" — read as an invitation to commit there.
- Three references pointed at files under `docs/plans/archive/` that were deleted by #1322.

That contradiction has real consequences: `docs/plans/2026-07-15-lora-control-plane-design.md` was force-added and is now the **sole tracked survivor** of the purge, and the Part B equivalent was caught in review on #1500 (thanks @jgchn) and removed from that stack.

## Changes

Canonical source and working copy updated together, per the source-of-truth map in `principles.md` (row: *File organization and architecture*):

| File | Change |
|---|---|
| `docs/reference/project-structure.md` (canonical) | `docs/plans/` marked local-only + gitignored; nonexistent `archive/` entry dropped; points at `specs/<NNN>-<feature>/` as the tracked home |
| `CLAUDE.md` (working copy) | Same, plus the `git check-ignore` gotcha |
| `docs/contributing/extension-recipes.md` | Dangling `archive/` ref → verified git-history pointer |
| `docs/contributing/templates/design-guidelines.md` | Two dangling `archive/` refs → verified git-history pointers |

The `check-ignore` note is worth stating explicitly because it's how this stays invisible: `git check-ignore <path>` is **silent for already-tracked paths**, so one `git add -f` hides a violation permanently. `git check-ignore -v --no-index <path>` shows the real rule.

Dangling refs are replaced with pointers that actually resolve, rather than deleted:

```
git show d25e1935:docs/plans/pr12-architectural-predesign.md
git show bd84b21a:docs/plans/2026-02-18-hardening-antipattern-refactoring-design.md
```

## Verification

- `go build ./...` — OK
- `go test -count=1 ./...` — 11 packages ok, **0 FAIL**
- `golangci-lint run ./...` — **0 issues**
- `mkdocs build --strict` — OK (remaining anchor INFOs are pre-existing, in files this PR does not touch)
- `git grep "docs/plans/archive"` over tracked docs — **no matches remain**
- Both git-history pointers confirmed to resolve

Docs-only; no behavioral change.

## Notes for reviewers

- **Not in scope, but noticed:** `pr-workflow.md` links `standards/principles.md#source-of-truth-map`, but that map is bold text rather than a heading in `principles.md`, so the anchor doesn't resolve. Happy to fix here or separately.
- `docs/plans/2026-07-15-lora-control-plane-design.md` is still tracked on `main`. Removing it, and deciding where the LoRA Part A/B design records durably live, is tracked in #1504 — deliberately left out of this PR.
- `pr-workflow.md` telling you to *save* plans to `docs/plans/` is correct and unchanged; that's the local working location. Only the "this is committed repo content" framing was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)