### PR TITLE
fix(cluster): correct PD-disaggregated TTFT — drop phantom OTPT, add decode-queue wait (#1510)

### DIFF
--- a/docs/guide/results.md
+++ b/docs/guide/results.md
@@ -232,7 +232,7 @@ When PD disaggregation is active (`--prefill-instances > 0`), BLIS prints a `===
 | **Prefill Throughput** | Sub-request completion rate on prefill instances (sub-req/s) |
 | **Decode Throughput** | Sub-request completion rate on decode instances (sub-req/s) |
 | **Load Imbalance Ratio** | `max(prefill_load, decode_load) / min(...)` — `1.0` = perfectly balanced; `inf` = one pool has no completions |
-| **Parent TTFT** | Client-visible TTFT (prefill TTFT + KV transfer duration + first decode step); distribution in microseconds |
+| **Parent TTFT** | Client-visible TTFT (decode-sub-request scheduling delay + first decode step) — the arrival → first-token-emitted-by-decode span, including the decode-queue wait and exactly one output-token processing overhead (#1510); distribution in microseconds |
 | **KV Transfer Duration** | Time to transfer KV blocks from prefill to decode instance; distribution in microseconds |
 | **Peak Concurrent Transfers** | Maximum simultaneous in-flight KV transfers (only with `--pd-transfer-contention`) |
 | **Mean Transfer Queue Depth** | Average queue depth at the transfer bandwidth bottleneck (only with `--pd-transfer-contention`) |

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1844,6 +1844,13 @@ func (c *ClusterSimulator) projectPDMetrics() {
 		delete(m.RequestTTFTs, pfx)
 		delete(m.RequestTTFTs, dec)
 		if completed {
+			// A decode sub-request that emitted a first token and THEN timed out mid-generation
+			// still has a recorded scheduling delay and a non-empty ITL, so it takes this
+			// primary branch and reports a real TTFT. That is intentional and correct: the user
+			// did receive that first token, so its arrival→first-token span is a genuine
+			// measurement (INV-5 holds — the first token preceded the timeout ≤ completion). A
+			// decode sub-request that timed out while still queued has an empty ITL and falls to
+			// the prefill fallback below. Both match the pre-#1510 behavior.
 			if hasPrefillTTFT && hasDecodeDelay && parent.DecodeSubReq != nil && len(parent.DecodeSubReq.ITL) > 0 {
 				firstDecodeStep := float64(parent.DecodeSubReq.ITL[0])
 				newTTFT := float64(decodeDelay) + firstDecodeStep

--- a/sim/cluster/cluster.go
+++ b/sim/cluster/cluster.go
@@ -1805,29 +1805,69 @@ func (c *ClusterSimulator) projectPDMetrics() {
 			}
 		}
 
-		// TTFT: user-visible time-to-first-token for PD disaggregation.
-		// In llm-d, the first token reaches the user from the decode pod, not
-		// prefill: prefill completes → KV transfers → decode pod recomputes last
-		// prompt token and samples first output token. User-visible TTFT =
-		// prefillTTFT + transferDuration + firstDecodeStep. See issue #930.
+		// TTFT: user-visible time-to-first-token for PD disaggregation (issue #1510,
+		// correcting the earlier #930 composition). In llm-d the first token reaches the
+		// user from the decode pod, not prefill: prefill completes → KV transfers →
+		// decode pod queues, recomputes the last prompt token, and samples the first
+		// output token. The correct user-visible TTFT is the arrival → first-token-emitted
+		// span:
+		//
+		//   TTFT = decodeSchedulingDelay + firstDecodeStep
+		//
+		// where decodeSchedulingDelay = RequestSchedulingDelays[decodeSubReqID] = the
+		// decode sub-request's (schedule − arrival). Because the decode sub-request's
+		// ArrivalTime is the parent's original arrival time (pd_events.go), that delay
+		// already spans prefill_queue + prefill_step + kv_transfer + decode_queue_wait —
+		// including the decode-queue wait that the previous
+		// (prefillTTFT + transferDuration + firstDecodeStep) formula omitted. It also
+		// carries exactly ONE OutputTokenProcessingTime: prefillTTFT (dropped here) held a
+		// second, phantom copy; firstDecodeStep = ITL[0] contributes the single legitimate
+		// one (the decode pod streams the first real token exactly once). This is
+		// structurally identical to the non-PD TTFT (scheduling_delay + first-token step).
 		//
 		// Read prefill TTFT before deleting sub-request keys (R1: no silent data loss).
-		// Gate on completed: dropped-request TTFTs must not enter the distribution.
+		// prefillTTFT is retained as the TTFTSum baseline: pre-projection TTFTSum holds
+		// exactly prefillTTFT for this parent (the decode sub-request never sets
+		// FirstTokenTime, so it contributes 0). Read the decode scheduling delay here too,
+		// before the scheduling-delay block below deletes it.
+		//
+		// Gate on `completed` (CompletionTime > 0 && DecodeInstanceID != ""). A
+		// late-drop (decode pod unroutable at transfer complete) leaves DecodeInstanceID
+		// set but nils DecodeSubReq, so it fails the primary guard and takes the
+		// prefill-only fallback. NOTE: a drop-at-transfer-start parent is still
+		// `completed == true` (DecodeInstanceID is set upfront at routing and dropAtStart
+		// stamps CompletionTime), so it too receives a prefill-only TTFT here — a
+		// pre-existing behavior unchanged by this fix (the old guard also routed these to
+		// the same fallback). Tracked separately in issue #1511.
 		prefillTTFT, hasPrefillTTFT := m.RequestTTFTs[pfx]
+		decodeDelay, hasDecodeDelay := m.RequestSchedulingDelays[dec]
 		delete(m.RequestTTFTs, pfx)
 		delete(m.RequestTTFTs, dec)
 		if completed {
-			if hasPrefillTTFT && parent.TransferStartTime > 0 && parent.TransferCompleteTime >= parent.TransferStartTime && parent.DecodeSubReq != nil && len(parent.DecodeSubReq.ITL) > 0 {
-				transferDuration := float64(parent.TransferCompleteTime - parent.TransferStartTime)
+			if hasPrefillTTFT && hasDecodeDelay && parent.DecodeSubReq != nil && len(parent.DecodeSubReq.ITL) > 0 {
 				firstDecodeStep := float64(parent.DecodeSubReq.ITL[0])
-				newTTFT := prefillTTFT + transferDuration + firstDecodeStep
-				m.RequestTTFTs[pid] = newTTFT
-				// BC-3: Keep TTFTSum consistent with the TTFT adjustment.
-				m.TTFTSum += int64(newTTFT - prefillTTFT)
+				newTTFT := float64(decodeDelay) + firstDecodeStep
+				if newTTFT < 0 {
+					// Defensive parity with the E2E block above: never emit a negative
+					// TTFT (a headline SLO metric). Unreachable in normal operation —
+					// decodeDelay ≥ 0 by shared-clock event ordering and firstDecodeStep > 0
+					// — but guards against a hypothetical clock regression rather than
+					// silently reporting a negative value.
+					logrus.Errorf("[cluster] projectPDMetrics: negative TTFT for %s (decodeDelay=%d firstDecodeStep=%.0f); using prefill TTFT",
+						pid, decodeDelay, firstDecodeStep)
+					m.RequestTTFTs[pid] = prefillTTFT // delta 0 vs baseline: TTFTSum untouched
+				} else {
+					m.RequestTTFTs[pid] = newTTFT
+					// BC-3: Keep TTFTSum consistent with the TTFT adjustment. The baseline
+					// prefillTTFT is replaced by newTTFT for this parent.
+					m.TTFTSum += int64(newTTFT - prefillTTFT)
+				}
 			} else if hasPrefillTTFT {
-				// Defensive fallback: use prefill-only TTFT if decode data unavailable.
+				// Defensive fallback: use prefill-only TTFT if decode data unavailable
+				// (no decode scheduling delay, nil DecodeSubReq, or empty ITL). TTFTSum
+				// unchanged (projected value equals the baseline).
 				m.RequestTTFTs[pid] = prefillTTFT
-				logrus.Warnf("[cluster] projectPDMetrics: parent %s missing decode ITL or TransferCompleteTime; using prefill TTFT", pid)
+				logrus.Warnf("[cluster] projectPDMetrics: parent %s missing decode scheduling delay, DecodeSubReq, or ITL; using prefill TTFT", pid)
 			} else {
 				logrus.Warnf("[cluster] projectPDMetrics: completed parent %s has no prefill TTFT (key %s)", pid, pfx)
 			}

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -895,8 +895,8 @@ func TestDisaggregation_MetricProjection_E2ECorrectness(t *testing.T) {
 // (prefillTTFT + transferDuration + firstDecodeStep), which double-counted OTPT and
 // omitted the decode-queue wait.
 //
-// Test independence (see docs/plans/pr1510-pd-ttft-plan.md Part 3): the assertions never
-// recompute the production formula. Instead they use two orthogonal guards —
+// Test independence: the assertions never recompute the production formula (the pre-#1510
+// test did, making it a tautology). Instead they use two orthogonal guards —
 //  (1) a residual reconstructed from ParentRequest phase timestamps
 //      (DecodeEnqueueTime − ArrivalTime), recorded by a different mechanism than the
 //      RequestSchedulingDelays map the fix reads; and
@@ -1164,11 +1164,17 @@ func TestDisaggregation_TTFT_ProjectionBranches(t *testing.T) {
 	tests := []struct {
 		name           string
 		parent         *ParentRequest
-		skipPrefill    bool  // omit prefill TTFT key → Branch C
-		setDecodeDelay bool  // set RequestSchedulingDelays[dec]
-		decodeDelay    int64 // value for the decode scheduling delay
-		wantEntry      bool  // whether a parent-keyed TTFT entry is expected
-		wantTTFT       float64
+		skipPrefill    bool    // omit prefill TTFT key → Branch C
+		setDecodeDelay bool    // set RequestSchedulingDelays[dec]
+		decodeDelay    int64   // value for the decode scheduling delay
+		wantEntry      bool    // whether a parent-keyed TTFT entry is expected
+		wantTTFT       float64 // expected projected TTFT (when wantEntry)
+		// wantSum is the expected TTFTSum after projection (pre-projection baseline is 0
+		// in these stubs). It is stated explicitly per case rather than derived, so it
+		// models production exactly: the delta is applied ONLY when the primary branch
+		// takes the newTTFT path; every fallback (incl. the negative-TTFT guard) leaves
+		// TTFTSum at 0.
+		wantSum int64
 	}{
 		{
 			// PRIMARY: full decode data present ⇒ TTFT = decodeDelay + ITL[0].
@@ -1182,6 +1188,7 @@ func TestDisaggregation_TTFT_ProjectionBranches(t *testing.T) {
 			},
 			setDecodeDelay: true, decodeDelay: 4000,
 			wantEntry: true, wantTTFT: 4000 + 300, // = 4300
+			wantSum: 4300 - 2500,                  // primary branch: newTTFT − prefillTTFT = 1800
 		},
 		{
 			// FALLBACK: decode scheduling delay never recorded ⇒ prefill-only.
@@ -1254,6 +1261,28 @@ func TestDisaggregation_TTFT_ProjectionBranches(t *testing.T) {
 			},
 			setDecodeDelay: true, decodeDelay: -5000, // newTTFT = -5000 + 100 = -4900 < 0
 			wantEntry: true, wantTTFT: prefillTTFT,
+			wantSum: 0, // negative guard falls back to prefillTTFT WITHOUT the delta: TTFTSum stays 0
+		},
+		{
+			// TIMED-OUT WITH PARTIAL ITL: a decode sub-request that emitted a first token
+			// and then timed out mid-generation still carries a scheduling delay and a
+			// non-empty ITL, so it takes the PRIMARY branch and reports a real TTFT. This is
+			// intentional and correct — the user did receive that first token, so its
+			// arrival→first-token span is a genuine measurement. Pinned here so the behavior
+			// (which the guard makes implicit) cannot silently regress. Modeled with a
+			// State=StateTimedOut decode sub-request; projectPDMetrics does not inspect State,
+			// exactly as intended.
+			name: "timed-out with partial ITL ⇒ primary branch (real TTFT)",
+			parent: &ParentRequest{
+				ID: "p6", PrefillSubReqID: "p6_prefill", DecodeSubReqID: "p6_decode",
+				OriginalRequest: origReq,
+				ArrivalTime:     0, CompletionTime: 5000, DecodeInstanceID: "inst-0",
+				TransferStartTime: 100, TransferCompleteTime: 200,
+				DecodeSubReq: &sim.Request{State: sim.StateTimedOut, ITL: []int64{300}},
+			},
+			setDecodeDelay: true, decodeDelay: 4000,
+			wantEntry: true, wantTTFT: 4000 + 300, // = 4300, same as a normal primary parent
+			wantSum: 4300 - 2500,                  // primary branch delta = 1800
 		},
 	}
 
@@ -1282,17 +1311,22 @@ func TestDisaggregation_TTFT_ProjectionBranches(t *testing.T) {
 				if math.Abs(got-tc.wantTTFT) > 1e-9 {
 					t.Errorf("parent %s: TTFT = %.1f, want %.1f", tc.parent.ID, got, tc.wantTTFT)
 				}
-				// TTFTSum delta: pre-projection TTFTSum was 0 in this stub; the primary
-				// branch adds (newTTFT − prefillTTFT); the fallback branch adds nothing.
-				var wantSum int64
-				if tc.setDecodeDelay && tc.parent.DecodeSubReq != nil && len(tc.parent.DecodeSubReq.ITL) > 0 {
-					wantSum = int64(tc.wantTTFT - prefillTTFT) // primary branch
+				// TTFTSum after projection: pre-projection baseline is 0 in these stubs.
+				// wantSum is stated explicitly per case (delta applied only when the primary
+				// branch takes the newTTFT path; every fallback — incl. the negative-TTFT
+				// guard — leaves TTFTSum at 0), so it models production exactly rather than
+				// re-deriving it from the input presence.
+				if m.TTFTSum != tc.wantSum {
+					t.Errorf("parent %s: TTFTSum = %d, want %d", tc.parent.ID, m.TTFTSum, tc.wantSum)
 				}
-				if m.TTFTSum != wantSum {
-					t.Errorf("parent %s: TTFTSum = %d, want %d", tc.parent.ID, m.TTFTSum, wantSum)
+			} else {
+				if ok {
+					t.Errorf("Branch C: unexpected TTFT entry for parent %s (no prefill key)", tc.parent.ID)
 				}
-			} else if ok {
-				t.Errorf("Branch C: unexpected TTFT entry for parent %s (no prefill key)", tc.parent.ID)
+				// Branch C also makes no TTFTSum contribution.
+				if m.TTFTSum != tc.wantSum {
+					t.Errorf("Branch C: parent %s: TTFTSum = %d, want %d", tc.parent.ID, m.TTFTSum, tc.wantSum)
+				}
 			}
 
 			// Sub-request keys must be deleted (INV-PD-6).

--- a/sim/cluster/disaggregation_test.go
+++ b/sim/cluster/disaggregation_test.go
@@ -888,12 +888,27 @@ func TestDisaggregation_MetricProjection_E2ECorrectness(t *testing.T) {
 	}
 }
 
-// TestDisaggregation_TTFT_IncludesTransferAndDecode verifies BC-1/BC-2/BC-3/BC-4:
-// In PD disaggregation, user-visible TTFT includes prefill + KV transfer + first
-// decode step (matching llm-d behavior where the decode pod produces the first
-// user-visible token). See issue #930.
+// TestDisaggregation_TTFT_IncludesTransferAndDecode verifies BC-1/BC-3/BC-4 (issue #1510):
+// In PD disaggregation, user-visible TTFT is the arrival → first-token-emitted-by-decode
+// span, composed as decodeSchedulingDelay + firstDecodeStep and containing exactly ONE
+// OutputTokenProcessingTime (OTPT). This replaces the pre-#1510 formula
+// (prefillTTFT + transferDuration + firstDecodeStep), which double-counted OTPT and
+// omitted the decode-queue wait.
+//
+// Test independence (see docs/plans/pr1510-pd-ttft-plan.md Part 3): the assertions never
+// recompute the production formula. Instead they use two orthogonal guards —
+//  (1) a residual reconstructed from ParentRequest phase timestamps
+//      (DecodeEnqueueTime − ArrivalTime), recorded by a different mechanism than the
+//      RequestSchedulingDelays map the fix reads; and
+//  (2) a differential comparison against the old buggy formula.
 func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 	config := newTestDisaggDeploymentConfig(4, 2, 2)
+	// OTPT (α₂) is the per-output-token processing overhead; the old formula carried a
+	// second, phantom copy. Require it positive so the low-load "reported < old"
+	// differential below is non-trivially caused by removing that phantom OTPT.
+	if otpt := config.AlphaCoeffs[2]; otpt <= 0 {
+		t.Fatalf("test precondition: OTPT (α₂) must be positive to distinguish the two-OTPT bug, got %.1f", otpt)
+	}
 	requests := newTestRequests(5)
 
 	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
@@ -901,7 +916,8 @@ func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 
 	m := cs.AggregatedMetrics()
 
-	// Collect prefill-only TTFTs from per-instance metrics (before projection).
+	// Collect prefill-only TTFTs from per-instance metrics (before projection) so the
+	// differential guard can reconstruct the OLD buggy formula independently.
 	prefillTTFTs := make(map[string]float64)
 	for _, inst := range cs.PerInstanceMetricsByID() {
 		for id, ttft := range inst.RequestTTFTs {
@@ -921,39 +937,58 @@ func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 			t.Errorf("parent %s: missing RequestTTFTs entry", pid)
 			continue
 		}
-
-		// BC-1: TTFT = prefillTTFT + transferDuration + firstDecodeStep.
-		// Prefill TTFT (instance-level) captures arrival → prefill completion.
-		// Transfer duration and first decode step are additive on top.
 		if parent.DecodeSubReq == nil || len(parent.DecodeSubReq.ITL) == 0 {
 			t.Errorf("parent %s: DecodeSubReq nil or empty ITL", pid)
 			continue
 		}
+		firstDecodeStep := float64(parent.DecodeSubReq.ITL[0])
+
+		// --- Guard 1: timestamp-decomposition residual (causality bound) ---
+		// The reported TTFT should decompose as:
+		//   (DecodeEnqueueTime − ArrivalTime)  [prefill queue + prefill step + transfer]
+		//   + decode_queue_wait                [schedule − enqueue: the previously-MISSING term]
+		//   + firstDecodeStep                  [carries exactly ONE OTPT]
+		// So residual := reported − (DecodeEnqueueTime − ArrivalTime) − firstDecodeStep
+		// equals the decode-queue wait, which must be >= 0 (causality: decode cannot be
+		// scheduled before it is enqueued). DecodeEnqueueTime/ArrivalTime are ParentRequest
+		// phase timestamps recorded independently of the RequestSchedulingDelays map the fix
+		// reads. NOTE: this is a one-sided CAUSALITY bound, not by itself a proof of the
+		// exact composition — at low load the OLD (buggy) formula also yields a non-negative
+		// residual (= one OTPT). The regression protection comes from Guard 2 below (the
+		// differential vs the old formula); the two together pin the reported value.
+		enqueueToArrival := float64(parent.DecodeEnqueueTime - parent.ArrivalTime)
+		if enqueueToArrival <= 0 {
+			t.Errorf("BC-1 precondition: parent %s: DecodeEnqueueTime−ArrivalTime=%.0f, expected positive (prefill+transfer span)",
+				pid, enqueueToArrival)
+		}
+		residual := ttft - enqueueToArrival - firstDecodeStep
+		if residual < -1e-9 {
+			t.Errorf("BC-1: parent %s: residual decode-queue wait = %.1f < 0 (reported TTFT=%.1f, enqueue−arrival=%.0f, firstDecodeStep=%.0f) — causality violated",
+				pid, residual, ttft, enqueueToArrival, firstDecodeStep)
+		}
+
+		// --- Guard 2: differential vs the OLD buggy formula (regression guard) ---
+		// old = prefillTTFT + transferDuration + firstDecodeStep. The old formula mixed a
+		// prefill-INSTANCE-local prefillTTFT (which includes a second, phantom OTPT) with
+		// cluster-clock transfer/decode terms. The fix uses a single cluster-clock span
+		// (decodeDelay) + one instance-local step, so it is not a simple ±OTPT shift of the
+		// old value — the two live in different clock domains. What holds robustly is the
+		// DIRECTION the issue states: at low load (decode_queue_wait ≈ 0) the old formula
+		// OVER-states TTFT, so reported < old. This light workload (~100µs inter-arrival,
+		// short decodes) keeps the decode pool idle between requests, so every parent has
+		// ~zero queue wait and reported < old. This deterministically catches any regression
+		// to the old formula (which would make reported == old). The exact-composition proof
+		// is Guard 1's residual; this is the anti-regression companion.
 		origPrefillTTFT, hasPrefill := prefillTTFTs[parent.PrefillSubReqID]
 		if !hasPrefill {
 			t.Errorf("parent %s: no prefill TTFT for %s in per-instance metrics", pid, parent.PrefillSubReqID)
 			continue
 		}
-		transferDuration := parent.TransferCompleteTime - parent.TransferStartTime
-		firstDecodeStep := parent.DecodeSubReq.ITL[0]
-		expectedTTFT := origPrefillTTFT + float64(transferDuration) + float64(firstDecodeStep)
-		if math.Abs(ttft-expectedTTFT) > 1e-9 {
-			t.Errorf("BC-1: parent %s: TTFT = %.1f, want %.1f (prefillTTFT=%.0f + transfer=%d + decode=%d)",
-				pid, ttft, expectedTTFT, origPrefillTTFT, transferDuration, firstDecodeStep)
-		}
-
-		// BC-2: User-visible TTFT > prefill-only TTFT (transfer + decode add positive time).
-		// Explicit non-triviality guards: if either addend is zero, BC-2 is vacuously true
-		// and a regression to prefill-only TTFT would not be caught.
-		if transferDuration <= 0 {
-			t.Errorf("BC-2 precondition: parent %s: transferDuration=%d, expected positive (verify PDTransferBandwidthGBps/PDTransferBaseLatencyMs in test config)", pid, transferDuration)
-		}
-		if firstDecodeStep <= 0 {
-			t.Errorf("BC-2 precondition: parent %s: firstDecodeStep=%d, expected positive (verify LatencyCoeffs in test config)", pid, firstDecodeStep)
-		}
-		if ttft <= origPrefillTTFT {
-			t.Errorf("BC-2: parent %s: TTFT (%.1f) <= prefill-only TTFT (%.1f), must include transfer+decode",
-				pid, ttft, origPrefillTTFT)
+		transferDuration := float64(parent.TransferCompleteTime - parent.TransferStartTime)
+		oldFormula := origPrefillTTFT + transferDuration + firstDecodeStep
+		if ttft >= oldFormula {
+			t.Errorf("defect-1: parent %s: reported TTFT (%.1f) >= old-formula value (%.1f); at low load the fix must drop the phantom OTPT so reported < old",
+				pid, ttft, oldFormula)
 		}
 
 		// BC-4: TTFT <= E2E (causality). Missing E2E for a completed parent is itself a violation.
@@ -964,6 +999,9 @@ func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 			t.Errorf("BC-4: parent %s: TTFT (%.1f) > E2E (%.1f), causality violated",
 				pid, ttft, e2e)
 		}
+		if ttft <= 0 {
+			t.Errorf("BC-4: parent %s: TTFT (%.1f) must be positive", pid, ttft)
+		}
 
 		verified++
 	}
@@ -971,15 +1009,118 @@ func TestDisaggregation_TTFT_IncludesTransferAndDecode(t *testing.T) {
 		t.Fatal("no completed PD parents found to verify")
 	}
 
-	// BC-3: TTFTSum must be consistent with RequestTTFTs after projection.
-	// Tolerance is 1.0 (1 µs) rather than 1e-9 because TTFTSum is int64 (truncated
-	// per accumulation) while manualSum accumulates float64 values; rounding is expected.
+	// BC-3: the aggregate TTFTSum must stay consistent with the per-request RequestTTFTs
+	// after projection — the full-pipeline law that reported mean TTFT (TTFTSum/n, as
+	// surfaced in MetricsOutput) equals the mean of the projected per-request values.
+	// Tolerance is 1.0 (1 µs) rather than 1e-9 because TTFTSum is int64 (truncated per
+	// accumulation) while manualSum accumulates float64 values; rounding is expected.
 	var manualSum float64
 	for _, k := range sortedKeys(m.RequestTTFTs) {
 		manualSum += m.RequestTTFTs[k]
 	}
 	if math.Abs(float64(m.TTFTSum)-manualSum) > 1.0 {
 		t.Errorf("BC-3: TTFTSum (%d) != sum(RequestTTFTs) (%.1f)", m.TTFTSum, manualSum)
+	}
+	// Mean law, stated explicitly: sum/n must match TTFTSum/n within the same rounding.
+	if n := len(m.RequestTTFTs); n > 0 {
+		wantMean := manualSum / float64(n)
+		gotMean := float64(m.TTFTSum) / float64(n)
+		if math.Abs(gotMean-wantMean) > 1.0 {
+			t.Errorf("BC-3: mean TTFT from TTFTSum (%.3f) != mean(RequestTTFTs) (%.3f)", gotMean, wantMean)
+		}
+	}
+}
+
+// TestDisaggregation_TTFT_IncludesDecodeQueueWait verifies BC-2 (issue #1510, defect 2):
+// under load, the decode sub-request waits in the decode instance's queue before its
+// first step, and that wait MUST appear in the reported TTFT. The pre-#1510 formula
+// (prefillTTFT + transferDuration + firstDecodeStep) omitted it entirely, so reported
+// TTFT was smaller than reality exactly under load.
+//
+// The scenario is pinned to deterministically produce a positive decode-queue wait:
+// a single decode instance with maxRunningReqs=1 (serialized decode) fed by several
+// short requests whose decodes overlap. It never relies on t.Skip.
+func TestDisaggregation_TTFT_IncludesDecodeQueueWait(t *testing.T) {
+	config := newTestDisaggDeploymentConfig(3, 2, 1) // 2 prefill, 1 decode
+	// maxRunningReqs=1: the single decode instance runs one sub-request at a time, so
+	// sub-requests transferred while an earlier decode is still running must queue.
+	config.BatchConfig = sim.NewBatchConfig(1, 2048, 0)
+	otpt := float64(config.AlphaCoeffs[2]) // OTPT (α₂); the differential threshold below
+	requests := newShortRequests(6)        // ~2000µs decode each, arriving 100µs apart → overlap
+
+	cs := NewClusterSimulator(config, NewSliceRequestSource(requests), nil)
+	mustRun(t, cs)
+
+	m := cs.AggregatedMetrics()
+
+	prefillTTFTs := make(map[string]float64)
+	for _, inst := range cs.PerInstanceMetricsByID() {
+		for id, ttft := range inst.RequestTTFTs {
+			prefillTTFTs[id] = ttft
+		}
+	}
+
+	withQueueWait := 0
+	for _, parent := range cs.ParentRequests() {
+		if parent.CompletionTime == 0 || parent.DecodeInstanceID == "" {
+			continue
+		}
+		pid := parent.ID
+		ttft, hasTTFT := m.RequestTTFTs[pid]
+		if !hasTTFT || parent.DecodeSubReq == nil || len(parent.DecodeSubReq.ITL) == 0 {
+			continue
+		}
+		firstDecodeStep := float64(parent.DecodeSubReq.ITL[0])
+
+		// Residual = reported − (DecodeEnqueueTime − ArrivalTime) − firstDecodeStep
+		//          = decode_queue_wait (schedule − enqueue). Recorded via ParentRequest
+		// phase timestamps, orthogonal to the RequestSchedulingDelays map the fix reads.
+		enqueueToArrival := float64(parent.DecodeEnqueueTime - parent.ArrivalTime)
+		queueWait := ttft - enqueueToArrival - firstDecodeStep
+
+		// Filter to parents whose decode-queue wait exceeds one OTPT. This threshold is
+		// aligned with the differential assertion below: old − reported = OTPT − queueWait,
+		// so reported > old holds iff queueWait > OTPT. In the serialized scenario
+		// (~2000µs decode steps ≫ OTPT=100µs) the very first queued parent already clears
+		// this, so the filter does not weaken coverage — it just makes the two assertions
+		// mutually consistent and robust to coefficient tweaks.
+		if queueWait <= otpt {
+			continue // not queued, or queued less than one OTPT; look for a clearly-loaded parent
+		}
+		withQueueWait++
+
+		// Direct proof defect 2 is fixed: the decode-queue wait is inside reported TTFT
+		// (residual > 0, in fact > OTPT here).
+		if queueWait <= 0 {
+			t.Errorf("BC-2: parent %s: decode-queue wait residual = %.1f, want >0", pid, queueWait)
+		}
+
+		// Differential vs old formula: old − reported = OTPT − decode_queue_wait. With the
+		// wait > OTPT, reported > old: the fix INCREASED TTFT under load, adding the
+		// previously-missing wait (and the equality old − reported == OTPT − queueWait is
+		// checked exactly below, tying both defects together).
+		origPrefillTTFT, hasPrefill := prefillTTFTs[parent.PrefillSubReqID]
+		if !hasPrefill {
+			t.Errorf("parent %s: no prefill TTFT for %s in per-instance metrics", pid, parent.PrefillSubReqID)
+			continue
+		}
+		transferDuration := float64(parent.TransferCompleteTime - parent.TransferStartTime)
+		oldFormula := origPrefillTTFT + transferDuration + firstDecodeStep
+		if ttft <= oldFormula {
+			t.Errorf("BC-2: parent %s: reported TTFT (%.1f) <= old-formula value (%.1f); the decode-queue wait (%.1f) must make it larger under load",
+				pid, ttft, oldFormula, queueWait)
+		}
+
+		// Causality still holds under load.
+		if e2e, hasE2E := m.RequestE2Es[pid]; hasE2E && ttft > e2e {
+			t.Errorf("BC-2: parent %s: TTFT (%.1f) > E2E (%.1f), causality violated", pid, ttft, e2e)
+		}
+	}
+
+	if withQueueWait == 0 {
+		t.Fatal("BC-2: no parent exhibited a decode-queue wait exceeding one OTPT; the loaded " +
+			"scenario (1 decode instance, maxRunningReqs=1, 6 short overlapping requests) is " +
+			"engineered to force queueing ≫ OTPT — its absence is a test-premise failure, not a pass")
 	}
 }
 
@@ -1003,31 +1144,64 @@ func TestDisaggregation_TTFT_NoSilentDrops(t *testing.T) {
 	}
 }
 
-// TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing exercises the defensive
-// fallback in projectPDMetrics: when a completed parent has TransferCompleteTime=0
-// or empty DecodeSubReq.ITL, TTFT falls back to the prefill-only value.
-func TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing(t *testing.T) {
-	prefillTTFT := 2500.0
-
+// TestDisaggregation_TTFT_ProjectionBranches unit-tests the three outcome branches of
+// the TTFT block in projectPDMetrics (issue #1510). It drives projectPDMetrics directly
+// on stub ParentRequests so each branch's trigger is isolated:
+//   - PRIMARY: prefill TTFT present, decode scheduling delay present, non-empty decode ITL
+//     ⇒ TTFT = decodeDelay + ITL[0], and TTFTSum tracks the delta vs the prefill baseline.
+//   - FALLBACK (prefill-only): prefill TTFT present but decode data unavailable
+//     (missing decode scheduling delay, nil DecodeSubReq, or empty ITL) ⇒ TTFT = prefillTTFT.
+//   - BRANCH C (no entry): completed parent with no prefill TTFT key ⇒ no TTFT entry.
+//
+// Post-#1510 the primary-branch guard is hasPrefillTTFT && hasDecodeDelay &&
+// DecodeSubReq!=nil && len(ITL)>0 — it no longer inspects TransferStartTime/
+// TransferCompleteTime (the formula uses the decode scheduling delay, not transfer
+// timestamps). The fallback cases below therefore trigger on the decode-side inputs.
+func TestDisaggregation_TTFT_ProjectionBranches(t *testing.T) {
+	const prefillTTFT = 2500.0
 	origReq := &sim.Request{ID: "orig", ArrivalTime: 0}
 
 	tests := []struct {
-		name            string
-		parent          *ParentRequest
-		skipPrefillTTFT bool
+		name           string
+		parent         *ParentRequest
+		skipPrefill    bool  // omit prefill TTFT key → Branch C
+		setDecodeDelay bool  // set RequestSchedulingDelays[dec]
+		decodeDelay    int64 // value for the decode scheduling delay
+		wantEntry      bool  // whether a parent-keyed TTFT entry is expected
+		wantTTFT       float64
 	}{
 		{
-			name: "TransferCompleteTime=0",
+			// PRIMARY: full decode data present ⇒ TTFT = decodeDelay + ITL[0].
+			name: "primary: decode delay + ITL[0]",
+			parent: &ParentRequest{
+				ID: "p0", PrefillSubReqID: "p0_prefill", DecodeSubReqID: "p0_decode",
+				OriginalRequest: origReq,
+				ArrivalTime:     0, CompletionTime: 5000, DecodeInstanceID: "inst-0",
+				TransferStartTime: 100, TransferCompleteTime: 200,
+				DecodeSubReq: &sim.Request{ITL: []int64{300}},
+			},
+			setDecodeDelay: true, decodeDelay: 4000,
+			wantEntry: true, wantTTFT: 4000 + 300, // = 4300
+		},
+		{
+			// FALLBACK: decode scheduling delay never recorded ⇒ prefill-only.
+			// (Pre-#1510 this case was labeled "TransferCompleteTime=0"; that field is
+			// no longer consulted — the true trigger is the missing decode delay.)
+			name: "fallback: missing decode scheduling delay",
 			parent: &ParentRequest{
 				ID: "p1", PrefillSubReqID: "p1_prefill", DecodeSubReqID: "p1_decode",
 				OriginalRequest: origReq,
 				ArrivalTime:     0, CompletionTime: 5000, DecodeInstanceID: "inst-0",
-				TransferStartTime: 0, TransferCompleteTime: 0,
+				TransferStartTime: 100, TransferCompleteTime: 200,
 				DecodeSubReq: &sim.Request{ITL: []int64{100}},
 			},
+			setDecodeDelay: false,
+			wantEntry:      true, wantTTFT: prefillTTFT,
 		},
 		{
-			name: "empty DecodeSubReq.ITL",
+			// FALLBACK: empty decode ITL ⇒ prefill-only (delay present, so this isolates
+			// the ITL guard).
+			name: "fallback: empty DecodeSubReq.ITL",
 			parent: &ParentRequest{
 				ID: "p2", PrefillSubReqID: "p2_prefill", DecodeSubReqID: "p2_decode",
 				OriginalRequest: origReq,
@@ -1035,9 +1209,12 @@ func TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing(t *testing.T) {
 				TransferStartTime: 100, TransferCompleteTime: 200,
 				DecodeSubReq: &sim.Request{ITL: nil},
 			},
+			setDecodeDelay: true, decodeDelay: 4000,
+			wantEntry: true, wantTTFT: prefillTTFT,
 		},
 		{
-			name: "nil DecodeSubReq",
+			// FALLBACK: nil DecodeSubReq ⇒ prefill-only (delay present, isolates the nil guard).
+			name: "fallback: nil DecodeSubReq",
 			parent: &ParentRequest{
 				ID: "p3", PrefillSubReqID: "p3_prefill", DecodeSubReqID: "p3_decode",
 				OriginalRequest: origReq,
@@ -1045,9 +1222,12 @@ func TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing(t *testing.T) {
 				TransferStartTime: 100, TransferCompleteTime: 200,
 				DecodeSubReq: nil,
 			},
+			setDecodeDelay: true, decodeDelay: 4000,
+			wantEntry: true, wantTTFT: prefillTTFT,
 		},
 		{
-			name: "no prefill TTFT key",
+			// BRANCH C: no prefill TTFT key ⇒ no entry (even with full decode data).
+			name: "branch C: no prefill TTFT key",
 			parent: &ParentRequest{
 				ID: "p4", PrefillSubReqID: "p4_prefill", DecodeSubReqID: "p4_decode",
 				OriginalRequest: origReq,
@@ -1055,17 +1235,38 @@ func TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing(t *testing.T) {
 				TransferStartTime: 100, TransferCompleteTime: 200,
 				DecodeSubReq: &sim.Request{ITL: []int64{100}},
 			},
-			skipPrefillTTFT: true,
+			skipPrefill:    true,
+			setDecodeDelay: true, decodeDelay: 4000,
+			wantEntry: false,
+		},
+		{
+			// NEGATIVE-TTFT DEFENSIVE GUARD: a negative decodeDelay (only reachable via a
+			// hypothetical shared-clock regression) makes newTTFT < 0. The guard must fall
+			// back to prefillTTFT with TTFTSum untouched (delta 0), never emit a negative
+			// headline metric. This exercises the otherwise-unreachable defensive branch.
+			name: "negative guard: negative decodeDelay ⇒ prefill fallback",
+			parent: &ParentRequest{
+				ID: "p5", PrefillSubReqID: "p5_prefill", DecodeSubReqID: "p5_decode",
+				OriginalRequest: origReq,
+				ArrivalTime:     0, CompletionTime: 5000, DecodeInstanceID: "inst-0",
+				TransferStartTime: 100, TransferCompleteTime: 200,
+				DecodeSubReq: &sim.Request{ITL: []int64{100}},
+			},
+			setDecodeDelay: true, decodeDelay: -5000, // newTTFT = -5000 + 100 = -4900 < 0
+			wantEntry: true, wantTTFT: prefillTTFT,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m := sim.NewMetrics()
-			if !tc.skipPrefillTTFT {
+			if !tc.skipPrefill {
 				m.RequestTTFTs[tc.parent.PrefillSubReqID] = prefillTTFT
 			}
-			m.RequestTTFTs[tc.parent.DecodeSubReqID] = 999.0
+			m.RequestTTFTs[tc.parent.DecodeSubReqID] = 999.0 // must be deleted (INV-PD-6)
+			if tc.setDecodeDelay {
+				m.RequestSchedulingDelays[tc.parent.DecodeSubReqID] = tc.decodeDelay
+			}
 
 			cs := &ClusterSimulator{
 				aggregatedMetrics: m,
@@ -1073,19 +1274,25 @@ func TestDisaggregation_TTFT_FallbackWhenDecodeDataMissing(t *testing.T) {
 			}
 			cs.projectPDMetrics()
 
-			if tc.skipPrefillTTFT {
-				// Branch C: completed parent with no prefill TTFT key must produce no entry.
-				if _, ok := m.RequestTTFTs[tc.parent.ID]; ok {
-					t.Errorf("Branch C: unexpected TTFT entry for parent %s (no prefill key)", tc.parent.ID)
-				}
-			} else {
-				got, ok := m.RequestTTFTs[tc.parent.ID]
+			got, ok := m.RequestTTFTs[tc.parent.ID]
+			if tc.wantEntry {
 				if !ok {
-					t.Fatalf("R1: parent %s TTFT entry missing after fallback", tc.parent.ID)
+					t.Fatalf("parent %s: TTFT entry missing after projection (R1)", tc.parent.ID)
 				}
-				if math.Abs(got-prefillTTFT) > 1e-9 {
-					t.Errorf("fallback: got TTFT=%.1f, want %.1f (prefill-only)", got, prefillTTFT)
+				if math.Abs(got-tc.wantTTFT) > 1e-9 {
+					t.Errorf("parent %s: TTFT = %.1f, want %.1f", tc.parent.ID, got, tc.wantTTFT)
 				}
+				// TTFTSum delta: pre-projection TTFTSum was 0 in this stub; the primary
+				// branch adds (newTTFT − prefillTTFT); the fallback branch adds nothing.
+				var wantSum int64
+				if tc.setDecodeDelay && tc.parent.DecodeSubReq != nil && len(tc.parent.DecodeSubReq.ITL) > 0 {
+					wantSum = int64(tc.wantTTFT - prefillTTFT) // primary branch
+				}
+				if m.TTFTSum != wantSum {
+					t.Errorf("parent %s: TTFTSum = %d, want %d", tc.parent.ID, m.TTFTSum, wantSum)
+				}
+			} else if ok {
+				t.Errorf("Branch C: unexpected TTFT entry for parent %s (no prefill key)", tc.parent.ID)
 			}
 
 			// Sub-request keys must be deleted (INV-PD-6).

--- a/sim/cluster/pd_metrics.go
+++ b/sim/cluster/pd_metrics.go
@@ -112,8 +112,10 @@ func CollectPDMetrics(
 
 		// BC-1: parent TTFT from the aggregated TTFT map, keyed by parent ID.
 		// After projectPDMetrics(), the user-visible TTFT is stored under the parent ID.
-		// Value = prefillTTFT + KV transfer duration + first decode step — the full
-		// time from arrival to the first token reaching the user (issue #930).
+		// Value = decodeSchedulingDelay + first decode step — the full arrival →
+		// first-token-emitted-by-decode span, carrying exactly one OutputTokenProcessingTime
+		// (issue #1510, correcting the earlier prefillTTFT+transfer+decode composition of
+		// #930 which double-counted OTPT and omitted the decode-queue wait).
 		// Missing key returns 0.0 in Go maps; exclude 0.0 values (BC-11).
 		if ttft := aggregated.RequestTTFTs[p.ID]; ttft > 0 {
 			ttftValues = append(ttftValues, ttft)


### PR DESCRIPTION
## Summary

On the PD-disaggregated (prefill/decode split) path, the user-visible **time-to-first-token (TTFT)** BLIS reports was assembled in `projectPDMetrics` with a formula that had two independent defects:

1. **Double-counted `OutputTokenProcessingTime` (OTPT)** — `prefillTTFT` already carries one OTPT (`sim/simulator.go:998`) and `firstDecodeStep = ITL[0]` carries a second (`sim/simulator.go:987`), so summing both landed **two** when exactly **one** is correct (the decode pod streams the first real token once).
2. **Omitted the decode-queue wait** — the time the decode sub-request spends queued on the decode instance between the KV transfer completing and its first decode step. Under load this term dominates, so reported TTFT was *smaller* than a real user sees — exactly the regime capacity planning cares about.

## The fix

Replace the composed formula with the decode sub-request's own scheduling delay plus the first decode step:

```go
newTTFT = decodeSchedulingDelay + firstDecodeStep
```

`decodeSchedulingDelay = RequestSchedulingDelays[decodeSubReqID]`. Because the decode sub-request's `ArrivalTime` is set to the parent's original arrival time (`sim/cluster/pd_events.go:139`), that delay already spans `prefill_queue + prefill_step + kv_transfer + decode_queue_wait` — adding the previously-missing wait — and `firstDecodeStep = ITL[0]` contributes the single legitimate OTPT. This is structurally identical to the non-PD TTFT (`scheduling_delay + first-token step`) and works for **every** disaggregating configuration (`RequestSchedulingDelays` is recorded unconditionally for any scheduled request).

Worked example from the issue (µs): `prefill_queue=100, prefill_step=400, OTPT=50, kv_transfer=200, decode_queue_wait=3000, first_decode_step=300`. Old formula reported **1100**; correct value is **4050**. The fix now yields the correct value.

## Behavioral contracts

- **BC-1** — GIVEN a completed PD parent with a recorded decode scheduling delay and non-empty decode ITL, WHEN `projectPDMetrics` runs, THEN reported TTFT = `decodeSchedulingDelay + firstDecodeStep` (the true arrival → first-token-emitted span, containing exactly one OTPT).
- **BC-2** — GIVEN a decode instance under load (positive decode-queue wait), WHEN TTFT is reported, THEN the wait is included (reported TTFT strictly exceeds the old formula's value). Verified under a **pinned loaded** decode instance, not by re-typing the formula.
- **BC-3** — GIVEN any PD run, WHEN projection completes, THEN `TTFTSum` stays consistent with the sum/mean of projected `RequestTTFTs` (pre-projection baseline per parent is `prefillTTFT`; the decode sub-request contributes 0, so the delta identity is unchanged), and `TTFT > 0`.
- **Guard** now gates on `hasPrefillTTFT && hasDecodeDelay && DecodeSubReq != nil && len(ITL) > 0` (the two transfer-timestamp guards are replaced by `hasDecodeDelay`; `hasPrefillTTFT` is retained as the `TTFTSum` baseline and to preserve the three outcome branches). Added a defensive `newTTFT < 0` fallback mirroring the adjacent E2E block.

## Why the tests changed (test epistemology)

The prior test (`disaggregation_test.go:939`) set `expectedTTFT` to the **production formula retyped** — a tautology (`code == recompute(code)`) that stayed green for *any* formula, including both buggy ones, and never exercised queue wait. Per this repo's "test laws, not values" standard it is replaced with:

1. **`TestDisaggregation_TTFT_IncludesTransferAndDecode`** — a residual decomposed against **independent** `ParentRequest` phase timestamps (`DecodeEnqueueTime − ArrivalTime`, recorded by a different mechanism than the scheduling-delay map the fix reads) plus a **differential vs the old formula** (`reported < old` at low load, proving the phantom OTPT is gone).
2. **`TestDisaggregation_TTFT_IncludesDecodeQueueWait`** — a **pinned loaded** scenario (1 decode instance, `maxRunningReqs=1`, 6 overlapping short requests) that deterministically forces `decode_queue_wait > OTPT`, asserts the residual proves the wait is included and `reported > old`, and `t.Fatal`s (never `t.Skip`) if no parent queued.
3. **`TestDisaggregation_TTFT_ProjectionBranches`** — unit-tests the primary / prefill-fallback / Branch-C / negative-guard branches and the `TTFTSum` delta.

## Testing verification

- `go build ./...` — passes
- `go test ./...` — all packages pass (11 ok, 0 fail)
- `golangci-lint run ./...` — 0 issues
- Determinism (INV-6) verified: 3 identical runs produce byte-identical `TTFTSum` and `sum(RequestTTFTs)`.

## Parity & invariants

Applies identically on `blis run` and `blis replay` (both reach the shared `projectPDMetrics` via `ClusterSimulator.Run()` — no separate replay TTFT path), so **INV-13** run/replay parity is preserved by construction. **INV-6** (determinism) holds (verified above). No `logrus.Fatalf` added to library code. Golden tests do not exercise the PD path, so their values are unaffected.

> **Note on INV-5 (`TTFT ≤ E2E`):** this PR does not claim INV-5 holds on the PD path. Review surfaced a **pre-existing** bug on `main` (independent of this change) in which the parent E2E under-counts the decode step, so `TTFT ≤ E2E` can be violated for short-output PD requests — filed as #1513. This PR corrects the TTFT numerator (reducing the discrepancy) but cannot eliminate the violation, since the breach is on the E2E side and out of scope here.

## Discovered Issues

- **#1511** — Pre-existing (not introduced here): drop-at-transfer-start PD parents evaluate `completed == true` and enter the TTFT/E2E distributions. The old formula routed them to the same prefill-only fallback, so this PR does not change the behavior; it is documented in a code comment and filed separately.
- **#1513** — Pre-existing (not introduced here): parent E2E under-counts the decode step advance on the PD path, so `TTFT ≤ E2E` (INV-5) can be violated for short-output requests. The breach is on the E2E side; this PR corrects the TTFT numerator (reducing the gap) but cannot close it, and the E2E fix is out of scope here.

Fixes #1510

