### PR TITLE
feat(kv-offload): fill hole H5 — capture vLLM's KV-offload config surface (#1587)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,17 @@ go build -o blis main.go
 # Run and export workload as TraceV2 (prefix auto-appends .yaml/.csv)
 ./blis run --model qwen/qwen3-14b --trace-output traces/run1
 
+# Run with a multi-tier KV-offload config (#1587). One strict-YAML flag captures vLLM's
+# offload config surface (kv_offload: block — cpu_bytes_to_use, block_size/blocks_per_chunk,
+# eviction_policy, offload_prompt_only [vLLM default TRUE], secondary_tiers[] with per-tier
+# device_class/direct_io/bandwidth). Absent => offload subsystem inert, byte-identical output
+# (BC-G5). Defaults match vLLM knob-for-knob; store_threshold>=2 and non-fs tiers fail loudly.
+# device_class names resolve against defaults.yaml kv_offload_devices. The resolved config is
+# recorded in the trace header and round-trips through replay (INV-13); on replay the header is
+# authoritative (a config it cannot reproduce is a hard error). Config-capture only today — the
+# consuming multi-tier mechanisms land separately.
+./blis run --model qwen/qwen3-14b --kv-offload-config offload.yaml --trace-output traces/run1
+
 # Replay a captured TraceV2 file through the DES (fixed timing from trace)
 ./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b
 

--- a/cmd/default_config.go
+++ b/cmd/default_config.go
@@ -30,6 +30,21 @@ type Config struct {
 	Workloads              map[string]Workload      `yaml:"workloads"`
 	TrainedPhysicsDefaults *TrainedPhysicsDefaults  `yaml:"trained_physics_coefficients,omitempty"`
 	LoRADefaults           *LoRADefaults            `yaml:"lora,omitempty"`
+	// KVOffloadDevices maps a device_class name to its bandwidth/latency physics for
+	// the KV-offload config surface (H5, #1587). Shipped constants (operator input),
+	// never fitted (BC-G4). Inert: only consulted when --kv-offload-config names a
+	// device_class. A struct-field map (decode target, read-only after load) — not an
+	// exported package var (R8-compatible, like Defaults/Workloads above).
+	KVOffloadDevices map[string]KVOffloadDeviceDefaults `yaml:"kv_offload_devices,omitempty"`
+}
+
+// KVOffloadDeviceDefaults is one device_class's resolved physics for KV offload
+// (H5, #1587). Bandwidths are bytes per microsecond; base_latency is microseconds.
+// Fields are plain float64 (always present within a device block).
+type KVOffloadDeviceDefaults struct {
+	ReadBandwidth  float64 `yaml:"read_bandwidth"`
+	WriteBandwidth float64 `yaml:"write_bandwidth"`
+	BaseLatency    float64 `yaml:"base_latency"`
 }
 
 // LoRADefaults holds inert defaults for the LoRA control-plane subsystem's cost

--- a/cmd/kv_offload.go
+++ b/cmd/kv_offload.go
@@ -1,0 +1,371 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// kvOffloadConfigPath backs the single new --kv-offload-config flag (H5, #1587).
+// Absent ("") ⇒ the offload subsystem is inert and output is byte-identical to a
+// build without the feature (BC-G5). Registered on run and replay via the shared
+// registerSimConfigFlags (INV-13 parity).
+var kvOffloadConfigPath string
+
+// kvOffloadFile is the on-disk shape of a --kv-offload-config YAML file: a single
+// top-level kv_offload: block. Strict-parsed (R10). Mirrors the --lora-config /
+// --saturation-config precedent.
+type kvOffloadFile struct {
+	KVOffload *kvOffloadBlock `yaml:"kv_offload"`
+}
+
+// kvOffloadBlock is the user-facing kv_offload: block. All fields are pointers so an
+// absent key is distinguishable from an explicit zero (R9): the resolver applies
+// vLLM's default only when the pointer is nil.
+//
+// NOTE store_threshold: it is captured (as *int) but is NOT a live knob on the
+// multi-tier path — vLLM's TieringOffloadingSpec rejects values >= 2 (it is
+// single-tier-only). The resolver rejects >= 2 loudly (BC-G1) and treats nil/0/1 as a
+// no-op (matching vLLM, which accepts 0/1 and ignores them on this path).
+type kvOffloadBlock struct {
+	CPUBytesToUse          *int64               `yaml:"cpu_bytes_to_use"`
+	BlockSize              *int64               `yaml:"block_size"`
+	BlocksPerChunk         *int64               `yaml:"blocks_per_chunk"`
+	TokensPerHash          *int64               `yaml:"tokens_per_hash"`
+	EvictionPolicy         *string              `yaml:"eviction_policy"`
+	OffloadPromptOnly      *bool                `yaml:"offload_prompt_only"`
+	SelfDescribingKVEvents *bool                `yaml:"self_describing_kv_events"`
+	StoreThreshold         *int                 `yaml:"store_threshold"`
+	SecondaryTiers         []kvOffloadTierBlock `yaml:"secondary_tiers"`
+}
+
+// kvOffloadTierBlock is one user-facing secondary tier. Pointer fields (R9).
+type kvOffloadTierBlock struct {
+	Type           *string  `yaml:"type"`
+	RootDir        *string  `yaml:"root_dir"`
+	NReadThreads   *int64   `yaml:"n_read_threads"`
+	NWriteThreads  *int64   `yaml:"n_write_threads"`
+	Locality       *string  `yaml:"locality"`
+	EnableKVEvents *bool    `yaml:"enable_kv_events"`
+	DirectIO       *bool    `yaml:"direct_io"`
+	DeviceClass    *string  `yaml:"device_class"`
+	ReadBandwidth  *float64 `yaml:"read_bandwidth"`
+	WriteBandwidth *float64 `yaml:"write_bandwidth"`
+	BaseLatency    *float64 `yaml:"base_latency"`
+}
+
+// loadKVOffloadConfigFile reads and strictly parses a --kv-offload-config file.
+// Returns an error (never Fatalf — so it is unit-testable/fuzzable, Deviation #9);
+// the CLI wrapper turns errors into logrus.Fatalf. Unknown keys error via
+// KnownFields(true) (R10).
+func loadKVOffloadConfigFile(path string) (kvOffloadFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return kvOffloadFile{}, fmt.Errorf("read --kv-offload-config file %q: %w", path, err)
+	}
+	f, err := parseKVOffloadBytes(data)
+	if err != nil {
+		return f, fmt.Errorf("parse --kv-offload-config file %q: %w", path, err)
+	}
+	return f, nil
+}
+
+// parseKVOffloadBytes strictly decodes kv_offload YAML bytes (R10). Split out so it is
+// directly fuzzable without touching disk.
+func parseKVOffloadBytes(data []byte) (kvOffloadFile, error) {
+	var f kvOffloadFile
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&f); err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
+// resolveKVOffload turns a parsed kv_offload block into a resolved, validated
+// sim.KVOffloadConfig. It is PURE and error-returning (Deviation #9) so every reject
+// branch is unit-testable and fuzzable. It applies vLLM's defaults knob-for-knob
+// (BC-G2), resolves device_class against the shipped device physics (explicit
+// read/write/base override the class), enforces the block_size XOR blocks_per_chunk
+// user-input rule then derives the canonical pair, rejects store_threshold>=2 and
+// non-fs tiers loudly (BC-G1), and finally runs cfg.Validate() (BC-G3).
+//
+// gpuBlockSizeTokens is the GPU block size (--block-size-in-tokens); vLLM's block_size
+// default equals it, and it converts between the block_size and blocks_per_chunk
+// encodings of the same quantity.
+func resolveKVOffload(block *kvOffloadBlock, devices map[string]KVOffloadDeviceDefaults, gpuBlockSizeTokens int64) (sim.KVOffloadConfig, error) {
+	if block == nil {
+		return sim.KVOffloadConfig{}, fmt.Errorf("kv_offload: the --kv-offload-config file has no top-level kv_offload: block")
+	}
+	if gpuBlockSizeTokens <= 0 {
+		return sim.KVOffloadConfig{}, fmt.Errorf("kv_offload: internal error — GPU block size must be > 0, got %d", gpuBlockSizeTokens)
+	}
+	cfg := sim.KVOffloadConfig{Enabled: true}
+
+	// cpu_bytes_to_use: required when the block is present (vLLM marks it required).
+	if block.CPUBytesToUse == nil {
+		return cfg, fmt.Errorf("kv_offload: cpu_bytes_to_use is required")
+	}
+	cfg.CPUBytesToUse = *block.CPUBytesToUse
+
+	// store_threshold: reject >= 2 (vLLM TieringOffloadingSpec); nil/0/1 are a no-op.
+	if block.StoreThreshold != nil && *block.StoreThreshold >= 2 {
+		return cfg, fmt.Errorf("kv_offload: store_threshold=%d: store_threshold is not supported for TieringOffloadingSpec (values >= 2 are rejected; it is single-tier-only and fixed at 1 on the multi-tier offload path)", *block.StoreThreshold)
+	}
+
+	// block_size XOR blocks_per_chunk (mutually exclusive alternate encodings of the
+	// same chunk-granularity quantity). Derive one canonical pair.
+	if block.BlockSize != nil && block.BlocksPerChunk != nil {
+		return cfg, fmt.Errorf("kv_offload: block_size and blocks_per_chunk are mutually exclusive (they encode the same quantity: block_size = blocks_per_chunk × gpu_block_size); set at most one")
+	}
+	switch {
+	case block.BlockSize != nil:
+		bs := *block.BlockSize
+		if bs <= 0 || bs%gpuBlockSizeTokens != 0 {
+			return cfg, fmt.Errorf("kv_offload: block_size (%d) must be a positive multiple of the GPU block size (%d)", bs, gpuBlockSizeTokens)
+		}
+		cfg.BlockSize = bs
+		cfg.BlocksPerChunk = bs / gpuBlockSizeTokens
+	case block.BlocksPerChunk != nil:
+		bpc := *block.BlocksPerChunk
+		if bpc <= 0 {
+			return cfg, fmt.Errorf("kv_offload: blocks_per_chunk must be > 0, got %d", bpc)
+		}
+		cfg.BlocksPerChunk = bpc
+		cfg.BlockSize = bpc * gpuBlockSizeTokens
+	default:
+		cfg.BlocksPerChunk = 1               // vLLM default
+		cfg.BlockSize = gpuBlockSizeTokens   // vLLM default = GPU block size
+	}
+
+	// tokens_per_hash: vLLM has no default (required); BLIS defaults to the GPU block
+	// size (natural one-hash-per-block stride).
+	if block.TokensPerHash != nil {
+		if *block.TokensPerHash <= 0 {
+			return cfg, fmt.Errorf("kv_offload: tokens_per_hash must be > 0, got %d", *block.TokensPerHash)
+		}
+		cfg.TokensPerHash = *block.TokensPerHash
+	} else {
+		cfg.TokensPerHash = gpuBlockSizeTokens
+	}
+
+	// eviction_policy: vLLM default "lru".
+	cfg.EvictionPolicy = "lru"
+	if block.EvictionPolicy != nil {
+		cfg.EvictionPolicy = *block.EvictionPolicy
+	}
+
+	// offload_prompt_only: vLLM DEFAULT TRUE (trap 1).
+	cfg.OffloadPromptOnly = true
+	if block.OffloadPromptOnly != nil {
+		cfg.OffloadPromptOnly = *block.OffloadPromptOnly
+	}
+
+	// self_describing_kv_events: vLLM default false.
+	if block.SelfDescribingKVEvents != nil {
+		cfg.SelfDescribingKVEvents = *block.SelfDescribingKVEvents
+	}
+
+	// secondary_tiers: vLLM default empty.
+	for i, tb := range block.SecondaryTiers {
+		tier, err := resolveKVOffloadTier(i, tb, devices)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.Tiers = append(cfg.Tiers, tier)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+// resolveKVOffloadTier resolves one secondary tier. index is used in error messages.
+func resolveKVOffloadTier(index int, tb kvOffloadTierBlock, devices map[string]KVOffloadDeviceDefaults) (sim.KVOffloadTier, error) {
+	var tier sim.KVOffloadTier
+
+	// type: required; only "fs" is representable (reject obj/p2p/example loudly, BC-G1).
+	if tb.Type == nil {
+		return tier, fmt.Errorf("kv_offload: secondary_tiers[%d].type is required", index)
+	}
+	tier.Type = *tb.Type
+	if tier.Type != "fs" {
+		return tier, fmt.Errorf("kv_offload: secondary_tiers[%d].type=%q is not supported in BLIS yet (only \"fs\" is representable; obj/p2p/example tiers have no faithful config mapping — see #1587/#1585)", index, tier.Type)
+	}
+
+	// root_dir: required for fs.
+	if tb.RootDir == nil || *tb.RootDir == "" {
+		return tier, fmt.Errorf("kv_offload: secondary_tiers[%d].root_dir is required for an \"fs\" tier", index)
+	}
+	tier.RootDir = *tb.RootDir
+
+	// n_read_threads / n_write_threads: vLLM default 16 each.
+	tier.NReadThreads = 16
+	if tb.NReadThreads != nil {
+		tier.NReadThreads = *tb.NReadThreads
+	}
+	tier.NWriteThreads = 16
+	if tb.NWriteThreads != nil {
+		tier.NWriteThreads = *tb.NWriteThreads
+	}
+
+	// locality: default unset ("").
+	if tb.Locality != nil {
+		tier.Locality = *tb.Locality
+	}
+
+	// enable_kv_events: vLLM default false.
+	if tb.EnableKVEvents != nil {
+		tier.EnableKVEvents = *tb.EnableKVEvents
+	}
+
+	// direct_io: REQUIRED — BLIS makes vLLM's runtime O_DIRECT probe an explicit
+	// config axis (direct vs buffered I/O are different physics regimes; a simulator
+	// cannot probe the operator's disk). No silent default.
+	if tb.DirectIO == nil {
+		return tier, fmt.Errorf("kv_offload: secondary_tiers[%d].direct_io must be set explicitly (BLIS makes vLLM's runtime O_DIRECT probe an explicit config axis; direct vs buffered I/O are materially different storage physics)", index)
+	}
+	tier.DirectIO = *tb.DirectIO
+
+	// bandwidth/latency: a device_class resolves the triple; explicit fields override.
+	hasClass := tb.DeviceClass != nil
+	if hasClass {
+		dev, ok := devices[*tb.DeviceClass]
+		if !ok {
+			return tier, fmt.Errorf("kv_offload: secondary_tiers[%d].device_class=%q is not defined in defaults.yaml kv_offload_devices (known: %s)", index, *tb.DeviceClass, knownDeviceClasses(devices))
+		}
+		tier.DeviceClass = *tb.DeviceClass
+		tier.ReadBandwidth = dev.ReadBandwidth
+		tier.WriteBandwidth = dev.WriteBandwidth
+		tier.BaseLatency = dev.BaseLatency
+	}
+	if tb.ReadBandwidth != nil {
+		tier.ReadBandwidth = *tb.ReadBandwidth
+	}
+	if tb.WriteBandwidth != nil {
+		tier.WriteBandwidth = *tb.WriteBandwidth
+	}
+	if tb.BaseLatency != nil {
+		tier.BaseLatency = *tb.BaseLatency
+	}
+	// Every tier needs a resolvable physics triple: either a device_class or the full
+	// explicit read_bandwidth + write_bandwidth + base_latency (per-(tier,direction)
+	// bandwidth is required — never a single number, #1588 BC-S3).
+	if !hasClass && (tb.ReadBandwidth == nil || tb.WriteBandwidth == nil || tb.BaseLatency == nil) {
+		return tier, fmt.Errorf("kv_offload: secondary_tiers[%d] needs a device_class OR an explicit read_bandwidth + write_bandwidth + base_latency triple", index)
+	}
+	return tier, nil
+}
+
+// knownDeviceClasses returns the sorted device_class names for a deterministic error
+// message (INV-6: no map-iteration order in output).
+func knownDeviceClasses(devices map[string]KVOffloadDeviceDefaults) string {
+	if len(devices) == 0 {
+		return "<none configured>"
+	}
+	names := make([]string, 0, len(devices))
+	for n := range devices {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// resolveKVOffloadConfig is the thin CLI wrapper (Deviation #9): it reads the flag,
+// loads the file + shipped device physics, calls the pure resolver, and logrus.Fatalf's
+// on any error (CLI boundary). Absent flag ⇒ inert zero value. Single construction
+// site (R4), shared by run and replay for INV-13 parity.
+func resolveKVOffloadConfig(cmd *cobra.Command) sim.KVOffloadConfig {
+	if kvOffloadConfigPath == "" {
+		return sim.KVOffloadConfig{}
+	}
+	f, err := loadKVOffloadConfigFile(kvOffloadConfigPath)
+	if err != nil {
+		logrus.Fatalf("%v", err)
+	}
+	devices := loadDefaultsConfig(defaultsFilePath).KVOffloadDevices
+	cfg, err := resolveKVOffload(f.KVOffload, devices, blockSizeTokens)
+	if err != nil {
+		logrus.Fatalf("--kv-offload-config %q: %v", kvOffloadConfigPath, err)
+	}
+	return cfg
+}
+
+// simToHeaderOffload converts a resolved sim.KVOffloadConfig into its trace-header
+// serialization (H5, #1587). Returns nil when inert, so a disabled run omits the
+// kv_offload header key entirely (BC-G5). Lossless inverse of headerToSimOffload.
+func simToHeaderOffload(c sim.KVOffloadConfig) *workload.TraceKVOffloadConfig {
+	if !c.IsEnabled() {
+		return nil
+	}
+	h := &workload.TraceKVOffloadConfig{
+		CPUBytesToUse:          c.CPUBytesToUse,
+		BlockSize:              c.BlockSize,
+		BlocksPerChunk:         c.BlocksPerChunk,
+		TokensPerHash:          c.TokensPerHash,
+		EvictionPolicy:         c.EvictionPolicy,
+		OffloadPromptOnly:      c.OffloadPromptOnly,
+		SelfDescribingKVEvents: c.SelfDescribingKVEvents,
+	}
+	for _, t := range c.Tiers {
+		h.Tiers = append(h.Tiers, workload.TraceKVOffloadTier{
+			Type:           t.Type,
+			RootDir:        t.RootDir,
+			NReadThreads:   t.NReadThreads,
+			NWriteThreads:  t.NWriteThreads,
+			Locality:       t.Locality,
+			EnableKVEvents: t.EnableKVEvents,
+			DirectIO:       t.DirectIO,
+			DeviceClass:    t.DeviceClass,
+			ReadBandwidth:  t.ReadBandwidth,
+			WriteBandwidth: t.WriteBandwidth,
+			BaseLatency:    t.BaseLatency,
+		})
+	}
+	return h
+}
+
+// headerToSimOffload reconstructs a resolved sim.KVOffloadConfig from a trace header
+// (BC-G6). Returns the inert zero value when the header carries no offload block.
+// Lossless inverse of simToHeaderOffload. The caller (replay) runs Validate() on the
+// result and logrus.Fatalf's if the recorded config cannot be reproduced.
+func headerToSimOffload(h *workload.TraceKVOffloadConfig) sim.KVOffloadConfig {
+	if h == nil {
+		return sim.KVOffloadConfig{}
+	}
+	c := sim.KVOffloadConfig{
+		Enabled:                true,
+		CPUBytesToUse:          h.CPUBytesToUse,
+		BlockSize:              h.BlockSize,
+		BlocksPerChunk:         h.BlocksPerChunk,
+		TokensPerHash:          h.TokensPerHash,
+		EvictionPolicy:         h.EvictionPolicy,
+		OffloadPromptOnly:      h.OffloadPromptOnly,
+		SelfDescribingKVEvents: h.SelfDescribingKVEvents,
+	}
+	for _, t := range h.Tiers {
+		c.Tiers = append(c.Tiers, sim.KVOffloadTier{
+			Type:           t.Type,
+			RootDir:        t.RootDir,
+			NReadThreads:   t.NReadThreads,
+			NWriteThreads:  t.NWriteThreads,
+			Locality:       t.Locality,
+			EnableKVEvents: t.EnableKVEvents,
+			DirectIO:       t.DirectIO,
+			DeviceClass:    t.DeviceClass,
+			ReadBandwidth:  t.ReadBandwidth,
+			WriteBandwidth: t.WriteBandwidth,
+			BaseLatency:    t.BaseLatency,
+		})
+	}
+	return c
+}

--- a/cmd/kv_offload.go
+++ b/cmd/kv_offload.go
@@ -107,7 +107,7 @@ func resolveKVOffload(block *kvOffloadBlock, devices map[string]KVOffloadDeviceD
 		return sim.KVOffloadConfig{}, fmt.Errorf("kv_offload: the --kv-offload-config file has no top-level kv_offload: block")
 	}
 	if gpuBlockSizeTokens <= 0 {
-		return sim.KVOffloadConfig{}, fmt.Errorf("kv_offload: internal error — GPU block size must be > 0, got %d", gpuBlockSizeTokens)
+		return sim.KVOffloadConfig{}, fmt.Errorf("kv_offload: GPU block size (--block-size-in-tokens) must be > 0, got %d", gpuBlockSizeTokens)
 	}
 	cfg := sim.KVOffloadConfig{Enabled: true}
 
@@ -117,9 +117,15 @@ func resolveKVOffload(block *kvOffloadBlock, devices map[string]KVOffloadDeviceD
 	}
 	cfg.CPUBytesToUse = *block.CPUBytesToUse
 
-	// store_threshold: reject >= 2 (vLLM TieringOffloadingSpec); nil/0/1 are a no-op.
-	if block.StoreThreshold != nil && *block.StoreThreshold >= 2 {
-		return cfg, fmt.Errorf("kv_offload: store_threshold=%d: store_threshold is not supported for TieringOffloadingSpec (values >= 2 are rejected; it is single-tier-only and fixed at 1 on the multi-tier offload path)", *block.StoreThreshold)
+	// store_threshold: reject < 0 (invalid) and >= 2 (vLLM TieringOffloadingSpec
+	// rejects it); 0/1 are accepted as a no-op on the multi-tier path (vLLM parity).
+	if block.StoreThreshold != nil {
+		if *block.StoreThreshold < 0 {
+			return cfg, fmt.Errorf("kv_offload: store_threshold must be >= 0, got %d", *block.StoreThreshold)
+		}
+		if *block.StoreThreshold >= 2 {
+			return cfg, fmt.Errorf("kv_offload: store_threshold=%d: store_threshold is not supported for TieringOffloadingSpec (values >= 2 are rejected; it is single-tier-only and fixed at 1 on the multi-tier offload path)", *block.StoreThreshold)
+		}
 	}
 
 	// block_size XOR blocks_per_chunk (mutually exclusive alternate encodings of the
@@ -142,9 +148,12 @@ func resolveKVOffload(block *kvOffloadBlock, devices map[string]KVOffloadDeviceD
 		}
 		cfg.BlocksPerChunk = bpc
 		cfg.BlockSize = bpc * gpuBlockSizeTokens
+		if cfg.BlockSize/gpuBlockSizeTokens != bpc { // int64 overflow guard
+			return cfg, fmt.Errorf("kv_offload: blocks_per_chunk (%d) is too large — block_size = blocks_per_chunk × gpu_block_size (%d) would overflow int64", bpc, gpuBlockSizeTokens)
+		}
 	default:
-		cfg.BlocksPerChunk = 1               // vLLM default
-		cfg.BlockSize = gpuBlockSizeTokens   // vLLM default = GPU block size
+		cfg.BlocksPerChunk = 1             // vLLM default
+		cfg.BlockSize = gpuBlockSizeTokens // vLLM default = GPU block size
 	}
 
 	// tokens_per_hash: vLLM has no default (required); BLIS defaults to the GPU block
@@ -343,6 +352,7 @@ func simToHeaderOffload(c sim.KVOffloadConfig) *workload.TraceKVOffloadConfig {
 //   - a --kv-offload-config flag is accepted only if it resolves identical to the
 //     header (INV-13 "identical flags"); a genuine mismatch ⇒ Fatalf;
 //   - a flag that would ADD offload to a trace captured without it ⇒ Fatalf.
+//
 // Returns the inert zero value when the trace carries no offload config.
 func reconcileReplayKVOffload(cmd *cobra.Command, headerBlock *workload.TraceKVOffloadConfig) sim.KVOffloadConfig {
 	flagChanged := cmd.Flags().Changed("kv-offload-config")

--- a/cmd/kv_offload.go
+++ b/cmd/kv_offload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -332,6 +333,49 @@ func simToHeaderOffload(c sim.KVOffloadConfig) *workload.TraceKVOffloadConfig {
 		})
 	}
 	return h
+}
+
+// reconcileReplayKVOffload resolves the KV-offload config for blis replay. Unlike
+// --lora-config (flags-only on replay), the offload config round-trips through the
+// trace header, so on replay the HEADER is authoritative (BC-G6):
+//   - a recorded config that this binary cannot reconstruct/validate ⇒ logrus.Fatalf
+//     (INV-13, never a silent degrade to single-tier);
+//   - a --kv-offload-config flag is accepted only if it resolves identical to the
+//     header (INV-13 "identical flags"); a genuine mismatch ⇒ Fatalf;
+//   - a flag that would ADD offload to a trace captured without it ⇒ Fatalf.
+// Returns the inert zero value when the trace carries no offload config.
+func reconcileReplayKVOffload(cmd *cobra.Command, headerBlock *workload.TraceKVOffloadConfig) sim.KVOffloadConfig {
+	flagChanged := cmd.Flags().Changed("kv-offload-config")
+	var flagCfg sim.KVOffloadConfig
+	if flagChanged {
+		// resolveKVOffloadConfig itself logrus.Fatalf's on a malformed flag file.
+		flagCfg = resolveKVOffloadConfig(cmd)
+	}
+	cfg, err := resolveReplayKVOffload(headerBlock, flagChanged, flagCfg)
+	if err != nil {
+		logrus.Fatalf("%v", err)
+	}
+	return cfg
+}
+
+// resolveReplayKVOffload is the PURE, error-returning core of replay's
+// header-authoritative reconciliation (Deviation #9 — every reject branch is
+// unit-testable). See reconcileReplayKVOffload for the policy summary.
+func resolveReplayKVOffload(headerBlock *workload.TraceKVOffloadConfig, flagChanged bool, flagCfg sim.KVOffloadConfig) (sim.KVOffloadConfig, error) {
+	headerOffload := headerToSimOffload(headerBlock)
+	if headerOffload.IsEnabled() {
+		if err := headerOffload.Validate(); err != nil {
+			return sim.KVOffloadConfig{}, fmt.Errorf("blis replay cannot reproduce the trace's kv_offload config: %w (INV-13: never silent degradation)", err)
+		}
+		if flagChanged && !reflect.DeepEqual(flagCfg, headerOffload) {
+			return sim.KVOffloadConfig{}, fmt.Errorf("--kv-offload-config conflicts with the kv_offload config recorded in the trace header; on replay the header is authoritative — omit the flag or pass the identical config")
+		}
+		return headerOffload, nil
+	}
+	if flagChanged && flagCfg.IsEnabled() {
+		return sim.KVOffloadConfig{}, fmt.Errorf("the trace was captured without a kv_offload config; --kv-offload-config cannot add one on replay (INV-13)")
+	}
+	return sim.KVOffloadConfig{}, nil
 }
 
 // headerToSimOffload reconstructs a resolved sim.KVOffloadConfig from a trace header

--- a/cmd/kv_offload_test.go
+++ b/cmd/kv_offload_test.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// testDevices is a fixed device map for resolver tests (independent of defaults.yaml).
+func testDevices() map[string]KVOffloadDeviceDefaults {
+	return map[string]KVOffloadDeviceDefaults{
+		"nvme_gen4": {ReadBandwidth: 7000, WriteBandwidth: 5000, BaseLatency: 80},
+		"sata_ssd":  {ReadBandwidth: 550, WriteBandwidth: 500, BaseLatency: 150},
+	}
+}
+
+func i64p(v int64) *int64     { return &v }
+func intp(v int) *int         { return &v }
+func f64p(v float64) *float64 { return &v }
+func strp(v string) *string   { return &v }
+func boolp(v bool) *bool      { return &v }
+
+// validTierBlock returns a minimal valid fs tier block using a device_class.
+func validTierBlock() kvOffloadTierBlock {
+	return kvOffloadTierBlock{
+		Type:        strp("fs"),
+		RootDir:     strp("/mnt/kv"),
+		DirectIO:    boolp(true),
+		DeviceClass: strp("nvme_gen4"),
+	}
+}
+
+// validBlock returns a minimal valid kv_offload block with one fs tier.
+func validBlock() *kvOffloadBlock {
+	return &kvOffloadBlock{
+		CPUBytesToUse:  i64p(17179869184),
+		SecondaryTiers: []kvOffloadTierBlock{validTierBlock()},
+	}
+}
+
+// T4: the committed defaults.yaml device block parses, and a device resolves to a triple.
+func TestKVOffloadDevices_DefaultsYAMLParses(t *testing.T) {
+	// Write a minimal defaults.yaml with a kv_offload_devices block and parse it via
+	// the real loader to exercise Config decoding of the new field (R10 strict).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "defaults.yaml")
+	content := "version: 0.0.1\n" +
+		"kv_offload_devices:\n" +
+		"  nvme_gen4: {read_bandwidth: 7.0e3, write_bandwidth: 5.0e3, base_latency: 80.0}\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadDefaultsConfig(path)
+	dev, ok := cfg.KVOffloadDevices["nvme_gen4"]
+	if !ok {
+		t.Fatalf("nvme_gen4 device class must parse from defaults.yaml")
+	}
+	if dev.ReadBandwidth != 7000 || dev.WriteBandwidth != 5000 || dev.BaseLatency != 80 {
+		t.Errorf("device triple mismatch: %+v", dev)
+	}
+}
+
+// T4: the actual committed repo defaults.yaml parses (catches a malformed block).
+func TestKVOffloadDevices_CommittedDefaultsParse(t *testing.T) {
+	cfg := loadDefaultsConfig("../defaults.yaml")
+	if len(cfg.KVOffloadDevices) == 0 {
+		t.Fatalf("committed defaults.yaml should define kv_offload_devices")
+	}
+	if _, ok := cfg.KVOffloadDevices["nvme_gen4"]; !ok {
+		t.Errorf("committed defaults.yaml should define nvme_gen4")
+	}
+}
+
+// T5: strict loader — valid parses; unknown key errors; store_threshold is captured.
+func TestParseKVOffloadBytes(t *testing.T) {
+	valid := "kv_offload:\n  cpu_bytes_to_use: 1024\n  eviction_policy: lru\n"
+	if _, err := parseKVOffloadBytes([]byte(valid)); err != nil {
+		t.Fatalf("valid config must parse, got %v", err)
+	}
+
+	unknown := "kv_offload:\n  cpu_bytes_to_use: 1024\n  not_a_field: 3\n"
+	if _, err := parseKVOffloadBytes([]byte(unknown)); err == nil {
+		t.Fatal("unknown key must error (KnownFields, R10)")
+	}
+
+	// store_threshold is a captured field (parses fine); the resolver, not the parser,
+	// rejects >= 2.
+	st := "kv_offload:\n  cpu_bytes_to_use: 1024\n  store_threshold: 1\n"
+	f, err := parseKVOffloadBytes([]byte(st))
+	if err != nil {
+		t.Fatalf("store_threshold key must parse, got %v", err)
+	}
+	if f.KVOffload == nil || f.KVOffload.StoreThreshold == nil || *f.KVOffload.StoreThreshold != 1 {
+		t.Errorf("store_threshold must be captured as 1")
+	}
+}
+
+// T6/BC-G2: omitted knobs resolve to vLLM's defaults, knob for knob.
+func TestResolveKVOffload_Defaults(t *testing.T) {
+	// gpu block size 16; block with only the required cpu_bytes_to_use and one tier.
+	cfg, err := resolveKVOffload(validBlock(), testDevices(), 16)
+	if err != nil {
+		t.Fatalf("valid minimal config must resolve, got %v", err)
+	}
+	if !cfg.Enabled {
+		t.Fatal("resolved config must be Enabled")
+	}
+	// vLLM defaults (BC-G2), knob for knob.
+	if cfg.EvictionPolicy != "lru" {
+		t.Errorf("eviction_policy default: got %q want lru", cfg.EvictionPolicy)
+	}
+	if !cfg.OffloadPromptOnly {
+		t.Errorf("offload_prompt_only default must be TRUE (trap 1)")
+	}
+	if cfg.SelfDescribingKVEvents {
+		t.Errorf("self_describing_kv_events default must be false")
+	}
+	if cfg.BlocksPerChunk != 1 {
+		t.Errorf("blocks_per_chunk default: got %d want 1", cfg.BlocksPerChunk)
+	}
+	if cfg.BlockSize != 16 {
+		t.Errorf("block_size default must equal GPU block size 16, got %d", cfg.BlockSize)
+	}
+	if cfg.TokensPerHash != 16 {
+		t.Errorf("tokens_per_hash default must equal GPU block size 16, got %d", cfg.TokensPerHash)
+	}
+	tr := cfg.Tiers[0]
+	if tr.NReadThreads != 16 || tr.NWriteThreads != 16 {
+		t.Errorf("n_read/write_threads default 16: got %d/%d", tr.NReadThreads, tr.NWriteThreads)
+	}
+	if tr.EnableKVEvents {
+		t.Errorf("enable_kv_events default must be false")
+	}
+	if tr.Locality != "" {
+		t.Errorf("locality default must be unset, got %q", tr.Locality)
+	}
+	// device_class resolved to the triple.
+	if tr.ReadBandwidth != 7000 || tr.WriteBandwidth != 5000 || tr.BaseLatency != 80 {
+		t.Errorf("device_class did not resolve triple: %+v", tr)
+	}
+}
+
+// T6: explicit bandwidth/latency overrides the device_class.
+func TestResolveKVOffload_ExplicitOverridesClass(t *testing.T) {
+	b := validBlock()
+	b.SecondaryTiers[0].ReadBandwidth = f64p(1234)
+	b.SecondaryTiers[0].BaseLatency = f64p(42)
+	cfg, err := resolveKVOffload(b, testDevices(), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := cfg.Tiers[0]
+	if tr.ReadBandwidth != 1234 || tr.BaseLatency != 42 {
+		t.Errorf("explicit override not applied: %+v", tr)
+	}
+	if tr.WriteBandwidth != 5000 {
+		t.Errorf("un-overridden write_bandwidth should keep class value 5000, got %v", tr.WriteBandwidth)
+	}
+}
+
+// T6: block_size supplied derives blocks_per_chunk (alternate encoding).
+func TestResolveKVOffload_BlockSizeDerivesChunk(t *testing.T) {
+	b := validBlock()
+	b.BlockSize = i64p(64) // 4 × gpu block size 16
+	cfg, err := resolveKVOffload(b, testDevices(), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BlockSize != 64 || cfg.BlocksPerChunk != 4 {
+		t.Errorf("block_size=64/gpu=16 must give blocks_per_chunk=4, got block=%d chunk=%d", cfg.BlockSize, cfg.BlocksPerChunk)
+	}
+}
+
+// T6/BC-G1/BC-G3: reject branches (each assertable — pure function, no os.Exit).
+func TestResolveKVOffload_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*kvOffloadBlock)
+		wantFrag string
+	}{
+		{"nil block handled elsewhere: missing cpu_bytes", func(b *kvOffloadBlock) { b.CPUBytesToUse = nil }, "cpu_bytes_to_use"},
+		{"store_threshold 2", func(b *kvOffloadBlock) { b.StoreThreshold = intp(2) }, "TieringOffloadingSpec"},
+		{"store_threshold 5", func(b *kvOffloadBlock) { b.StoreThreshold = intp(5) }, "TieringOffloadingSpec"},
+		{"both block sizes", func(b *kvOffloadBlock) { b.BlockSize = i64p(16); b.BlocksPerChunk = i64p(1) }, "mutually exclusive"},
+		{"block_size not multiple", func(b *kvOffloadBlock) { b.BlockSize = i64p(20) }, "multiple of the GPU block size"},
+		{"tokens_per_hash zero", func(b *kvOffloadBlock) { b.TokensPerHash = i64p(0) }, "tokens_per_hash"},
+		{"tier type obj", func(b *kvOffloadBlock) { b.SecondaryTiers[0].Type = strp("obj") }, "not supported"},
+		{"tier type p2p", func(b *kvOffloadBlock) { b.SecondaryTiers[0].Type = strp("p2p") }, "not supported"},
+		{"tier missing type", func(b *kvOffloadBlock) { b.SecondaryTiers[0].Type = nil }, "type is required"},
+		{"tier missing root_dir", func(b *kvOffloadBlock) { b.SecondaryTiers[0].RootDir = nil }, "root_dir is required"},
+		{"tier missing direct_io", func(b *kvOffloadBlock) { b.SecondaryTiers[0].DirectIO = nil }, "direct_io must be set"},
+		{"unknown device_class", func(b *kvOffloadBlock) { b.SecondaryTiers[0].DeviceClass = strp("floppy") }, "not defined in defaults.yaml"},
+		{"no class no triple", func(b *kvOffloadBlock) {
+			b.SecondaryTiers[0].DeviceClass = nil
+		}, "device_class OR an explicit"},
+		{"eviction bad", func(b *kvOffloadBlock) { b.EvictionPolicy = strp("fifo") }, "eviction_policy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := validBlock()
+			tc.mutate(b)
+			_, err := resolveKVOffload(b, testDevices(), 16)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantFrag) {
+				t.Fatalf("error %q must contain %q", err.Error(), tc.wantFrag)
+			}
+		})
+	}
+}
+
+// T6: store_threshold 0 and 1 are accepted (no-op on the multi-tier path, vLLM parity).
+func TestResolveKVOffload_StoreThresholdAllowsZeroAndOne(t *testing.T) {
+	for _, v := range []int{0, 1} {
+		b := validBlock()
+		b.StoreThreshold = intp(v)
+		if _, err := resolveKVOffload(b, testDevices(), 16); err != nil {
+			t.Errorf("store_threshold=%d must be accepted (no-op), got %v", v, err)
+		}
+	}
+}
+
+// T6: a nil block errors (a supplied file with no kv_offload: block).
+func TestResolveKVOffload_NilBlockErrors(t *testing.T) {
+	if _, err := resolveKVOffload(nil, testDevices(), 16); err == nil {
+		t.Fatal("nil block must error")
+	}
+}
+
+// T9 support: sim↔header conversion is a lossless inverse.
+func TestKVOffloadHeaderConversion_RoundTrip(t *testing.T) {
+	cfg, err := resolveKVOffload(validBlock(), testDevices(), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := headerToSimOffload(simToHeaderOffload(cfg))
+	if !reflect.DeepEqual(cfg, back) {
+		t.Errorf("sim→header→sim not identity:\n got  %+v\n want %+v", back, cfg)
+	}
+	// inert converts to nil header and back to inert.
+	if simToHeaderOffload(sim.KVOffloadConfig{}) != nil {
+		t.Error("inert config must convert to a nil header block")
+	}
+	if headerToSimOffload(nil).IsEnabled() {
+		t.Error("nil header must convert to an inert config")
+	}
+}
+
+// T7/BC-G3: metamorphic round-trip fuzz. Any bytes that parse+resolve+validate must
+// survive sim→header→marshal→unmarshal→header→sim unchanged (INV-13 idempotence). Also
+// asserts the resolver/loader never panic.
+func FuzzKVOffloadRoundTrip(f *testing.F) {
+	f.Add("kv_offload:\n  cpu_bytes_to_use: 17179869184\n  secondary_tiers:\n    - {type: fs, root_dir: /mnt, direct_io: true, device_class: nvme_gen4}\n")
+	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  store_threshold: 3\n")
+	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  block_size: 16\n  blocks_per_chunk: 1\n")
+	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  secondary_tiers:\n    - {type: p2p, root_dir: /x, direct_io: true}\n")
+	f.Add("not yaml: [")
+	devices := testDevices()
+	f.Fuzz(func(t *testing.T, data string) {
+		parsed, err := parseKVOffloadBytes([]byte(data))
+		if err != nil {
+			return // malformed YAML — loader correctly rejects
+		}
+		cfg, err := resolveKVOffload(parsed.KVOffload, devices, 16)
+		if err != nil {
+			return // invalid config — resolver correctly rejects
+		}
+		back := headerToSimOffload(simToHeaderOffload(cfg))
+		if !reflect.DeepEqual(cfg, back) {
+			t.Fatalf("round-trip not idempotent for input %q:\n got  %+v\n want %+v", data, back, cfg)
+		}
+	})
+}

--- a/cmd/kv_offload_test.go
+++ b/cmd/kv_offload_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
+	"github.com/spf13/cobra"
 )
 
 // testDevices is a fixed device map for resolver tests (independent of defaults.yaml).
@@ -275,4 +278,162 @@ func FuzzKVOffloadRoundTrip(f *testing.F) {
 			t.Fatalf("round-trip not idempotent for input %q:\n got  %+v\n want %+v", data, back, cfg)
 		}
 	})
+}
+
+// resolveReplayKVOffload branch coverage (T9, BC-G6): the trace header is
+// authoritative on replay; every reject branch is exercised via the pure function
+// (no os.Exit needed).
+func TestResolveReplayKVOffload(t *testing.T) {
+	// A valid recorded config (explicit triple so it validates without a device map).
+	validHeader := &workload.TraceKVOffloadConfig{
+		CPUBytesToUse: 1024, BlockSize: 16, BlocksPerChunk: 1, TokensPerHash: 16,
+		EvictionPolicy: "lru", OffloadPromptOnly: true,
+		Tiers: []workload.TraceKVOffloadTier{{
+			Type: "fs", RootDir: "/mnt", NReadThreads: 16, NWriteThreads: 16,
+			DirectIO: true, ReadBandwidth: 7000, WriteBandwidth: 5000, BaseLatency: 80,
+		}},
+	}
+	validSim := headerToSimOffload(validHeader)
+
+	t.Run("header authoritative, no flag", func(t *testing.T) {
+		got, err := resolveReplayKVOffload(validHeader, false, sim.KVOffloadConfig{})
+		if err != nil || !reflect.DeepEqual(got, validSim) {
+			t.Fatalf("header should be used verbatim: got %+v err %v", got, err)
+		}
+	})
+	t.Run("matching flag accepted", func(t *testing.T) {
+		got, err := resolveReplayKVOffload(validHeader, true, validSim)
+		if err != nil || !reflect.DeepEqual(got, validSim) {
+			t.Fatalf("identical flag must be accepted: got %+v err %v", got, err)
+		}
+	})
+	t.Run("conflicting flag rejected", func(t *testing.T) {
+		other := validSim
+		other.CPUBytesToUse = 2048
+		_, err := resolveReplayKVOffload(validHeader, true, other)
+		if err == nil || !strings.Contains(err.Error(), "conflicts") {
+			t.Fatalf("conflicting flag must error with 'conflicts', got %v", err)
+		}
+	})
+	t.Run("unreproducible header rejected", func(t *testing.T) {
+		// A header recording a tier type this binary cannot reconstruct.
+		bad := &workload.TraceKVOffloadConfig{
+			CPUBytesToUse: 1024, BlockSize: 16, BlocksPerChunk: 1, TokensPerHash: 16,
+			EvictionPolicy: "lru",
+			Tiers:          []workload.TraceKVOffloadTier{{Type: "p2p", RootDir: "/x"}},
+		}
+		_, err := resolveReplayKVOffload(bad, false, sim.KVOffloadConfig{})
+		if err == nil || !strings.Contains(err.Error(), "cannot reproduce") {
+			t.Fatalf("unreproducible header must fail loudly, got %v", err)
+		}
+	})
+	t.Run("no header, no flag -> inert", func(t *testing.T) {
+		got, err := resolveReplayKVOffload(nil, false, sim.KVOffloadConfig{})
+		if err != nil || got.IsEnabled() {
+			t.Fatalf("nil header + no flag must be inert, got %+v err %v", got, err)
+		}
+	})
+	t.Run("flag adds to a no-offload trace -> rejected", func(t *testing.T) {
+		_, err := resolveReplayKVOffload(nil, true, validSim)
+		if err == nil || !strings.Contains(err.Error(), "cannot add one on replay") {
+			t.Fatalf("adding offload to a no-offload trace must error, got %v", err)
+		}
+	})
+}
+
+// runToTraceWithOffload drives runCmd in-process with --kv-offload-config set, writing
+// a TraceV2 whose header records the resolved offload config. Mirrors the parity
+// harness (runSpecToTraceFiles) plus the one new flag; uses an explicit bandwidth
+// triple in the config so it does not depend on the fixture defaults.yaml device map.
+func runToTraceWithOffload(t *testing.T, offloadPath string, seedVal, horizon int64) (headerFile, dataFile string) {
+	t.Helper()
+	shape := paritySpecShapes()[0] // chatbot
+	tmpDir := t.TempDir()
+	tracePrefix := filepath.Join(tmpDir, "trace")
+	specPath := filepath.Join(tmpDir, "workload.yaml")
+	if err := os.WriteFile(specPath, []byte(shape.yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+
+	orig := captureCmdLevelVars()
+	defer orig.restore()
+	origOffload := kvOffloadConfigPath
+	defer func() { kvOffloadConfigPath = origOffload }()
+
+	traceOutput = tracePrefix
+	workloadSpecPath = specPath
+	workloadType = ""
+	simulationHorizon = horizon
+	seed = seedVal
+	lazyGeneration = false
+	requestTimeoutSecs = 300
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	testCmd.Flags().StringVar(&workloadSpecPath, "workload-spec", "", "")
+	testCmd.Flags().StringVar(&traceOutput, "trace-output", "", "")
+	testCmd.Flags().IntVar(&requestTimeoutSecs, "timeout", 300, "")
+	args := []string{
+		"--model", "qwen/qwen3-14b", "--latency-model", "trained-physics",
+		"--defaults-filepath", defaultsPath, "--model-config-folder", mcFolder,
+		"--hardware-config", hwPath, "--hardware", "H100", "--tp", "1",
+		"--total-kv-blocks", "1000", "--seed", strconv.FormatInt(seedVal, 10),
+		"--workload-spec", specPath, "--horizon", strconv.FormatInt(horizon, 10),
+		"--trace-output", tracePrefix, "--kv-offload-config", offloadPath,
+	}
+	if err := testCmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	runCmd.Run(testCmd, nil)
+	return tracePrefix + ".yaml", tracePrefix + ".csv"
+}
+
+// T9/BC-G6 end-to-end: a run with a multi-tier --kv-offload-config records the resolved
+// config in the trace header, and replaying that trace reproduces it (header
+// authoritative) without error.
+func TestKVOffload_EndToEnd_RunReplayRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	offloadPath := filepath.Join(dir, "offload.yaml")
+	offloadYAML := "kv_offload:\n" +
+		"  cpu_bytes_to_use: 17179869184\n" +
+		"  eviction_policy: lru\n" +
+		"  offload_prompt_only: true\n" +
+		"  secondary_tiers:\n" +
+		"    - type: fs\n" +
+		"      root_dir: /mnt/kv\n" +
+		"      direct_io: true\n" +
+		"      read_bandwidth: 7000.0\n" +
+		"      write_bandwidth: 5000.0\n" +
+		"      base_latency: 80.0\n"
+	if err := os.WriteFile(offloadPath, []byte(offloadYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	headerFile, dataFile := runToTraceWithOffload(t, offloadPath, 20260818, 60_000_000)
+
+	td, err := workload.LoadTraceV2(headerFile, dataFile)
+	if err != nil {
+		t.Fatalf("load exported trace: %v", err)
+	}
+	if td.Header.KVOffload == nil {
+		t.Fatal("run must record kv_offload in the trace header (BC-G6)")
+	}
+	h := td.Header.KVOffload
+	if h.CPUBytesToUse != 17179869184 || h.EvictionPolicy != "lru" || !h.OffloadPromptOnly {
+		t.Errorf("recorded scalars wrong: %+v", h)
+	}
+	if h.BlockSize != 16 || h.BlocksPerChunk != 1 || h.TokensPerHash != 16 {
+		t.Errorf("resolved defaults not recorded: %+v", h)
+	}
+	if len(h.Tiers) != 1 || h.Tiers[0].ReadBandwidth != 7000 || h.Tiers[0].WriteBandwidth != 5000 || !h.Tiers[0].DirectIO {
+		t.Errorf("recorded tier wrong: %+v", h.Tiers)
+	}
+
+	// Replay the trace: the header is authoritative; no flag passed. Must reproduce
+	// without a Fatalf and produce completed requests.
+	results := replaySpecTrace(t, headerFile, dataFile)
+	if len(results) == 0 {
+		t.Fatal("replay of an offload trace produced no completed requests")
+	}
 }

--- a/cmd/kv_offload_test.go
+++ b/cmd/kv_offload_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,7 @@ import (
 	"github.com/inference-sim/inference-sim/sim"
 	"github.com/inference-sim/inference-sim/sim/workload"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // testDevices is a fixed device map for resolver tests (independent of defaults.yaml).
@@ -185,9 +187,10 @@ func TestResolveKVOffload_Rejects(t *testing.T) {
 		mutate   func(*kvOffloadBlock)
 		wantFrag string
 	}{
-		{"nil block handled elsewhere: missing cpu_bytes", func(b *kvOffloadBlock) { b.CPUBytesToUse = nil }, "cpu_bytes_to_use"},
+		{"missing cpu_bytes", func(b *kvOffloadBlock) { b.CPUBytesToUse = nil }, "cpu_bytes_to_use"},
 		{"store_threshold 2", func(b *kvOffloadBlock) { b.StoreThreshold = intp(2) }, "TieringOffloadingSpec"},
 		{"store_threshold 5", func(b *kvOffloadBlock) { b.StoreThreshold = intp(5) }, "TieringOffloadingSpec"},
+		{"store_threshold negative", func(b *kvOffloadBlock) { b.StoreThreshold = intp(-1) }, "store_threshold must be >= 0"},
 		{"both block sizes", func(b *kvOffloadBlock) { b.BlockSize = i64p(16); b.BlocksPerChunk = i64p(1) }, "mutually exclusive"},
 		{"block_size not multiple", func(b *kvOffloadBlock) { b.BlockSize = i64p(20) }, "multiple of the GPU block size"},
 		{"tokens_per_hash zero", func(b *kvOffloadBlock) { b.TokensPerHash = i64p(0) }, "tokens_per_hash"},
@@ -254,14 +257,18 @@ func TestKVOffloadHeaderConversion_RoundTrip(t *testing.T) {
 	}
 }
 
-// T7/BC-G3: metamorphic round-trip fuzz. Any bytes that parse+resolve+validate must
-// survive sim→header→marshal→unmarshal→header→sim unchanged (INV-13 idempotence). Also
-// asserts the resolver/loader never panic.
+// T7/BC-G3 + INV-13: metamorphic round-trip fuzz. Any bytes that parse+resolve+validate
+// must survive the FULL trace-header serialization path unchanged —
+// sim→header→yaml.Marshal→strict-decode→header→sim (the exact primitives ExportTraceV2
+// and LoadTraceV2 use). This exercises the YAML tags and omitempty rules of
+// TraceKVOffloadConfig/TraceKVOffloadTier (not just in-memory converter idempotence),
+// and asserts the loader/resolver never panic on arbitrary parseable YAML.
 func FuzzKVOffloadRoundTrip(f *testing.F) {
 	f.Add("kv_offload:\n  cpu_bytes_to_use: 17179869184\n  secondary_tiers:\n    - {type: fs, root_dir: /mnt, direct_io: true, device_class: nvme_gen4}\n")
 	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  store_threshold: 3\n")
 	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  block_size: 16\n  blocks_per_chunk: 1\n")
 	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  secondary_tiers:\n    - {type: p2p, root_dir: /x, direct_io: true}\n")
+	f.Add("kv_offload:\n  cpu_bytes_to_use: 1024\n  secondary_tiers:\n    - {type: fs, root_dir: /m, direct_io: false, read_bandwidth: 100.0, write_bandwidth: 50.0, base_latency: 0.0, locality: REMOTE, enable_kv_events: true}\n")
 	f.Add("not yaml: [")
 	devices := testDevices()
 	f.Fuzz(func(t *testing.T, data string) {
@@ -273,9 +280,24 @@ func FuzzKVOffloadRoundTrip(f *testing.F) {
 		if err != nil {
 			return // invalid config — resolver correctly rejects
 		}
-		back := headerToSimOffload(simToHeaderOffload(cfg))
+		// Serialize through the real trace-header YAML path.
+		hdr := &workload.TraceHeader{
+			Version: 3, TimeUnit: "microseconds", Mode: "generated",
+			KVOffload: simToHeaderOffload(cfg),
+		}
+		out, err := yaml.Marshal(hdr)
+		if err != nil {
+			t.Fatalf("marshal header for %q: %v", data, err)
+		}
+		dec := yaml.NewDecoder(bytes.NewReader(out))
+		dec.KnownFields(true) // same strictness as LoadTraceV2
+		var got workload.TraceHeader
+		if err := dec.Decode(&got); err != nil {
+			t.Fatalf("strict-decode of self-marshaled header failed for %q: %v\n%s", data, err, out)
+		}
+		back := headerToSimOffload(got.KVOffload)
 		if !reflect.DeepEqual(cfg, back) {
-			t.Fatalf("round-trip not idempotent for input %q:\n got  %+v\n want %+v", data, back, cfg)
+			t.Fatalf("YAML round-trip not idempotent for input %q:\n got  %+v\n want %+v", data, back, cfg)
 		}
 	})
 }

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -166,6 +166,12 @@ Example:
 		loraCfg := resolveLoRAConfig(cmd)
 		loraReservedBytesForKV = adapterReservedBytesFor(loraCfg)
 
+		// KV-cache offload config (#1587, BC-G6): the trace header is authoritative on
+		// replay (unlike --lora-config, which is flags-only). Reconstruct the recorded
+		// config, Fatalf if this binary cannot reproduce it, and Fatalf on a genuine
+		// flag/header conflict. Inert when the trace carries no offload config (BC-G5).
+		kvOffloadCfg := reconcileReplayKVOffload(cmd, traceData.Header.KVOffload)
+
 		// Resolve latency backend configuration (single code path shared with runCmd).
 		lr := resolveLatencyConfig(cmd)
 
@@ -471,7 +477,8 @@ Example:
 				Horizon: replayHorizon,
 				Seed:    seed,
 				KVCacheConfig: sim.NewKVCacheConfig(totalKVBlocks, blockSizeTokens, kvCPUBlocks,
-					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency),
+					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency,
+					sim.WithKVOffload(kvOffloadCfg)),
 				BatchConfig:          sim.NewBatchConfig(maxNumSeqs, maxNumBatchedTokens, longPrefillTokenThreshold),
 				LatencyCoeffs:        sim.NewLatencyCoeffs(lr.BetaCoeffs, lr.AlphaCoeffs),
 				ModelHardwareConfig:  sim.NewModelHardwareConfig(lr.ModelConfig, lr.HWConfig, model, gpu, tensorParallelism, dataParallelism, enableExpertParallel, moeCommBackend, lr.Backend, maxModelLen),
@@ -570,7 +577,8 @@ Example:
 				Version:           3,
 				TimeUnit:          "microseconds",
 				Mode:              "replayed",
-				GoodputSLOTargets: goodputTargets, // #1413, BC-7
+				GoodputSLOTargets: goodputTargets,                   // #1413, BC-7
+				KVOffload:         simToHeaderOffload(kvOffloadCfg), // #1587, BC-G6: carry the offload config forward
 			}
 			if err := workload.ExportTraceV2(header, records, replayTraceOutput+".yaml", replayTraceOutput+".csv"); err != nil {
 				logrus.Fatalf("Trace export failed: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1467,6 +1467,11 @@ var runCmd = &cobra.Command{
 		loraCfg := resolveLoRAConfig(cmd)
 		loraReservedBytesForKV = adapterReservedBytesFor(loraCfg)
 
+		// KV-cache offload config surface (#1587): resolve ONCE (R4), validated at the
+		// CLI boundary. Inert (zero value) when --kv-offload-config is absent (BC-G5).
+		// Recorded in the exported trace header below for run/replay parity (BC-G6).
+		kvOffloadCfg := resolveKVOffloadConfig(cmd)
+
 		// Resolve latency backend configuration (single code path shared with replayCmd).
 		lr := resolveLatencyConfig(cmd)
 
@@ -2053,7 +2058,8 @@ var runCmd = &cobra.Command{
 				Horizon: simulationHorizon,
 				Seed:    seed,
 				KVCacheConfig: sim.NewKVCacheConfig(totalKVBlocks, blockSizeTokens, kvCPUBlocks,
-					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency),
+					kvOffloadThreshold, kvTransferBandwidth, kvTransferBaseLatency,
+					sim.WithKVOffload(kvOffloadCfg)),
 				BatchConfig:          sim.NewBatchConfig(maxNumSeqs, maxNumBatchedTokens, longPrefillTokenThreshold),
 				LatencyCoeffs:        sim.NewLatencyCoeffs(lr.BetaCoeffs, lr.AlphaCoeffs),
 				ModelHardwareConfig:  sim.NewModelHardwareConfig(lr.ModelConfig, lr.HWConfig, model, gpu, tensorParallelism, dataParallelism, enableExpertParallel, moeCommBackend, lr.Backend, maxModelLen),
@@ -2241,7 +2247,8 @@ var runCmd = &cobra.Command{
 				TimeUnit:          "microseconds",
 				Mode:              "generated",
 				WorkloadSeed:      &spec.Seed,
-				GoodputSLOTargets: goodputTargets, // #1413, BC-7: persist resolved targets for downstream replay/calibrate
+				GoodputSLOTargets: goodputTargets,               // #1413, BC-7: persist resolved targets for downstream replay/calibrate
+				KVOffload:         simToHeaderOffload(kvOffloadCfg), // #1587, BC-G6: nil when inert (omitted); round-trips resolved config
 			}
 			if err := workload.ExportTraceV2(header, records, traceOutput+".yaml", traceOutput+".csv"); err != nil {
 				logrus.Fatalf("Trace export failed: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1227,6 +1227,15 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().Float64Var(&loraLoadBaseLatencyUs, "lora-load-base-latency-us", 0, "Cold adapter-load fixed latency in µs. Applied only when set; else --lora-config / defaults.yaml.")
 	cmd.Flags().Float64Var(&loraLoadBandwidthBytesUs, "lora-load-bandwidth-bytes-us", 0, "Cold adapter-load bandwidth in bytes/µs (>0). Applied only when set; else --lora-config / defaults.yaml.")
 	cmd.Flags().Float64Var(&loraFootprintBytesPerRank, "lora-footprint-bytes-per-rank", 0, "Adapter HBM footprint per rank unit in bytes (>0). Applied only when set; else --lora-config / defaults.yaml.")
+
+	// KV-cache offload config surface (H5, #1587). One flag: a strict-YAML file with a
+	// single top-level kv_offload: block (CPU tier + ordered secondary tiers, per-tier
+	// device physics). Registered on run and replay (INV-13). Absent => the offload
+	// subsystem is inert and output is byte-identical to a build without the feature
+	// (BC-G5). On replay the trace header is authoritative; a passed flag must match the
+	// header (see resolveKVOffloadConfig / the replay wiring). device_class names resolve
+	// against defaults.yaml kv_offload_devices.
+	cmd.Flags().StringVar(&kvOffloadConfigPath, "kv-offload-config", "", "Path to a YAML file with a top-level kv_offload: block (multi-tier KV-cache offload config: cpu_bytes_to_use, block_size/blocks_per_chunk, eviction_policy, offload_prompt_only, secondary_tiers[] with per-tier device_class/direct_io/bandwidth). Absent => offload subsystem inert. On replay the trace header is authoritative.")
 }
 
 // loraConfigFile is the on-disk shape of a --lora-config YAML file: a single

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -197,4 +197,19 @@ lora:
     8: {k6: 0.02, k7: 1.0}
     16: {k6: 0.035, k7: 1.0}
     32: {k6: 0.06, k7: 1.0}
+# KV-cache offload device physics (H5, #1587). INERT: these seed the bandwidth/latency
+# classes for --kv-offload-config's per-tier `device_class` field. With no
+# --kv-offload-config the offload subsystem is a no-op and output is byte-identical to a
+# pre-feature build (INV-6/BC-G5). Shipped constants (operator input), never fitted
+# (BC-G4). read_bandwidth/write_bandwidth are bytes per microsecond; base_latency is
+# microseconds. A per-tier explicit read_bandwidth/write_bandwidth/base_latency triple
+# overrides the class (same override shape as --lora-load-base-latency-us over the lora
+# block). Numbers are representative device classes seeded for the multi-tier offload
+# holes (#1588/#1589); operators override per run for their hardware.
+kv_offload_devices:
+  nvme_gen4: {read_bandwidth: 7.0e3, write_bandwidth: 5.0e3, base_latency: 80.0}
+  nvme_gen3: {read_bandwidth: 3.5e3, write_bandwidth: 3.0e3, base_latency: 100.0}
+  sata_ssd:  {read_bandwidth: 5.5e2, write_bandwidth: 5.0e2, base_latency: 150.0}
+  cpu_dram:  {read_bandwidth: 2.0e4, write_bandwidth: 2.0e4, base_latency: 1.0}
+  s3:        {read_bandwidth: 1.0e3, write_bandwidth: 1.0e3, base_latency: 30000.0}
 version: 0.0.1

--- a/docs/guide/kv-cache.md
+++ b/docs/guide/kv-cache.md
@@ -74,6 +74,57 @@ BLIS models tiered KV cache with GPU→CPU offloading:
 | `--kv-transfer-bandwidth` | 100.0 | GPU→CPU transfer rate in blocks/tick |
 | `--kv-transfer-base-latency` | 0 | Fixed per-transfer latency in ticks |
 
+### Multi-Tier Offload Config Surface (`--kv-offload-config`)
+
+The scalar flags above cover the single CPU tier. For vLLM's **multi-tier** offload
+(CPU → disk / object store), BLIS captures the full config surface through one strict-YAML
+file — `--kv-offload-config <path>` — with a single top-level `kv_offload:` block. This
+mirrors `--lora-config` / `--saturation-config`: absent ⇒ the offload subsystem is inert and
+output is byte-identical to a build without it.
+
+```bash
+./blis run --model qwen/qwen3-14b --kv-offload-config offload.yaml
+```
+
+```yaml
+kv_offload:
+  cpu_bytes_to_use: 17179869184     # required when the block is present
+  block_size: 16                    # optional; default = GPU block size (mutually
+                                    #   exclusive with blocks_per_chunk)
+  # blocks_per_chunk: 1             # alternate encoding of block_size (default 1)
+  eviction_policy: lru              # lru | arc  (default lru)
+  offload_prompt_only: true         # vLLM DEFAULT — decode KV is NOT offloaded unless false
+  # self_describing_kv_events: false
+  # tokens_per_hash: 16             # default = GPU block size
+  secondary_tiers:
+    - type: fs                      # only "fs" is representable today; obj/p2p error loudly
+      root_dir: /mnt/kv-cache
+      n_read_threads: 16            # vLLM default 16
+      n_write_threads: 16           # vLLM default 16
+      locality: LOCAL               # LOCAL | REMOTE (optional)
+      direct_io: true               # REQUIRED — BLIS makes vLLM's runtime O_DIRECT probe explicit
+      device_class: nvme_gen4       # resolves read/write bandwidth + latency from defaults.yaml
+      # read_bandwidth: 7000.0      # bytes/µs — overrides device_class (per-direction, required as a pair)
+      # write_bandwidth: 5000.0
+      # base_latency: 80.0          # µs
+```
+
+Defaults match vLLM knob-for-knob. Anything vLLM accepts either maps to a BLIS config or
+fails **loudly** at startup — never silently ignored: `store_threshold >= 2` is rejected
+(vLLM's `TieringOffloadingSpec` rejects it), and `obj`/`p2p`/`example` tier types are rejected
+(no faithful BLIS mapping yet). `device_class` names resolve against the `kv_offload_devices:`
+block shipped in `defaults.yaml` (bandwidth in bytes/µs, latency in µs); an explicit
+`read_bandwidth`/`write_bandwidth`/`base_latency` triple overrides the class.
+
+The resolved config is recorded in the exported trace header, so a `blis run --trace-output`
+round-trips through `blis replay` (INV-13): on replay the header is authoritative and a config
+the binary cannot reproduce fails loudly rather than silently degrading to single-tier.
+
+!!! note "Config surface only (today)"
+    `--kv-offload-config` currently **captures and validates** the offload configuration; the
+    multi-tier transfer/keying mechanisms that consume these knobs are landing separately.
+    With no `--kv-offload-config`, behavior is unchanged.
+
 ## Chunked Prefill
 
 Long prefill sequences can cause **head-of-line (HOL) blocking** — a 2,048-token prefill takes ~97ms on Qwen3-14B / H100 / TP=1 (roofline mode), blocking shorter requests from starting.

--- a/sim/config.go
+++ b/sim/config.go
@@ -13,14 +13,34 @@ type KVCacheConfig struct {
 	KVOffloadThreshold    float64 // DEPRECATED: Ignored in vLLM v1 mirror model. Was: GPU utilization threshold for offload. (CLI default: 0.9, zero-value: 0)
 	KVTransferBandwidth   float64 // blocks/tick transfer rate (CLI default: 100.0, zero-value: 0)
 	KVTransferBaseLatency int64   // fixed cost per transfer (ticks, default 0)
+	// Offload captures vLLM's multi-tier KV-offload config surface (H5, #1587). Its
+	// zero value is inert (Enabled=false) and unread by sim/kv in this PR (INV-6);
+	// it is set only via the WithKVOffload option. Kept as a nested sub-config value
+	// rather than more positional constructor args (R16, R4).
+	Offload KVOffloadConfig
+}
+
+// KVCacheOption is a functional option applied inside NewKVCacheConfig. It lets the
+// constructor accept the nested KVOffloadConfig value without a 7th positional
+// parameter (which would break every existing call site) while keeping the single
+// struct-literal construction site intact (R4).
+type KVCacheOption func(*KVCacheConfig)
+
+// WithKVOffload sets the KVOffloadConfig sub-config. Absent (no option passed) ⇒ the
+// offload subsystem is inert and output is byte-identical to a build without the
+// feature (BC-G5).
+func WithKVOffload(o KVOffloadConfig) KVCacheOption {
+	return func(c *KVCacheConfig) { c.Offload = o }
 }
 
 // NewKVCacheConfig creates a KVCacheConfig with all fields explicitly set.
 // This is the canonical constructor — all construction sites must use it (R4).
-// Parameter order matches struct field order.
+// Parameter order matches struct field order. Optional KVCacheOptions (e.g.
+// WithKVOffload) set nested sub-configs; existing call sites pass none and get the
+// inert zero-value Offload.
 func NewKVCacheConfig(totalKVBlocks, blockSizeTokens, kvCPUBlocks int64,
 	kvOffloadThreshold, kvTransferBandwidth float64,
-	kvTransferBaseLatency int64) KVCacheConfig {
+	kvTransferBaseLatency int64, opts ...KVCacheOption) KVCacheConfig {
 	if totalKVBlocks <= 0 {
 		panic(fmt.Sprintf("NewKVCacheConfig: TotalKVBlocks must be > 0, got %d", totalKVBlocks))
 	}
@@ -41,7 +61,7 @@ func NewKVCacheConfig(totalKVBlocks, blockSizeTokens, kvCPUBlocks int64,
 			panic(fmt.Sprintf("NewKVCacheConfig: KVTransferBaseLatency must be >= 0 when KVCPUBlocks > 0, got %d", kvTransferBaseLatency))
 		}
 	}
-	return KVCacheConfig{
+	cfg := KVCacheConfig{
 		TotalKVBlocks:         totalKVBlocks,
 		BlockSizeTokens:       blockSizeTokens,
 		KVCPUBlocks:           kvCPUBlocks,
@@ -49,6 +69,17 @@ func NewKVCacheConfig(totalKVBlocks, blockSizeTokens, kvCPUBlocks int64,
 		KVTransferBandwidth:   kvTransferBandwidth,
 		KVTransferBaseLatency: kvTransferBaseLatency,
 	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	// Factory validation (R3): an enabled offload sub-config must be self-consistent.
+	// The CLI resolver validates and logrus.Fatalf's before reaching here, so this is
+	// defense-in-depth for other callers (tests, future code). Panic matches this
+	// constructor's existing panic-on-invalid contract.
+	if err := cfg.Offload.Validate(); err != nil {
+		panic(fmt.Sprintf("NewKVCacheConfig: invalid offload config: %v", err))
+	}
+	return cfg
 }
 
 // BatchConfig groups batch formation parameters.

--- a/sim/kv_offload_config.go
+++ b/sim/kv_offload_config.go
@@ -1,0 +1,195 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+)
+
+// KVOffloadConfig is the resolved, validated KV-cache offload configuration
+// captured from vLLM's offload CLI/config surface (H5, issue #1587). It is a
+// sub-config of KVCacheConfig (R16): grouped by module, independently validatable.
+//
+// SCOPE: this is the config *surface* only. In this PR the offload subsystem is
+// INERT — no mechanism reads these fields (the consuming physics live in sibling
+// holes #1588/#1589 and later). The zero value has Enabled=false, so a run without
+// --kv-offload-config is byte-identical to a build without this feature (BC-G5,
+// INV-6): sim/kv never reads Offload.
+//
+// The resolved struct carries fully-derived values (device classes already resolved
+// to bandwidth/latency numbers, all defaults applied); it is what round-trips through
+// the trace header (BC-G6). It is read-only after construction (BC-G4, never fitted):
+// operator input, structurally separate from trained coefficients.
+type KVOffloadConfig struct {
+	// Enabled is true iff a kv_offload: block was supplied. The zero value (false)
+	// is inert. All other fields are meaningful only when Enabled is true.
+	Enabled bool
+
+	// CPUBytesToUse is vLLM's cpu_bytes_to_use: CPU-tier capacity in bytes. Required
+	// (>0) when Enabled — vLLM marks it required with no default.
+	CPUBytesToUse int64
+
+	// BlockSize is the offload block size in TOKENS. vLLM default = GPU block size.
+	// It is an alternate encoding of BlocksPerChunk (BlockSize = BlocksPerChunk ×
+	// gpu_block_size); the resolver keeps the two consistent, so both are always set.
+	BlockSize int64
+
+	// BlocksPerChunk is vLLM's blocks_per_chunk: GPU blocks coalesced into one offload
+	// chunk (job batching width, #1588 BC-S5). vLLM default 1.
+	BlocksPerChunk int64
+
+	// TokensPerHash is vLLM's tokens_per_hash: the block-hash key stride (#1589 BC-K4).
+	// vLLM makes it required with no default; BLIS defaults it to the GPU block size
+	// (the natural one-hash-per-block stride).
+	TokensPerHash int64
+
+	// EvictionPolicy is vLLM's eviction_policy: which block is dropped. vLLM default
+	// "lru"; "arc" also accepted.
+	EvictionPolicy string
+
+	// OffloadPromptOnly is vLLM's offload_prompt_only. vLLM DEFAULT TRUE (trap 1):
+	// decode KV is NOT offloaded unless explicitly disabled.
+	OffloadPromptOnly bool
+
+	// SelfDescribingKVEvents is vLLM's self_describing_kv_events (observability only).
+	// vLLM default false.
+	SelfDescribingKVEvents bool
+
+	// Tiers are the ordered secondary offload tiers (vLLM secondary_tiers). Tier 0 is
+	// consulted before tier 1, etc. vLLM default empty (single CPU tier, no spill).
+	// A slice (not a map, R8) so ordering is deterministic (INV-6).
+	Tiers []KVOffloadTier
+}
+
+// KVOffloadTier is one resolved secondary offload tier. Only the filesystem ("fs")
+// tier type is representable in BLIS today; the resolver rejects obj/p2p/example
+// loudly (BC-G1). Bandwidths are per-(tier, direction) — never a single number
+// (#1588 BC-S3).
+type KVOffloadTier struct {
+	// Type is the tier kind. Only "fs" is accepted; obj/p2p/example are rejected at
+	// resolution (BC-G1 fails-loudly branch).
+	Type string
+
+	// RootDir is the fs tier's device directory (vLLM root_dir), required for "fs".
+	RootDir string
+
+	// NReadThreads / NWriteThreads are vLLM's per-tier read/write server counts
+	// (#1588 BC-S1/S2). vLLM default 16 each.
+	NReadThreads  int64
+	NWriteThreads int64
+
+	// Locality is vLLM's locality: "" (unset), "LOCAL", or "REMOTE". Latency class.
+	Locality string
+
+	// EnableKVEvents is vLLM's per-tier enable_kv_events. vLLM default false.
+	EnableKVEvents bool
+
+	// DirectIO makes vLLM's runtime O_DIRECT probe an EXPLICIT config axis: vLLM
+	// discovers O_DIRECT support at startup and silently falls back to buffered I/O,
+	// but a simulator cannot probe the operator's disk and the two modes have
+	// substantially different physics. BLIS requires it to be declared per fs tier
+	// (enforced in the resolver) and records it, since a buffered-I/O trace is not
+	// comparable to a direct-I/O one. BLIS-only; no vLLM knob.
+	DirectIO bool
+
+	// DeviceClass is a BLIS-only informational echo of the device_class that resolved
+	// the bandwidth/latency triple. The resolved numbers below are authoritative on
+	// replay (never re-resolved against the replay host's defaults.yaml — cross-host
+	// INV-13).
+	DeviceClass string
+
+	// ReadBandwidth / WriteBandwidth are the resolved per-direction bandwidths in
+	// bytes per microsecond. BaseLatency is the fixed per-access latency in
+	// microseconds.
+	ReadBandwidth  float64
+	WriteBandwidth float64
+	BaseLatency    float64
+}
+
+// Valid enumerations for the offload config surface.
+const (
+	kvOffloadEvictionLRU = "lru"
+	kvOffloadEvictionARC = "arc"
+
+	kvOffloadTierFS = "fs"
+
+	kvOffloadLocalityLocal  = "LOCAL"
+	kvOffloadLocalityRemote = "REMOTE"
+)
+
+// IsEnabled reports whether the offload subsystem is configured. A zero-value
+// KVOffloadConfig is inert (BC-G5).
+func (c KVOffloadConfig) IsEnabled() bool { return c.Enabled }
+
+// Validate checks the invariants of a RESOLVED KVOffloadConfig (BC-G3). It is a
+// no-op when the config is inert. It returns an error (never panics — R6) naming the
+// offending field; the CLI boundary turns that into logrus.Fatalf.
+//
+// Validate operates on the already-resolved struct: it does NOT re-check the
+// block_size / blocks_per_chunk mutual-exclusion (that is a user-input check in the
+// resolver — both fields are always present and consistent here), and it does NOT
+// check that direct_io was explicitly supplied (a resolved bool has no "unset" state;
+// the resolver enforces the explicit-declaration requirement). Float fields are
+// guarded against NaN/Inf, mirroring NewKVCacheConfig and sim/kv/tiered.go.
+func (c KVOffloadConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.CPUBytesToUse <= 0 {
+		return fmt.Errorf("kv_offload: cpu_bytes_to_use must be > 0 when offload is enabled, got %d", c.CPUBytesToUse)
+	}
+	if c.BlockSize <= 0 {
+		return fmt.Errorf("kv_offload: block_size must be > 0, got %d", c.BlockSize)
+	}
+	if c.BlocksPerChunk <= 0 {
+		return fmt.Errorf("kv_offload: blocks_per_chunk must be > 0, got %d", c.BlocksPerChunk)
+	}
+	if c.TokensPerHash <= 0 {
+		return fmt.Errorf("kv_offload: tokens_per_hash must be > 0, got %d", c.TokensPerHash)
+	}
+	if c.EvictionPolicy != kvOffloadEvictionLRU && c.EvictionPolicy != kvOffloadEvictionARC {
+		return fmt.Errorf("kv_offload: eviction_policy must be %q or %q, got %q", kvOffloadEvictionLRU, kvOffloadEvictionARC, c.EvictionPolicy)
+	}
+	for i, t := range c.Tiers {
+		if err := t.validate(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validate checks one resolved tier. index is used only for error messages.
+func (t KVOffloadTier) validate(index int) error {
+	if t.Type != kvOffloadTierFS {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].type must be %q (only the filesystem tier is representable in BLIS; obj/p2p/example are not yet supported), got %q", index, kvOffloadTierFS, t.Type)
+	}
+	if t.RootDir == "" {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].root_dir is required for an %q tier", index, kvOffloadTierFS)
+	}
+	if t.Locality != "" && t.Locality != kvOffloadLocalityLocal && t.Locality != kvOffloadLocalityRemote {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].locality must be %q or %q (or unset), got %q", index, kvOffloadLocalityLocal, kvOffloadLocalityRemote, t.Locality)
+	}
+	if t.NReadThreads <= 0 {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].n_read_threads must be > 0, got %d", index, t.NReadThreads)
+	}
+	if t.NWriteThreads <= 0 {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].n_write_threads must be > 0, got %d", index, t.NWriteThreads)
+	}
+	if err := validatePositiveFinite(t.ReadBandwidth, index, "read_bandwidth"); err != nil {
+		return err
+	}
+	if err := validatePositiveFinite(t.WriteBandwidth, index, "write_bandwidth"); err != nil {
+		return err
+	}
+	if math.IsNaN(t.BaseLatency) || math.IsInf(t.BaseLatency, 0) || t.BaseLatency < 0 {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].base_latency must be a finite value >= 0, got %v", index, t.BaseLatency)
+	}
+	return nil
+}
+
+// validatePositiveFinite rejects a non-finite or non-positive bandwidth, naming the field.
+func validatePositiveFinite(v float64, index int, field string) error {
+	if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+		return fmt.Errorf("kv_offload: secondary_tiers[%d].%s must be a finite value > 0, got %v", index, field, v)
+	}
+	return nil
+}

--- a/sim/kv_offload_config_test.go
+++ b/sim/kv_offload_config_test.go
@@ -1,0 +1,152 @@
+package sim
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// validFSTier returns a fully-resolved, valid fs tier for use as a test baseline.
+func validFSTier() KVOffloadTier {
+	return KVOffloadTier{
+		Type:           "fs",
+		RootDir:        "/mnt/kv",
+		NReadThreads:   16,
+		NWriteThreads:  16,
+		Locality:       "LOCAL",
+		EnableKVEvents: false,
+		DirectIO:       true,
+		DeviceClass:    "nvme_gen4",
+		ReadBandwidth:  7000,
+		WriteBandwidth: 5000,
+		BaseLatency:    80,
+	}
+}
+
+// validEnabledConfig returns a valid resolved multi-tier config.
+func validEnabledConfig() KVOffloadConfig {
+	return KVOffloadConfig{
+		Enabled:                true,
+		CPUBytesToUse:          17179869184,
+		BlockSize:              16,
+		BlocksPerChunk:         1,
+		TokensPerHash:          16,
+		EvictionPolicy:         "lru",
+		OffloadPromptOnly:      true,
+		SelfDescribingKVEvents: false,
+		Tiers:                  []KVOffloadTier{validFSTier()},
+	}
+}
+
+// T1: zero value is inert.
+func TestKVOffloadConfig_ZeroValueInert(t *testing.T) {
+	var c KVOffloadConfig
+	if c.IsEnabled() {
+		t.Fatalf("zero-value KVOffloadConfig must be inert (IsEnabled()==false)")
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("inert config must validate as a no-op, got %v", err)
+	}
+}
+
+// T2: Validate accepts a valid config and rejects each invariant violation, naming the field.
+func TestKVOffloadConfig_Validate(t *testing.T) {
+	if err := validEnabledConfig().Validate(); err != nil {
+		t.Fatalf("valid config must pass Validate, got %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(*KVOffloadConfig)
+		wantFrag string
+	}{
+		{"cpu_bytes zero", func(c *KVOffloadConfig) { c.CPUBytesToUse = 0 }, "cpu_bytes_to_use"},
+		{"cpu_bytes negative", func(c *KVOffloadConfig) { c.CPUBytesToUse = -1 }, "cpu_bytes_to_use"},
+		{"block_size zero", func(c *KVOffloadConfig) { c.BlockSize = 0 }, "block_size"},
+		{"blocks_per_chunk zero", func(c *KVOffloadConfig) { c.BlocksPerChunk = 0 }, "blocks_per_chunk"},
+		{"tokens_per_hash zero", func(c *KVOffloadConfig) { c.TokensPerHash = 0 }, "tokens_per_hash"},
+		{"unknown eviction policy", func(c *KVOffloadConfig) { c.EvictionPolicy = "fifo" }, "eviction_policy"},
+		{"tier type obj", func(c *KVOffloadConfig) { c.Tiers[0].Type = "obj" }, "type"},
+		{"tier type p2p", func(c *KVOffloadConfig) { c.Tiers[0].Type = "p2p" }, "type"},
+		{"tier type example", func(c *KVOffloadConfig) { c.Tiers[0].Type = "example" }, "type"},
+		{"missing root_dir", func(c *KVOffloadConfig) { c.Tiers[0].RootDir = "" }, "root_dir"},
+		{"bad locality", func(c *KVOffloadConfig) { c.Tiers[0].Locality = "somewhere" }, "locality"},
+		{"read threads zero", func(c *KVOffloadConfig) { c.Tiers[0].NReadThreads = 0 }, "n_read_threads"},
+		{"write threads zero", func(c *KVOffloadConfig) { c.Tiers[0].NWriteThreads = 0 }, "n_write_threads"},
+		{"read bw zero", func(c *KVOffloadConfig) { c.Tiers[0].ReadBandwidth = 0 }, "read_bandwidth"},
+		{"read bw NaN", func(c *KVOffloadConfig) { c.Tiers[0].ReadBandwidth = math.NaN() }, "read_bandwidth"},
+		{"read bw Inf", func(c *KVOffloadConfig) { c.Tiers[0].ReadBandwidth = math.Inf(1) }, "read_bandwidth"},
+		{"write bw negative", func(c *KVOffloadConfig) { c.Tiers[0].WriteBandwidth = -5 }, "write_bandwidth"},
+		{"write bw NaN", func(c *KVOffloadConfig) { c.Tiers[0].WriteBandwidth = math.NaN() }, "write_bandwidth"},
+		{"base latency negative", func(c *KVOffloadConfig) { c.Tiers[0].BaseLatency = -1 }, "base_latency"},
+		{"base latency NaN", func(c *KVOffloadConfig) { c.Tiers[0].BaseLatency = math.NaN() }, "base_latency"},
+		{"base latency Inf", func(c *KVOffloadConfig) { c.Tiers[0].BaseLatency = math.Inf(1) }, "base_latency"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validEnabledConfig()
+			tc.mutate(&c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("expected Validate error for %q, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantFrag) {
+				t.Fatalf("error %q must name the offending field %q", err.Error(), tc.wantFrag)
+			}
+		})
+	}
+}
+
+// T2: a valid config with zero secondary tiers (CPU-only offload) is valid.
+func TestKVOffloadConfig_Validate_NoSecondaryTiers(t *testing.T) {
+	c := validEnabledConfig()
+	c.Tiers = nil
+	if err := c.Validate(); err != nil {
+		t.Fatalf("enabled config with no secondary tiers (CPU-only) must validate, got %v", err)
+	}
+}
+
+// T2: base_latency == 0 is allowed (finite, >= 0).
+func TestKVOffloadConfig_Validate_ZeroBaseLatencyOK(t *testing.T) {
+	c := validEnabledConfig()
+	c.Tiers[0].BaseLatency = 0
+	if err := c.Validate(); err != nil {
+		t.Fatalf("zero base_latency must be allowed, got %v", err)
+	}
+}
+
+// T3: NewKVCacheConfig without options yields an inert Offload (byte-identical behavior).
+func TestNewKVCacheConfig_NoOffloadOption_Inert(t *testing.T) {
+	cfg := NewKVCacheConfig(1000, 16, 0, 0, 0, 0)
+	if cfg.Offload.IsEnabled() {
+		t.Fatalf("NewKVCacheConfig without WithKVOffload must leave Offload inert")
+	}
+	if cfg.Offload.CPUBytesToUse != 0 || cfg.Offload.BlockSize != 0 || len(cfg.Offload.Tiers) != 0 {
+		t.Fatalf("Offload must be the zero value, got %+v", cfg.Offload)
+	}
+}
+
+// T3: WithKVOffload threads the resolved sub-config through the constructor.
+func TestNewKVCacheConfig_WithKVOffload(t *testing.T) {
+	want := validEnabledConfig()
+	cfg := NewKVCacheConfig(1000, 16, 0, 0, 0, 0, WithKVOffload(want))
+	if !cfg.Offload.IsEnabled() {
+		t.Fatalf("WithKVOffload must set Offload enabled")
+	}
+	if cfg.Offload.CPUBytesToUse != want.CPUBytesToUse || len(cfg.Offload.Tiers) != 1 {
+		t.Fatalf("Offload not threaded through: got %+v", cfg.Offload)
+	}
+}
+
+// T3: an invalid enabled offload triggers factory validation (panic), matching the
+// constructor's panic-on-invalid contract.
+func TestNewKVCacheConfig_WithInvalidOffload_Panics(t *testing.T) {
+	bad := validEnabledConfig()
+	bad.CPUBytesToUse = 0 // invalid
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("NewKVCacheConfig must panic on an invalid enabled offload config")
+		}
+	}()
+	_ = NewKVCacheConfig(1000, 16, 0, 0, 0, 0, WithKVOffload(bad))
+}

--- a/sim/kv_offload_config_test.go
+++ b/sim/kv_offload_config_test.go
@@ -1,7 +1,11 @@
 package sim
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"math"
+	"os"
 	"strings"
 	"testing"
 )
@@ -149,4 +153,57 @@ func TestNewKVCacheConfig_WithInvalidOffload_Panics(t *testing.T) {
 		}
 	}()
 	_ = NewKVCacheConfig(1000, 16, 0, 0, 0, 0, WithKVOffload(bad))
+}
+
+// TestKVOffloadConfig_ReadOnly_BC_G4 is the BC-G4 static-analysis guard: no code in
+// the sim package (outside the type definition in kv_offload_config.go and the
+// constructor in config.go) may WRITE KVOffloadConfig/KVOffloadTier fields — the
+// config is operator input, resolved and validated once in cmd/, never fitted at
+// runtime.
+//
+// SCOPE (honest): this scans the sim package only. The single legitimate write site
+// is cmd/kv_offload.go (resolution/construction); the sim-side write sites are the
+// KVCacheConfig.Offload assignment inside WithKVOffload (config.go) and the type
+// definitions (kv_offload_config.go), both allow-listed. Because the offload
+// subsystem is INERT in this PR (no sim/ consumer reads the field yet), a sim-only
+// scan is sufficient; when consumers land they will be added to this package and this
+// guard extends to them automatically.
+func TestKVOffloadConfig_ReadOnly_BC_G4(t *testing.T) {
+	allow := map[string]bool{
+		"kv_offload_config.go": true, // type definitions
+		"config.go":            true, // WithKVOffload option (the sole write of .Offload)
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || allow[name] {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CompositeLit:
+				if id, ok := node.Type.(*ast.Ident); ok {
+					if id.Name == "KVOffloadConfig" || id.Name == "KVOffloadTier" {
+						t.Errorf("%s: %s{...} composite literal outside the allow-list — offload config must be constructed only in cmd/ (BC-G4)", name, id.Name)
+					}
+				}
+			case *ast.AssignStmt:
+				for _, lhs := range node.Lhs {
+					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "Offload" {
+						pos := fset.Position(sel.Pos())
+						t.Errorf("%s:%d: assignment to .Offload outside the allow-list — the offload sub-config is read-only after construction (BC-G4)", name, pos.Line)
+					}
+				}
+			}
+			return true
+		})
+	}
 }

--- a/sim/kv_offload_config_test.go
+++ b/sim/kv_offload_config_test.go
@@ -197,9 +197,20 @@ func TestKVOffloadConfig_ReadOnly_BC_G4(t *testing.T) {
 				}
 			case *ast.AssignStmt:
 				for _, lhs := range node.Lhs {
-					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "Offload" {
+					sel, ok := lhs.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+					// Whole-field write: x.Offload = ...
+					if sel.Sel.Name == "Offload" {
 						pos := fset.Position(sel.Pos())
 						t.Errorf("%s:%d: assignment to .Offload outside the allow-list — the offload sub-config is read-only after construction (BC-G4)", name, pos.Line)
+					}
+					// Deep write into the sub-config: x.Offload.Field = ... (the LHS
+					// receiver is itself a selector whose leaf is "Offload").
+					if inner, ok := sel.X.(*ast.SelectorExpr); ok && inner.Sel.Name == "Offload" {
+						pos := fset.Position(sel.Pos())
+						t.Errorf("%s:%d: assignment into .Offload.%s outside the allow-list — the offload sub-config is read-only after construction (BC-G4)", name, pos.Line, sel.Sel.Name)
 					}
 				}
 			}

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -36,6 +36,49 @@ type TraceHeader struct {
 	// version 3; old binaries reading new traces will hard-fail under
 	// KnownFields(true) — intentional, signaled by Version (BC-N3).
 	GoodputSLOTargets map[string]SLODimTargets `yaml:"goodput_slo_targets,omitempty"`
+
+	// KVOffload records the RESOLVED KV-cache offload configuration (H5, #1587) so it
+	// round-trips run→replay (BC-G6, INV-13). Absent (nil, omitempty) when no
+	// --kv-offload-config was supplied — so a run without offload writes a
+	// byte-identical header to a pre-feature build (BC-G5). The resolved bandwidth /
+	// latency numbers are recorded (not device_class), so replay reproduces the exact
+	// physics regardless of the replay host's defaults.yaml; replay uses them
+	// authoritatively and logrus.Fatalf's on any config it cannot reconstruct.
+	KVOffload *TraceKVOffloadConfig `yaml:"kv_offload,omitempty"`
+}
+
+// TraceKVOffloadConfig is the trace-header serialization of a resolved
+// sim.KVOffloadConfig (H5, #1587). It is a workload-package struct — decoupled from
+// sim.KVOffloadConfig so the on-disk trace format is stable independent of the
+// internal config type — mirroring the TraceServerConfig / TraceNetworkConfig
+// precedent. cmd/ owns the sim↔header conversion. Read strictly (KnownFields) via
+// LoadTraceV2, so an unknown offload sub-key is a hard error (BC-N3 version guard).
+type TraceKVOffloadConfig struct {
+	CPUBytesToUse          int64                `yaml:"cpu_bytes_to_use"`
+	BlockSize              int64                `yaml:"block_size"`
+	BlocksPerChunk         int64                `yaml:"blocks_per_chunk"`
+	TokensPerHash          int64                `yaml:"tokens_per_hash"`
+	EvictionPolicy         string               `yaml:"eviction_policy"`
+	OffloadPromptOnly      bool                 `yaml:"offload_prompt_only"`
+	SelfDescribingKVEvents bool                 `yaml:"self_describing_kv_events"`
+	Tiers                  []TraceKVOffloadTier `yaml:"secondary_tiers,omitempty"`
+}
+
+// TraceKVOffloadTier is the trace-header serialization of one resolved
+// sim.KVOffloadTier. Bandwidths/latency are the RESOLVED numbers (bytes/µs, µs);
+// device_class is an informational echo only.
+type TraceKVOffloadTier struct {
+	Type           string  `yaml:"type"`
+	RootDir        string  `yaml:"root_dir"`
+	NReadThreads   int64   `yaml:"n_read_threads"`
+	NWriteThreads  int64   `yaml:"n_write_threads"`
+	Locality       string  `yaml:"locality,omitempty"`
+	EnableKVEvents bool    `yaml:"enable_kv_events"`
+	DirectIO       bool    `yaml:"direct_io"`
+	DeviceClass    string  `yaml:"device_class,omitempty"`
+	ReadBandwidth  float64 `yaml:"read_bandwidth"`
+	WriteBandwidth float64 `yaml:"write_bandwidth"`
+	BaseLatency    float64 `yaml:"base_latency"`
 }
 
 // TraceServerConfig captures server configuration in trace header.

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -1935,3 +1935,103 @@ func TestExportTraceV2_XRequestID_CoexistsWithOtherOptionalColumns(t *testing.T)
 		t.Errorf("XRequestID: got %q, want %q", got.XRequestID, "uuid-zzz")
 	}
 }
+
+// TestTraceV2_RoundTrip_WithKVOffload verifies the resolved KV-offload config
+// (H5, #1587, BC-G6) survives export→load with all fields intact, and that a header
+// without offload omits the key (BC-G5).
+func TestTraceV2_RoundTrip_WithKVOffload(t *testing.T) {
+	header := &TraceHeader{
+		Version: 3, TimeUnit: "microseconds", Mode: "generated",
+		KVOffload: &TraceKVOffloadConfig{
+			CPUBytesToUse:          17179869184,
+			BlockSize:              16,
+			BlocksPerChunk:         1,
+			TokensPerHash:          16,
+			EvictionPolicy:         "lru",
+			OffloadPromptOnly:      true,
+			SelfDescribingKVEvents: false,
+			Tiers: []TraceKVOffloadTier{
+				{
+					Type: "fs", RootDir: "/mnt/kv-cache",
+					NReadThreads: 16, NWriteThreads: 16,
+					Locality: "LOCAL", EnableKVEvents: false, DirectIO: true,
+					DeviceClass: "nvme_gen4",
+					ReadBandwidth: 7000, WriteBandwidth: 5000, BaseLatency: 80,
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, nil, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := loaded.Header.KVOffload
+	if got == nil {
+		t.Fatal("kv_offload config should round-trip, got nil")
+	}
+	if got.CPUBytesToUse != 17179869184 || got.EvictionPolicy != "lru" || !got.OffloadPromptOnly {
+		t.Errorf("scalar mismatch after round-trip: %+v", got)
+	}
+	if len(got.Tiers) != 1 {
+		t.Fatalf("tiers: got %d, want 1", len(got.Tiers))
+	}
+	tr := got.Tiers[0]
+	if tr.Type != "fs" || tr.RootDir != "/mnt/kv-cache" || !tr.DirectIO ||
+		tr.ReadBandwidth != 7000 || tr.WriteBandwidth != 5000 || tr.BaseLatency != 80 ||
+		tr.NReadThreads != 16 || tr.Locality != "LOCAL" || tr.DeviceClass != "nvme_gen4" {
+		t.Errorf("tier mismatch after round-trip: %+v", tr)
+	}
+}
+
+// TestTraceV2_NoKVOffload_OmitsKey verifies a header without offload writes no
+// kv_offload key (BC-G5 byte-identity for the disabled case).
+func TestTraceV2_NoKVOffload_OmitsKey(t *testing.T) {
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, nil, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(headerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "kv_offload") {
+		t.Errorf("header without offload must not contain a kv_offload key:\n%s", data)
+	}
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Header.KVOffload != nil {
+		t.Error("KVOffload must be nil when absent")
+	}
+}
+
+// TestTraceV2_KVOffload_UnknownSubKey_Errors verifies strict parsing rejects an
+// unknown offload sub-key (BC-G6: replay must fail loudly on a config it cannot
+// reconstruct, e.g. one written by a future binary).
+func TestTraceV2_KVOffload_UnknownSubKey_Errors(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	yaml := "trace_version: 3\ntime_unit: microseconds\nmode: generated\n" +
+		"warm_up_requests: 0\nkv_offload:\n  cpu_bytes_to_use: 1\n  future_knob: 42\n"
+	if err := os.WriteFile(headerPath, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dataPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTraceV2(headerPath, dataPath); err == nil {
+		t.Fatal("expected strict-parse error for unknown kv_offload sub-key, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Fills hole **H5 `kv_offload_config`** (sub-issue of #1585): captures vLLM's KV-cache **offload CLI/config surface** as a first-class, validated, round-trippable BLIS config — so BLIS can be *configured into* the offload mechanisms the sibling holes (#1588/#1589 and later) will implement.

This PR is **config-capture only** — the offload subsystem is **inert**: no `sim/` code reads the new config yet, so a run without `--kv-offload-config` is byte-identical to a build without the feature (BC-G5). The consuming multi-tier transfer/keying physics land separately.

**Exactly one new flag** (`--kv-offload-config`, flag count 112 → 113), one new `defaults.yaml` block (`kv_offload_devices:`), one new sub-config type (`sim.KVOffloadConfig`).

## Design

Follows the `--lora-config` / `--saturation-config` precedent: a strict-YAML file with a single top-level `kv_offload:` block, registered on `run` and `replay` via the shared `registerSimConfigFlags`. Absent ⇒ subsystem inert.

- **`sim.KVOffloadConfig`** — a sub-config of `KVCacheConfig` (R16), resolved/validated/read-only (BC-G4). Threaded through the canonical `NewKVCacheConfig` via a **variadic `WithKVOffload` option** rather than a 7th positional param (which would break all 161 existing call sites); the single struct-literal site is preserved (R4).
- **cmd side** — pointer-typed YAML structs (R9), strict `KnownFields(true)` parsing (R10), a **pure error-returning `resolveKVOffload`** (unit-testable/fuzzable) + a thin CLI wrapper that `logrus.Fatalf`s. `device_class` names resolve against the shipped `kv_offload_devices:` block; an explicit `read_bandwidth`/`write_bandwidth`/`base_latency` triple overrides the class.
- **Trace round-trip (INV-13)** — the *resolved* config (bandwidth/latency numbers, not `device_class`) is recorded in `TraceHeader.KVOffload`; on `replay` the header is authoritative — a config the binary cannot reconstruct/validate fails loudly, a matching `--kv-offload-config` is accepted, a genuine mismatch or adding offload to a no-offload trace is a hard error.

## Behavioral Contracts

- **BC-G1 (representable-or-loud)** — GIVEN a config naming an unrepresentable knob (`store_threshold >= 2`; tier `type` obj/p2p/example) WHEN resolved THEN startup fails with an actionable error — never silent.
- **BC-G2 (defaults match vLLM)** — omitted knobs resolve to vLLM's defaults knob-for-knob: `offload_prompt_only=true` (trap 1), `eviction_policy=lru`, `n_read_threads=n_write_threads=16`, `enable_kv_events=self_describing_kv_events=false`, `blocks_per_chunk=1`, `block_size=`GPU block size, `secondary_tiers=[]`. Verified against vLLM `63a9a5010a`.
- **BC-G3 (validated at construction)** — every enabled tier is complete/consistent (type/root_dir/direct_io/finite per-direction bandwidth), `block_size` XOR `blocks_per_chunk`; NaN/Inf guarded.
- **BC-G4 (read-only, never fitted)** — AST-scan guard: no `sim/` write to the sub-config outside its type definition + constructor.
- **BC-G5 (byte-identical when disabled)** — no flag ⇒ inert zero value, `kv_offload` header key omitted, stdout unchanged (INV-6). Guaranteed by existing run/replay byte-identity parity tests still passing.
- **BC-G6 (round-trip + loud replay)** — resolved config round-trips run→replay through the header; an unreproducible config `logrus.Fatalf`s, never a silent degrade to single-tier (INV-13).

## Traps handled (from the issue)

1. `offload_prompt_only` **defaults to `true`** — decode KV not offloaded unless disabled.
2. **O_DIRECT is explicit**: `direct_io` is a required per-fs-tier field (vLLM probes it at runtime; a simulator can't, and the two regimes are different physics), and it is recorded in the trace.
3. **`store_threshold`**: `TieringOffloadingSpec` rejects `>= 2` — BLIS rejects `>= 2` with vLLM's exact message; `0`/`1` are accepted as a no-op on the multi-tier path (vLLM parity), negatives rejected.

## Testing

`go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean. New coverage:
- Property tests for `Validate()` (BC-G3) and the resolver reject table (BC-G1).
- Per-row default assertions vs vLLM (BC-G2).
- Metamorphic fuzz through the real trace-header YAML serialization path (INV-13 round-trip idempotence, ~285k execs clean).
- BC-G4 static-analysis AST scan.
- End-to-end `run --kv-offload-config` → header records resolved config → `replay` reproduces it; plus header strict-parse + omit-when-absent tests.
- Existing run/replay byte-identity parity tests confirm BC-G5.

Closes #1587
