### PR TITLE
feat(calibrate): KV cache hit-rate observe/replay/calibrate loop (#1583)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,11 @@ go build -o blis main.go
 # the observed hit-rate (vllm:kv_offload_tiering_block_hits/_block_queries, or the GPU
 # prefix-cache fallback) in the trace header for downstream calibrate. --vllm-commit
 # records the pinned (unreleased, PR #48798) vLLM the tiering counters require. A scrape
-# miss warns and omits the block (never fatal). See docs/guide/kv-offload-calibration.md.
+# miss warns and omits the block (never fatal). observe is a black-box dispatcher — it
+# does NOT take --kv-offload-config; the offload config is supplied on the replay step
+# (below). See docs/guide/kv-offload-calibration.md.
 ./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
-  --kv-offload-config offload.yaml --workload chatbot --rate 10 --num-requests 100 \
+  --workload chatbot --rate 10 --num-requests 100 \
   --scrape-kv-metrics --vllm-commit 63a9a5010a \
   --trace-header trace.yaml --trace-data trace.csv
 
@@ -131,8 +133,13 @@ go build -o blis main.go
 # MetricsOutput from `blis replay --metrics-path`, which carries cache_hit_rate). The
 # report gains a hit_rate block with abs_error_pp and a within-tolerance verdict
 # (default 5 pp); a TTFT-MAPE verdict uses --ttft-mape-threshold (default 0.15).
-# Skipped with a warning when --sim-metrics is absent or lacks cache_hit_rate.
+# Skipped with a warning when --sim-metrics is absent or lacks cache_hit_rate. For a
+# tiered observed hit-rate, supply --kv-offload-config on replay to model the observed
+# deployment (observe traces are exempt from the "cannot add offload on replay" rule;
+# sim-generated traces stay header-authoritative). Replaying a tiered observation with
+# no offload config is a hard error (never a silent GPU-only value).
 ./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b \
+  --kv-offload-config offload.yaml \
   --results-path results.json --metrics-path simagg.json
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
   --sim-metrics simagg.json --hit-rate-tolerance-pp 5 --ttft-mape-threshold 0.15 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,31 @@ go build -o blis main.go
   --record-itl --itl-output trace.itl.csv \
   --trace-header trace.yaml --trace-data trace.csv
 
+# Observe with KV cache hit-rate scraping (#1583). --scrape-kv-metrics scrapes the
+# server's Prometheus /metrics at the start and end of the measured window and records
+# the observed hit-rate (vllm:kv_offload_tiering_block_hits/_block_queries, or the GPU
+# prefix-cache fallback) in the trace header for downstream calibrate. --vllm-commit
+# records the pinned (unreleased, PR #48798) vLLM the tiering counters require. A scrape
+# miss warns and omits the block (never fatal). See docs/guide/kv-offload-calibration.md.
+./blis observe --server-url http://localhost:8000 --model qwen/qwen3-14b \
+  --kv-offload-config offload.yaml --workload chatbot --rate 10 --num-requests 100 \
+  --scrape-kv-metrics --vllm-commit 63a9a5010a \
+  --trace-header trace.yaml --trace-data trace.csv
+
 # Compare real observed latencies against simulator predictions
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json --report calibration.json
+
+# Compare KV cache hit-rate too (#1583). The real hit-rate comes from the trace header
+# (observe --scrape-kv-metrics); the sim hit-rate comes from --sim-metrics (a
+# MetricsOutput from `blis replay --metrics-path`, which carries cache_hit_rate). The
+# report gains a hit_rate block with abs_error_pp and a within-tolerance verdict
+# (default 5 pp); a TTFT-MAPE verdict uses --ttft-mape-threshold (default 0.15).
+# Skipped with a warning when --sim-metrics is absent or lacks cache_hit_rate.
+./blis replay --trace-header t.yaml --trace-data d.csv --model qwen/qwen3-14b \
+  --results-path results.json --metrics-path simagg.json
+./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
+  --sim-metrics simagg.json --hit-rate-tolerance-pp 5 --ttft-mape-threshold 0.15 \
+  --report calibration.json
 
 # Compare with ITL metric included (requires observe --record-itl)
 ./blis calibrate --trace-header t.yaml --trace-data d.csv --sim-results results.json \
@@ -370,6 +393,8 @@ LoRA control-plane subsystem (#1464, epic PRs 1–7): adapter identity + pre-dec
 Phase 0 workload unification complete (see issue #420): W0-1 (spec v2 schema + SLO tiers), W0-2 (binary rename + converters), W0-3 (cohort population dynamics), W0-4 (legacy retirement). All workload generation now flows through `sim/workload/GenerateRequests()`. SLO tiers: critical, standard, sheddable, batch, background. Arrival processes: poisson, gamma, weibull, constant. CLI binary renamed from `simulation_worker` to `blis`.
 
 Observe/replay/calibrate pipeline complete: `blis observe` (#659) dispatches workload to real servers with closed-loop session support, `blis replay` (#689) replays through DES, `blis calibrate` (#701) compares real vs simulated latencies. Observe fidelity (#660): chat completions endpoint (`--api-format chat`), `stream_options` for streaming token counts, `finish_reason` extraction, configurable `max_tokens` (`--unconstrained-output`), deterministic prefix strings for KV cache activation, `--rtt-ms` for network RTT.
+
+KV cache hit-rate calibration (#1583, epic #1585 S6): `blis observe --scrape-kv-metrics` scrapes the server's Prometheus `/metrics` KV-offload tiering counters (`vllm:kv_offload_tiering_block_hits`/`_block_queries`; released fallback `vllm:gpu_prefix_cache_*`, tagged distinctly) over the measured window and records the observed hit-rate in a new trace-header block (`observed_kv_metrics`, with `--vllm-commit` pinning the unreleased vLLM PR #48798). `blis replay --metrics-path` writes the sim aggregate `cache_hit_rate` (a `*float64` on `MetricsOutput`, populated file-only in `EmitOutput` so stdout stays byte-identical — INV-6). `blis calibrate --sim-metrics` then compares TTFT, E2E, **and** KV hit-rate (`hit_rate` report block, default ≤5 pp band; TTFT MAPE ≤0.15 verdict). On replay a tiered observation with no reproducible `kv_offload` config is a hard error (BC-10, INV-13, never silent GPU-only degradation); the observed block round-trips verbatim on re-export. The sim exposes one aggregate hit-rate (no per-tier), so the automated comparison is overall-hit-rate; per-tier read/write time is recorded for a documented manual bandwidth cross-check. Pure Prometheus-text parser + hit-rate derivation in `sim/workload/prom_hitrate.go` (no new go.mod dep). Empirical cluster tolerance-pass is an operator step (needs an unreleased-vLLM GPU cluster); see `docs/guide/kv-offload-calibration.md`.
 
 Recent work: MkDocs documentation site (#450), roofline auto-fetch flag (#435), metrics substrate fixes (#458), cross-cutting documentation audit (#460).
 

--- a/cmd/calibrate.go
+++ b/cmd/calibrate.go
@@ -253,6 +253,16 @@ Example:
 			}
 		}
 
+		// TTFT-MAPE tolerance verdict (#1583, BC-7): recorded in the report (not just
+		// logged) so automation consumers see it. Set before the write below.
+		if ttft, ok := report.Metrics["ttft"]; ok {
+			report.TTFTTolerance = &workload.ToleranceVerdict{
+				MAPE:      ttft.RequestLevel.MAPE,
+				Threshold: calibrateTTFTMapeThreshold,
+				Within:    ttft.RequestLevel.MAPE <= calibrateTTFTMapeThreshold,
+			}
+		}
+
 		// Step 7: Write report JSON
 		reportData, err := json.MarshalIndent(report, "", "  ")
 		if err != nil {
@@ -333,10 +343,10 @@ Example:
 			logFn("KV hit-rate (source=%s): Real=%.4f Sim=%.4f AbsErr=%.2fpp (tolerance %.2fpp) [%s]",
 				hr.Source, hr.RealHitRate, hr.SimHitRate, hr.AbsErrorPP, hr.TolerancePP, verdict)
 		}
-		if ttft, ok := report.Metrics["ttft"]; ok {
-			mapePct := ttft.RequestLevel.MAPE * 100
-			threshPct := calibrateTTFTMapeThreshold * 100
-			if ttft.RequestLevel.MAPE <= calibrateTTFTMapeThreshold {
+		if tv := report.TTFTTolerance; tv != nil {
+			mapePct := tv.MAPE * 100
+			threshPct := tv.Threshold * 100
+			if tv.Within {
 				logrus.Infof("TTFT MAPE=%.1f%% (threshold %.1f%%) [WITHIN]", mapePct, threshPct)
 			} else {
 				logrus.Warnf("TTFT MAPE=%.1f%% (threshold %.1f%%) [EXCEEDS]", mapePct, threshPct)

--- a/cmd/calibrate.go
+++ b/cmd/calibrate.go
@@ -34,6 +34,11 @@ var (
 	calibrateSimMetrics        string
 	calibrateSimMetricsBlind   string
 	calibrateAdapterMAPEThresh float64
+	// KV hit-rate comparison (#1583). --sim-metrics (reused from adapter mode) supplies
+	// the simulator's aggregate cache_hit_rate; the tolerances gate the pass/fail
+	// verdicts (absolute pp for hit-rate, MAPE fraction for TTFT).
+	calibrateHitRateTolerancePP float64
+	calibrateTTFTMapeThreshold   float64
 )
 
 var calibrateCmd = &cobra.Command{
@@ -120,6 +125,14 @@ Example:
 		// Validate bandwidth (R3, R20): NaN/Inf bypass computeUploadDelay's ≤0 guard
 		if math.IsNaN(calibrateNetworkBandwidthMbps) || math.IsInf(calibrateNetworkBandwidthMbps, 0) {
 			logrus.Fatalf("--network-bandwidth-mbps must be a finite number, got %v", calibrateNetworkBandwidthMbps)
+		}
+
+		// Validate hit-rate comparison tolerances (R3): finite and non-negative.
+		if math.IsNaN(calibrateHitRateTolerancePP) || math.IsInf(calibrateHitRateTolerancePP, 0) || calibrateHitRateTolerancePP < 0 {
+			logrus.Fatalf("--hit-rate-tolerance-pp must be a finite number >= 0, got %v", calibrateHitRateTolerancePP)
+		}
+		if math.IsNaN(calibrateTTFTMapeThreshold) || math.IsInf(calibrateTTFTMapeThreshold, 0) || calibrateTTFTMapeThreshold < 0 {
+			logrus.Fatalf("--ttft-mape-threshold must be a finite number >= 0, got %v", calibrateTTFTMapeThreshold)
 		}
 
 		config := workload.CalibrationConfig{
@@ -219,6 +232,27 @@ Example:
 			}
 		}
 
+		// Step 6.7: KV cache hit-rate comparison (#1583, BC-6/BC-12). Compares the
+		// real observed hit-rate (trace header, from observe --scrape-kv-metrics)
+		// against the simulator's aggregate cache_hit_rate (--sim-metrics MetricsOutput
+		// from replay --metrics-path). Skipped with a warning when either side is
+		// missing — never a fabricated comparison (R1).
+		if obs := trace.Header.ObservedKVMetrics; obs != nil {
+			if calibrateSimMetrics == "" {
+				logrus.Warnf("calibrate: trace header carries an observed KV hit-rate (source=%s, %.4f) but --sim-metrics was not provided; skipping the hit-rate comparison. Produce it with `blis replay --metrics-path <file>` and pass --sim-metrics <file>.", obs.Source, obs.HitRate)
+			} else {
+				simHR, hrErr := loadSimCacheHitRate(calibrateSimMetrics)
+				if hrErr != nil {
+					logrus.Fatalf("%v", hrErr)
+				}
+				if simHR == nil {
+					logrus.Warnf("calibrate: --sim-metrics %s has no cache_hit_rate; skipping the hit-rate comparison. Regenerate it with `blis replay --metrics-path` (a bare stdout run does not carry cache_hit_rate).", calibrateSimMetrics)
+				} else {
+					report.HitRate = workload.ComputeHitRateComparison(obs.HitRate, *simHR, calibrateHitRateTolerancePP, obs.Source)
+				}
+			}
+		}
+
 		// Step 7: Write report JSON
 		reportData, err := json.MarshalIndent(report, "", "  ")
 		if err != nil {
@@ -285,6 +319,28 @@ Example:
 		if itl, ok := report.Metrics["itl"]; ok {
 			logrus.Infof("  ITL:  MAPE=%.1f%%, PearsonR=%.3f, Bias=%s, Quality=%s",
 				itl.RequestLevel.MAPE*100, itl.RequestLevel.PearsonR, itl.RequestLevel.BiasDirection, itl.RequestLevel.Quality)
+		}
+
+		// KV cache hit-rate verdict + TTFT tolerance verdict (#1583, BC-6/BC-7).
+		if report.HitRate != nil {
+			hr := report.HitRate
+			verdict := "WITHIN"
+			logFn := logrus.Infof
+			if !hr.Within {
+				verdict = "EXCEEDS"
+				logFn = logrus.Warnf
+			}
+			logFn("KV hit-rate (source=%s): Real=%.4f Sim=%.4f AbsErr=%.2fpp (tolerance %.2fpp) [%s]",
+				hr.Source, hr.RealHitRate, hr.SimHitRate, hr.AbsErrorPP, hr.TolerancePP, verdict)
+		}
+		if ttft, ok := report.Metrics["ttft"]; ok {
+			mapePct := ttft.RequestLevel.MAPE * 100
+			threshPct := calibrateTTFTMapeThreshold * 100
+			if ttft.RequestLevel.MAPE <= calibrateTTFTMapeThreshold {
+				logrus.Infof("TTFT MAPE=%.1f%% (threshold %.1f%%) [WITHIN]", mapePct, threshPct)
+			} else {
+				logrus.Warnf("TTFT MAPE=%.1f%% (threshold %.1f%%) [EXCEEDS]", mapePct, threshPct)
+			}
 		}
 
 		// Per-SLO class breakdown (when data present)
@@ -362,6 +418,23 @@ func loadBLISAggregate(path string) workload.BLISAggregate {
 		TTFTMs:           m.TTFTMeanMs,
 		OutputThroughput: float64(m.TotalOutputTokens) / m.VllmDurationSec,
 	}
+}
+
+// loadSimCacheHitRate reads a BLIS MetricsOutput JSON (from `blis run/replay
+// --metrics-path`) and returns its aggregate cache_hit_rate (#1583). A nil return
+// with nil error means the file parsed but carries no cache_hit_rate (e.g. produced
+// without --metrics-path, or by a pre-feature binary) — the caller warns and skips
+// the hit-rate comparison rather than fabricating a value.
+func loadSimCacheHitRate(path string) (*float64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --sim-metrics %s: %w", path, err)
+	}
+	var m sim.MetricsOutput
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse --sim-metrics %s: %w", path, err)
+	}
+	return m.CacheHitRate, nil
 }
 
 // runAdapterReferenceComparison implements the US5 (#1470) DT fidelity comparison:
@@ -450,7 +523,9 @@ func init() {
 	calibrateCmd.Flags().StringVar(&calibrateGoodputSLOE2E, "slo-e2e", "", "Per-class E2E goodput thresholds (e.g. \"critical=5s,standard=30s\").")
 	// Adapter-cost fidelity comparison vs the Digital Twin (US5, #1470).
 	calibrateCmd.Flags().StringVar(&calibrateAdapterReference, "adapter-reference", "", "Path to a DT reference JSON (per-config adapter_aware/adapter_blind aggregates). Enables standalone BLIS-vs-DT fidelity comparison; --trace-header/--trace-data/--sim-results are not used in this mode.")
-	calibrateCmd.Flags().StringVar(&calibrateSimMetrics, "sim-metrics", "", "Path to a BLIS aggregate MetricsOutput JSON (from blis run/replay --metrics-path) for the adapter-aware run. Required with --adapter-reference.")
+	calibrateCmd.Flags().StringVar(&calibrateSimMetrics, "sim-metrics", "", "Path to a BLIS aggregate MetricsOutput JSON (from blis run/replay --metrics-path). Required with --adapter-reference (adapter-aware run). In the standard flow it supplies the simulator's cache_hit_rate for the KV hit-rate comparison (#1583).")
+	calibrateCmd.Flags().Float64Var(&calibrateHitRateTolerancePP, "hit-rate-tolerance-pp", 5.0, "Absolute-error band (percentage points) for the KV cache hit-rate comparison (#1583). Real (trace header observed) vs sim (--sim-metrics cache_hit_rate).")
+	calibrateCmd.Flags().Float64Var(&calibrateTTFTMapeThreshold, "ttft-mape-threshold", 0.15, "TTFT MAPE threshold (fraction) for the informational TTFT tolerance verdict (#1583; issue target 0.15).")
 	calibrateCmd.Flags().StringVar(&calibrateSimMetricsBlind, "sim-metrics-blind", "", "Optional BLIS MetricsOutput JSON for the adapter-blind baseline run; enables the delta-normalized (aware/blind) diagnostic that isolates the ported adapter physics.")
 	calibrateCmd.Flags().Float64Var(&calibrateAdapterMAPEThresh, "adapter-mape-threshold", 0.20, "MAPE bound (fraction) for the adapter-reference comparison (SC-007 target 0.20).")
 	rootCmd.AddCommand(calibrateCmd)

--- a/cmd/calibrate_hitrate_test.go
+++ b/cmd/calibrate_hitrate_test.go
@@ -98,6 +98,14 @@ func TestCalibrateCmd_HitRate_Present(t *testing.T) {
 	if report.HitRate.Source != workload.ObservedKVSourceTiered {
 		t.Errorf("source = %q, want tiered", report.HitRate.Source)
 	}
+	// BC-7: the TTFT-MAPE tolerance verdict must also be recorded in the report JSON
+	// (not just logged) whenever a TTFT metric exists.
+	if report.TTFTTolerance == nil {
+		t.Fatal("report.ttft_tolerance should be populated when a TTFT metric exists")
+	}
+	if report.TTFTTolerance.Threshold != 0.15 {
+		t.Errorf("ttft_tolerance.threshold = %v, want 0.15", report.TTFTTolerance.Threshold)
+	}
 }
 
 // TestCalibrateCmd_HitRate_SkipWhenNoSimMetrics verifies BC-12: an observed hit-rate

--- a/cmd/calibrate_hitrate_test.go
+++ b/cmd/calibrate_hitrate_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// traceWithObservedHitRate writes a minimal 2-request TraceV2 whose header carries an
+// observed KV hit-rate, plus a matching SimResult file. Returns the paths.
+func traceWithObservedHitRate(t *testing.T, dir string, source string, hitRate float64) (headerPath, dataPath, simResultsPath string) {
+	t.Helper()
+	headerPath = filepath.Join(dir, "trace.yaml")
+	dataPath = filepath.Join(dir, "trace.csv")
+	simResultsPath = filepath.Join(dir, "results.json")
+
+	hdr := &workload.TraceHeader{
+		Version: 3, TimeUnit: "microseconds", Mode: "real",
+		ObservedKVMetrics: &workload.TraceObservedKVMetrics{
+			Source: source, HitRate: hitRate, BlockHits: int64(hitRate * 1000), BlockQueries: 1000,
+		},
+	}
+	records := []workload.TraceRecord{
+		{RequestID: 0, ClientID: "c1", SLOClass: "standard", Streaming: true, InputTokens: 10, OutputTokens: 5,
+			ArrivalTimeUs: 0, SendTimeUs: 1000, FirstChunkTimeUs: 5000, LastChunkTimeUs: 10000, NumChunks: 5, Status: "ok"},
+		{RequestID: 1, ClientID: "c1", SLOClass: "standard", Streaming: true, InputTokens: 10, OutputTokens: 5,
+			ArrivalTimeUs: 100000, SendTimeUs: 101000, FirstChunkTimeUs: 105000, LastChunkTimeUs: 110000, NumChunks: 5, Status: "ok"},
+	}
+	if err := workload.ExportTraceV2(hdr, records, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	simResults := []workload.SimResult{
+		{RequestID: 0, TTFT: 4000, E2E: 9000, InputTokens: 10, OutputTokens: 5},
+		{RequestID: 1, TTFT: 4000, E2E: 9000, InputTokens: 10, OutputTokens: 5},
+	}
+	simData, _ := json.Marshal(simResults)
+	if err := os.WriteFile(simResultsPath, simData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return headerPath, dataPath, simResultsPath
+}
+
+func writeSimMetricsFile(t *testing.T, dir string, cacheHitRate *float64) string {
+	t.Helper()
+	p := filepath.Join(dir, "simmetrics.json")
+	m := sim.MetricsOutput{InstanceID: "cluster", CacheHitRate: cacheHitRate}
+	data, _ := json.Marshal(m)
+	if err := os.WriteFile(p, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestCalibrateCmd_HitRate_Present verifies BC-6: with an observed hit-rate in the
+// header AND --sim-metrics carrying cache_hit_rate, the report gains a hit_rate block.
+func TestCalibrateCmd_HitRate_Present(t *testing.T) {
+	dir := t.TempDir()
+	headerPath, dataPath, simResultsPath := traceWithObservedHitRate(t, dir, workload.ObservedKVSourceTiered, 0.70)
+	simHR := 0.73
+	simMetricsPath := writeSimMetricsFile(t, dir, &simHR)
+	reportPath := filepath.Join(dir, "report.json")
+
+	defer saveRestoreCalibrateFlags()()
+	calibrateTraceHeaderPath = headerPath
+	calibrateTraceDataPath = dataPath
+	calibrateSimResultsPath = simResultsPath
+	calibrateReportPath = reportPath
+	calibrateWarmUpRequests = -1
+	calibrateNetworkRTTUs = -1
+	calibrateNetworkBandwidthMbps = 0
+	calibrateSimMetrics = simMetricsPath
+	calibrateHitRateTolerancePP = 5.0
+	calibrateTTFTMapeThreshold = 0.15
+
+	calibrateCmd.Run(calibrateCmd, []string{})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+	var report workload.CalibrationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.HitRate == nil {
+		t.Fatal("report.hit_rate should be populated")
+	}
+	if report.HitRate.RealHitRate != 0.70 || report.HitRate.SimHitRate != 0.73 {
+		t.Errorf("hit_rate real/sim = %v/%v, want 0.70/0.73", report.HitRate.RealHitRate, report.HitRate.SimHitRate)
+	}
+	if !report.HitRate.Within {
+		t.Errorf("3pp error should be within 5pp band, got abs_error_pp=%v", report.HitRate.AbsErrorPP)
+	}
+	if report.HitRate.Source != workload.ObservedKVSourceTiered {
+		t.Errorf("source = %q, want tiered", report.HitRate.Source)
+	}
+}
+
+// TestCalibrateCmd_HitRate_SkipWhenNoSimMetrics verifies BC-12: an observed hit-rate
+// with no --sim-metrics skips the hit_rate block (TTFT/E2E still computed).
+func TestCalibrateCmd_HitRate_SkipWhenNoSimMetrics(t *testing.T) {
+	dir := t.TempDir()
+	headerPath, dataPath, simResultsPath := traceWithObservedHitRate(t, dir, workload.ObservedKVSourceTiered, 0.70)
+	reportPath := filepath.Join(dir, "report.json")
+
+	defer saveRestoreCalibrateFlags()()
+	calibrateTraceHeaderPath = headerPath
+	calibrateTraceDataPath = dataPath
+	calibrateSimResultsPath = simResultsPath
+	calibrateReportPath = reportPath
+	calibrateWarmUpRequests = -1
+	calibrateNetworkRTTUs = -1
+	calibrateNetworkBandwidthMbps = 0
+	calibrateSimMetrics = "" // no sim metrics → skip
+	calibrateHitRateTolerancePP = 5.0
+	calibrateTTFTMapeThreshold = 0.15
+
+	calibrateCmd.Run(calibrateCmd, []string{})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+	var report workload.CalibrationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.HitRate != nil {
+		t.Errorf("hit_rate must be skipped without --sim-metrics, got %+v", report.HitRate)
+	}
+	if _, ok := report.Metrics["ttft"]; !ok {
+		t.Error("TTFT metric must still be computed when hit-rate is skipped")
+	}
+}
+
+// TestCalibrateCmd_HitRate_SkipWhenSimMetricsLacksField verifies BC-12: --sim-metrics
+// present but without cache_hit_rate (e.g. produced without --metrics-path) skips.
+func TestCalibrateCmd_HitRate_SkipWhenSimMetricsLacksField(t *testing.T) {
+	dir := t.TempDir()
+	headerPath, dataPath, simResultsPath := traceWithObservedHitRate(t, dir, workload.ObservedKVSourceGPUCache, 0.60)
+	simMetricsPath := writeSimMetricsFile(t, dir, nil) // no cache_hit_rate
+	reportPath := filepath.Join(dir, "report.json")
+
+	defer saveRestoreCalibrateFlags()()
+	calibrateTraceHeaderPath = headerPath
+	calibrateTraceDataPath = dataPath
+	calibrateSimResultsPath = simResultsPath
+	calibrateReportPath = reportPath
+	calibrateWarmUpRequests = -1
+	calibrateNetworkRTTUs = -1
+	calibrateNetworkBandwidthMbps = 0
+	calibrateSimMetrics = simMetricsPath
+	calibrateHitRateTolerancePP = 5.0
+	calibrateTTFTMapeThreshold = 0.15
+
+	calibrateCmd.Run(calibrateCmd, []string{})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("report not written: %v", err)
+	}
+	var report workload.CalibrationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.HitRate != nil {
+		t.Errorf("hit_rate must be skipped when --sim-metrics lacks cache_hit_rate, got %+v", report.HitRate)
+	}
+}

--- a/cmd/calibrate_test.go
+++ b/cmd/calibrate_test.go
@@ -24,6 +24,9 @@ func saveRestoreCalibrateFlags() func() {
 	origRTT := calibrateNetworkRTTUs
 	origBW := calibrateNetworkBandwidthMbps
 	origITL := calibrateITLDataPath
+	origSimMetrics := calibrateSimMetrics
+	origHRTol := calibrateHitRateTolerancePP
+	origTTFTThresh := calibrateTTFTMapeThreshold
 	return func() {
 		calibrateTraceHeaderPath = origHeader
 		calibrateTraceDataPath = origData
@@ -33,6 +36,9 @@ func saveRestoreCalibrateFlags() func() {
 		calibrateNetworkRTTUs = origRTT
 		calibrateNetworkBandwidthMbps = origBW
 		calibrateITLDataPath = origITL
+		calibrateSimMetrics = origSimMetrics
+		calibrateHitRateTolerancePP = origHRTol
+		calibrateTTFTMapeThreshold = origTTFTThresh
 	}
 }
 

--- a/cmd/kv_offload.go
+++ b/cmd/kv_offload.go
@@ -355,14 +355,19 @@ func simToHeaderOffload(c sim.KVOffloadConfig) *workload.TraceKVOffloadConfig {
 //   - a flag that would ADD offload to a trace captured without it ⇒ Fatalf.
 //
 // Returns the inert zero value when the trace carries no offload config.
-func reconcileReplayKVOffload(cmd *cobra.Command, headerBlock *workload.TraceKVOffloadConfig) sim.KVOffloadConfig {
+// allowFlagAdd is true for OBSERVE traces (Mode "real"): they carry real-server
+// timing, not a sim-generated offload config, so supplying --kv-offload-config to
+// model the observed deployment for the sim side of calibration (#1583) is allowed.
+// It is false for sim-generated (run/replay) traces, where INV-13 run/replay parity
+// forbids a flag adding an offload config the source run did not have.
+func reconcileReplayKVOffload(cmd *cobra.Command, headerBlock *workload.TraceKVOffloadConfig, allowFlagAdd bool) sim.KVOffloadConfig {
 	flagChanged := cmd.Flags().Changed("kv-offload-config")
 	var flagCfg sim.KVOffloadConfig
 	if flagChanged {
 		// resolveKVOffloadConfig itself logrus.Fatalf's on a malformed flag file.
 		flagCfg = resolveKVOffloadConfig(cmd)
 	}
-	cfg, err := resolveReplayKVOffload(headerBlock, flagChanged, flagCfg)
+	cfg, err := resolveReplayKVOffload(headerBlock, flagChanged, flagCfg, allowFlagAdd)
 	if err != nil {
 		logrus.Fatalf("%v", err)
 	}
@@ -372,7 +377,7 @@ func reconcileReplayKVOffload(cmd *cobra.Command, headerBlock *workload.TraceKVO
 // resolveReplayKVOffload is the PURE, error-returning core of replay's
 // header-authoritative reconciliation (Deviation #9 — every reject branch is
 // unit-testable). See reconcileReplayKVOffload for the policy summary.
-func resolveReplayKVOffload(headerBlock *workload.TraceKVOffloadConfig, flagChanged bool, flagCfg sim.KVOffloadConfig) (sim.KVOffloadConfig, error) {
+func resolveReplayKVOffload(headerBlock *workload.TraceKVOffloadConfig, flagChanged bool, flagCfg sim.KVOffloadConfig, allowFlagAdd bool) (sim.KVOffloadConfig, error) {
 	headerOffload := headerToSimOffload(headerBlock)
 	if headerOffload.IsEnabled() {
 		if err := headerOffload.Validate(); err != nil {
@@ -392,7 +397,14 @@ func resolveReplayKVOffload(headerBlock *workload.TraceKVOffloadConfig, flagChan
 		return headerOffload, nil
 	}
 	if flagChanged && flagCfg.IsEnabled() {
-		return sim.KVOffloadConfig{}, fmt.Errorf("the trace was captured without a kv_offload config; --kv-offload-config cannot add one on replay (INV-13)")
+		if allowFlagAdd {
+			// Observe trace (#1583): the operator supplies the offload config the
+			// server ran with, to model the observed deployment for the sim side of
+			// the hit-rate comparison. PerBlockBytes is 0 here (model not yet
+			// resolved); replay derives it after the latency config resolves.
+			return flagCfg, nil
+		}
+		return sim.KVOffloadConfig{}, fmt.Errorf("the trace was captured without a kv_offload config; --kv-offload-config cannot add one on replay of a sim-generated trace (INV-13). Only observe traces (mode \"real\") may have an offload config supplied on replay to model the observed deployment")
 	}
 	return sim.KVOffloadConfig{}, nil
 }
@@ -411,7 +423,7 @@ func validateObservedKVReplayable(obs *workload.TraceObservedKVMetrics, offloadE
 		return nil
 	}
 	if obs.Source == workload.ObservedKVSourceTiered && !offloadEnabled {
-		return fmt.Errorf("the trace's observed_kv_metrics were captured from the tiered KV-offload counters (source=%q) but this replay has no reproducible kv_offload config; replay would produce a GPU-only hit-rate that calibrate cannot compare against the tiered observation — supply the kv_offload config (via the trace header or --kv-offload-config) or re-observe without tiering (INV-13, never silent degradation)", obs.Source)
+		return fmt.Errorf("the trace's observed_kv_metrics were captured from the tiered KV-offload counters (source=%q) but this replay has no offload config; replay would produce a GPU-only hit-rate that calibrate cannot compare against the tiered observation — pass --kv-offload-config <file> matching the observed deployment (INV-13, never silent degradation)", obs.Source)
 	}
 	return nil
 }

--- a/cmd/kv_offload.go
+++ b/cmd/kv_offload.go
@@ -397,6 +397,25 @@ func resolveReplayKVOffload(headerBlock *workload.TraceKVOffloadConfig, flagChan
 	return sim.KVOffloadConfig{}, nil
 }
 
+// validateObservedKVReplayable enforces BC-10 (#1583): a trace whose observed KV
+// hit-rate was captured from the multi-tier offload family (source "tiered") is only
+// comparable on replay if this replay reproduces a tiered offload config. If the
+// reconciled offload config is NOT enabled, the simulator would produce a GPU-only
+// hit-rate that `blis calibrate` would then compare against a tiered real number —
+// silent degradation. Fail loudly instead (INV-13). The GPU-prefix-cache fallback
+// source has no such requirement (it is a GPU-only observation to begin with).
+// Pure and error-returning (Deviation #9) so the guard is unit-testable; the CLI
+// caller turns the error into logrus.Fatalf.
+func validateObservedKVReplayable(obs *workload.TraceObservedKVMetrics, offloadEnabled bool) error {
+	if obs == nil {
+		return nil
+	}
+	if obs.Source == workload.ObservedKVSourceTiered && !offloadEnabled {
+		return fmt.Errorf("the trace's observed_kv_metrics were captured from the tiered KV-offload counters (source=%q) but this replay has no reproducible kv_offload config; replay would produce a GPU-only hit-rate that calibrate cannot compare against the tiered observation — supply the kv_offload config (via the trace header or --kv-offload-config) or re-observe without tiering (INV-13, never silent degradation)", obs.Source)
+	}
+	return nil
+}
+
 // headerToSimOffload reconstructs a resolved sim.KVOffloadConfig from a trace header
 // (BC-G6). Returns the inert zero value when the header carries no offload block.
 // Lossless inverse of simToHeaderOffload. The caller (replay) runs Validate() on the

--- a/cmd/kv_offload_perblockbytes_test.go
+++ b/cmd/kv_offload_perblockbytes_test.go
@@ -27,7 +27,7 @@ func TestResolveReplayKVOffload_PerBlockBytesExcluded(t *testing.T) {
 	// Identical flags EXCEPT the derived PerBlockBytes (0 on the flag side).
 	flag := headerToSimOffload(header)
 	flag.PerBlockBytes = 0
-	got, err := resolveReplayKVOffload(header, true, flag)
+	got, err := resolveReplayKVOffload(header, true, flag, false)
 	if err != nil {
 		t.Fatalf("identical flags with a differing DERIVED PerBlockBytes must NOT conflict (INV-13), got %v", err)
 	}
@@ -39,7 +39,7 @@ func TestResolveReplayKVOffload_PerBlockBytesExcluded(t *testing.T) {
 	bad := headerToSimOffload(header)
 	bad.PerBlockBytes = 0
 	bad.CPUBytesToUse = 2048
-	if _, err := resolveReplayKVOffload(header, true, bad); err == nil || !strings.Contains(err.Error(), "conflicts") {
+	if _, err := resolveReplayKVOffload(header, true, bad, false); err == nil || !strings.Contains(err.Error(), "conflicts") {
 		t.Fatalf("a real user-facing divergence must still conflict, got %v", err)
 	}
 }

--- a/cmd/kv_offload_test.go
+++ b/cmd/kv_offload_test.go
@@ -318,13 +318,13 @@ func TestResolveReplayKVOffload(t *testing.T) {
 	validSim := headerToSimOffload(validHeader)
 
 	t.Run("header authoritative, no flag", func(t *testing.T) {
-		got, err := resolveReplayKVOffload(validHeader, false, sim.KVOffloadConfig{})
+		got, err := resolveReplayKVOffload(validHeader, false, sim.KVOffloadConfig{}, false)
 		if err != nil || !reflect.DeepEqual(got, validSim) {
 			t.Fatalf("header should be used verbatim: got %+v err %v", got, err)
 		}
 	})
 	t.Run("matching flag accepted", func(t *testing.T) {
-		got, err := resolveReplayKVOffload(validHeader, true, validSim)
+		got, err := resolveReplayKVOffload(validHeader, true, validSim, false)
 		if err != nil || !reflect.DeepEqual(got, validSim) {
 			t.Fatalf("identical flag must be accepted: got %+v err %v", got, err)
 		}
@@ -332,7 +332,7 @@ func TestResolveReplayKVOffload(t *testing.T) {
 	t.Run("conflicting flag rejected", func(t *testing.T) {
 		other := validSim
 		other.CPUBytesToUse = 2048
-		_, err := resolveReplayKVOffload(validHeader, true, other)
+		_, err := resolveReplayKVOffload(validHeader, true, other, false)
 		if err == nil || !strings.Contains(err.Error(), "conflicts") {
 			t.Fatalf("conflicting flag must error with 'conflicts', got %v", err)
 		}
@@ -344,19 +344,19 @@ func TestResolveReplayKVOffload(t *testing.T) {
 			EvictionPolicy: "lru",
 			Tiers:          []workload.TraceKVOffloadTier{{Type: "p2p", RootDir: "/x"}},
 		}
-		_, err := resolveReplayKVOffload(bad, false, sim.KVOffloadConfig{})
+		_, err := resolveReplayKVOffload(bad, false, sim.KVOffloadConfig{}, false)
 		if err == nil || !strings.Contains(err.Error(), "cannot reproduce") {
 			t.Fatalf("unreproducible header must fail loudly, got %v", err)
 		}
 	})
 	t.Run("no header, no flag -> inert", func(t *testing.T) {
-		got, err := resolveReplayKVOffload(nil, false, sim.KVOffloadConfig{})
+		got, err := resolveReplayKVOffload(nil, false, sim.KVOffloadConfig{}, false)
 		if err != nil || got.IsEnabled() {
 			t.Fatalf("nil header + no flag must be inert, got %+v err %v", got, err)
 		}
 	})
 	t.Run("flag adds to a no-offload trace -> rejected", func(t *testing.T) {
-		_, err := resolveReplayKVOffload(nil, true, validSim)
+		_, err := resolveReplayKVOffload(nil, true, validSim, false)
 		if err == nil || !strings.Contains(err.Error(), "cannot add one on replay") {
 			t.Fatalf("adding offload to a no-offload trace must error, got %v", err)
 		}

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -440,6 +440,61 @@ func (c *RealClient) handleStreamingResponse(resp *http.Response, record *Reques
 	return record, nil
 }
 
+// ScrapeKVMetrics fetches the server's Prometheus /metrics endpoint and parses it
+// into a family→summed-value map (#1583). metricsURL overrides the default
+// baseURL+"/metrics" when non-empty (e.g. metrics served on a sidecar port). The
+// returned map feeds workload.DeriveObservedHitRate over the measured window.
+func (c *RealClient) ScrapeKVMetrics(ctx context.Context, metricsURL string) (map[string]float64, error) {
+	url := metricsURL
+	if url == "" {
+		url = c.baseURL + "/metrics"
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build /metrics request: %w", err)
+	}
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s body: %w", url, err)
+	}
+	return workload.ParsePromMetrics(string(body)), nil
+}
+
+// resolveObservedKVMetrics performs the end-of-window /metrics scrape and derives the
+// observed KV hit-rate block for the trace header (#1583). It returns nil (with a
+// warning) on any scrape/parse/derive failure — a metrics miss must never abort the
+// observe run or emit a bogus value (BC-11). A nil startSamples (scrape disabled, or
+// the start-of-window scrape failed) yields nil without a second scrape.
+func resolveObservedKVMetrics(ctx context.Context, client *RealClient, metricsURL string, startSamples map[string]float64, vllmCommit string) *workload.TraceObservedKVMetrics {
+	if startSamples == nil {
+		return nil
+	}
+	end, err := client.ScrapeKVMetrics(ctx, metricsURL)
+	if err != nil {
+		logrus.Warnf("observe: --scrape-kv-metrics: end-of-window /metrics scrape failed: %v; omitting observed KV hit-rate from the trace header", err)
+		return nil
+	}
+	block, err := workload.DeriveObservedHitRate(startSamples, end, vllmCommit)
+	if err != nil {
+		logrus.Warnf("observe: --scrape-kv-metrics: %v; omitting observed KV hit-rate from the trace header", err)
+		return nil
+	}
+	logrus.Infof("observe: observed KV hit-rate = %.4f (source=%s, block_hits=%d, block_queries=%d)",
+		block.HitRate, block.Source, block.BlockHits, block.BlockQueries)
+	return block
+}
+
 // Recorder captures per-request timing and metrics (goroutine-safe).
 type Recorder struct {
 	mu         sync.Mutex

--- a/cmd/observe_cmd.go
+++ b/cmd/observe_cmd.go
@@ -65,6 +65,12 @@ var (
 	observeTimeout             int
 	observePrewarmDuration     time.Duration
 	observeLazyGeneration      bool // --lazy-generation: stream requests from generator (alpha, #1441/#1443)
+	// KV hit-rate scraping (#1583): scrape the server's Prometheus /metrics endpoint
+	// at the start and end of the measured window and record the observed hit-rate in
+	// the trace header for downstream `blis calibrate`. Off by default (BC-8).
+	observeScrapeKVMetrics bool
+	observeVLLMCommit      string
+	observeKVMetricsURL    string
 	// saturationReport is declared in root.go and shared across run, replay, observe
 )
 
@@ -137,6 +143,10 @@ func init() {
 	observeCmd.Flags().IntVar(&observeMaxConcur, "max-concurrency", 256, "Maximum simultaneous in-flight requests")
 	observeCmd.Flags().IntVar(&observeWarmup, "warmup-requests", 0, "Number of initial requests to exclude from trace")
 	observeCmd.Flags().DurationVar(&observePrewarmDuration, "prewarm-duration", 0, "Duration of system priming phase before real workload (e.g., 60s). Sends small fixed requests at low concurrency to warm CUDA/EPP/memory. 0 = disabled.")
+	// KV hit-rate scraping (#1583).
+	observeCmd.Flags().BoolVar(&observeScrapeKVMetrics, "scrape-kv-metrics", false, "Scrape the server's Prometheus /metrics endpoint at the start and end of the measured window and record the observed KV-cache hit-rate (vllm:kv_offload_tiering_* counters, or the GPU prefix-cache fallback) in the trace header for downstream `blis calibrate`. Off by default; a scrape miss warns and omits the block (never fatal).")
+	observeCmd.Flags().StringVar(&observeVLLMCommit, "vllm-commit", "", "Pinned vLLM commit the server is running; recorded verbatim in the observed KV-metrics header block (the tiering counters require an unreleased vLLM, PR #48798). Only meaningful with --scrape-kv-metrics.")
+	observeCmd.Flags().StringVar(&observeKVMetricsURL, "kv-metrics-url", "", "Override URL for the Prometheus /metrics endpoint (default: <server-url>/metrics). Use when metrics are served on a separate port/host. Only meaningful with --scrape-kv-metrics.")
 	observeCmd.Flags().BoolVar(&observeNoStreaming, "no-streaming", false, "Disable streaming (use non-streaming HTTP)")
 	observeCmd.Flags().Int64Var(&observeSeed, "seed", 42, "RNG seed for workload generation")
 	observeCmd.Flags().Int64Var(&observeHorizon, "horizon", 0, "Observation horizon in microseconds (0 = from spec or unlimited)")
@@ -549,6 +559,19 @@ func runObserve(cmd *cobra.Command, _ []string) {
 		logrus.Fatalf("%v", satErr)
 	}
 
+	// KV hit-rate scrape (#1583): capture the start-of-window Prometheus counters
+	// AFTER prewarm and BEFORE the measured workload, so the end-start delta reflects
+	// the measured window. A start-scrape failure warns and disables the derivation
+	// (kvScrapeStart stays nil) — never aborts the run (BC-11).
+	var kvScrapeStart map[string]float64
+	if observeScrapeKVMetrics {
+		if s, err := client.ScrapeKVMetrics(ctx, observeKVMetricsURL); err != nil {
+			logrus.Warnf("observe: --scrape-kv-metrics: start-of-window /metrics scrape failed: %v; the observed KV hit-rate will be omitted from the trace header", err)
+		} else {
+			kvScrapeStart = s
+		}
+	}
+
 	// Run orchestrator
 	startTime := time.Now()
 	runObserveOrchestrator(ctx, client, recorder, sessionMgr, observeSource, observeNoStreaming, observeMaxConcur, observeWarmup, prefixes, prefixLengths, observeUnconstrainedOutput, observeRecordITL, tokensPerWord)
@@ -602,6 +625,9 @@ func runObserve(cmd *cobra.Command, _ []string) {
 	if spec != nil {
 		header.WorkloadSeed = &spec.Seed
 	}
+	// KV hit-rate (#1583): end-of-window scrape + derive, then record in the header.
+	// nil when scraping was off or any step failed (BC-8/BC-11).
+	header.ObservedKVMetrics = resolveObservedKVMetrics(ctx, client, observeKVMetricsURL, kvScrapeStart, observeVLLMCommit)
 
 	if err := recorder.Export(header, observeTraceHeader, observeTraceData); err != nil {
 		logrus.Fatalf("Failed to export trace: %v", err)

--- a/cmd/observe_kvscrape_test.go
+++ b/cmd/observe_kvscrape_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// TestScrapeKVMetrics_ParsesServedMetrics verifies the HTTP scrape + parse path
+// against a server exposing tiering counters (#1583).
+func TestScrapeKVMetrics_ParsesServedMetrics(t *testing.T) {
+	body := "# TYPE vllm:kv_offload_tiering_block_hits counter\n" +
+		"vllm:kv_offload_tiering_block_hits{tier=\"cpu\"} 30\n" +
+		"vllm:kv_offload_tiering_block_hits{tier=\"disk\"} 12\n" +
+		"vllm:kv_offload_tiering_block_queries 100\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	client := NewRealClient(srv.URL, "", "m", "vllm")
+	got, err := client.ScrapeKVMetrics(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[workload.PromTieringBlockHits] != 42 {
+		t.Errorf("block_hits = %v, want 42 (summed across tiers)", got[workload.PromTieringBlockHits])
+	}
+	if got[workload.PromTieringBlockQueries] != 100 {
+		t.Errorf("block_queries = %v, want 100", got[workload.PromTieringBlockQueries])
+	}
+}
+
+// TestResolveObservedKVMetrics_EndToEnd verifies the end-of-window scrape + derive
+// wiring: given a start snapshot and a server serving the end snapshot, the derived
+// header block reflects the windowed delta (BC-1).
+func TestResolveObservedKVMetrics_EndToEnd(t *testing.T) {
+	// End-of-window server state.
+	end := "vllm:kv_offload_tiering_block_hits 800\nvllm:kv_offload_tiering_block_queries 1000\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(end))
+	}))
+	defer srv.Close()
+	client := NewRealClient(srv.URL, "", "m", "vllm")
+
+	// Start-of-window snapshot: 300 hits / 500 queries. Delta = 500 / 500 = 1.0? No:
+	// hits delta = 500, queries delta = 500 → 1.0. Use different numbers for clarity.
+	start := map[string]float64{
+		workload.PromTieringBlockHits:    200,
+		workload.PromTieringBlockQueries: 600,
+	}
+	block := resolveObservedKVMetrics(context.Background(), client, "", start, "pinned-sha")
+	if block == nil {
+		t.Fatal("expected a derived observed-KV-metrics block")
+	}
+	// hits delta 600 / queries delta 400 = 1.5 → but hit rate can't exceed 1; use the
+	// actual arithmetic: (800-200)/(1000-600) = 600/400 = 1.5. That is a degenerate
+	// (impossible) real scenario; adjust expectations to the arithmetic the function
+	// performs so the test asserts behavior, not physical plausibility.
+	if block.Source != workload.ObservedKVSourceTiered {
+		t.Errorf("source = %q, want tiered", block.Source)
+	}
+	if block.BlockHits != 600 || block.BlockQueries != 400 {
+		t.Errorf("deltas = %d/%d, want 600/400", block.BlockHits, block.BlockQueries)
+	}
+	if block.VLLMCommit != "pinned-sha" {
+		t.Errorf("commit = %q, want pinned-sha", block.VLLMCommit)
+	}
+}
+
+// TestResolveObservedKVMetrics_DisabledReturnsNil verifies a nil start snapshot
+// (scrape disabled or start-scrape failed) yields nil with no second scrape (BC-8).
+func TestResolveObservedKVMetrics_DisabledReturnsNil(t *testing.T) {
+	if got := resolveObservedKVMetrics(context.Background(), nil, "", nil, ""); got != nil {
+		t.Errorf("nil start snapshot must yield nil, got %+v", got)
+	}
+}
+
+// TestResolveObservedKVMetrics_ScrapeMissWarnsAndOmits verifies an unreachable /metrics
+// (HTTP 404) at end-of-window warns and omits the block rather than aborting (BC-11).
+func TestResolveObservedKVMetrics_ScrapeMissWarnsAndOmits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	client := NewRealClient(srv.URL, "", "m", "vllm")
+	start := map[string]float64{workload.PromTieringBlockQueries: 1, workload.PromTieringBlockHits: 1}
+	if got := resolveObservedKVMetrics(context.Background(), client, "", start, ""); got != nil {
+		t.Errorf("a 404 /metrics scrape must yield nil (graceful omit), got %+v", got)
+	}
+}
+
+// TestResolveObservedKVMetrics_NoCountersWarnsAndOmits verifies that a reachable
+// /metrics with no recognized KV counters warns and omits the block (BC-11).
+func TestResolveObservedKVMetrics_NoCountersWarnsAndOmits(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = fmt.Fprint(w, "vllm:num_requests_running 3\n")
+	}))
+	defer srv.Close()
+	client := NewRealClient(srv.URL, "", "m", "vllm")
+	start := map[string]float64{"vllm:num_requests_running": 2}
+	if got := resolveObservedKVMetrics(context.Background(), client, "", start, ""); got != nil {
+		t.Errorf("no recognized counters must yield nil, got %+v", got)
+	}
+}

--- a/cmd/observe_kvscrape_test.go
+++ b/cmd/observe_kvscrape_test.go
@@ -42,18 +42,19 @@ func TestScrapeKVMetrics_ParsesServedMetrics(t *testing.T) {
 
 // TestResolveObservedKVMetrics_EndToEnd verifies the end-of-window scrape + derive
 // wiring: given a start snapshot and a server serving the end snapshot, the derived
-// header block reflects the windowed delta (BC-1).
+// header block reflects the windowed delta (BC-1). Values keep hits <= queries so the
+// derived hit-rate stays in [0,1].
 func TestResolveObservedKVMetrics_EndToEnd(t *testing.T) {
-	// End-of-window server state.
-	end := "vllm:kv_offload_tiering_block_hits 800\nvllm:kv_offload_tiering_block_queries 1000\n"
+	// End-of-window server state: 500 hits / 1200 queries.
+	end := "vllm:kv_offload_tiering_block_hits 500\nvllm:kv_offload_tiering_block_queries 1200\n"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(end))
 	}))
 	defer srv.Close()
 	client := NewRealClient(srv.URL, "", "m", "vllm")
 
-	// Start-of-window snapshot: 300 hits / 500 queries. Delta = 500 / 500 = 1.0? No:
-	// hits delta = 500, queries delta = 500 → 1.0. Use different numbers for clarity.
+	// Start-of-window snapshot: 200 hits / 600 queries. Window delta = (500-200)/(1200-600)
+	// = 300/600 = 0.5 (strictly interior, hits <= queries).
 	start := map[string]float64{
 		workload.PromTieringBlockHits:    200,
 		workload.PromTieringBlockQueries: 600,
@@ -62,15 +63,15 @@ func TestResolveObservedKVMetrics_EndToEnd(t *testing.T) {
 	if block == nil {
 		t.Fatal("expected a derived observed-KV-metrics block")
 	}
-	// hits delta 600 / queries delta 400 = 1.5 → but hit rate can't exceed 1; use the
-	// actual arithmetic: (800-200)/(1000-600) = 600/400 = 1.5. That is a degenerate
-	// (impossible) real scenario; adjust expectations to the arithmetic the function
-	// performs so the test asserts behavior, not physical plausibility.
+	// (500-200)/(1200-600) = 300/600 = 0.5.
 	if block.Source != workload.ObservedKVSourceTiered {
 		t.Errorf("source = %q, want tiered", block.Source)
 	}
-	if block.BlockHits != 600 || block.BlockQueries != 400 {
-		t.Errorf("deltas = %d/%d, want 600/400", block.BlockHits, block.BlockQueries)
+	if block.BlockHits != 300 || block.BlockQueries != 600 {
+		t.Errorf("deltas = %d/%d, want 300/600", block.BlockHits, block.BlockQueries)
+	}
+	if block.HitRate != 0.5 {
+		t.Errorf("hit_rate = %v, want 0.5", block.HitRate)
 	}
 	if block.VLLMCommit != "pinned-sha" {
 		t.Errorf("commit = %q, want pinned-sha", block.VLLMCommit)

--- a/cmd/observed_kv_replay_test.go
+++ b/cmd/observed_kv_replay_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/cluster"
+	"github.com/inference-sim/inference-sim/sim/latency"
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// TestValidateObservedKVReplayable enforces BC-10 (#1583): a tiered observed hit-rate
+// requires a reproducible offload config on replay; all other cases pass.
+func TestValidateObservedKVReplayable(t *testing.T) {
+	tiered := &workload.TraceObservedKVMetrics{Source: workload.ObservedKVSourceTiered, HitRate: 0.5}
+	gpu := &workload.TraceObservedKVMetrics{Source: workload.ObservedKVSourceGPUCache, HitRate: 0.5}
+
+	if err := validateObservedKVReplayable(tiered, false); err == nil {
+		t.Error("tiered observation with offload DISABLED must error (BC-10)")
+	}
+	if err := validateObservedKVReplayable(tiered, true); err != nil {
+		t.Errorf("tiered observation with offload ENABLED must pass, got %v", err)
+	}
+	if err := validateObservedKVReplayable(gpu, false); err != nil {
+		t.Errorf("gpu-fallback observation must pass regardless of offload, got %v", err)
+	}
+	if err := validateObservedKVReplayable(nil, false); err != nil {
+		t.Errorf("nil observation must pass, got %v", err)
+	}
+}
+
+// TestValidateObservedKVReplayable_ErrorMentionsConfig verifies the BC-10 error is
+// actionable (names the missing config), not a bare failure.
+func TestValidateObservedKVReplayable_ErrorMentionsConfig(t *testing.T) {
+	tiered := &workload.TraceObservedKVMetrics{Source: workload.ObservedKVSourceTiered}
+	err := validateObservedKVReplayable(tiered, false)
+	if err == nil || !strings.Contains(err.Error(), "kv_offload") {
+		t.Errorf("BC-10 error must mention kv_offload config, got %v", err)
+	}
+}
+
+// makeSharedPrefixGroupRequests builds requests that carry PrefixGroup + PrefixLength
+// so the shared prefix ROUND-TRIPS through the trace: RequestsToTraceRecords records
+// the group/length, and LoadTraceV2Requests reconstructs the same group-shared
+// structure on replay (token values differ but the sharing structure — and thus the
+// hit/miss counts — is identical). Distinct from makeSharedPrefixRequests, whose
+// explicit shared token IDs do NOT round-trip (no PrefixGroup ⇒ replay synthesizes
+// independent per-request tokens).
+func makeSharedPrefixGroupRequests() []*sim.Request {
+	const prefixLen = 48 // 3 shared prompt blocks (blockSize 16)
+	shared := make([]sim.TokenID, prefixLen)
+	for j := range shared {
+		shared[j] = sim.TokenID(1000 + j)
+	}
+	reqs := make([]*sim.Request, 4)
+	for i := range reqs {
+		in := append([]sim.TokenID{}, shared...)
+		in = append(in, sim.TokenID(9000+i)) // per-request tail
+		out := make([]sim.TokenID, 4)
+		for j := range out {
+			out[j] = sim.TokenID(200 + j)
+		}
+		reqs[i] = &sim.Request{
+			ID:           fmt.Sprintf("request_%d", i),
+			ArrivalTime:  int64(i) * 50_000,
+			InputTokens:  in,
+			OutputTokens: out,
+			MaxOutputLen: 100,
+			PrefixGroup:  "g",
+			PrefixLength: prefixLen,
+		}
+	}
+	return reqs
+}
+
+// TestINV13_RunReplayParity_CacheHitRate verifies BC-5: with the KV-offload chain
+// active, a run and a replay of the same shared-prefix requests produce identical
+// aggregate cache_hit_rate — the value calibrate reads from --metrics-path (INV-13).
+func TestINV13_RunReplayParity_CacheHitRate(t *testing.T) {
+	const fixedSeed int64 = 99
+	requests := makeSharedPrefixGroupRequests()
+
+	mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
+	dir := t.TempDir()
+
+	hfConfig, err := latency.ParseHFConfig(filepath.Join(mcFolder, "config.json"))
+	if err != nil {
+		t.Fatalf("ParseHFConfig: %v", err)
+	}
+	mc, err := latency.GetModelConfigFromHF(hfConfig)
+	if err != nil {
+		t.Fatalf("GetModelConfigFromHF: %v", err)
+	}
+	hwCfg, err := latency.GetHWConfig(hwPath, "H100")
+	if err != nil {
+		t.Fatalf("GetHWConfig: %v", err)
+	}
+	perTok, err := latency.KVBytesPerToken(*mc, 1)
+	if err != nil {
+		t.Fatalf("KVBytesPerToken: %v", err)
+	}
+	offload := sim.KVOffloadConfig{
+		Enabled: true, CPUBytesToUse: 1 << 30, PerBlockBytes: int64(perTok * 16),
+		BlockSize: 16, BlocksPerChunk: 1, TokensPerHash: 16,
+		EvictionPolicy: "lru", OffloadPromptOnly: true,
+		Tiers: []sim.KVOffloadTier{{
+			Type: "fs", RootDir: "/mnt", NReadThreads: 16, NWriteThreads: 16,
+			DirectIO: true, ReadBandwidth: 7000, WriteBandwidth: 5000, BaseLatency: 80,
+		}},
+	}
+	betaCfg := []float64{0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0}
+	alphaCfg := []float64{100.0, 1.0, 100.0}
+	cfg := cluster.DeploymentConfig{
+		SimConfig: sim.SimConfig{
+			Horizon:             10_000_000,
+			Seed:                fixedSeed,
+			KVCacheConfig:       sim.NewKVCacheConfig(1000, 16, 0, 0.9, 100.0, 0, sim.WithKVOffload(offload)),
+			BatchConfig:         sim.NewBatchConfig(64, 2048, 0),
+			LatencyCoeffs:       sim.NewLatencyCoeffs(betaCfg, alphaCfg),
+			ModelHardwareConfig: sim.NewModelHardwareConfig(*mc, hwCfg, "test-model", "H100", 1, 1, false, "", "trained-physics", 4096),
+			PolicyConfig:        sim.NewPolicyConfig("fcfs", ""),
+		},
+		NumInstances:    1,
+		AdmissionPolicy: "always-admit",
+		RoutingPolicy:   "round-robin",
+	}
+
+	cs1 := cluster.NewClusterSimulator(cfg, cluster.NewSliceRequestSource(requests), nil)
+	if err := cs1.Run(); err != nil {
+		t.Fatalf("direct run failed: %v", err)
+	}
+	runHitRate := cs1.AggregatedMetrics().CacheHitRate
+
+	traceRecords := workload.RequestsToTraceRecords(requests)
+	traceHdr := &workload.TraceHeader{Version: 2, TimeUnit: "microseconds", Mode: "generated"}
+	traceHeaderFile := filepath.Join(dir, "trace.yaml")
+	traceDataFile := filepath.Join(dir, "trace.csv")
+	if err := workload.ExportTraceV2(traceHdr, traceRecords, traceHeaderFile, traceDataFile); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+	traceData, err := workload.LoadTraceV2(traceHeaderFile, traceDataFile)
+	if err != nil {
+		t.Fatalf("LoadTraceV2: %v", err)
+	}
+	replayReqs, err := workload.LoadTraceV2Requests(traceData, fixedSeed)
+	if err != nil {
+		t.Fatalf("LoadTraceV2Requests: %v", err)
+	}
+	cs2 := cluster.NewClusterSimulator(cfg, cluster.NewSliceRequestSource(replayReqs), nil)
+	if err := cs2.Run(); err != nil {
+		t.Fatalf("replay run failed: %v", err)
+	}
+	replayHitRate := cs2.AggregatedMetrics().CacheHitRate
+
+	if runHitRate != replayHitRate {
+		t.Errorf("INV-13: cache_hit_rate mismatch run=%v replay=%v", runHitRate, replayHitRate)
+	}
+	if runHitRate <= 0 {
+		t.Errorf("shared-prefix offload run should register a positive hit rate, got %v (test would be vacuous)", runHitRate)
+	}
+}

--- a/cmd/observed_kv_replay_test.go
+++ b/cmd/observed_kv_replay_test.go
@@ -37,8 +37,8 @@ func TestValidateObservedKVReplayable(t *testing.T) {
 func TestValidateObservedKVReplayable_ErrorMentionsConfig(t *testing.T) {
 	tiered := &workload.TraceObservedKVMetrics{Source: workload.ObservedKVSourceTiered}
 	err := validateObservedKVReplayable(tiered, false)
-	if err == nil || !strings.Contains(err.Error(), "kv_offload") {
-		t.Errorf("BC-10 error must mention kv_offload config, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "--kv-offload-config") {
+		t.Errorf("BC-10 error must point at --kv-offload-config, got %v", err)
 	}
 }
 
@@ -74,6 +74,29 @@ func makeSharedPrefixGroupRequests() []*sim.Request {
 		}
 	}
 	return reqs
+}
+
+// TestResolveReplayKVOffload_ObserveTraceAllowsFlagAdd verifies the #1583 fix for the
+// tiered observe→replay workflow: an observe trace (allowFlagAdd=true) with no header
+// offload config accepts a --kv-offload-config-supplied config to model the observed
+// deployment; a sim-generated trace (allowFlagAdd=false) still rejects it (INV-13).
+func TestResolveReplayKVOffload_ObserveTraceAllowsFlagAdd(t *testing.T) {
+	flagCfg := sim.KVOffloadConfig{
+		Enabled: true, CPUBytesToUse: 1 << 30, BlockSize: 16, BlocksPerChunk: 1,
+		TokensPerHash: 16, EvictionPolicy: "lru", OffloadPromptOnly: true,
+	}
+	// Observe trace: no header offload, flag supplied, add ALLOWED.
+	got, err := resolveReplayKVOffload(nil, true, flagCfg, true)
+	if err != nil {
+		t.Fatalf("observe trace must accept --kv-offload-config, got %v", err)
+	}
+	if !got.IsEnabled() {
+		t.Fatal("returned config should be the flag-supplied offload config")
+	}
+	// Sim-generated trace: identical inputs, add NOT allowed → error (INV-13).
+	if _, err := resolveReplayKVOffload(nil, true, flagCfg, false); err == nil {
+		t.Fatal("sim-generated trace must still reject a flag-added offload config (INV-13)")
+	}
 }
 
 // TestINV13_RunReplayParity_CacheHitRate verifies BC-5: with the KV-offload chain

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -25,6 +25,7 @@ var (
 	traceHeaderPath     string
 	traceDataPath       string
 	replayTraceOutput   string // File prefix for TraceV2 re-export (<prefix>.yaml + <prefix>.csv)
+	replayMetricsPath   string // File to write aggregate MetricsOutput JSON (incl. cache_hit_rate, #1583); symmetric with `blis run --metrics-path`
 	replaySessionMode   string
 	replayThinkTimeMs   int
 	replayThinkTimeDist string // distribution spec for think time (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s")
@@ -177,6 +178,12 @@ Example:
 		// the library-level panic in NewKVStore.
 		if kvOffloadCfg.IsEnabled() && kvCPUBlocks > 0 {
 			logrus.Fatalf("--kv-cpu-blocks conflicts with the trace's kv_offload config (distinct KV-offload models); set only one")
+		}
+		// #1583 (BC-10): a tiered observed hit-rate in the header is only replayable
+		// into a comparable sim number if this replay reproduces a tiered offload
+		// config. Fail loudly rather than silently produce a GPU-only hit-rate.
+		if err := validateObservedKVReplayable(traceData.Header.ObservedKVMetrics, kvOffloadCfg.IsEnabled()); err != nil {
+			logrus.Fatalf("%v", err)
 		}
 
 		// Resolve latency backend configuration (single code path shared with runCmd).
@@ -586,6 +593,11 @@ Example:
 				Mode:              "replayed",
 				GoodputSLOTargets: goodputTargets,                   // #1413, BC-7
 				KVOffload:         simToHeaderOffload(kvOffloadCfg), // #1587, BC-G6: carry the offload config forward
+				// #1583, BC-4: preserve the real-side observed KV hit-rate verbatim.
+				// It is a real-server observation replay cannot regenerate; carrying it
+				// forward keeps it available to a downstream calibrate and never
+				// silently drops it.
+				ObservedKVMetrics: traceData.Header.ObservedKVMetrics,
 			}
 			if err := workload.ExportTraceV2(header, records, replayTraceOutput+".yaml", replayTraceOutput+".csv"); err != nil {
 				logrus.Fatalf("Trace export failed: %v", err)
@@ -626,7 +638,12 @@ Example:
 			}
 		}
 
-		if err := aggregated.EmitOutput(clusterOutput, ""); err != nil {
+		// --metrics-path (#1583): write the aggregate MetricsOutput JSON (which gains
+		// the file-only cache_hit_rate) so `blis calibrate --sim-metrics` can read the
+		// simulator's hit-rate. Empty path → stdout only, byte-identical to before
+		// (BC-8). run and replay --metrics-path of the same trace produce identical
+		// cache_hit_rate (INV-13).
+		if err := aggregated.EmitOutput(clusterOutput, replayMetricsPath); err != nil {
 			logrus.Fatalf("SaveResults: %v", err)
 		}
 
@@ -767,6 +784,7 @@ func init() {
 	replayCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "Path to TraceV2 data CSV file (required)")
 	replayCmd.Flags().StringVar(&resultsPath, "results-path", "", "File to write []SimResult JSON (request_id, ttft_us, e2e_us, input_tokens, output_tokens, slo_class, model, itl_mean_us) for blis calibrate consumption.")
 	replayCmd.Flags().StringVar(&replayTraceOutput, "trace-output", "", "Export replay results as TraceV2 files (<prefix>.yaml + <prefix>.csv); header mode is \"replayed\"")
+	replayCmd.Flags().StringVar(&replayMetricsPath, "metrics-path", "", "File to write aggregate MetricsOutput JSON (incl. cache_hit_rate for `blis calibrate --sim-metrics`, #1583). Symmetric with `blis run --metrics-path`; stdout is unaffected.")
 
 	// Saturation trace flags (#1516): --detectors + --saturation-config + --saturation-report.
 	registerDetectorFlags(replayCmd)

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -171,7 +171,10 @@ Example:
 		// replay (unlike --lora-config, which is flags-only). Reconstruct the recorded
 		// config, Fatalf if this binary cannot reproduce it, and Fatalf on a genuine
 		// flag/header conflict. Inert when the trace carries no offload config (BC-G5).
-		kvOffloadCfg := reconcileReplayKVOffload(cmd, traceData.Header.KVOffload)
+		// Observe traces (mode "real") may model the observed deployment's offload via
+		// --kv-offload-config for the sim side of the #1583 hit-rate comparison; sim-
+		// generated traces remain header-authoritative (INV-13).
+		kvOffloadCfg := reconcileReplayKVOffload(cmd, traceData.Header.KVOffload, traceData.Header.Mode == "real")
 		// #1590 (H1): parity with run — the multi-tier offload chain (from the trace
 		// header or --kv-offload-config) and the legacy --kv-cpu-blocks single CPU tier
 		// are distinct offload models; refuse both with a clean CLI error rather than
@@ -188,6 +191,22 @@ Example:
 
 		// Resolve latency backend configuration (single code path shared with runCmd).
 		lr := resolveLatencyConfig(cmd)
+
+		// #1583: derive PerBlockBytes for an offload config supplied by --kv-offload-config
+		// (the observe-trace calibration path). A sim-generated trace header already
+		// carries the run-computed value (>0), so this is skipped for run/replay parity;
+		// a flag-supplied config has PerBlockBytes==0 until the model resolves. Mirrors
+		// the derivation in cmd/root.go (runCmd) so run and replay agree.
+		if kvOffloadCfg.IsEnabled() && kvOffloadCfg.PerBlockBytes == 0 {
+			perTokenKVBytes, pbErr := latency.KVBytesPerToken(lr.ModelConfig, tensorParallelism)
+			if pbErr != nil {
+				logrus.Fatalf("kv_offload: cannot derive per_block_bytes from the model: %v", pbErr)
+			}
+			kvOffloadCfg.PerBlockBytes = int64(perTokenKVBytes * float64(kvOffloadCfg.BlockSize))
+			if kvOffloadCfg.PerBlockBytes <= 0 {
+				logrus.Fatalf("kv_offload: derived per_block_bytes must be > 0 (KVBytesPerToken=%v × block_size=%d)", perTokenKVBytes, kvOffloadCfg.BlockSize)
+			}
+		}
 
 		// Numeric flag validation (same as runCmd)
 		if numInstances < 1 {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -670,14 +670,17 @@ func TestRunCmd_HasMetricsPathFlag(t *testing.T) {
 	}
 }
 
-// TestReplayCmd_HasResultsPathFlag verifies BC-2: blis replay exposes --results-path,
-// not --metrics-path.
+// TestReplayCmd_HasResultsPathFlag verifies blis replay exposes --results-path (the
+// per-request SimResult path) AND, as of #1583, --metrics-path (the aggregate
+// MetricsOutput path, symmetric with `blis run`). The latter carries the simulator's
+// cache_hit_rate for `blis calibrate --sim-metrics`; it aligns replay with the
+// already-documented "run/replay --metrics-path" adapter-reference workflow.
 func TestReplayCmd_HasResultsPathFlag(t *testing.T) {
 	if replayCmd.Flags().Lookup("results-path") == nil {
-		t.Error("BC-2: replayCmd missing --results-path flag")
+		t.Error("replayCmd missing --results-path flag")
 	}
-	if replayCmd.Flags().Lookup("metrics-path") != nil {
-		t.Error("BC-2: replayCmd must NOT have --metrics-path flag")
+	if replayCmd.Flags().Lookup("metrics-path") == nil {
+		t.Error("#1583: replayCmd must expose --metrics-path (aggregate MetricsOutput incl. cache_hit_rate)")
 	}
 }
 

--- a/docs/guide/kv-offload-calibration.md
+++ b/docs/guide/kv-offload-calibration.md
@@ -1,0 +1,97 @@
+# KV Cache Hit-Rate Calibration
+
+This note documents how to validate BLIS's tiered KV-offload model against real vLLM
+runs using the `observe → replay → calibrate` pipeline (issue #1583, part of the
+multi-tier KV-offload epic #1585). It complements
+[Observe / Replay / Calibrate](observe-replay-calibrate.md) and
+[KV Cache & Memory](kv-cache.md).
+
+## What gets compared
+
+`blis calibrate` compares **TTFT**, **E2E**, and — as of #1583 — the **KV cache
+hit-rate**:
+
+- **Real hit-rate** is scraped from the vLLM server's Prometheus `/metrics` endpoint
+  by `blis observe --scrape-kv-metrics` and recorded in the trace header
+  (`observed_kv_metrics`).
+- **Simulated hit-rate** is the DES aggregate `cache_hit_rate`, written to the
+  `blis replay --metrics-path` MetricsOutput file.
+- `blis calibrate --sim-metrics <that file>` reports the absolute error in percentage
+  points and a pass/fail verdict against `--hit-rate-tolerance-pp` (default **5 pp**),
+  plus a TTFT-MAPE verdict against `--ttft-mape-threshold` (default **0.15**).
+
+BLIS exposes a single aggregate hit-rate (GPU tier plus offload misses), so the
+comparison is on the **overall** hit-rate. Per-tier read/write time is recorded in the
+header (`read_time_total` / `write_time_total`) as informational data for a manual
+bandwidth cross-check — the simulator has no per-tier hit counters to compare against.
+
+## Dependency on an unreleased vLLM
+
+The tiered counters `vllm:kv_offload_tiering_block_hits` /
+`vllm:kv_offload_tiering_block_queries` (and `..._read_time` / `..._write_time`) come
+from vLLM PR #48798, which is **in no release tag**. Record the exact commit the
+cluster ran with `--vllm-commit <sha>` — it is stored verbatim in the header so the
+dependency is explicit and reproducible.
+
+If the server exposes only released metrics, `--scrape-kv-metrics` falls back to the
+GPU-only `vllm:gpu_prefix_cache_*` family and tags the observation
+`source: gpu-prefix-cache-fallback`. This is a **weaker** validation (GPU tier only,
+no offload tiers) and is never conflated with a tiered hit-rate — treat it as a
+separate, weaker check.
+
+## Minimal experiment set
+
+Validate against the four canonical cache paths, over a small prefix-length sweep,
+single replica, TP=1:
+
+| Path | How to elicit it |
+|------|------------------|
+| **GPU hit** | Repeat a prompt whose prefix is still resident in the GPU KV cache. |
+| **CPU hit** | Repeat a prefix that has been offloaded to the CPU staging tier but evicted from GPU. |
+| **Storage hit** | Repeat a prefix that has cascaded to a secondary `fs` tier and been evicted from CPU. |
+| **Full miss** | A unique prefix with no cached blocks anywhere. |
+
+Sweep the shared prefix length (e.g. 256 / 1024 / 4096 tokens) so the hit-rate spans
+its range. Keep the deployment to a single replica at TP=1 so the aggregate hit-rate
+is unambiguous.
+
+## Procedure
+
+```bash
+# 1. Observe the real server, scraping the per-tier counters into the trace header.
+#    --vllm-commit records the pinned (unreleased) vLLM the counters require.
+blis observe --server-url http://localhost:8000 --model <model> \
+  --kv-offload-config offload.yaml \
+  --workload-spec sweep.yaml \
+  --scrape-kv-metrics --vllm-commit <sha> \
+  --trace-header t.yaml --trace-data t.csv
+
+# 2. Replay the captured trace through the DES; --metrics-path carries the sim's
+#    aggregate cache_hit_rate. The header's kv_offload config is reproduced
+#    authoritatively; a tiered observation with no reproducible config is a hard error.
+blis replay --trace-header t.yaml --trace-data t.csv --model <model> \
+  --results-path sim.json --metrics-path simagg.json
+
+# 3. Compare. TTFT/E2E come from --sim-results; the hit-rate comes from --sim-metrics.
+blis calibrate --trace-header t.yaml --trace-data t.csv \
+  --sim-results sim.json --sim-metrics simagg.json \
+  --hit-rate-tolerance-pp 5 --ttft-mape-threshold 0.15 \
+  --report calibration.json
+```
+
+The report's `hit_rate` block reports `real_hit_rate`, `sim_hit_rate`, `abs_error_pp`,
+`tolerance_pp`, `within`, and `source`. Targets on the minimal set: **TTFT MAPE ≤ 15%**
+and **hit-rate absolute error ≤ 5 pp**.
+
+## Notes and caveats
+
+- The counter delta spans the whole measured window, which includes any warm-up
+  requests (they are excluded from TTFT/E2E calibration but not from the engine-level
+  counter delta). Keep warm-up small, or prefer `--prewarm-duration` (which runs before
+  the start scrape).
+- A scrape miss (unreachable `/metrics`, no recognized counters, zero queries, or a
+  counter reset mid-window) is **not fatal**: `observe` warns and omits
+  `observed_kv_metrics`; the workload trace is still exported.
+- The `read_time`/`write_time` counters are vLLM **device service time excluding queue
+  wait** — they calibrate the offload tiers' *service* term, not the queueing term. Do
+  not fit queue wait against them.

--- a/docs/guide/kv-offload-calibration.md
+++ b/docs/guide/kv-offload-calibration.md
@@ -59,17 +59,21 @@ is unambiguous.
 
 ```bash
 # 1. Observe the real server, scraping the per-tier counters into the trace header.
-#    --vllm-commit records the pinned (unreleased) vLLM the counters require.
+#    --vllm-commit records the pinned (unreleased) vLLM the counters require. observe
+#    dispatches to a real server and does not itself model the offload tiers, so no
+#    --kv-offload-config is passed here — the observed hit-rate is whatever the server
+#    reports.
 blis observe --server-url http://localhost:8000 --model <model> \
-  --kv-offload-config offload.yaml \
   --workload-spec sweep.yaml \
   --scrape-kv-metrics --vllm-commit <sha> \
   --trace-header t.yaml --trace-data t.csv
 
-# 2. Replay the captured trace through the DES; --metrics-path carries the sim's
-#    aggregate cache_hit_rate. The header's kv_offload config is reproduced
-#    authoritatively; a tiered observation with no reproducible config is a hard error.
+# 2. Replay the captured trace through the DES to produce the SIM-side hit-rate. Supply
+#    --kv-offload-config matching the observed deployment — replay models the tiers and
+#    derives the aggregate cache_hit_rate into --metrics-path. (A tiered observation
+#    replayed WITHOUT an offload config is a hard error, never a silent GPU-only value.)
 blis replay --trace-header t.yaml --trace-data t.csv --model <model> \
+  --kv-offload-config offload.yaml \
   --results-path sim.json --metrics-path simagg.json
 
 # 3. Compare. TTFT/E2E come from --sim-results; the hit-rate comes from --sim-metrics.
@@ -78,6 +82,13 @@ blis calibrate --trace-header t.yaml --trace-data t.csv \
   --hit-rate-tolerance-pp 5 --ttft-mape-threshold 0.15 \
   --report calibration.json
 ```
+
+> **Note.** `blis observe` records the observed hit-rate and its source, but not the
+> offload config — it is a black-box dispatcher against a real server. The operator
+> supplies the deployment's `--kv-offload-config` on the **replay** step so the
+> simulator reproduces the tiered behaviour. For a sim-generated trace
+> (`blis run --kv-offload-config … --trace-output`) the config is instead recorded in
+> the header and reproduced authoritatively on replay (INV-13).
 
 The report's `hit_rate` block reports `real_hit_rate`, `sim_hit_rate`, `abs_error_pp`,
 `tolerance_pp`, `within`, and `source`. Targets on the minimal set: **TTFT MAPE ≤ 15%**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - Cluster Simulation: guide/cluster.md
       - Metrics & Results: guide/results.md
       - Observe / Replay / Calibrate: guide/observe-replay-calibrate.md
+      - KV Hit-Rate Calibration: guide/kv-offload-calibration.md
       - Hypothesis Experimentation: guide/experimentation.md
       - Archon PR Review: guide/archon-pr-review.md
       - Skills & Plugins: guide/skills-and-plugins.md

--- a/sim/metrics.go
+++ b/sim/metrics.go
@@ -266,6 +266,14 @@ func (m *Metrics) EmitOutput(output MetricsOutput, outputFilePath string) error 
 	fmt.Println(string(data))
 
 	if outputFilePath != "" {
+		// Aggregate KV-cache hit rate (#1583): file-only, alongside Requests[] below.
+		// Kept off stdout (the marshal above already ran) so stdout stays
+		// byte-identical to a pre-feature build (INV-6, BC-9). calibrate --sim-metrics
+		// reads this as the simulator's hit rate. run and replay of the same trace
+		// produce identical values (INV-13).
+		hitRate := m.CacheHitRate
+		output.CacheHitRate = &hitRate
+
 		// request-level metrics for detailed output in file
 		// Iterate over all registered requests (not just completed prefill)
 		// so incomplete requests appear with zero-valued metrics.

--- a/sim/metrics_cachehitrate_test.go
+++ b/sim/metrics_cachehitrate_test.go
@@ -1,0 +1,73 @@
+package sim
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEmitOutput_CacheHitRate_FileOnly verifies the aggregate cache_hit_rate (#1583)
+// is written to the --metrics-path file but NOT to the stdout MetricsOutput shape
+// (BC-5, BC-9, INV-6). BuildOutput (the value marshaled to stdout) must leave the
+// field nil so omitempty drops it; the file marshal populates it.
+func TestEmitOutput_CacheHitRate_FileOnly(t *testing.T) {
+	m := NewMetrics()
+	m.CacheHitRate = 0.625
+
+	// The stdout shape comes from BuildOutput — the field must be absent there.
+	out := m.BuildOutput("cluster")
+	if out.CacheHitRate != nil {
+		t.Fatalf("BuildOutput (stdout shape) must not set cache_hit_rate; got %v", *out.CacheHitRate)
+	}
+	stdoutJSON, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(stdoutJSON), "cache_hit_rate") {
+		t.Errorf("stdout MetricsOutput must not contain cache_hit_rate:\n%s", stdoutJSON)
+	}
+
+	// The --metrics-path file must contain the value.
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "metrics.json")
+	if err := m.EmitOutput(out, fpath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(fpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fileOut MetricsOutput
+	if err := json.Unmarshal(data, &fileOut); err != nil {
+		t.Fatal(err)
+	}
+	if fileOut.CacheHitRate == nil {
+		t.Fatal("metrics-path file must contain cache_hit_rate")
+	}
+	if *fileOut.CacheHitRate != 0.625 {
+		t.Errorf("file cache_hit_rate = %v, want 0.625", *fileOut.CacheHitRate)
+	}
+}
+
+// TestEmitOutput_CacheHitRate_ZeroWrittenToFile verifies a zero hit rate is still
+// written to the file (a valid observation), since EmitOutput sets the pointer
+// unconditionally in the file branch.
+func TestEmitOutput_CacheHitRate_ZeroWrittenToFile(t *testing.T) {
+	m := NewMetrics()
+	m.CacheHitRate = 0.0
+	out := m.BuildOutput("cluster")
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "metrics.json")
+	if err := m.EmitOutput(out, fpath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(fpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "cache_hit_rate") {
+		t.Errorf("file must record cache_hit_rate even when 0:\n%s", data)
+	}
+}

--- a/sim/metrics_utils.go
+++ b/sim/metrics_utils.go
@@ -82,6 +82,14 @@ type MetricsOutput struct {
 	SchedulingDelayP99Ms     float64          `json:"scheduling_delay_p99_ms"`
 	KVAllocationFailures    int64            `json:"kv_allocation_failures,omitempty"`
 	PreemptionCount         int64            `json:"preemption_count"`
+	// CacheHitRate is the aggregate KV-cache hit rate (a fraction in [0,1]) at
+	// finalization (#1583). It is populated ONLY into the --metrics-path file (the
+	// file branch of EmitOutput), alongside the file-only Requests[] — never onto
+	// stdout, so a run's stdout stays byte-identical to a pre-feature build (INV-6,
+	// BC-9). A nil pointer (default) is dropped by omitempty; the human-readable rate
+	// is still printed to stdout via printKVCacheMetrics. `blis calibrate --sim-metrics`
+	// reads it as the simulator's hit-rate for the real-vs-sim comparison.
+	CacheHitRate            *float64         `json:"cache_hit_rate,omitempty"`
 	DroppedUnservable       int              `json:"dropped_unservable"`
 	LengthCappedRequests    int              `json:"length_capped_requests"`
 	TimedOutRequests        int              `json:"timed_out_requests"`

--- a/sim/workload/calibrate.go
+++ b/sim/workload/calibrate.go
@@ -69,6 +69,46 @@ type CalibrationReport struct {
 	// goodput targets were configured (issue #1413, BC-9). Omitted when targets
 	// are absent so old consumers see the legacy report shape unchanged.
 	Goodput *GoodputComparisonReport `json:"goodput,omitempty"`
+	// HitRate holds the real-vs-sim KV cache hit-rate comparison (#1583, BC-6).
+	// Populated when the trace header carries an observed hit-rate AND a sim
+	// MetricsOutput with cache_hit_rate is supplied (--sim-metrics); omitted
+	// otherwise so the legacy report shape is unchanged.
+	HitRate *HitRateComparison `json:"hit_rate,omitempty"`
+}
+
+// HitRateComparison holds the real-vs-simulated KV cache hit-rate comparison (#1583).
+// Real is the observed hit-rate scraped by `blis observe --scrape-kv-metrics` (trace
+// header); Sim is the simulator's aggregate cache_hit_rate (from `blis replay
+// --metrics-path`). The error is reported in percentage points, and Within tests it
+// against the configured tolerance (default 5 pp).
+type HitRateComparison struct {
+	RealHitRate float64 `json:"real_hit_rate"`
+	SimHitRate  float64 `json:"sim_hit_rate"`
+	AbsErrorPP  float64 `json:"abs_error_pp"` // |sim − real| × 100 (percentage points)
+	TolerancePP float64 `json:"tolerance_pp"`
+	Within      bool    `json:"within"`
+	// Source echoes the observation family ("tiered" or "gpu-prefix-cache-fallback")
+	// so a weaker GPU-only comparison is never mistaken for a tiered one.
+	Source string `json:"source"`
+}
+
+// ComputeHitRateComparison builds a HitRateComparison from a real (observed) and a
+// simulated hit-rate, both fractions in [0,1]. tolerancePP is the absolute-error band
+// in percentage points; Within is true when |sim − real| × 100 ≤ tolerancePP.
+func ComputeHitRateComparison(realHitRate, simHitRate, tolerancePP float64, source string) *HitRateComparison {
+	absErrPP := math.Abs(simHitRate-realHitRate) * 100
+	// A tiny epsilon keeps the band inclusive at its intended boundary despite
+	// float representation (e.g. |0.75−0.70|×100 = 5.000000000000004, which would
+	// otherwise fail a "≤ 5 pp" band spuriously).
+	const boundaryEps = 1e-9
+	return &HitRateComparison{
+		RealHitRate: realHitRate,
+		SimHitRate:  simHitRate,
+		AbsErrorPP:  absErrPP,
+		TolerancePP: tolerancePP,
+		Within:      absErrPP <= tolerancePP+boundaryEps,
+		Source:      source,
+	}
 }
 
 // GoodputComparisonReport summarizes observed-vs-simulated goodput per SLO class.

--- a/sim/workload/calibrate.go
+++ b/sim/workload/calibrate.go
@@ -74,6 +74,18 @@ type CalibrationReport struct {
 	// MetricsOutput with cache_hit_rate is supplied (--sim-metrics); omitted
 	// otherwise so the legacy report shape is unchanged.
 	HitRate *HitRateComparison `json:"hit_rate,omitempty"`
+	// TTFTTolerance records the TTFT-MAPE tolerance verdict (#1583, BC-7) in the
+	// report so automation consumers see it, not only the stderr log. Populated
+	// whenever a TTFT metric exists; omitted otherwise.
+	TTFTTolerance *ToleranceVerdict `json:"ttft_tolerance,omitempty"`
+}
+
+// ToleranceVerdict is a compact machine-readable pass/fail against a MAPE threshold
+// (#1583). MAPE and Threshold are fractions (not percentages).
+type ToleranceVerdict struct {
+	MAPE      float64 `json:"mape"`
+	Threshold float64 `json:"threshold"`
+	Within    bool    `json:"within"`
 }
 
 // HitRateComparison holds the real-vs-simulated KV cache hit-rate comparison (#1583).

--- a/sim/workload/hitrate_compare_test.go
+++ b/sim/workload/hitrate_compare_test.go
@@ -1,0 +1,40 @@
+package workload
+
+import (
+	"math"
+	"testing"
+)
+
+func TestComputeHitRateComparison(t *testing.T) {
+	cases := []struct {
+		name       string
+		real, sim  float64
+		tolPP      float64
+		wantErrPP  float64
+		wantWithin bool
+	}{
+		{"exact match", 0.70, 0.70, 5, 0, true},
+		{"within band", 0.70, 0.73, 5, 3, true},
+		{"at boundary", 0.70, 0.75, 5, 5, true},
+		{"exceeds band", 0.70, 0.80, 5, 10, false},
+		{"sim under real still within", 0.70, 0.66, 5, 4, true},
+		{"zero real", 0.0, 0.03, 5, 3, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ComputeHitRateComparison(c.real, c.sim, c.tolPP, "tiered")
+			if math.Abs(got.AbsErrorPP-c.wantErrPP) > 1e-9 {
+				t.Errorf("abs_error_pp = %v, want %v", got.AbsErrorPP, c.wantErrPP)
+			}
+			if got.Within != c.wantWithin {
+				t.Errorf("within = %v, want %v (err=%v tol=%v)", got.Within, c.wantWithin, got.AbsErrorPP, c.tolPP)
+			}
+			if got.Source != "tiered" {
+				t.Errorf("source = %q, want tiered", got.Source)
+			}
+			if got.RealHitRate != c.real || got.SimHitRate != c.sim {
+				t.Errorf("real/sim not echoed: got %v/%v", got.RealHitRate, got.SimHitRate)
+			}
+		})
+	}
+}

--- a/sim/workload/prom_hitrate.go
+++ b/sim/workload/prom_hitrate.go
@@ -1,0 +1,176 @@
+package workload
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Prometheus metric family names for the vLLM KV-offload tiering hit-rate signal
+// (unreleased vLLM, PR #48798; constants from kv_offload/tiering/base.py). These are
+// the PRIMARY signal: a true multi-tier offload hit-rate.
+const (
+	PromTieringBlockHits    = "vllm:kv_offload_tiering_block_hits"
+	PromTieringBlockQueries = "vllm:kv_offload_tiering_block_queries"
+	PromTieringReadTime     = "vllm:kv_offload_tiering_read_time"
+	PromTieringWriteTime    = "vllm:kv_offload_tiering_write_time"
+)
+
+// Prometheus metric family names for the released-vLLM GPU-only prefix-cache
+// fallback. This is a WEAKER signal (GPU tier only, no offload tiers) and is tagged
+// distinctly in the trace header so it is never conflated with a tiered hit-rate.
+const (
+	PromGPUPrefixCacheHits    = "vllm:gpu_prefix_cache_hits"
+	PromGPUPrefixCacheQueries = "vllm:gpu_prefix_cache_queries"
+	PromGPUPrefixCacheHitRate = "vllm:gpu_prefix_cache_hit_rate"
+)
+
+// Observed-hit-rate source tags recorded in TraceObservedKVMetrics.Source.
+const (
+	ObservedKVSourceTiered   = "tiered"
+	ObservedKVSourceGPUCache = "gpu-prefix-cache-fallback"
+)
+
+// ParsePromMetrics parses Prometheus text-exposition output into a family→value map,
+// summing the value across ALL label series of each metric family (so a per-tier
+// counter such as `foo{tier="cpu"} 3` + `foo{tier="disk"} 4` collapses to foo→7).
+//
+// It tolerates `# HELP`/`# TYPE`/comment lines, blank lines, an optional trailing
+// scrape timestamp (`name{...} value [timestamp]` — only the value is read), and the
+// Prometheus-client convention of appending `_total` to counter names (a `_total`
+// series is folded into its base family). Malformed value fields are skipped rather
+// than aborting the whole scrape (R20: degenerate input is tolerated, not fatal).
+func ParsePromMetrics(text string) map[string]float64 {
+	sums := make(map[string]float64)
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, rest := splitPromLine(line)
+		if name == "" || rest == "" {
+			continue
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			continue // not a numeric sample line
+		}
+		// Fold the counter `_total` convention into the base family name so callers
+		// can look up either spelling with one key.
+		name = strings.TrimSuffix(name, "_total")
+		sums[name] += v
+	}
+	return sums
+}
+
+// splitPromLine splits a Prometheus sample line into its metric name and the
+// remainder (the value, plus any labels having been consumed). Handles the two
+// shapes: `name value` and `name{label="x",...} value`.
+func splitPromLine(line string) (name, rest string) {
+	brace := strings.IndexByte(line, '{')
+	space := strings.IndexByte(line, ' ')
+	// Labels present and precede the first space → name ends at '{', rest starts
+	// after the matching '}'.
+	if brace >= 0 && (space < 0 || brace < space) {
+		close := strings.IndexByte(line, '}')
+		if close < 0 || close < brace {
+			return "", ""
+		}
+		return line[:brace], strings.TrimSpace(line[close+1:])
+	}
+	if space < 0 {
+		return "", ""
+	}
+	return line[:space], strings.TrimSpace(line[space:])
+}
+
+// DeriveObservedHitRate computes the observed KV-cache hit-rate over a measurement
+// window from two Prometheus scrapes (start and end of the measured workload),
+// returning a resolved TraceObservedKVMetrics block for the trace header (#1583).
+//
+// Precedence: the tiered offload family (PRIMARY) is used when its queries family is
+// present; otherwise the GPU prefix-cache family (FALLBACK, weaker) is used. Within a
+// family, all values are DELTAS (end − start) so cumulative counters yield the rate
+// over the measured window.
+//
+// Errors (the CLI caller warns and omits the block — BC-11/BC-13, never fatal, never a
+// bogus value):
+//   - no recognized counter family present in the scrape;
+//   - a counter went backwards (delta < 0 — e.g. a server restart mid-window);
+//   - zero queries in the window (division guard, R11) with no gauge fallback.
+func DeriveObservedHitRate(start, end map[string]float64, vllmCommit string) (*TraceObservedKVMetrics, error) {
+	// PRIMARY: tiered offload family (present iff the queries family appears).
+	if _, ok := end[PromTieringBlockQueries]; ok {
+		queries, qErr := familyDelta(start, end, PromTieringBlockQueries)
+		if qErr != nil {
+			return nil, qErr
+		}
+		hits, hErr := familyDelta(start, end, PromTieringBlockHits)
+		if hErr != nil {
+			return nil, hErr
+		}
+		if queries <= 0 {
+			return nil, fmt.Errorf("tiered KV counters show zero block_queries over the measured window (%.0f); cannot derive a hit-rate", queries)
+		}
+		readDelta, _ := familyDelta(start, end, PromTieringReadTime)
+		writeDelta, _ := familyDelta(start, end, PromTieringWriteTime)
+		return &TraceObservedKVMetrics{
+			Source:         ObservedKVSourceTiered,
+			HitRate:        hits / queries,
+			BlockHits:      int64(hits + 0.5),
+			BlockQueries:   int64(queries + 0.5),
+			ReadTimeTotal:  readDelta,
+			WriteTimeTotal: writeDelta,
+			VLLMCommit:     vllmCommit,
+		}, nil
+	}
+
+	// FALLBACK: GPU prefix-cache counters (delta), then the hit_rate gauge (end value).
+	if _, ok := end[PromGPUPrefixCacheQueries]; ok {
+		queries, qErr := familyDelta(start, end, PromGPUPrefixCacheQueries)
+		if qErr != nil {
+			return nil, qErr
+		}
+		hits, hErr := familyDelta(start, end, PromGPUPrefixCacheHits)
+		if hErr != nil {
+			return nil, hErr
+		}
+		if queries <= 0 {
+			return nil, fmt.Errorf("GPU prefix-cache counters show zero queries over the measured window (%.0f); cannot derive a hit-rate", queries)
+		}
+		return &TraceObservedKVMetrics{
+			Source:       ObservedKVSourceGPUCache,
+			HitRate:      hits / queries,
+			BlockHits:    int64(hits + 0.5),
+			BlockQueries: int64(queries + 0.5),
+			VLLMCommit:   vllmCommit,
+		}, nil
+	}
+	if rate, ok := end[PromGPUPrefixCacheHitRate]; ok {
+		// Gauge: a point-in-time rate, not a windowed delta. The weakest signal.
+		return &TraceObservedKVMetrics{
+			Source:     ObservedKVSourceGPUCache,
+			HitRate:    rate,
+			VLLMCommit: vllmCommit,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no recognized KV cache counters found in /metrics (looked for %s and %s families)",
+		PromTieringBlockQueries, PromGPUPrefixCacheQueries)
+}
+
+// familyDelta returns end[name] − start[name], erroring if the counter went backwards
+// (a reset/restart makes a windowed delta meaningless). A missing start value is
+// treated as 0 (the counter first appeared during the window).
+func familyDelta(start, end map[string]float64, name string) (float64, error) {
+	delta := end[name] - start[name]
+	if delta < 0 {
+		return 0, fmt.Errorf("counter %s went backwards over the measured window (start=%.0f end=%.0f, likely a server restart); cannot derive a windowed hit-rate",
+			name, start[name], end[name])
+	}
+	return delta, nil
+}

--- a/sim/workload/prom_hitrate.go
+++ b/sim/workload/prom_hitrate.go
@@ -116,6 +116,9 @@ func DeriveObservedHitRate(start, end map[string]float64, vllmCommit string) (*T
 		if queries <= 0 {
 			return nil, fmt.Errorf("tiered KV counters show zero block_queries over the measured window (%.0f); cannot derive a hit-rate", queries)
 		}
+		if hits > queries {
+			return nil, fmt.Errorf("tiered KV counters report more block_hits (%.0f) than block_queries (%.0f) over the window (hit-rate > 1 is impossible; likely a scrape/counter anomaly); refusing to record a bogus value", hits, queries)
+		}
 		readDelta, _ := familyDelta(start, end, PromTieringReadTime)
 		writeDelta, _ := familyDelta(start, end, PromTieringWriteTime)
 		return &TraceObservedKVMetrics{
@@ -141,6 +144,9 @@ func DeriveObservedHitRate(start, end map[string]float64, vllmCommit string) (*T
 		}
 		if queries <= 0 {
 			return nil, fmt.Errorf("GPU prefix-cache counters show zero queries over the measured window (%.0f); cannot derive a hit-rate", queries)
+		}
+		if hits > queries {
+			return nil, fmt.Errorf("GPU prefix-cache counters report more hits (%.0f) than queries (%.0f) over the window (hit-rate > 1 is impossible); refusing to record a bogus value", hits, queries)
 		}
 		return &TraceObservedKVMetrics{
 			Source:       ObservedKVSourceGPUCache,

--- a/sim/workload/prom_hitrate_test.go
+++ b/sim/workload/prom_hitrate_test.go
@@ -1,0 +1,134 @@
+package workload
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParsePromMetrics_SumsLabelSeriesAndFoldsTotal(t *testing.T) {
+	text := `# HELP vllm:kv_offload_tiering_block_hits Number of block hits.
+# TYPE vllm:kv_offload_tiering_block_hits counter
+vllm:kv_offload_tiering_block_hits{model="x",tier="cpu"} 100
+vllm:kv_offload_tiering_block_hits{model="x",tier="disk"} 40
+
+vllm:kv_offload_tiering_block_queries{model="x",tier="cpu"} 120 1699999999999
+vllm:kv_offload_tiering_block_queries{model="x",tier="disk"} 80
+# a comment
+vllm:gpu_prefix_cache_hits_total 55
+irrelevant_metric{a="b"} 9`
+	got := ParsePromMetrics(text)
+	if got[PromTieringBlockHits] != 140 {
+		t.Errorf("block_hits summed = %v, want 140", got[PromTieringBlockHits])
+	}
+	if got[PromTieringBlockQueries] != 200 {
+		t.Errorf("block_queries summed = %v, want 200 (trailing timestamp ignored)", got[PromTieringBlockQueries])
+	}
+	// `_total` folds into the base family name.
+	if got[PromGPUPrefixCacheHits] != 55 {
+		t.Errorf("gpu hits (_total folded) = %v, want 55", got[PromGPUPrefixCacheHits])
+	}
+}
+
+func TestParsePromMetrics_ToleratesMalformedValue(t *testing.T) {
+	text := "vllm:kv_offload_tiering_block_hits notanumber\nvllm:kv_offload_tiering_block_queries 10\n"
+	got := ParsePromMetrics(text)
+	if _, ok := got[PromTieringBlockHits]; ok {
+		t.Errorf("malformed value line must be skipped, got %v", got[PromTieringBlockHits])
+	}
+	if got[PromTieringBlockQueries] != 10 {
+		t.Errorf("valid line after malformed one must still parse, got %v", got[PromTieringBlockQueries])
+	}
+}
+
+func TestDeriveObservedHitRate_TieredDelta(t *testing.T) {
+	start := map[string]float64{
+		PromTieringBlockHits: 1000, PromTieringBlockQueries: 2000,
+		PromTieringReadTime: 5, PromTieringWriteTime: 2,
+	}
+	end := map[string]float64{
+		PromTieringBlockHits: 1734, PromTieringBlockQueries: 3000,
+		PromTieringReadTime: 17.5, PromTieringWriteTime: 5.25,
+	}
+	got, err := DeriveObservedHitRate(start, end, "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != ObservedKVSourceTiered {
+		t.Errorf("source = %q, want tiered", got.Source)
+	}
+	// hits delta 734 / queries delta 1000 = 0.734
+	if math.Abs(got.HitRate-0.734) > 1e-9 {
+		t.Errorf("hit_rate = %v, want 0.734", got.HitRate)
+	}
+	if got.BlockHits != 734 || got.BlockQueries != 1000 {
+		t.Errorf("deltas = %d/%d, want 734/1000", got.BlockHits, got.BlockQueries)
+	}
+	if math.Abs(got.ReadTimeTotal-12.5) > 1e-9 || math.Abs(got.WriteTimeTotal-3.25) > 1e-9 {
+		t.Errorf("read/write time deltas = %v/%v, want 12.5/3.25", got.ReadTimeTotal, got.WriteTimeTotal)
+	}
+	if got.VLLMCommit != "abc123" {
+		t.Errorf("commit = %q", got.VLLMCommit)
+	}
+}
+
+func TestDeriveObservedHitRate_FallbackToGPUCounters(t *testing.T) {
+	start := map[string]float64{PromGPUPrefixCacheHits: 10, PromGPUPrefixCacheQueries: 100}
+	end := map[string]float64{PromGPUPrefixCacheHits: 60, PromGPUPrefixCacheQueries: 200}
+	got, err := DeriveObservedHitRate(start, end, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != ObservedKVSourceGPUCache {
+		t.Errorf("source = %q, want gpu-prefix-cache-fallback", got.Source)
+	}
+	// hits delta 50 / queries delta 100 = 0.5
+	if math.Abs(got.HitRate-0.5) > 1e-9 {
+		t.Errorf("hit_rate = %v, want 0.5", got.HitRate)
+	}
+}
+
+func TestDeriveObservedHitRate_FallbackToGaugeWhenOnlyRatePresent(t *testing.T) {
+	end := map[string]float64{PromGPUPrefixCacheHitRate: 0.42}
+	got, err := DeriveObservedHitRate(map[string]float64{}, end, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != ObservedKVSourceGPUCache || math.Abs(got.HitRate-0.42) > 1e-9 {
+		t.Errorf("gauge fallback = %+v, want source gpu-prefix-cache-fallback hit_rate 0.42", got)
+	}
+}
+
+func TestDeriveObservedHitRate_TieredPreferredOverGPU(t *testing.T) {
+	start := map[string]float64{PromTieringBlockHits: 0, PromTieringBlockQueries: 0, PromGPUPrefixCacheHits: 0, PromGPUPrefixCacheQueries: 0}
+	end := map[string]float64{PromTieringBlockHits: 8, PromTieringBlockQueries: 10, PromGPUPrefixCacheHits: 99, PromGPUPrefixCacheQueries: 100}
+	got, err := DeriveObservedHitRate(start, end, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != ObservedKVSourceTiered || math.Abs(got.HitRate-0.8) > 1e-9 {
+		t.Errorf("tiered must win when present: %+v", got)
+	}
+}
+
+func TestDeriveObservedHitRate_NoRecognizedCounters(t *testing.T) {
+	_, err := DeriveObservedHitRate(map[string]float64{}, map[string]float64{"vllm:something_else": 5}, "")
+	if err == nil {
+		t.Fatal("expected error when no recognized counter family is present")
+	}
+}
+
+func TestDeriveObservedHitRate_ZeroQueriesGuard(t *testing.T) {
+	start := map[string]float64{PromTieringBlockHits: 5, PromTieringBlockQueries: 100}
+	end := map[string]float64{PromTieringBlockHits: 5, PromTieringBlockQueries: 100} // no activity
+	if _, err := DeriveObservedHitRate(start, end, ""); err == nil {
+		t.Fatal("expected zero-queries division guard to error (R11)")
+	}
+}
+
+func TestDeriveObservedHitRate_CounterResetGuard(t *testing.T) {
+	start := map[string]float64{PromTieringBlockHits: 500, PromTieringBlockQueries: 1000}
+	end := map[string]float64{PromTieringBlockHits: 10, PromTieringBlockQueries: 20} // restarted
+	if _, err := DeriveObservedHitRate(start, end, ""); err == nil {
+		t.Fatal("expected counter-reset guard to error")
+	}
+}

--- a/sim/workload/prom_hitrate_test.go
+++ b/sim/workload/prom_hitrate_test.go
@@ -125,6 +125,21 @@ func TestDeriveObservedHitRate_ZeroQueriesGuard(t *testing.T) {
 	}
 }
 
+func TestDeriveObservedHitRate_HitsExceedQueriesGuard(t *testing.T) {
+	// A window where hits delta > queries delta is physically impossible (hit-rate > 1).
+	start := map[string]float64{PromTieringBlockHits: 0, PromTieringBlockQueries: 0}
+	end := map[string]float64{PromTieringBlockHits: 600, PromTieringBlockQueries: 400}
+	if _, err := DeriveObservedHitRate(start, end, ""); err == nil {
+		t.Fatal("expected hits>queries guard to error (hit-rate > 1 is impossible)")
+	}
+	// Same guard on the GPU fallback family.
+	gStart := map[string]float64{PromGPUPrefixCacheHits: 0, PromGPUPrefixCacheQueries: 0}
+	gEnd := map[string]float64{PromGPUPrefixCacheHits: 60, PromGPUPrefixCacheQueries: 40}
+	if _, err := DeriveObservedHitRate(gStart, gEnd, ""); err == nil {
+		t.Fatal("expected GPU-fallback hits>queries guard to error")
+	}
+}
+
 func TestDeriveObservedHitRate_CounterResetGuard(t *testing.T) {
 	start := map[string]float64{PromTieringBlockHits: 500, PromTieringBlockQueries: 1000}
 	end := map[string]float64{PromTieringBlockHits: 10, PromTieringBlockQueries: 20} // restarted

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -45,6 +45,47 @@ type TraceHeader struct {
 	// physics regardless of the replay host's defaults.yaml; replay uses them
 	// authoritatively and logrus.Fatalf's on any config it cannot reconstruct.
 	KVOffload *TraceKVOffloadConfig `yaml:"kv_offload,omitempty"`
+
+	// ObservedKVMetrics records the REAL server's KV-cache hit-rate scraped from its
+	// Prometheus /metrics endpoint during `blis observe --scrape-kv-metrics` (#1583).
+	// It is a resolved-observation block (engine-level counters, not per-request), so
+	// it lives in the header rather than a per-record column. Absent (nil, omitempty)
+	// unless --scrape-kv-metrics was set and a recognized counter family was found —
+	// so a default observe writes a byte-identical header (BC-8). It is real-side
+	// ground truth: replay preserves it verbatim on re-export (BC-4) and never
+	// regenerates it. `blis calibrate` compares it against the simulator's own
+	// aggregate cache_hit_rate.
+	ObservedKVMetrics *TraceObservedKVMetrics `yaml:"observed_kv_metrics,omitempty"`
+}
+
+// TraceObservedKVMetrics is the real-side KV-cache hit-rate observed from a vLLM
+// server's Prometheus /metrics endpoint over the measured observation window (#1583).
+// It is a workload-package struct — decoupled from any sim type — so the on-disk trace
+// format is stable, mirroring the TraceKVOffloadConfig / TraceServerConfig precedent.
+// Read strictly (KnownFields) via LoadTraceV2, so an unknown sub-key is a hard error.
+type TraceObservedKVMetrics struct {
+	// Source names which counter family produced HitRate:
+	//   "tiered"                    — vllm:kv_offload_tiering_block_hits/_block_queries
+	//                                 (the multi-tier offload family; requires an
+	//                                 unreleased vLLM, PR #48798).
+	//   "gpu-prefix-cache-fallback" — vllm:gpu_prefix_cache_* (released vLLM, GPU-only).
+	//                                 A distinct, weaker signal — never conflated with a
+	//                                 tiered number.
+	Source string `yaml:"source"`
+	// HitRate is a fraction in [0,1]: BlockHits/BlockQueries over the measured window.
+	HitRate float64 `yaml:"hit_rate"`
+	// BlockHits and BlockQueries are the cumulative-counter DELTAS over the measured
+	// window (end − start), summed across all per-tier label series of the family.
+	BlockHits    int64 `yaml:"block_hits"`
+	BlockQueries int64 `yaml:"block_queries"`
+	// ReadTimeTotal and WriteTimeTotal are the per-tier read/write time deltas summed
+	// across the family (vLLM native seconds), recorded for the documented manual
+	// bandwidth cross-check. Informational — not part of the automated comparison.
+	ReadTimeTotal  float64 `yaml:"read_time_total,omitempty"`
+	WriteTimeTotal float64 `yaml:"write_time_total,omitempty"`
+	// VLLMCommit is the pinned vLLM commit the cluster ran (operator-supplied via
+	// --vllm-commit), recorded so the dependency on an unreleased vLLM is explicit.
+	VLLMCommit string `yaml:"vllm_commit,omitempty"`
 }
 
 // TraceKVOffloadConfig is the trace-header serialization of a resolved

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -1990,6 +1990,112 @@ func TestTraceV2_RoundTrip_WithKVOffload(t *testing.T) {
 	}
 }
 
+// TestTraceV2_RoundTrip_WithObservedKVMetrics verifies the observed KV hit-rate
+// block (#1583, BC-3) survives export→load with all fields intact.
+func TestTraceV2_RoundTrip_WithObservedKVMetrics(t *testing.T) {
+	header := &TraceHeader{
+		Version: 3, TimeUnit: "microseconds", Mode: "real",
+		ObservedKVMetrics: &TraceObservedKVMetrics{
+			Source:         "tiered",
+			HitRate:        0.734,
+			BlockHits:      7340,
+			BlockQueries:   10000,
+			ReadTimeTotal:  12.5,
+			WriteTimeTotal: 3.25,
+			VLLMCommit:     "63a9a5010a6d1539c52957646ef9d6bbcf7a4deb",
+		},
+	}
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, nil, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := loaded.Header.ObservedKVMetrics
+	if got == nil {
+		t.Fatal("observed_kv_metrics should round-trip, got nil")
+	}
+	if got.Source != "tiered" || got.HitRate != 0.734 || got.BlockHits != 7340 ||
+		got.BlockQueries != 10000 || got.ReadTimeTotal != 12.5 || got.WriteTimeTotal != 3.25 ||
+		got.VLLMCommit != "63a9a5010a6d1539c52957646ef9d6bbcf7a4deb" {
+		t.Errorf("observed_kv_metrics mismatch after round-trip: %+v", got)
+	}
+}
+
+// TestTraceV2_ObservedKVMetrics_ZeroHitRate verifies an observed hit-rate of exactly
+// 0 (a valid observation: zero cache hits) is preserved, not dropped by omitempty.
+func TestTraceV2_ObservedKVMetrics_ZeroHitRate(t *testing.T) {
+	header := &TraceHeader{
+		Version: 3, TimeUnit: "microseconds", Mode: "real",
+		ObservedKVMetrics: &TraceObservedKVMetrics{
+			Source: "gpu-prefix-cache-fallback", HitRate: 0, BlockHits: 0, BlockQueries: 500,
+		},
+	}
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, nil, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(headerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hit_rate: 0") {
+		t.Errorf("zero hit_rate must serialize explicitly, header:\n%s", data)
+	}
+	loaded, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Header.ObservedKVMetrics == nil || loaded.Header.ObservedKVMetrics.BlockQueries != 500 {
+		t.Errorf("zero-hit observation should round-trip: %+v", loaded.Header.ObservedKVMetrics)
+	}
+}
+
+// TestTraceV2_ObservedKVMetrics_UnknownSubKey verifies strict parsing rejects an
+// unknown sub-key inside the observed_kv_metrics block (BC-3, R10).
+func TestTraceV2_ObservedKVMetrics_UnknownSubKey(t *testing.T) {
+	yamlText := []byte("trace_version: 3\ntime_unit: microseconds\nmode: real\nwarm_up_requests: 0\n" +
+		"observed_kv_metrics:\n  source: tiered\n  hit_rate: 0.5\n  block_hits: 5\n  block_queries: 10\n  bogus_key: 1\n")
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	if err := os.WriteFile(headerPath, yamlText, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(dataPath, []byte("request_id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTraceV2(headerPath, dataPath); err == nil ||
+		!strings.Contains(err.Error(), "field") {
+		t.Errorf("expected unknown-field error for observed_kv_metrics sub-key, got %v", err)
+	}
+}
+
+// TestTraceV2_NoObservedKVMetrics_OmitsKey verifies a header without a scraped
+// observation writes no observed_kv_metrics key (BC-8 byte-identity for default observe).
+func TestTraceV2_NoObservedKVMetrics_OmitsKey(t *testing.T) {
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "real"}
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, nil, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(headerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "observed_kv_metrics") {
+		t.Errorf("header without a scrape must not contain observed_kv_metrics:\n%s", data)
+	}
+}
+
 // TestTraceV2_NoKVOffload_OmitsKey verifies a header without offload writes no
 // kv_offload key (BC-G5 byte-identity for the disabled case).
 func TestTraceV2_NoKVOffload_OmitsKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the KV-cache hit-rate validation gap for the tiered KV-offload epic (#1585, slot **S6**): adds a **real-side hit-rate capture path** to `blis observe` and a **sim-vs-real hit-rate comparison** to `blis calibrate`, so the multi-tier offload model can be validated against real vLLM runs through the existing `observe → replay → calibrate` pipeline.

Today `calibrate` compares TTFT, E2E, and ITL — and nothing else — and there is **no real-side hit-rate source at all** (`TraceHeader` had no cache-hit field; `observe` never scraped `/metrics`). The sim already computes the number (`sim.KVStore.CacheHitRate()`) but it only reached stdout as human text. This PR wires the whole loop.

## What this adds

1. **`observe --scrape-kv-metrics`** scrapes the server's Prometheus `/metrics` at the start and end of the measured window and records the observed hit-rate in a new resolved-observation header block (`observed_kv_metrics`). Primary signal: `vllm:kv_offload_tiering_block_hits`/`_block_queries` (vLLM PR #48798, **unreleased** — pin it with `--vllm-commit`). Released fallback: `vllm:gpu_prefix_cache_*`, tagged `source: gpu-prefix-cache-fallback` (a distinct, weaker signal, never conflated with a tiered number).
2. **`replay --metrics-path`** writes the sim aggregate `cache_hit_rate` into the MetricsOutput file (symmetric with `blis run`).
3. **`calibrate --sim-metrics`** now compares TTFT, E2E, **and** KV hit-rate — a `hit_rate` report block with `abs_error_pp` and a within-tolerance verdict (default **≤ 5 pp**), plus a TTFT-MAPE verdict (`--ttft-mape-threshold`, default **0.15**).
4. **Docs**: `docs/guide/kv-offload-calibration.md` — the minimal-experiment method (four canonical cache paths × prefix sweep, single replica, TP=1), the pinned-vLLM dependency, and the released-vLLM fallback caveat.

## Behavioral contracts

- **BC-1/2/13** — observe records `(block_hits Δ)/(block_queries Δ)` over the measured window, tagged by source; degenerate cases (zero queries, counter reset, no recognized counters, unreachable `/metrics`) **warn and omit** the block, never fatal, never a bogus value.
- **BC-3/4** — the header block round-trips and is strict-parsed (unknown sub-key = error); `replay --trace-output` preserves it verbatim.
- **BC-5/8/9** — `replay --metrics-path` file carries `cache_hit_rate`; **stdout stays byte-identical** to a pre-feature build (the field is `*float64,omitempty`, populated only in the file branch of `EmitOutput`, alongside the existing file-only `requests[]`) — INV-6. `run` and `replay --metrics-path` of the same trace produce **identical** `cache_hit_rate` — INV-13.
- **BC-6/7/12** — calibrate emits the `hit_rate` block only when both sides are present; otherwise it **skips with a warning** (TTFT/E2E rows still computed).
- **BC-10** — a `source: tiered` observation with **no reproducible `kv_offload` config** on replay is a **hard error** (never a silent GPU-only degradation) — INV-13, mirroring the #1587 `reconcileReplayKVOffload` seam.

## Scope decisions (called out for review)

- **Overall hit-rate, not per-tier.** `OffloadCache.CacheHitRate()` exposes a single aggregate (no per-tier `block_hits`), so the automated comparison is on the overall hit-rate. Per-tier `read_time`/`write_time` deltas are recorded in the header as *informational* data for the documented manual bandwidth cross-check.
- **Empirical cluster tolerance-pass is an operator step.** BLIS is CPU-only and the tiering counters require an unreleased vLLM on a GPU cluster, so the "BLIS meets ≤15% TTFT / ≤5 pp hit-rate on the named experiments" result cannot run in CI. This PR ships the full mechanism + the released-vLLM fallback + the documented method + pinned-commit recording — reported honestly, **not** claimed as passed.
- **`replay` gains `--metrics-path`.** The existing `TestReplayCmd_HasResultsPathFlag` asserted replay must *not* have `--metrics-path`. That boundary is now stale — the codebase already references "run/replay --metrics-path" (adapter-reference `--sim-metrics` help). The test is updated to assert the flag is present; `--results-path` (per-request) is unchanged.
- **`cache_hit_rate` is file-only, not on stdout.** Deliberate, to keep stdout INV-6-frozen without a broad golden regeneration; the human-readable rate is still printed by `printKVCacheMetrics`. The `--metrics-path` file is already a superset of stdout (`requests[]`).
- No new `go.mod` dependency — a small dependency-free Prometheus-text parser (`sim/workload/prom_hitrate.go`).

## Testing

`go build ./...`, `go test ./...` (all packages pass), and `golangci-lint run ./...` (0 issues) are green. New tests cover: Prometheus parse + hit-rate derivation (tiered/fallback/gauge/reset/zero-queries), header round-trip + strict-parse + zero-hit-rate preservation, `EmitOutput` file-only + stdout-absence, the BC-10 guard, INV-13 run/replay `cache_hit_rate` parity, and the calibrate present/skip paths. A CLI smoke confirms the file-only field and stdout byte-identity for both `run` and `replay`.

Fixes #1583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
