### PR TITLE
feat(cmd): blis convert weka — Weka CC agentic trace JSONL to TraceV2 (PR-F of #1477)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,8 @@ go build -o blis main.go
 # traffic (+312% on this dataset). Replayed input length / KV pressure / hit-rate is therefore
 # a substantial UPPER BOUND — do NOT read it as a faithful reproduction of the recorded ISL.
 # (Property of the PR-A/PR-B accumulate delta law, not this converter; the conversion is exact
-# per that law. A non-lossy think encoding is tracked in #1608.)
+# per that law. Faithful compaction support is tracked in #1609; the separate think-time
+# lossy-0 sentinel is #1608.)
 ./blis convert weka --input traces.jsonl --trace-output corpus \
   --context-growth accumulate --max-think-time 0
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,10 @@ go build -o blis main.go
 # = uncapped, since Weka gaps are genuine away-from-keyboard times). Reads `in` directly
 # (never len(hash_ids)×64). Weka ISL is huge (p50 ≈ 110K, p90 ≈ 395K), so replay MUST raise
 # --max-model-len (the ~41K default drops every request unservable) and scale --total-kv-blocks.
+# Fidelity note: real agentic traces compact/trim context often (~28% of rounds on the
+# 051926 dataset have in_N < in_{N-1}+out_{N-1}); such non-monotone rounds clamp their input
+# delta to 0, so the accumulate buffer OVER-counts the true per-round ISL (it cannot shrink).
+# Replayed KV pressure / hit-rate is therefore an UPPER BOUND, not an exact reproduction.
 ./blis convert weka --input traces.jsonl --trace-output corpus \
   --context-growth accumulate --max-think-time 0
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,10 +227,14 @@ go build -o blis main.go
 # = uncapped, since Weka gaps are genuine away-from-keyboard times). Reads `in` directly
 # (never len(hash_ids)×64). Weka ISL is huge (p50 ≈ 110K, p90 ≈ 395K), so replay MUST raise
 # --max-model-len (the ~41K default drops every request unservable) and scale --total-kv-blocks.
-# Fidelity note: real agentic traces compact/trim context often (~28% of rounds on the
-# 051926 dataset have in_N < in_{N-1}+out_{N-1}); such non-monotone rounds clamp their input
-# delta to 0, so the accumulate buffer OVER-counts the true per-round ISL (it cannot shrink).
-# Replayed KV pressure / hit-rate is therefore an UPPER BOUND, not an exact reproduction.
+# Fidelity note (important): real agentic traces compact/trim context heavily — ~30% of
+# rounds on the full 051926 dataset (219 sessions, 37.7K rounds) have in_N < in_{N-1}+out_{N-1}.
+# Such non-monotone rounds clamp their input delta to 0 (the accumulate buffer can only grow,
+# never shrink), so it OVER-counts the true cumulative input by ≈3–4× on real Claude Code
+# traffic (+312% on this dataset). Replayed input length / KV pressure / hit-rate is therefore
+# a substantial UPPER BOUND — do NOT read it as a faithful reproduction of the recorded ISL.
+# (Property of the PR-A/PR-B accumulate delta law, not this converter; the conversion is exact
+# per that law. A non-lossy think encoding is tracked in #1608.)
 ./blis convert weka --input traces.jsonl --trace-output corpus \
   --context-growth accumulate --max-think-time 0
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,17 +207,37 @@ go build -o blis main.go
 ./blis convert inference-perf --spec spec.yaml
 ./blis compose --from spec1.yaml --from spec2.yaml
 
-# Convert OTel agentic trace JSON to a TraceV2 corpus (accumulate = strict growing prefix)
-./blis convert otel --input otel_json/ --trace-output corpus \
-  --context-growth accumulate --max-think-time 15s
-
-# Replay a fixed pool of N concurrent closed-loop sessions from the corpus
-# (--total-sessions duplicates the corpus with cache-busting to fill the target)
-# Real agentic prompts can be huge (tens of thousands to >100K tokens) and grow
-# each round — raise --max-model-len (default ~41K) and scale --total-kv-blocks
-# accordingly, or every request drops as unservable (completed_requests: 0).
+# Convert captured agentic traces to a TraceV2 corpus for closed-loop replay (#1477).
+# Both readers feed the shared session→TraceV2 encoder (#1479): each session becomes
+# rounds 0..N with per-round input DELTAS, TraceRecord.Model left empty (routing safety —
+# the recorded cross-model name would drop every request under --model), and closed-loop
+# replay's accumulate buffer reconstructs the growing prompt. Output is delta-encoded, so
+# it MUST be replayed with --session-mode closed-loop (or --concurrent-sessions, which
+# auto-promotes); the default --session-mode fixed would misread the deltas as absolutes.
+#
+# convert otel — OpenTelemetry agentic trace JSON (file / dir of *.json / *.jsonl); one
+# LLM chat span per round; think derived from arrival gaps (--max-think-time default 15s).
+./blis convert otel --input traces.jsonl --trace-output corpus \
+  --context-growth accumulate
+#
+# convert weka — SemiAnalysis WekaTrace JSONL (#1604, PR-F; one proxy session per line).
+# Filters requests[] to the linear main-agent stream (type:"subagent" groups skipped,
+# deferred to PR-E); recomputes pure client think as max(0, t_i − t_{i-1} − api_time_{i-1})
+# between consecutive main turns into the think_time_us column (--max-think-time default 0
+# = uncapped, since Weka gaps are genuine away-from-keyboard times). Reads `in` directly
+# (never len(hash_ids)×64). Weka ISL is huge (p50 ≈ 110K, p90 ≈ 395K), so replay MUST raise
+# --max-model-len (the ~41K default drops every request unservable) and scale --total-kv-blocks.
+./blis convert weka --input traces.jsonl --trace-output corpus \
+  --context-growth accumulate --max-think-time 0
+#
+# Replay a corpus (from either converter) closed-loop — reconstructs each session's growing prompt.
 ./blis replay --trace-header corpus.yaml --trace-data corpus.csv \
-  --model qwen/qwen3-14b --concurrent-sessions 8 --total-sessions 200
+  --model qwen/qwen3-14b --session-mode closed-loop --max-model-len 1000000
+# Or replay a fixed pool of N concurrent closed-loop sessions (#1486, PR-C); --total-sessions
+# duplicates the corpus with cache-busting to fill the target (--concurrent-sessions auto-promotes
+# to closed-loop). Same huge-ISL caveat — raise --max-model-len and scale --total-kv-blocks.
+./blis replay --trace-header corpus.yaml --trace-data corpus.csv \
+  --model qwen/qwen3-14b --concurrent-sessions 8 --total-sessions 200 --max-model-len 1000000
 
 # Run with gateway queue flow control (utilization-based saturation gating)
 ./blis run --model qwen/qwen3-14b --flow-control --saturation-detector utilization \

--- a/cmd/convert_weka.go
+++ b/cmd/convert_weka.go
@@ -25,10 +25,9 @@ var convertWekaCmd = &cobra.Command{
 TraceV2 pair (<prefix>.yaml + <prefix>.csv) suitable for 'blis replay --session-mode closed-loop'
 (or 'blis replay --concurrent-sessions', which auto-promotes to closed-loop).
 
-Input is a .jsonl file (one session per line; a directory of *.json or a single JSON
-session file also work). Each session's requests[] is filtered to the linear main-agent
-stream — type:"subagent" groups are skipped (deferred to PR-E) — and each main turn
-becomes one round. Per-round input token counts are stored as deltas so accumulate replay
+Input is a .jsonl file (one session per line) — the native Weka shape. Each session's
+requests[] is filtered to the linear main-agent stream — type:"subagent" groups are
+skipped (deferred to PR-E) — and each main turn becomes one round. Per-round input token counts are stored as deltas so accumulate replay
 reconstructs the exact growing prompt with a strictly-identical shared prefix. Per-round
 pure client think time is recomputed as max(0, t_i − t_{i-1} − api_time_{i-1}) between
 consecutive main turns and carried in the think_time_us column.

--- a/cmd/convert_weka.go
+++ b/cmd/convert_weka.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+var (
+	wekaInputPath     string
+	wekaTraceOutput   string
+	wekaContextGrowth string
+	wekaMaxThinkTime  time.Duration
+	wekaMinRounds     int
+)
+
+var convertWekaCmd = &cobra.Command{
+	Use:   "weka",
+	Short: "Convert SemiAnalysis WekaTrace agentic JSONL to a TraceV2 file for closed-loop replay",
+	Long: `Convert SemiAnalysis WekaTrace agentic JSONL (one proxy session per line) into a
+TraceV2 pair (<prefix>.yaml + <prefix>.csv) suitable for 'blis replay --session-mode closed-loop'
+(or 'blis replay --concurrent-sessions', which auto-promotes to closed-loop).
+
+Input is a .jsonl file (one session per line; a directory of *.json or a single JSON
+session file also work). Each session's requests[] is filtered to the linear main-agent
+stream — type:"subagent" groups are skipped (deferred to PR-E) — and each main turn
+becomes one round. Per-round input token counts are stored as deltas so accumulate replay
+reconstructs the exact growing prompt with a strictly-identical shared prefix. Per-round
+pure client think time is recomputed as max(0, t_i − t_{i-1} − api_time_{i-1}) between
+consecutive main turns and carried in the think_time_us column.
+
+Caveats: Weka input token counts are huge (p50 ≈ 110K, p90 ≈ 395K); raise --max-model-len
+(the ~41K default drops every request as unservable) and scale --total-kv-blocks at replay.
+The recorded model name (claude-*) is dropped so requests inherit --model (routing safety).
+
+Note: unlike other 'blis convert' subcommands (which emit a WorkloadSpec to stdout),
+'convert weka' writes TraceV2 files, because it targets 'blis replay' (fixed per-call
+token counts) rather than 'blis run' (distribution sampling).`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if wekaContextGrowth != "accumulate" && wekaContextGrowth != "independent" {
+			logrus.Fatalf("--context-growth must be \"accumulate\" or \"independent\", got %q", wekaContextGrowth)
+		}
+		if wekaMinRounds < 1 {
+			logrus.Fatalf("--min-rounds must be >= 1, got %d", wekaMinRounds)
+		}
+		if wekaMaxThinkTime < 0 {
+			logrus.Fatalf("--max-think-time must be >= 0, got %s", wekaMaxThinkTime)
+		}
+		opts := workload.WekaConvertOptions{
+			ContextGrowth:  wekaContextGrowth,
+			MaxThinkTimeUs: wekaMaxThinkTime.Microseconds(),
+			MinRounds:      wekaMinRounds,
+		}
+		if err := runConvertWeka(wekaInputPath, wekaTraceOutput, opts); err != nil {
+			logrus.Fatalf("Weka conversion failed: %v", err)
+		}
+	},
+}
+
+// runConvertWeka reads all Weka sessions at inputPath, converts each to session
+// records, assigns global request IDs, and writes a TraceV2 pair to
+// <outPrefix>.yaml / <outPrefix>.csv. Reuses collectTraceInputs (defined in
+// convert_otel.go — format-agnostic: it splits .jsonl by line, reads *.json in a
+// directory, or treats any other file as a single payload).
+func runConvertWeka(inputPath, outPrefix string, opts workload.WekaConvertOptions) error {
+	// Return errors (do not Fatalf): the cobra Run wrapper owns the CLI exit
+	// boundary (R6 — library-style helpers surface errors, the CLI layer
+	// terminates). --input/--trace-output are also MarkFlagRequired'd, so these
+	// guards are defense-in-depth.
+	if inputPath == "" {
+		return fmt.Errorf("--input is required")
+	}
+	if outPrefix == "" {
+		return fmt.Errorf("--trace-output is required")
+	}
+	inputs, err := collectTraceInputs(inputPath)
+	if err != nil {
+		return err
+	}
+
+	var allRecords []workload.TraceRecord
+	nextID := 0
+	skipped := 0
+	for _, in := range inputs {
+		recs, err := workload.ConvertWekaSession(in.raw, opts)
+		if err != nil {
+			logrus.Warnf("skipping unparseable weka session %s: %v", in.name, err)
+			skipped++
+			continue
+		}
+		if recs == nil {
+			logrus.Debugf("skipping weka session %s: below --min-rounds", in.name)
+			skipped++
+			continue // below MinRounds
+		}
+		for i := range recs {
+			recs[i].RequestID = nextID
+			nextID++
+		}
+		allRecords = append(allRecords, recs...)
+	}
+
+	if len(allRecords) == 0 {
+		return fmt.Errorf("no usable sessions found in %q (skipped %d)", inputPath, skipped)
+	}
+
+	growth := opts.ContextGrowth
+	if growth == "independent" {
+		growth = "" // empty header value = per-round-independent inputs
+	}
+	header := &workload.TraceHeader{
+		Version:              3,
+		TimeUnit:             "microseconds",
+		Mode:                 "generated",
+		SessionContextGrowth: growth,
+	}
+	if err := workload.ExportTraceV2(header, allRecords, outPrefix+".yaml", outPrefix+".csv"); err != nil {
+		return err
+	}
+	logrus.Infof("Wrote %d records from %d sessions to %s.{yaml,csv} (skipped %d)",
+		len(allRecords), len(inputs)-skipped, outPrefix, skipped)
+	return nil
+}
+
+func init() {
+	convertWekaCmd.Flags().StringVar(&wekaInputPath, "input", "", "Path to WekaTrace JSONL file (one session per line), directory of *.json, or single JSON session (required)")
+	convertWekaCmd.Flags().StringVar(&wekaTraceOutput, "trace-output", "", "Output TraceV2 prefix; writes <prefix>.yaml + <prefix>.csv (required)")
+	convertWekaCmd.Flags().StringVar(&wekaContextGrowth, "context-growth", "accumulate", "Prefix model: \"accumulate\" (strict growing shared prefix) or \"independent\"")
+	convertWekaCmd.Flags().DurationVar(&wekaMaxThinkTime, "max-think-time", 0, "Cap on the recomputed per-round think gap; 0 = no cap (Weka gaps are genuine away-from-keyboard times)")
+	convertWekaCmd.Flags().IntVar(&wekaMinRounds, "min-rounds", 1, "Skip sessions with fewer than N usable main-agent turns")
+	_ = convertWekaCmd.MarkFlagRequired("input")
+	_ = convertWekaCmd.MarkFlagRequired("trace-output")
+
+	convertCmd.AddCommand(convertWekaCmd)
+}

--- a/cmd/convert_weka_test.go
+++ b/cmd/convert_weka_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/inference-sim/inference-sim/sim/workload"
+)
+
+// T9 — end-to-end: runConvertWeka → LoadTraceV2 (header accumulate, global IDs
+// 0..N) → LoadTraceV2SessionBlueprints + SessionManager reconstructs each
+// monotone session's recorded absolute per-round inputs via the accumulate
+// buffer, and the ThinkTimeSampler yields the recomputed pure-think values
+// (which drive follow-up arrival = completion + think, INV-10).
+func TestConvertWeka_EndToEndAndAccumulateReconstruction(t *testing.T) {
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "traces.jsonl")
+	// One monotone session, 3 main turns (in 100/150/215, out 10/20/5),
+	// think gaps: t1−t0−api0 = 8−0−1 = 7s; t2−t1−api1 = 20−8−2 = 10s.
+	session := `{"id":"sess-1","models":["claude-sonnet-4"],"requests":[` +
+		`{"type":"n","t":0.0,"in":100,"out":10,"api_time":1.0},` +
+		`{"type":"s","t":8.0,"in":150,"out":20,"api_time":2.0},` +
+		`{"type":"n","t":20.0,"in":215,"out":5,"api_time":1.0}` +
+		`]}`
+	if err := os.WriteFile(inPath, []byte(session+"\n"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	outPrefix := filepath.Join(dir, "out")
+
+	if err := runConvertWeka(inPath, outPrefix, workload.WekaConvertOptions{ContextGrowth: "accumulate", MinRounds: 1}); err != nil {
+		t.Fatalf("runConvertWeka: %v", err)
+	}
+
+	trace, err := workload.LoadTraceV2(outPrefix+".yaml", outPrefix+".csv")
+	if err != nil {
+		t.Fatalf("load exported trace: %v", err)
+	}
+	if trace.Header.SessionContextGrowth != "accumulate" {
+		t.Errorf("header growth = %q, want accumulate", trace.Header.SessionContextGrowth)
+	}
+	if len(trace.Records) != 3 {
+		t.Fatalf("records = %d, want 3", len(trace.Records))
+	}
+	for i, r := range trace.Records {
+		if r.RequestID != i {
+			t.Errorf("record %d RequestID = %d, want %d (assigned in stream order)", i, r.RequestID, i)
+		}
+		if r.Model != "" {
+			t.Errorf("record %d Model = %q, want empty (routing safety)", i, r.Model)
+		}
+	}
+	// think_time_us column round-trips: recorded 7s / 10s on rounds 1, 2.
+	if trace.Records[1].ThinkTimeUs != 7_000_000 || trace.Records[2].ThinkTimeUs != 10_000_000 {
+		t.Errorf("think_time_us = [_,%d,%d], want [_,7e6,10e6]", trace.Records[1].ThinkTimeUs, trace.Records[2].ThinkTimeUs)
+	}
+
+	// Closed-loop reconstruction through the SessionManager (accumulate buffer).
+	r0, bps, err := workload.LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("LoadTraceV2SessionBlueprints: %v", err)
+	}
+	if len(bps) != 1 {
+		t.Fatalf("blueprints = %d, want 1", len(bps))
+	}
+	// ThinkTimeSampler yields the recorded pure-think sequence (INV-10 spacing):
+	// round 1 arrives at completion[0]+7s, round 2 at completion[1]+10s.
+	ts := bps[0].ThinkTimeSampler
+	if ts == nil {
+		t.Fatal("expected a ThinkTimeSampler (recorded think present)")
+	}
+	if g1, g2 := ts.Sample(nil), ts.Sample(nil); g1 != 7_000_000 || g2 != 10_000_000 {
+		t.Errorf("think samples = [%d, %d], want recorded [7e6, 10e6]", g1, g2)
+	}
+
+	// Reconstruct absolute per-round inputs via the accumulate buffer.
+	sm := workload.NewSessionManager(bps)
+	round0 := r0[0]
+	if round0.InputLen() != 100 {
+		t.Fatalf("round0 input len = %d, want 100", round0.InputLen())
+	}
+	round0.State = sim.StateCompleted
+	round0.ProgressIndex = int64(round0.InputLen()) + 10 // 10 output tokens generated
+	fu := sm.OnComplete(round0, 8_000_000)
+	if len(fu) != 1 {
+		t.Fatalf("round0 follow-ups = %d, want 1", len(fu))
+	}
+	round1 := fu[0]
+	// Round 1 absolute input = 100 + 10 + delta(40) = 150 (the recorded in_1).
+	if round1.InputLen() != 150 {
+		t.Fatalf("round1 reconstructed input len = %d, want 150 (recorded in_1)", round1.InputLen())
+	}
+	round1.State = sim.StateCompleted
+	round1.ProgressIndex = int64(round1.InputLen()) + 20 // 20 output tokens
+	fu = sm.OnComplete(round1, 30_000_000)
+	if len(fu) != 1 {
+		t.Fatalf("round1 follow-ups = %d, want 1", len(fu))
+	}
+	round2 := fu[0]
+	// Round 2 absolute input = 150 + 20 + delta(45) = 215 (the recorded in_2).
+	if round2.InputLen() != 215 {
+		t.Fatalf("round2 reconstructed input len = %d, want 215 (recorded in_2)", round2.InputLen())
+	}
+}
+
+// T10 — CLI corpus paths: .jsonl multi-session with deterministic global IDs in
+// file order, "independent"→empty-header mapping, warn+skip of a malformed line
+// and a below-min-rounds session, and the no-usable-sessions hard error (writes
+// no output files).
+func TestConvertWeka_JSONLIndependentAndSkips(t *testing.T) {
+	t.Run("jsonl multi-session, independent growth, deterministic IDs", func(t *testing.T) {
+		dir := t.TempDir()
+		inPath := filepath.Join(dir, "traces.jsonl")
+		// Two sessions, each 2 main turns. File order sess-a then sess-b.
+		a := `{"id":"sess-a","requests":[{"type":"n","t":0.0,"in":100,"out":10,"api_time":1.0},{"type":"n","t":8.0,"in":150,"out":20,"api_time":1.0}]}`
+		b := `{"id":"sess-b","requests":[{"type":"n","t":0.0,"in":60,"out":6,"api_time":0.5},{"type":"n","t":5.0,"in":90,"out":9,"api_time":0.5}]}`
+		if err := os.WriteFile(inPath, []byte(a+"\n"+b+"\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		outPrefix := filepath.Join(dir, "out")
+		if err := runConvertWeka(inPath, outPrefix, workload.WekaConvertOptions{ContextGrowth: "independent", MinRounds: 1}); err != nil {
+			t.Fatalf("runConvertWeka: %v", err)
+		}
+		trace, err := workload.LoadTraceV2(outPrefix+".yaml", outPrefix+".csv")
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		// "independent" → empty header value (NOT the literal "independent").
+		if trace.Header.SessionContextGrowth != "" {
+			t.Errorf("header growth = %q, want empty for independent", trace.Header.SessionContextGrowth)
+		}
+		if len(trace.Records) != 4 {
+			t.Fatalf("records = %d, want 4 (2 sessions × 2 rounds)", len(trace.Records))
+		}
+		// Global IDs 0..3 in file order (sess-a rounds first, then sess-b).
+		for i, r := range trace.Records {
+			if r.RequestID != i {
+				t.Errorf("record %d RequestID = %d, want %d", i, r.RequestID, i)
+			}
+		}
+		if trace.Records[0].SessionID != "sess-a" || trace.Records[2].SessionID != "sess-b" {
+			t.Errorf("session order = %q..%q, want sess-a then sess-b (file order)", trace.Records[0].SessionID, trace.Records[2].SessionID)
+		}
+	})
+
+	t.Run("skips malformed line and below-min-rounds", func(t *testing.T) {
+		dir := t.TempDir()
+		inPath := filepath.Join(dir, "traces.jsonl")
+		kept := `{"id":"sess-keep","requests":[{"type":"n","t":0.0,"in":100,"out":10,"api_time":1.0},{"type":"n","t":8.0,"in":150,"out":20,"api_time":1.0}]}`
+		tooFew := `{"id":"sess-toofew","requests":[{"type":"n","t":0.0,"in":50,"out":5,"api_time":1.0}]}` // 1 round < MinRounds:2
+		malformed := `{not json`
+		if err := os.WriteFile(inPath, []byte(kept+"\n"+tooFew+"\n"+malformed+"\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		outPrefix := filepath.Join(dir, "out")
+		if err := runConvertWeka(inPath, outPrefix, workload.WekaConvertOptions{ContextGrowth: "accumulate", MinRounds: 2}); err != nil {
+			t.Fatalf("runConvertWeka should skip bad lines, not fail: %v", err)
+		}
+		trace, err := workload.LoadTraceV2(outPrefix+".yaml", outPrefix+".csv")
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(trace.Records) != 2 {
+			t.Fatalf("records = %d, want 2 (only sess-keep)", len(trace.Records))
+		}
+		for _, r := range trace.Records {
+			if r.SessionID != "sess-keep" {
+				t.Errorf("unexpected record from %q; only sess-keep should contribute", r.SessionID)
+			}
+		}
+	})
+
+	t.Run("no usable sessions errors and writes no files", func(t *testing.T) {
+		dir := t.TempDir()
+		inPath := filepath.Join(dir, "traces.jsonl")
+		// A single-round session under MinRounds:2 → zero usable sessions.
+		j := `{"id":"s","requests":[{"type":"n","t":0.0,"in":50,"out":5,"api_time":1.0}]}`
+		if err := os.WriteFile(inPath, []byte(j+"\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		outPrefix := filepath.Join(dir, "out")
+		if err := runConvertWeka(inPath, outPrefix, workload.WekaConvertOptions{ContextGrowth: "accumulate", MinRounds: 2}); err == nil {
+			t.Fatal("expected error when no usable sessions are found, got nil")
+		}
+		if _, statErr := os.Stat(outPrefix + ".csv"); !os.IsNotExist(statErr) {
+			t.Errorf("out.csv should not exist on the failure path; stat err = %v", statErr)
+		}
+	})
+}

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -338,7 +338,8 @@ names are dropped during conversion (same routing-safety reason as OTel).
     total by ≈3–4×** (+312% on that dataset). Treat replayed input length, KV pressure,
     and hit-rate as a substantial **upper bound**, not a faithful reproduction of the
     recorded workload. (This is a property of the accumulate delta law, not the
-    converter; the think-time lossy-sentinel corner is tracked in #1608.)
+    converter; faithful compaction support is tracked in #1609, and the separate
+    think-time lossy-0 sentinel corner in #1608.)
 
 ---
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -304,6 +304,42 @@ silently dropped.
     cover the largest round, and scale `--total-kv-blocks` up proportionally so
     the KV cache can hold the growing sessions.
 
+### Weka CC traces (`blis convert weka`)
+
+The [SemiAnalysis WekaTrace](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-with-subagents-051926)
+datasets are a second agentic-trace family. Unlike the OTel/Exgentic corpus they ship
+as **JSONL** — one proxy session per line — so no Parquet explosion step is needed:
+
+```bash
+# Convert (one session per JSONL line) to the same TraceV2 corpus format.
+blis convert weka --input traces.jsonl --trace-output corpus \
+  --context-growth accumulate --max-think-time 0
+
+# Replay closed-loop (or as a concurrent pool, exactly as for OTel above).
+blis replay --trace-header corpus.yaml --trace-data corpus.csv \
+  --model qwen/qwen3-14b --session-mode closed-loop --max-model-len 1000000
+```
+
+The reader filters each session's `requests[]` to the **linear main-agent stream** —
+`type:"subagent"` groups are skipped (deferred to a later PR); their wall-clock is
+absorbed into the following main turn's think gap. Per-round **pure client think** is
+recomputed as `max(0, t_i − t_{i-1} − api_time_{i-1})` between consecutive main turns
+(carried in the `think_time_us` column, `--max-think-time` default `0` = uncapped,
+since Weka gaps are genuine away-from-keyboard times). The recorded `claude-*` model
+names are dropped during conversion (same routing-safety reason as OTel).
+
+!!! warning "Weka replay ISL is an upper bound (context compaction)"
+    Weka input token counts are very large (p50 ≈ 110K, p90 ≈ 395K), so the
+    `--max-model-len` / `--total-kv-blocks` sizing warning above applies with extra
+    force. More subtly: real Claude Code traffic **compacts/trims context constantly**
+    — ~30% of rounds on the full `051926` dataset have `in_N < in_{N-1}+out_{N-1}`.
+    The accumulate buffer can only grow, never shrink, so each such round clamps its
+    input delta to 0 and the reconstructed cumulative input **over-counts the recorded
+    total by ≈3–4×** (+312% on that dataset). Treat replayed input length, KV pressure,
+    and hit-rate as a substantial **upper bound**, not a faithful reproduction of the
+    recorded workload. (This is a property of the accumulate delta law, not the
+    converter; the think-time lossy-sentinel corner is tracked in #1608.)
+
 ---
 
 ## `blis calibrate`

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -124,8 +124,9 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 // overlap-clamped rounds) reads as false here and falls back to the arrival-gap path
 // — which bundles service time into the gap (see the gap-derivation note below), the
 // very effect think_time_us exists to avoid. The impact is bounded (a ~0 recorded
-// think replaced by the recorded arrival gap); a non-lossy encoding is deferred to the
-// Weka converter (#1604). Pinned by TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap.
+// think replaced by the recorded arrival gap); a non-lossy encoding is deferred to
+// #1608 (the Weka converter #1604 intentionally kept this lossy 0-sentinel). Pinned by
+// TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap.
 func sessionHasRecordedThinkTime(rounds []TraceRecord) bool {
 	for i := 1; i < len(rounds); i++ {
 		if rounds[i].ThinkTimeUs != 0 {

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -185,7 +185,7 @@ type TraceRecord struct {
 	FinishReason      string // server-reported finish_reason ("stop", "length", "abort", etc.); empty = not recorded
 	XRequestID        string // client-generated UUID sent as x-request-id header (real-mode only); empty = not recorded
 	Adapter           string // LoRA adapter id serving this request (registry key; #1464); empty = base-model-only
-	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end). Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay. NOTE: 0 is a LOSSY SENTINEL for "not recorded" — a genuinely-zero recorded think time (e.g. Weka's overlap-clamped rounds) is indistinguishable from an absent column, so an all-zero session falls back to arrival-gap derivation. A non-lossy encoding (distinguishing recorded-0 from absent) is deferred to the Weka converter work (#1604).
+	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end). Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay. NOTE: 0 is a LOSSY SENTINEL for "not recorded" — a genuinely-zero recorded think time (e.g. Weka's overlap-clamped rounds) is indistinguishable from an absent column, so an all-zero session falls back to arrival-gap derivation. A non-lossy encoding (distinguishing recorded-0 from absent) is deferred to #1608 (the Weka converter #1604 intentionally kept this lossy 0-sentinel).
 }
 
 // TraceV2 combines header and records for a complete trace.

--- a/sim/workload/weka_convert.go
+++ b/sim/workload/weka_convert.go
@@ -1,0 +1,142 @@
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// WekaConvertOptions configures Weka-session → TraceRecord conversion.
+type WekaConvertOptions struct {
+	// ContextGrowth is not read by ConvertWekaSession itself; it is read by the
+	// caller (the `blis convert weka` command) to choose the exported trace
+	// header's session_context_growth value: "accumulate" (default) or
+	// "independent". See TraceHeader.SessionContextGrowth in tracev2.go.
+	ContextGrowth string
+	// MaxThinkTimeUs caps each recomputed inter-turn think gap; 0 = no cap.
+	// Weka's gaps are genuine away-from-keyboard times, so uncapped (0) is
+	// fidelity-preserving (unlike OTel's 15s default); a bounded-horizon
+	// capacity run may set a cap so a single multi-minute away-gap does not
+	// idle a pooled session for that long of sim time.
+	MaxThinkTimeUs int64
+	// MinRounds skips sessions with fewer usable main-agent turns (default 1).
+	MinRounds int
+}
+
+// wekaSession is one JSONL line (one proxy session). Unknown fields are ignored
+// (standard encoding/json behavior — do NOT use DisallowUnknownFields; real
+// traces carry many fields we don't model: models, block_size, hash_id_scope).
+type wekaSession struct {
+	ID       string        `json:"id"`
+	Requests []wekaRequest `json:"requests"`
+}
+
+// wekaRequest is one entry in a session's requests[]: a main-agent request
+// (type "n" non-streaming / "s" streaming) or a sub-agent group (type
+// "subagent"), which this converter skips (deferred to PR-E, #1477).
+type wekaRequest struct {
+	Type string  `json:"type"`     // "n", "s", or "subagent"
+	T    float64 `json:"t"`        // seconds since trace start (arrival)
+	In   *int    `json:"in"`       // effective o200k input tokens; read directly (never derived from hash_ids)
+	Out  *int    `json:"out"`      // output tokens (Anthropic-reported)
+	API  float64 `json:"api_time"` // real end-to-end server time (sec); used to recompute pure think
+	// The recorded model name (`model`) is intentionally NOT parsed: it is
+	// routing-significant at replay (buildRouterState filters instances by it),
+	// and Weka records claude-* which would never match --model → every request
+	// silently dropped. encoding/json simply ignores the key; the shared encoder
+	// leaves TraceRecord.Model empty. hash_ids / think_time / ttft are likewise
+	// not consumed (think is recomputed; hash_ids is future work).
+}
+
+// ConvertWekaSession converts one Weka JSONL session into ordered TraceRecords
+// with per-round input-token deltas. It filters requests[] to the linear
+// main-agent stream (skipping type:"subagent" groups), keeps main turns in
+// stream order (a linear agent conversation is inherently sequential, unlike
+// OTel's parallel spans — context accumulation depends on call order, not
+// timestamp order), and recomputes each round's pure client think time as
+// max(0, t_i − t_{i-1} − api_time_{i-1}) between consecutive main turns.
+//
+// RoundIndex is 0..N over main turns. RequestID is left 0 (the caller assigns
+// global ids). Returns (nil, nil) when the session has fewer than
+// opts.MinRounds usable main turns (e.g. an all-subagent session).
+//
+// Recomputing think (rather than trusting the recorded `think_time`) keeps the
+// main chain clean when sub-agent entries are removed: a recorded `think_time`
+// may reference a chronologically-preceding sub-agent inner request. The
+// wall-clock a skipped sub-agent group ran is absorbed into the following main
+// turn's think gap (the main agent really was blocked on the Task tool); PR-E
+// models the fan-out explicitly.
+func ConvertWekaSession(raw []byte, opts WekaConvertOptions) ([]TraceRecord, error) {
+	minRounds := opts.MinRounds
+	if minRounds < 1 {
+		minRounds = 1
+	}
+
+	var s wekaSession
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("parsing weka session: %w", err)
+	}
+	if s.ID == "" {
+		return nil, fmt.Errorf("no session id (\"id\") in weka session")
+	}
+
+	// Filter to usable main-agent turns in stream order. `in`/`out` are read
+	// directly from the record (never derived from len(hash_ids)×64, which would
+	// over-count up to 63 tokens/request on the v5 dataset encoding). A main turn
+	// missing either count is dropped (defensive — real data always carries them).
+	type mainTurn struct {
+		t, api float64
+		in     int
+		out    int
+	}
+	var turns []mainTurn
+	for i := range s.Requests {
+		r := &s.Requests[i]
+		if r.Type == "subagent" {
+			continue // sub-agent fan-out deferred to PR-E (#1477)
+		}
+		if r.In == nil || r.Out == nil {
+			continue // no ground-truth token counts → unusable
+		}
+		turns = append(turns, mainTurn{t: r.T, api: r.API, in: *r.In, out: *r.Out})
+	}
+
+	if len(turns) < minRounds {
+		return nil, nil
+	}
+
+	// Build the source-agnostic normalized session; the shared encoder
+	// (EncodeSessionToTraceRecords) computes per-round input deltas and leaves
+	// TraceRecord.Model empty (routing safety). ThinkUs carries the recomputed
+	// pure client think (#1478), preferred over arrival-gap think at replay.
+	rounds := make([]NormalizedRound, 0, len(turns))
+	for i, tn := range turns {
+		var thinkUs int64
+		if i > 0 {
+			prev := turns[i-1]
+			// Pure client think: wall-clock from the previous turn's RESPONSE
+			// (its end = t_{i-1} + api_time_{i-1}) to this turn's arrival.
+			gapUs := int64(math.Round((tn.t - prev.t - prev.api) * 1e6))
+			if gapUs < 0 {
+				gapUs = 0 // clamp (INV-3): overlapping turns — round i started before round i-1's response elapsed
+			}
+			if opts.MaxThinkTimeUs > 0 && gapUs > opts.MaxThinkTimeUs {
+				gapUs = opts.MaxThinkTimeUs
+			}
+			thinkUs = gapUs
+		}
+		rounds = append(rounds, NormalizedRound{
+			InputTokensAbs: tn.in,
+			OutputTokens:   tn.out,
+			// Absolute per-session arrival (Weka `t` is seconds since trace
+			// start, and each JSONL line is one session, so `t` is already
+			// per-session-relative). Round 0 = the first main turn's `t` (may be
+			// >0 when a skipped sub-agent group preceded it). Follow-up spacing at
+			// closed-loop replay comes from ThinkUs, not this arrival.
+			ArrivalUs: int64(math.Round(tn.t * 1e6)),
+			ThinkUs:   thinkUs,
+			Status:    "ok", // Weka errors are filtered at source
+		})
+	}
+	return EncodeSessionToTraceRecords(s.ID, rounds), nil
+}

--- a/sim/workload/weka_convert.go
+++ b/sim/workload/weka_convert.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+
+	"github.com/sirupsen/logrus"
 )
 
 // WekaConvertOptions configures Weka-session → TraceRecord conversion.
@@ -96,7 +98,12 @@ func ConvertWekaSession(raw []byte, opts WekaConvertOptions) ([]TraceRecord, err
 			continue // sub-agent fan-out deferred to PR-E (#1477)
 		}
 		if r.In == nil || r.Out == nil {
-			continue // no ground-truth token counts → unusable
+			// No ground-truth token counts → unusable. Real Weka main turns always
+			// carry in/out (0 drops observed across the 051926 dataset), so this is
+			// defense-in-depth; log it (not a silent continue, R1) so a future
+			// data-shape change that starts dropping turns is debuggable.
+			logrus.Debugf("convert weka: session %q request %d dropped — main turn missing in/out", s.ID, i)
+			continue
 		}
 		turns = append(turns, mainTurn{t: r.T, api: r.API, in: *r.In, out: *r.Out})
 	}

--- a/sim/workload/weka_convert_test.go
+++ b/sim/workload/weka_convert_test.go
@@ -219,6 +219,34 @@ func TestConvertWekaSession_MinRoundsAndAllSubagentSkip(t *testing.T) {
 	}
 }
 
+// T7b — a main turn missing `in` (or `out`) is dropped (defense-in-depth; real
+// data always carries them). Surviving main turns renumber contiguously and the
+// delta spans the survivors — the dropped turn's wall-clock is absorbed into the
+// following kept turn's think gap. Mirrors OTel's DropsSpanMissingTokenCount.
+func TestConvertWekaSession_DropsMainTurnMissingTokens(t *testing.T) {
+	// Middle main turn omits `in` → dropped; survivors are the 0s and 8s turns.
+	j := `{"id":"s","requests":[
+	  {"type":"n","t":0.0,"in":100,"out":10,"api_time":1.0},
+	  {"type":"n","t":4.0,"out":9,"api_time":1.0},
+	  {"type":"n","t":8.0,"in":150,"out":20,"api_time":1.0}
+	]}`
+	recs, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2 (main turn with missing `in` dropped)", len(recs))
+	}
+	// RoundIndex renumbers 0,1 with no gap; delta spans survivors: 150-100-10 = 40.
+	if recs[1].RoundIndex != 1 || recs[1].InputTokens != 40 {
+		t.Errorf("survivor round1 = ri %d in %d, want 1/40", recs[1].RoundIndex, recs[1].InputTokens)
+	}
+	// Think for the kept round spans the dropped turn: t2-t0-api0 = 8-0-1 = 7s.
+	if recs[1].ThinkTimeUs != 7_000_000 {
+		t.Errorf("round1 think = %d, want 7e6 (dropped turn's wall-clock absorbed into the gap)", recs[1].ThinkTimeUs)
+	}
+}
+
 // T8 — a session with no `id` cannot be identified: ConvertWekaSession errors
 // rather than emitting records under an empty session id. The corpus-level
 // warn+skip of this error is covered in cmd/convert_weka_test.go.

--- a/sim/workload/weka_convert_test.go
+++ b/sim/workload/weka_convert_test.go
@@ -1,0 +1,230 @@
+package workload
+
+import (
+	"testing"
+)
+
+// A 3-main-turn session with a type:"subagent" group interleaved between turns
+// 0 and 1. Main turns: in 100/150/215, out 10/20/5; the sub-agent group at
+// t=2.0 (dropped) sits between the 0s and 6s main turns. api_time on each main
+// turn drives think recompute; think_time is the recorded value (equals the
+// recomputed gap on this subagent-free-between-consecutive-mains chain).
+const wekaThreeTurnWithSubagent = `{
+  "id": "sess-1",
+  "models": ["claude-sonnet-4"],
+  "block_size": 64,
+  "hash_id_scope": "local",
+  "requests": [
+    {"type":"n","t":0.0,"model":"claude-sonnet-4","in":100,"out":10,"hash_ids":[1,2],"api_time":1.0},
+    {"type":"subagent","t":2.0,"agent_id":"sa-1","subagent_type":"search","duration_ms":3000,"total_tokens":500,"requests":[{"type":"n","t":2.5,"in":9999,"out":9999,"api_time":0.5}]},
+    {"type":"s","t":6.0,"model":"claude-sonnet-4","in":150,"out":20,"hash_ids":[1,2,3],"api_time":2.0,"think_time":5.0,"ttft":0.3},
+    {"type":"n","t":10.0,"model":"claude-sonnet-4","in":215,"out":5,"hash_ids":[1,2,3,4],"api_time":1.0,"think_time":2.0}
+  ]
+}`
+
+// T1 — reader core: delta reconstruction, RoundIndex over main turns only,
+// sub-agent group excluded, Model routing-safety.
+func TestConvertWekaSession_DeltaReconstructionAndSubagentSkip(t *testing.T) {
+	recs, err := ConvertWekaSession([]byte(wekaThreeTurnWithSubagent), WekaConvertOptions{ContextGrowth: "accumulate", MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	// 3 main turns → 3 records; the type:"subagent" group produces none.
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3 (sub-agent group excluded)", len(recs))
+	}
+	// RoundIndex 0..N over main turns in stream order.
+	for i, r := range recs {
+		if r.RoundIndex != i {
+			t.Errorf("record %d RoundIndex = %d, want %d (main turns only, stream order)", i, r.RoundIndex, i)
+		}
+	}
+	// Round 0: full first prompt.
+	if recs[0].InputTokens != 100 || recs[0].OutputTokens != 10 {
+		t.Errorf("round0 = in %d out %d, want 100/10", recs[0].InputTokens, recs[0].OutputTokens)
+	}
+	// Round 1 delta: 150 - 100 - 10 = 40.
+	if recs[1].InputTokens != 40 {
+		t.Errorf("round1 delta = %d, want 40", recs[1].InputTokens)
+	}
+	// Round 2 delta: 215 - 150 - 20 = 45.
+	if recs[2].InputTokens != 45 {
+		t.Errorf("round2 delta = %d, want 45", recs[2].InputTokens)
+	}
+	// Delta reconstruction law: prefix + running(delta+output) == recorded totals.
+	wantTotals := []int{100, 150, 215}
+	running := 0
+	for i, r := range recs {
+		if i == 0 {
+			running = r.InputTokens
+		} else {
+			running += r.InputTokens
+		}
+		if running != wantTotals[i] {
+			t.Errorf("round %d reconstructed input = %d, want %d", i, running, wantTotals[i])
+		}
+		running += r.OutputTokens
+	}
+	// SessionID from `id`.
+	if recs[0].SessionID != "sess-1" {
+		t.Errorf("session id = %q, want sess-1", recs[0].SessionID)
+	}
+	// Model MUST be empty even though every turn records "claude-sonnet-4":
+	// TraceRecord.Model is routing-significant, so a recorded name differing from
+	// --model would drop every request at routing.
+	for i, r := range recs {
+		if r.Model != "" {
+			t.Errorf("round %d Model = %q, want empty (recorded model must not reach the routing-significant field)", i, r.Model)
+		}
+	}
+}
+
+// T2 — think recompute equals both the formula and the recorded think_time on a
+// subagent-free chain; and the sub-agent group's wall-clock is absorbed into the
+// FOLLOWING main turn's think gap (BC-2, BC-3). The fixture above places a
+// sub-agent group (t=2..~5) between main turn 0 (t=0, api 1.0) and main turn 1
+// (t=6): the recomputed think for main turn 1 is 6.0 − 0.0 − 1.0 = 5.0s, which
+// spans and thus ABSORBS the sub-agent's wall-clock. It equals the recorded
+// think_time (5.0). Main turn 2: 10.0 − 6.0 − 2.0 = 2.0s == recorded 2.0.
+func TestConvertWekaSession_ThinkTimeRecompute(t *testing.T) {
+	recs, err := ConvertWekaSession([]byte(wekaThreeTurnWithSubagent), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	if recs[0].ThinkTimeUs != 0 {
+		t.Errorf("round0 think = %d, want 0 (round 0 has no predecessor)", recs[0].ThinkTimeUs)
+	}
+	// Round 1 think absorbs the skipped sub-agent group's wall-clock: 5.0s.
+	if recs[1].ThinkTimeUs != 5_000_000 {
+		t.Errorf("round1 think = %d, want 5e6 (t1−t0−api0 = 6−0−1, absorbs sub-agent wall-clock; == recorded think_time 5.0)", recs[1].ThinkTimeUs)
+	}
+	// Round 2 think: consecutive main turns, no sub-agent between: 2.0s.
+	if recs[2].ThinkTimeUs != 2_000_000 {
+		t.Errorf("round2 think = %d, want 2e6 (t2−t1−api1 = 10−6−2; == recorded think_time 2.0)", recs[2].ThinkTimeUs)
+	}
+}
+
+// T3 — overlapping main turns (round i arrives before round i-1's response
+// elapsed → negative raw gap, real in these traces) yield ThinkTimeUs == 0,
+// never negative (INV-3, BC-4). Mirrors the input-delta clamp.
+func TestConvertWekaSession_NegativeGapThinkClampsToZero(t *testing.T) {
+	// Round 1 arrives at t=1.0 but round 0's response ends at 0.0+2.0=2.0 →
+	// raw gap 1.0−0.0−2.0 = −1.0s → clamp to 0.
+	j := `{"id":"s","requests":[
+	  {"type":"n","t":0.0,"in":100,"out":10,"api_time":2.0},
+	  {"type":"n","t":1.0,"in":150,"out":20,"api_time":1.0}
+	]}`
+	recs, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	if recs[1].ThinkTimeUs != 0 {
+		t.Errorf("round1 think = %d, want 0 (negative raw gap clamped; never negative)", recs[1].ThinkTimeUs)
+	}
+}
+
+// T4 — --max-think-time caps the recomputed gap (>0); 0 leaves it uncapped.
+func TestConvertWekaSession_MaxThinkTimeCapAndUncapped(t *testing.T) {
+	// 100s think gap (t1=101, api0=1 → 100s), no sub-agent.
+	j := `{"id":"s","requests":[
+	  {"type":"n","t":0.0,"in":50,"out":5,"api_time":1.0},
+	  {"type":"n","t":101.0,"in":70,"out":8,"api_time":1.0}
+	]}`
+	capped, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1, MaxThinkTimeUs: 15_000_000})
+	if err != nil {
+		t.Fatalf("capped: %v", err)
+	}
+	if capped[1].ThinkTimeUs != 15_000_000 {
+		t.Errorf("capped think = %d, want 15e6", capped[1].ThinkTimeUs)
+	}
+	uncapped, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1, MaxThinkTimeUs: 0})
+	if err != nil {
+		t.Fatalf("uncapped: %v", err)
+	}
+	if uncapped[1].ThinkTimeUs != 100_000_000 {
+		t.Errorf("uncapped think = %d, want 100e6 (no cap when MaxThinkTimeUs == 0)", uncapped[1].ThinkTimeUs)
+	}
+}
+
+// T5 — non-monotone input (context compaction/trimming): in_1 < in_0 + out_0 →
+// raw input delta negative → clamped to 0 by the shared encoder, never negative
+// (BC-1 edge). Reconstructed absolute over-counts by the clamped deficit
+// (accepted, documented deviation — same as OTel).
+func TestConvertWekaSession_NonMonotoneInputClampsToZero(t *testing.T) {
+	// Round 1 recorded input (120) < round 0 input+output (200+50=250).
+	j := `{"id":"s","requests":[
+	  {"type":"n","t":0.0,"in":200,"out":50,"api_time":1.0},
+	  {"type":"n","t":5.0,"in":120,"out":8,"api_time":1.0}
+	]}`
+	recs, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	if recs[0].InputTokens != 200 {
+		t.Errorf("round0 input = %d, want 200", recs[0].InputTokens)
+	}
+	if recs[1].InputTokens != 0 {
+		t.Errorf("round1 delta = %d, want 0 (clamped, never negative)", recs[1].InputTokens)
+	}
+	// Reconstructed round-1 absolute = 200 + 50 + 0 = 250 (over-counts recorded 120 by 130).
+	reconstructed := recs[0].InputTokens + recs[0].OutputTokens + recs[1].InputTokens
+	if reconstructed != 250 {
+		t.Errorf("reconstructed round1 absolute = %d, want 250 (over-counts recorded 120 by the clamped 130)", reconstructed)
+	}
+}
+
+// T6 — `in` is read directly, NEVER derived from len(hash_ids)×64. This is the
+// v5 (051926) encoding: in ≤ len(hash_ids)×64. Here in=100 but len(hash_ids)=1
+// (which would be 64 if recomputed) → InputTokens must reflect 100 (BC-6).
+func TestConvertWekaSession_ReadsInDirectlyNotHashIds(t *testing.T) {
+	j := `{"id":"s","requests":[
+	  {"type":"n","t":0.0,"in":100,"out":10,"hash_ids":[7],"api_time":1.0}
+	]}`
+	recs, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("ConvertWekaSession: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	if recs[0].InputTokens != 100 {
+		t.Errorf("round0 input = %d, want 100 (read `in` directly; NOT len(hash_ids)×64 = 64)", recs[0].InputTokens)
+	}
+}
+
+// T7 — a session with fewer than MinRounds usable main turns is skipped
+// (nil,nil): both the all-subagent (0 usable main turns) case and a plain
+// below-min-rounds case. No panic, no records (BC-8).
+func TestConvertWekaSession_MinRoundsAndAllSubagentSkip(t *testing.T) {
+	// All-subagent session: 0 usable main turns → skipped even at MinRounds:1.
+	allSub := `{"id":"s","requests":[
+	  {"type":"subagent","t":0.0,"agent_id":"a","requests":[{"type":"n","t":0.1,"in":10,"out":2,"api_time":0.1}]}
+	]}`
+	recs, err := ConvertWekaSession([]byte(allSub), WekaConvertOptions{MinRounds: 1})
+	if err != nil {
+		t.Fatalf("all-subagent: %v", err)
+	}
+	if recs != nil {
+		t.Fatalf("all-subagent session got %d records, want nil (0 usable main turns)", len(recs))
+	}
+
+	// Single main turn below MinRounds:2 → skipped.
+	oneTurn := `{"id":"s","requests":[{"type":"n","t":0.0,"in":50,"out":5,"api_time":1.0}]}`
+	recs, err = ConvertWekaSession([]byte(oneTurn), WekaConvertOptions{MinRounds: 2})
+	if err != nil {
+		t.Fatalf("below-min-rounds: %v", err)
+	}
+	if recs != nil {
+		t.Fatalf("below-min-rounds got %d records, want nil", len(recs))
+	}
+}
+
+// T8 — a session with no `id` cannot be identified: ConvertWekaSession errors
+// rather than emitting records under an empty session id. The corpus-level
+// warn+skip of this error is covered in cmd/convert_weka_test.go.
+func TestConvertWekaSession_NoSessionIDErrors(t *testing.T) {
+	j := `{"requests":[{"type":"n","t":0.0,"in":50,"out":5,"api_time":1.0}]}`
+	if _, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1}); err == nil {
+		t.Fatal("expected error for a weka session with no id, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds **`blis convert weka`** — a second `blis convert` front-end (alongside `otel`) that reads the **SemiAnalysis WekaTrace** JSONL schema and produces the same normalized session the shared PR-B encoder (`EncodeSessionToTraceRecords`, #1479) turns into a TraceV2 corpus. The replay engine (accumulate fidelity #1478, session pool #1480, observe pool #1487) is source-agnostic and **unchanged** — this is a convert-only PR.

Depends on (both merged into `main`): **PR-A #1478** (`think_time_us` column + `session_context_growth` header) and **PR-B #1479** (shared session→TraceV2 encoder). Part of #1477.

```bash
blis convert weka --input traces.jsonl --trace-output corpus \
  --context-growth accumulate --max-think-time 0
blis replay --trace-header corpus.yaml --trace-data corpus.csv \
  --model qwen/qwen3-14b --session-mode closed-loop --max-model-len 1000000
```

## Behavioral contracts

- **BC-1 (delta reconstruction).** GIVEN a monotone Weka session, WHEN converted, THEN round 0's `InputTokens == in_0` and round `k>0` = `max(0, in_k − in_{k-1} − out_{k-1})`; the accumulate buffer reconstructs each round's absolute input exactly. (Reuses the merged encoder's delta law verbatim.)
- **BC-2 (sub-agent exclusion).** `requests[]` is filtered to the linear main-agent stream; `type:"subagent"` groups are skipped (deferred to PR-E). `RoundIndex` is 0..N over main turns in stream order; a skipped group's wall-clock is absorbed into the *following* main turn's think gap.
- **BC-3 (think recompute).** `ThinkTimeUs[k] = round((t_k − t_{k-1} − api_time_{k-1})·1e6)` for `k>0`, `0` for round 0; on a subagent-free chain this equals `round(think_time_k·1e6)`. Recomputing (not trusting the recorded `think_time`) keeps the main chain clean when sub-agent entries are removed.
- **BC-4 (clamp, INV-3).** Overlapping main turns (negative raw gap — real in these traces) → `ThinkTimeUs == 0`, never negative.
- **BC-5 (cap).** `--max-think-time D>0` caps the recomputed gap; `0` (default) leaves it uncapped (Weka gaps are genuine away-from-keyboard times).
- **BC-6 (`in` read directly).** `in` is read directly, never derived from `len(hash_ids)×64` (would over-count ≤63 tok/req on the v5 encoding).
- **BC-7 (Model routing-safety).** Every emitted `TraceRecord.Model == ""` so requests inherit `--model` at replay instead of being dropped at routing (Weka records `claude-*`).
- **BC-8 (min-rounds skip).** Below `--min-rounds` (incl. all-`subagent` / 0-main-turn) → `(nil, nil)`, no records, no panic.
- **BC-9/BC-10 (corpus).** `independent`→empty header; sessions consumed in file order with global request IDs assigned in order (INV-6).

## Testing

- `sim/workload/weka_convert_test.go` — 8 unit tests: delta reconstruction + sub-agent skip, think recompute (== formula AND == recorded `think_time`, with sub-agent wall-clock absorption), negative-gap clamp, max-think cap/uncapped, non-monotone input clamp, `in`-read-directly (v5), min-rounds/all-subagent skip, no-session-id error.
- `cmd/convert_weka_test.go` — end-to-end convert → `LoadTraceV2` → `SessionManager` accumulate reconstruction of absolute per-round inputs + `ThinkTimeSampler` yields recorded think (INV-10 spacing); plus `.jsonl` multi-session determinism, `independent`→empty header, warn+skip of malformed/below-min-rounds lines, no-usable-sessions hard error (writes no files).
- `go build ./...`, full `go test ./...`, and `golangci-lint run ./...` all green.
- **Manual smoke (operator step, needs HF LFS dataset):** a byte-range slice of a real `traces.jsonl` → `convert weka` → `replay --session-mode closed-loop --max-model-len 1000000`. Not automated (dataset not in CI), mirroring how PR-B/PR-C handled real-data validation.

## Caveats (documented in CLAUDE.md)

- **Huge ISL** (p50 ≈ 110K, p90 ≈ 395K): the ~41K default `--max-model-len` drops every request unservable — raise it and scale `--total-kv-blocks` at replay.
- **Delta-encoded output** MUST be replayed with `--session-mode closed-loop` (or `--concurrent-sessions`, which auto-promotes); the default `fixed` mode would misread deltas as absolutes.
- **Sub-agents skipped** — their token/latency content is not replayed (only their wall-clock is absorbed into the following main turn's think). Deferred to PR-E.

## Notes / deviations

- The issue's "Add a doc admonition (mirrors the existing Exgentic note)" references a note not present in `main` (it lived only in unmerged fork branches; merged PR-B added no guide docs and didn't list `convert otel` in CLAUDE.md). This PR documents the Weka caveats in **CLAUDE.md** — the canonical always-loaded doc — alongside a brief `convert otel`/`convert weka` note, keeping scope minimal (no new guide-doc section) to match PR-B's precedent.

## Out of scope

- Sub-agent fan-out (`type:"subagent"`) → PR-E.
- `hash_ids`-driven prefix sharing → future KV-model feature (this PR relies on the accumulate buffer's approximate growing prefix).

Closes #1604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
