### PR TITLE
fix(kv): consult offload tiers on every request, not only on GPU alloc failure (#1586)

### DIFF
--- a/sim/kv/tiered.go
+++ b/sim/kv/tiered.go
@@ -193,14 +193,34 @@ func NewTieredKVCache(gpu *KVCacheState, cpuBlocks int64, threshold, bandwidth f
 }
 
 func (t *TieredKVCache) AllocateKVBlocks(req *sim.Request, startIndex, endIndex int64, cachedBlocks []int64) bool {
-	ok := t.gpu.AllocateKVBlocks(req, startIndex, endIndex, cachedBlocks)
-	if ok {
-		return true
+	// BC-D3.3 (#1586): consult the CPU offload tier on EVERY request, before GPU
+	// allocation — mirroring vLLM's offload connector (get_num_new_matched_tokens on
+	// the normal waiting-queue path, with no reference to GPU pressure). Previously the
+	// reload ran only after GPU allocation failed, so under light GPU load a prefix
+	// resident on CPU-but-evicted-from-GPU was silently recomputed and counted as a
+	// miss — making cache-hit accounting load-shaped rather than load-independent.
+	//
+	// Resume the prefix hash chain just past the GPU-resident prefix the caller already
+	// matched (cachedBlocks), using its last block's hash as the chain seed. This keeps
+	// the common fully-GPU-cached case at one hash + one CPU lookup instead of
+	// re-hashing the whole prefix from block 0 (hot-path mitigation, evidence P).
+	reloadStartBlock := int64(len(cachedBlocks))
+	reloadPrevHash := ""
+	if reloadStartBlock > 0 {
+		reloadPrevHash = t.gpu.Blocks[cachedBlocks[reloadStartBlock-1]].Hash
 	}
-	// GPU allocation failed — try targeted CPU reload for this request's prefix.
-	reloaded := t.reloadPrefixFromCPU(req.FullInputTokens())
-	if reloaded {
-		// Re-compute cached blocks now that CPU content is back on GPU
+	// A continuing (running) request already owns its prefix blocks (cachedBlocks is empty
+	// on that path); resume past what it owns so we never reload a block position it
+	// already holds — in particular its partially-filled last block, whose empty hash
+	// would also break the chain seed. Reloading such a position would place a duplicate,
+	// full copy on the free list that the running-request path never claims but the GPU
+	// pre-check still budgets for, spuriously failing the allocation.
+	if owned, ok := t.gpu.RequestMap[req.ID]; ok && int64(len(owned)) > reloadStartBlock {
+		reloadStartBlock = int64(len(owned))
+		reloadPrevHash = t.gpu.Blocks[owned[len(owned)-1]].Hash
+	}
+	if t.reloadPrefixFromCPU(req.FullInputTokens(), reloadStartBlock, reloadPrevHash) {
+		// Re-compute cached blocks now that CPU content is back on the GPU free list.
 		newCached := t.gpu.GetCachedBlocks(req.FullInputTokens())
 		newStart := int64(len(newCached)) * t.gpu.BlockSize()
 		if newStart > startIndex {
@@ -250,11 +270,18 @@ func (t *TieredKVCache) AllocateKVBlocks(req *sim.Request, startIndex, endIndex 
 			}
 			return t.gpu.AllocateKVBlocks(req, newStart, endIndex, newCached)
 		}
-		// No new cache hits — retry with original params (reload freed up space)
+		// Reload produced no prefix hit beyond startIndex — allocate with the
+		// caller's original params (any space freed by the reload still helps).
 		return t.gpu.AllocateKVBlocks(req, startIndex, endIndex, cachedBlocks)
 	}
-	t.cpuMissCount++
-	return false
+	// No CPU-resident continuation: allocate on GPU exactly as the single-tier path.
+	// cpuMissCount++ preserves the pre-#1586 semantic — incremented only when the CPU
+	// tier could not help AND the GPU allocation fails.
+	ok := t.gpu.AllocateKVBlocks(req, startIndex, endIndex, cachedBlocks)
+	if !ok {
+		t.cpuMissCount++
+	}
+	return ok
 }
 
 // reloadPrefixFromCPU attempts to reload prefix-matching blocks from CPU to GPU.
@@ -262,16 +289,22 @@ func (t *TieredKVCache) AllocateKVBlocks(req *sim.Request, startIndex, endIndex 
 // Reloaded blocks are placed back on the GPU free list with valid hashes (not allocated).
 // Returns true if any blocks were reloaded.
 //
+// The scan begins at startBlock, whose predecessor's block hash is prevHash (the empty
+// string when startBlock == 0). Callers pass the length of the already-GPU-resident
+// prefix and that prefix's last block hash so the scan resumes at the first uncached
+// block instead of re-hashing blocks already on GPU (#1586 hot-path mitigation). The
+// hierarchical hash chain is identical to a scan from block 0, since GPU-resident blocks
+// would only be skipped anyway.
+//
 // The maxReloads guard ensures we never pop the same GPU free block twice —
 // each reload uses a distinct free block. Without this, pop+append creates
 // a cycle where block A's hash is destroyed on the second pop.
-func (t *TieredKVCache) reloadPrefixFromCPU(tokens []sim.TokenID) bool {
+func (t *TieredKVCache) reloadPrefixFromCPU(tokens []sim.TokenID, startBlock int64, prevHash string) bool {
 	n := util.Len64(tokens) / t.gpu.BlockSize()
 	maxReloads := t.gpu.countFreeBlocks() // limit to distinct free blocks
-	prevHash := ""
 	reloaded := false
 	reloadCount := int64(0)
-	for i := int64(0); i < n; i++ {
+	for i := startBlock; i < n; i++ {
 		start := i * t.gpu.BlockSize()
 		end := start + t.gpu.BlockSize()
 		h := hash.HashBlock(prevHash, tokens[start:end])

--- a/sim/kv/tiered_test.go
+++ b/sim/kv/tiered_test.go
@@ -1039,3 +1039,233 @@ func TestTieredLazyHashDeletion_CPUReload(t *testing.T) {
 	// (lazy hash deletion in CPU reload path clears old hash before filling with CPU content)
 	// This verifies the lazy deletion in tiered.go reloadFromCPU path
 }
+
+// --- BC-D3 (#1586): consult offload tiers on EVERY request, not only on GPU alloc failure ---
+
+// runSharedPrefixReuseWorkload drives a FIXED shared-prefix workload through the
+// TieredKVCache exactly as batch_formation does (GetCachedBlocks -> AllocateKVBlocks ->
+// MirrorToCPU -> ReleaseKVBlocks per request), round-robin across K distinct system
+// prefixes so each prefix's reuse is interleaved with churn from the others. Returns the
+// final CacheHitRate(). The workload is identical across GPU capacities; only gpuBlocks
+// varies — this is the metamorphic knob for BC-D3.3.
+func runSharedPrefixReuseWorkload(gpuBlocks int64) float64 {
+	const (
+		blockSize = int64(2)
+		numPrefix = 6 // K distinct system prompts
+		prefixBlk = int64(4)
+		rounds    = 8 // reuses per prefix
+		suffixBlk = int64(1)
+	)
+	gpu := NewKVCacheState(gpuBlocks, blockSize)
+	tiered := NewTieredKVCache(gpu, 100000, 0.0, 1.0, 0) // CPU tier large: never evicts
+
+	prefixes := make([][]sim.TokenID, numPrefix)
+	for k := 0; k < numPrefix; k++ {
+		p := make([]sim.TokenID, prefixBlk*blockSize)
+		for i := range p {
+			p[i] = sim.TokenID(1000*(k+1) + i) // disjoint token range per prefix
+		}
+		prefixes[k] = p
+	}
+
+	reqSeq := 0
+	for r := 0; r < rounds; r++ {
+		for k := 0; k < numPrefix; k++ {
+			reqSeq++
+			toks := make([]sim.TokenID, 0, (prefixBlk+suffixBlk)*blockSize)
+			toks = append(toks, prefixes[k]...)
+			for j := int64(0); j < suffixBlk*blockSize; j++ {
+				toks = append(toks, sim.TokenID(9000000+reqSeq*10+int(j))) // unique suffix
+			}
+			req := &sim.Request{ID: fmt.Sprintf("r%d", reqSeq), InputTokens: toks}
+			cached := tiered.GetCachedBlocks(req.FullInputTokens())
+			startIndex := int64(len(cached)) * blockSize
+			endIndex := int64(len(toks))
+			if !tiered.AllocateKVBlocks(req, startIndex, endIndex, cached) {
+				continue
+			}
+			tiered.MirrorToCPU([]*sim.Request{req})
+			tiered.ReleaseKVBlocks(req)
+		}
+	}
+	return tiered.CacheHitRate()
+}
+
+// TestTieredKVCache_HitRate_FlatAcrossGPUCapacity is the discriminating BC-D3.3 test.
+// With the CPU tier and workload fixed, the cache hit rate must be FLAT as GPU capacity
+// is swept upward. Under the pre-fix code (CPU consulted only on GPU alloc failure) the
+// hit rate RISES with capacity, because larger GPUs retain more prefixes on-GPU while
+// smaller GPUs evict them to CPU-only where the old code ignored them.
+func TestTieredKVCache_HitRate_FlatAcrossGPUCapacity(t *testing.T) {
+	capacities := []int64{14, 22, 40, 80}
+	rates := make([]float64, len(capacities))
+	minR, maxR := 1.0, 0.0
+	for i, c := range capacities {
+		rates[i] = runSharedPrefixReuseWorkload(c)
+		if rates[i] < minR {
+			minR = rates[i]
+		}
+		if rates[i] > maxR {
+			maxR = rates[i]
+		}
+	}
+	// Flatness: the spread across capacities must be within noise.
+	assert.Less(t, maxR-minR, 0.02,
+		"BC-D3.3: hit rate must be flat across GPU capacity, got rates=%v (spread=%.4f)", rates, maxR-minR)
+	// Sanity: reloads actually happen (not trivially flat because everything misses).
+	assert.Greater(t, minR, 0.5,
+		"BC-D3.3: CPU reloads should keep hit rate high at every capacity, got rates=%v", rates)
+}
+
+// TestTieredKVCache_GetCachedBlocks_ReflectsCPUTierAfterAllocate is the BC-D3.1 test.
+// A prefix resident only on CPU (evicted from GPU) must be consulted and materialized on
+// GPU during AllocateKVBlocks EVEN WHEN the GPU has free space (the light-load case the
+// pre-fix code skipped). Discriminator: cpuHitCount increases despite free GPU blocks.
+func TestTieredKVCache_GetCachedBlocks_ReflectsCPUTierAfterAllocate(t *testing.T) {
+	gpu := NewKVCacheState(10, 2) // blockSize=2
+	tiered := NewTieredKVCache(gpu, 100, 0.0, 1.0, 0)
+
+	prefix := []sim.TokenID{1, 2, 3, 4, 5, 6} // 3 blocks
+
+	// Seed: allocate prefix, mirror to CPU, release.
+	seed := &sim.Request{ID: "seed", InputTokens: prefix}
+	require.True(t, tiered.AllocateKVBlocks(seed, 0, 6, []int64{}))
+	tiered.MirrorToCPU([]*sim.Request{seed})
+	tiered.ReleaseKVBlocks(seed)
+
+	// Evict the prefix from GPU by fully churning ALL 10 blocks with unique content
+	// (popFreeBlock overwrites the seed's hashes), then release the churn so the GPU
+	// is empty (LIGHT LOAD: 10 free blocks). Fill entirely before releasing so every
+	// block — including the seed's — is popped and its hash cleared.
+	for i := 0; i < 10; i++ {
+		f := &sim.Request{ID: fmt.Sprintf("churn%d", i), InputTokens: []sim.TokenID{sim.TokenID(500 + i*2), sim.TokenID(501 + i*2)}}
+		require.True(t, tiered.AllocateKVBlocks(f, 0, 2, []int64{}))
+	}
+	for i := 0; i < 10; i++ {
+		tiered.ReleaseKVBlocks(&sim.Request{ID: fmt.Sprintf("churn%d", i)})
+	}
+	require.Equal(t, int64(10), gpu.countFreeBlocks(), "GPU must have free space (light load)")
+	require.Equal(t, 0, len(tiered.GetCachedBlocks(prefix)), "prefix must be evicted from GPU")
+
+	// WHEN a new request with the same prefix is allocated (free GPU space available).
+	hitsBefore := tiered.cpuHitCount
+	newReq := &sim.Request{ID: "new", InputTokens: prefix}
+	cached := tiered.GetCachedBlocks(newReq.FullInputTokens()) // empty (GPU-only, pure)
+	require.True(t, tiered.AllocateKVBlocks(newReq, int64(len(cached))*2, 6, cached))
+
+	// THEN the CPU tier was consulted despite free GPU space (BC-D3.3 light-load) ...
+	assert.Greater(t, tiered.cpuHitCount, hitsBefore,
+		"BC-D3.1/3.3: CPU tier must be consulted with GPU space available")
+	// ... and GetCachedBlocks now reflects the materialized prefix (BC-D3.1).
+	assert.Equal(t, 3, len(tiered.GetCachedBlocks(prefix)),
+		"BC-D3.1: GetCachedBlocks must reflect the prefix after tier consultation materializes it on GPU")
+}
+
+// TestTieredKVCache_HitRate_MonotoneInCPUResidency is the BC-D3.2 test: adding a matching
+// block to the (lower) CPU tier must not decrease the observed cache hit rate.
+func TestTieredKVCache_HitRate_MonotoneInCPUResidency(t *testing.T) {
+	// Two identical runs; one seeds the shared prefix into CPU, the other does not.
+	run := func(seedCPU bool) float64 {
+		gpu := NewKVCacheState(12, 2)
+		tiered := NewTieredKVCache(gpu, 100, 0.0, 1.0, 0)
+		prefix := []sim.TokenID{7, 8, 9, 10, 11, 12} // 3 blocks
+
+		if seedCPU {
+			// Materialize the prefix into CPU (and evict from GPU) before the measured run.
+			s := &sim.Request{ID: "s", InputTokens: prefix}
+			require.True(t, tiered.AllocateKVBlocks(s, 0, 6, []int64{}))
+			tiered.MirrorToCPU([]*sim.Request{s})
+			tiered.ReleaseKVBlocks(s)
+			for i := 0; i < 6; i++ { // churn all 12 blocks to evict prefix from GPU
+				f := &sim.Request{ID: fmt.Sprintf("c%d", i), InputTokens: []sim.TokenID{sim.TokenID(400 + i*2), sim.TokenID(401 + i*2)}}
+				require.True(t, tiered.AllocateKVBlocks(f, 0, 2, []int64{}))
+				tiered.ReleaseKVBlocks(f)
+			}
+			// Reset counters so both runs measure only the workload below.
+			gpu.CacheHits, gpu.CacheMisses, tiered.cpuMissCount = 0, 0, 0
+		}
+
+		for r := 0; r < 4; r++ {
+			toks := append(append([]sim.TokenID{}, prefix...), sim.TokenID(8000+r*2), sim.TokenID(8001+r*2))
+			req := &sim.Request{ID: fmt.Sprintf("w%d", r), InputTokens: toks}
+			cached := tiered.GetCachedBlocks(req.FullInputTokens())
+			if !tiered.AllocateKVBlocks(req, int64(len(cached))*2, int64(len(toks)), cached) {
+				continue
+			}
+			tiered.MirrorToCPU([]*sim.Request{req})
+			tiered.ReleaseKVBlocks(req)
+		}
+		return tiered.CacheHitRate()
+	}
+	withCPU := run(true)
+	withoutCPU := run(false)
+	assert.GreaterOrEqual(t, withCPU, withoutCPU,
+		"BC-D3.2: hit rate must not decrease when a matching block is resident in the CPU tier (withCPU=%.4f, withoutCPU=%.4f)", withCPU, withoutCPU)
+}
+
+// BenchmarkTieredAllocate_GPUCachedPrefix measures the per-request AllocateKVBlocks cost
+// on the hot path introduced by #1586 (the CPU tier is now consulted on EVERY request).
+// The request has a long, fully-GPU-resident shared prefix plus a fresh suffix block —
+// the common shared-prefix serving case. The startBlock mitigation resumes the reload
+// scan just past the GPU-cached prefix, so per request it costs ~one hash + one CPU
+// lookup rather than re-hashing the whole prefix. Reported to demonstrate no material
+// regression (evidence P); compare against the single-tier baseline below.
+func BenchmarkTieredAllocate_GPUCachedPrefix(b *testing.B) {
+	const blockSize = int64(16)
+	const prefixBlocks = int64(32) // 512-token shared prefix
+	gpu := NewKVCacheState(1<<20, blockSize)
+	tiered := NewTieredKVCache(gpu, 1<<20, 0.0, 100.0, 0)
+
+	toks := make([]sim.TokenID, (prefixBlocks+1)*blockSize) // prefix + 1 suffix block
+	for i := range toks {
+		toks[i] = sim.TokenID(i + 1)
+	}
+	// Prime the prefix onto GPU (hashes survive release) and CPU (mirror).
+	seed := &sim.Request{ID: "seed", InputTokens: toks}
+	tiered.AllocateKVBlocks(seed, 0, int64(len(toks)), nil)
+	tiered.MirrorToCPU([]*sim.Request{seed})
+	tiered.ReleaseKVBlocks(seed)
+
+	req := &sim.Request{ID: "r", InputTokens: toks}
+	suffixPos := int(prefixBlocks * blockSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		toks[suffixPos] = sim.TokenID(1000000 + i) // fresh suffix block each iteration
+		cached := tiered.GetCachedBlocks(req.FullInputTokens())
+		startIndex := int64(len(cached)) * blockSize
+		tiered.AllocateKVBlocks(req, startIndex, int64(len(toks)), cached)
+		b.StopTimer()
+		tiered.ReleaseKVBlocks(req)
+		b.StartTimer()
+	}
+}
+
+// BenchmarkSingleTierAllocate_GPUCachedPrefix is the single-tier baseline for the above:
+// identical workload with no CPU tier, so no reload scan runs at all. The delta between
+// the two is the per-request cost the #1586 tier consultation adds.
+func BenchmarkSingleTierAllocate_GPUCachedPrefix(b *testing.B) {
+	const blockSize = int64(16)
+	const prefixBlocks = int64(32)
+	gpu := NewKVCacheState(1<<20, blockSize)
+
+	toks := make([]sim.TokenID, (prefixBlocks+1)*blockSize)
+	for i := range toks {
+		toks[i] = sim.TokenID(i + 1)
+	}
+	seed := &sim.Request{ID: "seed", InputTokens: toks}
+	gpu.AllocateKVBlocks(seed, 0, int64(len(toks)), nil)
+	gpu.ReleaseKVBlocks(seed)
+
+	req := &sim.Request{ID: "r", InputTokens: toks}
+	suffixPos := int(prefixBlocks * blockSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		toks[suffixPos] = sim.TokenID(1000000 + i)
+		cached := gpu.GetCachedBlocks(req.FullInputTokens())
+		startIndex := int64(len(cached)) * blockSize
+		gpu.AllocateKVBlocks(req, startIndex, int64(len(toks)), cached)
+		b.StopTimer()
+		gpu.ReleaseKVBlocks(req)
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
## Summary

`TieredKVCache` consulted the CPU offload tier **only after GPU allocation failed**
([`sim/kv/tiered.go:195`](https://github.com/inference-sim/inference-sim/blob/52161669e133afc100f0d99223dde933c8b1b924/sim/kv/tiered.go#L195-L201)).
Under light GPU load (space available) a prefix resident on CPU-but-evicted-from-GPU was
silently recomputed and counted as a **MISS**. This made cache-hit accounting **load-shaped**:
sweeping GPU capacity upward changed the hit rate, so any latency coefficient fitted across a
capacity sweep absorbed a load-dependent bias.

This PR moves the CPU-tier consultation to the **front** of `AllocateKVBlocks` so it runs on
**every** request, before GPU allocation — mirroring vLLM's offload connector
(`get_num_new_matched_tokens` on the normal waiting-queue path, with no reference to GPU
pressure). The existing reload + commit machinery is reused verbatim; only the call site moves.

**Closes #1586** (sub-issue of the multi-tier KV offload epic #1585 — the prerequisite bug fix).

## What changed

- `AllocateKVBlocks` consults the CPU tier on every request (before GPU allocation) instead of
  only on the alloc-failure path.
- `reloadPrefixFromCPU` gained a `startBlock`/`prevHash` parameter so the scan resumes just past
  the prefix the request already owns/matched (hot-path mitigation, evidence P) and never reloads
  a block position the request already holds — in particular a partially-filled last block, whose
  empty hash would otherwise place a duplicate on the free list that the running-request path never
  claims but the GPU pre-check still budgets for.
- `cpuMissCount` keeps its pre-#1586 semantic exactly: incremented only when the CPU tier cannot
  help **and** the GPU allocation fails.

## Behavioral contracts (GIVEN / WHEN / THEN)

| ID | Guarantee | Test |
|---|---|---|
| **BC-D3.1** | GIVEN a prefix resident only on CPU, WHEN a request with that prefix is allocated (even with free GPU space), THEN the tier is consulted and `GetCachedBlocks` reflects the materialized prefix | `TestTieredKVCache_GetCachedBlocks_ReflectsCPUTierAfterAllocate` |
| **BC-D3.2** | `CacheHitRate` does not decrease when a matching block is resident in the CPU tier | `TestTieredKVCache_HitRate_MonotoneInCPUResidency` |
| **BC-D3.3** (discriminating) | With tier + workload fixed, `CacheHitRate` is **flat** as GPU capacity is swept (it *rose* under the bug) | `TestTieredKVCache_HitRate_FlatAcrossGPUCapacity` |
| **BC-D3.4** | INV-4 (`allocated + free = total`) holds across light-load reloads | existing conservation tests + light-load path |
| **BC-D3.5** | INV-6: byte-identical stdout | non-tiered runs (exact) + committed golden datasets (unchanged) |

`BC-D3.3` is the law-not-value test required by the BDD/TDD rules: it fails on the unmodified
code (hit rate `[0, 0, 0.7, 0.7]` across capacities) and passes after the fix (flat).

## Why `GetCachedBlocks` stays a pure GPU query (BC-D3.1 interpretation)

`GetCachedBlocks` is called **live** on the routing/scoring path
(`InstanceSimulator.GetCachedBlockCount` → `KVCache.GetCachedBlocks`) in Immediate snapshot mode
(INV-7). Making it reload CPU→GPU would mutate KV state on non-selected candidate instances during
scoring and pollute transfer latency — a worse bug than the one fixed. So `GetCachedBlocks` and
`SnapshotCachedBlocksFn` are left untouched (pure, GPU-only), and BC-D3.1 is satisfied at the
**allocation boundary**: `AllocateKVBlocks` consults all tiers on every request and materializes
CPU-resident prefix blocks onto the GPU, after which `GetCachedBlocks` reflects them.

## Evidence

**Unit (metamorphic + property):** the three BC-D3 tests above; the discriminating BC-D3.3 test was
confirmed to fail pre-fix and pass post-fix.

**End-to-end** (roofline, `meta-llama/llama-3.1-8b-instruct`, shared-prefix workload, 40 unique
system prompts, low arrival rate so prefixes evict to CPU-only with free space at re-admission),
sweeping `--total-kv-blocks`:

| `--total-kv-blocks` | OLD `Cache Hit Rate` | this PR |
|---|---|---|
| 1200 | 0.8003 | 0.8050 |
| 8000 | 0.8047 | 0.8047 |

OLD **rises** with capacity (undercounts CPU-resident prefixes at small capacity); this PR is
**flat** — the load-shaped bias is removed. At large capacity both agree, because prefixes stay on
GPU and the buggy condition never fires.

**Golden datasets are byte-identical** (`go test ./sim/cluster -run Golden` passes unmodified). The
committed roofline tiered cases use large GPUs relative to their working set, so they never evict a
prefix to CPU-only and never hit the buggy condition. INV-6 therefore holds even for tiered configs
here; the metamorphic + end-to-end evidence above stands in for a golden re-baseline. (The issue
anticipated a golden change; empirically the committed workloads don't trigger the bug.)

**Performance (evidence P — reload now runs per request):**

```
BenchmarkTieredAllocate_GPUCachedPrefix-24        58631 ns/op   10281 B/op   224 allocs/op
BenchmarkSingleTierAllocate_GPUCachedPrefix-24    53287 ns/op   10074 B/op   220 allocs/op
```

~10% on the KV-allocate micro-op for a 33-block request (negligible end-to-end, where allocation is
a small fraction of step time). The `startBlock` mitigation bounds this to ~one hash + one CPU
lookup for a GPU-cached prefix; without it, reload would re-hash the entire prefix on every request.

## Scope

Interior change to `sim/kv.TieredKVCache`. `sim.KVStore` surface unchanged (12 methods); no new
`sim/kv` import; `GetCachedBlocks`/`SnapshotCachedBlocksFn` untouched.

## Verification

- `go build ./...` — clean
- `go test ./...` — all 11 packages pass
- `golangci-lint run ./...` (v2.9.0) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
