### PR TITLE
fix(workload): non-lossy think_time_us encoding — distinguish recorded-0 from absent (#1608)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,8 +234,10 @@ go build -o blis main.go
 # traffic (+312% on this dataset). Replayed input length / KV pressure / hit-rate is therefore
 # a substantial UPPER BOUND — do NOT read it as a faithful reproduction of the recorded ISL.
 # (Property of the PR-A/PR-B accumulate delta law, not this converter; the conversion is exact
-# per that law. Faithful compaction support is tracked in #1609; the separate think-time
-# lossy-0 sentinel is #1608.)
+# per that law. Faithful compaction support is tracked in #1609.) The recorded think time is
+# non-lossy (#1608): a genuinely-zero recorded think (an overlapping turn) is a &0 in the
+# think_time_us column, distinct from a not-recorded (empty) cell, so an all-overlap session
+# uses the recorded zeros rather than degrading to arrival-gap think at replay.
 ./blis convert weka --input traces.jsonl --trace-output corpus \
   --context-growth accumulate --max-think-time 0
 #

--- a/cmd/convert_weka_test.go
+++ b/cmd/convert_weka_test.go
@@ -51,9 +51,10 @@ func TestConvertWeka_EndToEndAndAccumulateReconstruction(t *testing.T) {
 			t.Errorf("record %d Model = %q, want empty (routing safety)", i, r.Model)
 		}
 	}
-	// think_time_us column round-trips: recorded 7s / 10s on rounds 1, 2.
-	if trace.Records[1].ThinkTimeUs != 7_000_000 || trace.Records[2].ThinkTimeUs != 10_000_000 {
-		t.Errorf("think_time_us = [_,%d,%d], want [_,7e6,10e6]", trace.Records[1].ThinkTimeUs, trace.Records[2].ThinkTimeUs)
+	// think_time_us column round-trips: recorded 7s / 10s on rounds 1, 2 (non-nil, #1608).
+	if trace.Records[1].ThinkTimeUs == nil || *trace.Records[1].ThinkTimeUs != 7_000_000 ||
+		trace.Records[2].ThinkTimeUs == nil || *trace.Records[2].ThinkTimeUs != 10_000_000 {
+		t.Errorf("think_time_us = [_,%v,%v], want [_,&7e6,&10e6]", trace.Records[1].ThinkTimeUs, trace.Records[2].ThinkTimeUs)
 	}
 
 	// Closed-loop reconstruction through the SessionManager (accumulate buffer).

--- a/cmd/observe_corpus_test.go
+++ b/cmd/observe_corpus_test.go
@@ -289,8 +289,8 @@ func TestObserveCorpusMode_MultiRoundAccumulate(t *testing.T) {
 	header := &workload.TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
 	records := []workload.TraceRecord{
 		{RequestID: 0, SessionID: "s0", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0, Status: "ok"},
-		{RequestID: 1, SessionID: "s0", RoundIndex: 1, InputTokens: 40, OutputTokens: 10, ArrivalTimeUs: 1000, ThinkTimeUs: 1000, Status: "ok"},
-		{RequestID: 2, SessionID: "s0", RoundIndex: 2, InputTokens: 25, OutputTokens: 10, ArrivalTimeUs: 2000, ThinkTimeUs: 1000, Status: "ok"},
+		{RequestID: 1, SessionID: "s0", RoundIndex: 1, InputTokens: 40, OutputTokens: 10, ArrivalTimeUs: 1000, ThinkTimeUs: i64p(1000), Status: "ok"},
+		{RequestID: 2, SessionID: "s0", RoundIndex: 2, InputTokens: 25, OutputTokens: 10, ArrivalTimeUs: 2000, ThinkTimeUs: i64p(1000), Status: "ok"},
 	}
 	if err := workload.ExportTraceV2(header, records, headerPath, dataPath); err != nil {
 		t.Fatalf("export corpus: %v", err)

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -395,8 +395,11 @@ The reader filters each session's `requests[]` to the **linear main-agent stream
 absorbed into the following main turn's think gap. Per-round **pure client think** is
 recomputed as `max(0, t_i − t_{i-1} − api_time_{i-1})` between consecutive main turns
 (carried in the `think_time_us` column, `--max-think-time` default `0` = uncapped,
-since Weka gaps are genuine away-from-keyboard times). The recorded `claude-*` model
-names are dropped during conversion (same routing-safety reason as OTel).
+since Weka gaps are genuine away-from-keyboard times). The column is **non-lossy**
+(#1608): a genuinely-zero recomputed think (an overlapping turn) is recorded as `&0`,
+distinct from a not-recorded (empty) cell, so an all-overlap session replays with the
+recorded zeros rather than degrading to arrival-gap think. The recorded `claude-*`
+model names are dropped during conversion (same routing-safety reason as OTel).
 
 !!! warning "Weka replay ISL is an upper bound (context compaction)"
     Weka input token counts are very large (p50 ≈ 110K, p90 ≈ 395K), so the
@@ -408,8 +411,8 @@ names are dropped during conversion (same routing-safety reason as OTel).
     total by ≈3–4×** (+312% on that dataset). Treat replayed input length, KV pressure,
     and hit-rate as a substantial **upper bound**, not a faithful reproduction of the
     recorded workload. (This is a property of the accumulate delta law, not the
-    converter; faithful compaction support is tracked in #1609, and the separate
-    think-time lossy-0 sentinel corner in #1608.)
+    converter; faithful compaction support is tracked in #1609. The separate
+    think-time lossy-0 sentinel was resolved in #1608 — see the non-lossy note above.)
 
 ---
 

--- a/sim/workload/otel_convert.go
+++ b/sim/workload/otel_convert.go
@@ -163,9 +163,9 @@ func ConvertOTelTrace(raw []byte, opts OTelConvertOptions) ([]TraceRecord, error
 	// (EncodeSessionToTraceRecords) computes per-round input deltas and leaves
 	// TraceRecord.Model empty (routing safety — a recorded cross-model name would
 	// drop every request at routing under a differing --model; see the encoder's
-	// doc comment and #1477). ThinkUs is left 0: OTel has no reliable
-	// response-complete time (end_time is often a placeholder), so per-round think
-	// is derived from arrival gaps at replay rather than recorded here.
+	// doc comment and #1477). ThinkUs is left nil (not recorded, #1608): OTel has no
+	// reliable response-complete time (end_time is often a placeholder), so per-round
+	// think is derived from arrival gaps at replay rather than recorded here.
 	t0 := spans[0].startUs
 	rounds := make([]NormalizedRound, 0, len(spans))
 	for i, sp := range spans {

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -249,8 +249,10 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			for i := 1; i < len(rounds); i++ {
 				// derefInt64(nil) == 0: a recorded &0 and (defensively) a nil interior
 				// round both yield 0 think. sessionHasRecordedThinkTime guarantees at
-				// least one round here is non-nil; in practice a recorded session's
-				// rounds 1..N are all non-nil.
+				// least one round here is non-nil. No shipped converter produces a mixed
+				// interior (OTel leaves every round nil; Weka sets every round 1..N), so
+				// the nil-interior branch is unreachable today — the deref pins a defined
+				// behavior (0 think) if a future converter ever recorded think sparsely.
 				t := derefInt64(rounds[i].ThinkTimeUs)
 				if t < 0 {
 					t = 0 // defensive; LoadTraceV2 already rejects negatives (INV-3)

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -119,17 +119,17 @@ func LoadTraceV2Requests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
 // time is meaningless and ignored. When true, closed-loop replay prefers the recorded
 // per-round think time over arrival-gap derivation.
 //
-// LOSSY SENTINEL (F1, #1484 review): a value of 0 means "not recorded", so a session
-// whose every round has a genuinely-zero recorded think time (real for Weka's
-// overlap-clamped rounds) reads as false here and falls back to the arrival-gap path
-// — which bundles service time into the gap (see the gap-derivation note below), the
-// very effect think_time_us exists to avoid. The impact is bounded (a ~0 recorded
-// think replaced by the recorded arrival gap); a non-lossy encoding is deferred to
-// #1608 (the Weka converter #1604 intentionally kept this lossy 0-sentinel). Pinned by
-// TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap.
+// PRESENCE, not non-zero (#1608): ThinkTimeUs is now a *int64, so a recorded &0 is
+// distinguishable from an absent (nil) value. A session whose every round genuinely
+// recorded think == 0 (real for Weka's overlap-clamped rounds) now reads as recorded
+// here and uses those zeros (back-to-back rounds) — it no longer falls back to the
+// arrival-gap path, which bundles service time into the gap (see the gap-derivation
+// note below), the very effect think_time_us exists to avoid. Only a truly absent
+// (nil) value falls back. Pinned by
+// TestLoadTraceV2SessionBlueprints_AllRecordedZeroThink_UsesRecordedZeros.
 func sessionHasRecordedThinkTime(rounds []TraceRecord) bool {
 	for i := 1; i < len(rounds); i++ {
-		if rounds[i].ThinkTimeUs != 0 {
+		if rounds[i].ThinkTimeUs != nil {
 			return true
 		}
 	}
@@ -247,7 +247,11 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			// i-1's end). Round 0 carries no think; rounds 1..N supply the sequence.
 			thinkTimes := make([]int, len(rounds)-1)
 			for i := 1; i < len(rounds); i++ {
-				t := rounds[i].ThinkTimeUs
+				// derefInt64(nil) == 0: a recorded &0 and (defensively) a nil interior
+				// round both yield 0 think. sessionHasRecordedThinkTime guarantees at
+				// least one round here is non-nil; in practice a recorded session's
+				// rounds 1..N are all non-nil.
+				t := derefInt64(rounds[i].ThinkTimeUs)
 				if t < 0 {
 					t = 0 // defensive; LoadTraceV2 already rejects negatives (INV-3)
 				}

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -322,9 +322,9 @@ func TestLoadTraceV2SessionBlueprints_PrefersRecordedThinkTime(t *testing.T) {
 	// gap derivation which bundles service time).
 	trace := &TraceV2{
 		Records: []TraceRecord{
-			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
-			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: 300},
-			{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 300, OutputTokens: 90, ArrivalTimeUs: 12000, ThinkTimeUs: 400},
+			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: i64p(300)},
+			{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 300, OutputTokens: 90, ArrivalTimeUs: 12000, ThinkTimeUs: i64p(400)},
 		},
 	}
 
@@ -349,8 +349,8 @@ func TestLoadTraceV2SessionBlueprints_RecordedThinkTime_CLIOverrides(t *testing.
 	// THEN the caller sampler wins (#1478 precedence: CLI > recorded > gap).
 	trace := &TraceV2{
 		Records: []TraceRecord{
-			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
-			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: 300},
+			{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+			{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 200, OutputTokens: 80, ArrivalTimeUs: 5000, ThinkTimeUs: i64p(300)},
 		},
 	}
 	sampler := &ConstantSampler{value: 500_000}
@@ -1015,15 +1015,18 @@ func TestAccumulateReplay_StrictPrefixIdentity(t *testing.T) {
 	}
 }
 
-// TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap pins the
-// F1 lossy-sentinel behavior (#1484 review): a session whose every round records
-// think_time_us == 0 (real for Weka's overlap-clamped rounds) is indistinguishable
-// from an absent column, so it falls back to arrival-gap derivation.
-func TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap(t *testing.T) {
+// TestLoadTraceV2SessionBlueprints_AllRecordedZeroThink_UsesRecordedZeros pins the
+// non-lossy fix (#1608, was the F1 lossy-sentinel behavior of #1484): a session whose
+// every non-round-0 round RECORDS think == 0 (non-nil &0, real for Weka's
+// overlap-clamped rounds) now USES those recorded zeros (back-to-back rounds) —
+// it no longer degrades to arrival-gap derivation, which bundled service time into
+// the gap.
+func TestLoadTraceV2SessionBlueprints_AllRecordedZeroThink_UsesRecordedZeros(t *testing.T) {
 	trace := &TraceV2{Records: []TraceRecord{
-		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
-		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: 0},
-		{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ArrivalTimeUs: 12000, ThinkTimeUs: 0},
+		// Round 0 not recorded (nil); rounds 1..2 recorded &0 (overlapping turns).
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: i64p(0)},
+		{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ArrivalTimeUs: 12000, ThinkTimeUs: i64p(0)},
 	}}
 	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
@@ -1033,24 +1036,49 @@ func TestLoadTraceV2SessionBlueprints_AllZeroRecordedThink_FallsBackToGap(t *tes
 	if s == nil {
 		t.Fatal("expected a think sampler for a multi-round session")
 	}
-	// Falls back to arrival gaps [5000, 7000], NOT the recorded zeros.
-	if g1, g2 := s.Sample(nil), s.Sample(nil); g1 != 5000 || g2 != 7000 {
-		t.Errorf("all-zero recorded think: sampler = [%d, %d], want arrival gaps [5000, 7000] (documented lossy-sentinel fallback)", g1, g2)
+	// Uses the RECORDED zeros [0, 0], NOT the arrival gaps [5000, 7000].
+	if g1, g2 := s.Sample(nil), s.Sample(nil); g1 != 0 || g2 != 0 {
+		t.Errorf("all-recorded-zero think: sampler = [%d, %d], want recorded zeros [0, 0] (#1608 non-lossy), not arrival gaps [5000, 7000]", g1, g2)
 	}
 }
 
-// TestLoadTraceV2SessionBlueprints_MixedThinkSessions covers F4 (#1484 review): the
-// export gate (includeThinkTime) is global, but think-time selection is per-session,
-// so a trace mixing a recorded-think session with an all-zero one must select each
-// independently — A uses its recorded think, B falls back to arrival gaps.
+// TestLoadTraceV2SessionBlueprints_AbsentThink_FallsBackToGap pins the surviving
+// fallback path (#1608): a session whose non-round-0 rounds are all NOT recorded
+// (nil, real for OTel / generated traces) still derives think from arrival gaps.
+func TestLoadTraceV2SessionBlueprints_AbsentThink_FallsBackToGap(t *testing.T) {
+	trace := &TraceV2{Records: []TraceRecord{
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: nil},
+		{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ArrivalTimeUs: 12000, ThinkTimeUs: nil},
+	}}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s := bps[0].ThinkTimeSampler
+	if s == nil {
+		t.Fatal("expected a think sampler for a multi-round session")
+	}
+	// No recorded think → arrival gaps [5000, 7000].
+	if g1, g2 := s.Sample(nil), s.Sample(nil); g1 != 5000 || g2 != 7000 {
+		t.Errorf("absent think: sampler = [%d, %d], want arrival gaps [5000, 7000]", g1, g2)
+	}
+}
+
+// TestLoadTraceV2SessionBlueprints_MixedThinkSessions covers F4 (#1484 review),
+// updated for #1608: think-time selection is per-session, so a trace mixing a
+// recorded-think session with a not-recorded one selects each independently — A uses
+// its recorded think, B (nil) falls back to arrival gaps. (Under the non-lossy
+// encoding, a recorded &0 would NOT fall back — see AllRecordedZeroThink — so B must
+// be genuinely absent (nil) to exercise the fallback.)
 func TestLoadTraceV2SessionBlueprints_MixedThinkSessions(t *testing.T) {
 	trace := &TraceV2{Records: []TraceRecord{
 		// A: recorded think 300; arrival gap (9999) deliberately differs so the two are distinguishable.
-		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
-		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 9999, ThinkTimeUs: 300},
-		// B: all-zero recorded think; arrival gap 5000.
-		{RequestID: 4, SessionID: "B", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: 0},
-		{RequestID: 5, SessionID: "B", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: 0},
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 9999, ThinkTimeUs: i64p(300)},
+		// B: NOT recorded (nil); arrival gap 5000.
+		{RequestID: 4, SessionID: "B", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+		{RequestID: 5, SessionID: "B", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 5000, ThinkTimeUs: nil},
 	}}
 	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
 	if err != nil {
@@ -1064,7 +1092,7 @@ func TestLoadTraceV2SessionBlueprints_MixedThinkSessions(t *testing.T) {
 		t.Errorf("session A think = %d, want recorded 300", got)
 	}
 	if got := byID["B"].ThinkTimeSampler.Sample(nil); got != 5000 {
-		t.Errorf("session B think = %d, want arrival gap 5000 (all-zero fallback)", got)
+		t.Errorf("session B think = %d, want arrival gap 5000 (not-recorded fallback)", got)
 	}
 }
 

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -1065,6 +1065,35 @@ func TestLoadTraceV2SessionBlueprints_AbsentThink_FallsBackToGap(t *testing.T) {
 	}
 }
 
+// TestLoadTraceV2SessionBlueprints_MixedInteriorThink_DerefDefensive exercises the
+// defensive nil-interior path (#1608, blis-pr-review + qa-review G1 optional note): a
+// single session with a nil interior round (round 1) among recorded rounds (round 2
+// non-nil). sessionHasRecordedThinkTime is true (round 2 recorded), so the whole
+// session uses the recorded path — and the nil interior round derefs to 0 think, NOT
+// to its arrival gap. No shipped converter emits such a session; this pins the deref
+// behavior for a hypothetical future sparse-think converter.
+func TestLoadTraceV2SessionBlueprints_MixedInteriorThink_DerefDefensive(t *testing.T) {
+	trace := &TraceV2{Records: []TraceRecord{
+		// Arrival gaps would be [3000, 7000] if this fell back — it must NOT.
+		{RequestID: 1, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, ThinkTimeUs: nil},
+		{RequestID: 2, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ArrivalTimeUs: 3000, ThinkTimeUs: nil},      // interior nil
+		{RequestID: 3, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ArrivalTimeUs: 10000, ThinkTimeUs: i64p(5000)}, // recorded
+	}}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s := bps[0].ThinkTimeSampler
+	if s == nil {
+		t.Fatal("expected a think sampler for a multi-round session")
+	}
+	// Recorded path (round 2 non-nil) with nil interior derefing to 0: [0, 5000],
+	// NOT the arrival gaps [3000, 7000].
+	if g1, g2 := s.Sample(nil), s.Sample(nil); g1 != 0 || g2 != 5000 {
+		t.Errorf("mixed-interior think: sampler = [%d, %d], want [0, 5000] (nil interior → 0 deref, round 2 recorded), not arrival gaps [3000, 7000]", g1, g2)
+	}
+}
+
 // TestLoadTraceV2SessionBlueprints_MixedThinkSessions covers F4 (#1484 review),
 // updated for #1608: think-time selection is per-session, so a trace mixing a
 // recorded-think session with a not-recorded one selects each independently — A uses

--- a/sim/workload/trace_encode.go
+++ b/sim/workload/trace_encode.go
@@ -10,7 +10,7 @@ type NormalizedRound struct {
 	InputTokensAbs int    // absolute recorded prompt tokens for this round
 	OutputTokens   int    // recorded output tokens
 	ArrivalUs      int64  // arrival time (µs), relative to session start
-	ThinkUs        int64  // recorded pure client think time (µs); 0 = not recorded
+	ThinkUs        *int64 // recorded pure client think time (µs); nil = not recorded, &0 = recorded zero (#1608)
 	Status         string // "ok" or "error"
 }
 
@@ -28,9 +28,11 @@ type NormalizedRound struct {
 // TraceRecord.Model is left empty deliberately: it is routing-significant at
 // replay (buildRouterState filters instances by it), so writing a recorded
 // cross-model name would drop every request at routing. Empty makes requests
-// inherit --model (#1477). ThinkUs, when a reader sets it, is written to the
-// think_time_us column (#1478) and preferred over arrival-gap think at replay;
-// the OTel reader leaves it 0 (no reliable response-complete time), Weka sets it.
+// inherit --model (#1477). ThinkUs, when a reader sets it (non-nil), is written to
+// the think_time_us column (#1478) and preferred over arrival-gap think at replay;
+// the OTel reader leaves it nil (no reliable response-complete time → arrival-gap
+// fallback), Weka sets it — including a recorded &0 for an overlapping turn, which
+// (#1608) is no longer conflated with "not recorded".
 func EncodeSessionToTraceRecords(sessionID string, rounds []NormalizedRound) []TraceRecord {
 	recs := make([]TraceRecord, 0, len(rounds))
 	prevIn, prevOut := 0, 0

--- a/sim/workload/trace_encode_test.go
+++ b/sim/workload/trace_encode_test.go
@@ -2,15 +2,20 @@ package workload
 
 import "testing"
 
+// i64p returns a pointer to v, for constructing a RECORDED (non-nil) think time in
+// tests (#1608). A recorded &0 (i64p(0)) is distinct from a nil (not-recorded) think:
+// TraceRecord.ThinkTimeUs and NormalizedRound.ThinkUs are *int64 presence signals.
+func i64p(v int64) *int64 { return &v }
+
 // TestEncodeSessionToTraceRecords_DeltaLaw verifies the shared encoder's core
 // contract (#1479): absolute per-round inputs → per-round deltas, round-0 full,
 // non-monotone clamp to 0, Model left empty (routing safety), RequestID left 0,
 // and ThinkUs surfaced onto the think_time_us column (#1478).
 func TestEncodeSessionToTraceRecords_DeltaLaw(t *testing.T) {
 	rounds := []NormalizedRound{
-		{InputTokensAbs: 100, OutputTokens: 50, ArrivalUs: 0, Status: "ok"},
-		{InputTokensAbs: 200, OutputTokens: 80, ArrivalUs: 5000, ThinkUs: 300, Status: "ok"},
-		{InputTokensAbs: 120, OutputTokens: 10, ArrivalUs: 9000, Status: "error"}, // non-monotone → clamp
+		{InputTokensAbs: 100, OutputTokens: 50, ArrivalUs: 0, Status: "ok"}, // round 0: ThinkUs nil (not recorded)
+		{InputTokensAbs: 200, OutputTokens: 80, ArrivalUs: 5000, ThinkUs: i64p(300), Status: "ok"},
+		{InputTokensAbs: 120, OutputTokens: 10, ArrivalUs: 9000, Status: "error"}, // non-monotone → clamp; ThinkUs nil
 	}
 	recs := EncodeSessionToTraceRecords("sess", rounds)
 	if len(recs) != 3 {
@@ -44,9 +49,13 @@ func TestEncodeSessionToTraceRecords_DeltaLaw(t *testing.T) {
 		}
 	}
 
-	// ThinkUs → think_time_us column; arrival, output, status propagate.
-	if recs[0].ThinkTimeUs != 0 || recs[1].ThinkTimeUs != 300 {
-		t.Errorf("ThinkTimeUs = [%d, %d], want [0, 300]", recs[0].ThinkTimeUs, recs[1].ThinkTimeUs)
+	// ThinkUs → think_time_us column: nil propagates as nil (not recorded), a set
+	// value propagates through (#1608). Round 0 nil; round 1 recorded &300.
+	if recs[0].ThinkTimeUs != nil {
+		t.Errorf("round0 ThinkTimeUs = %v, want nil (not recorded)", recs[0].ThinkTimeUs)
+	}
+	if recs[1].ThinkTimeUs == nil || *recs[1].ThinkTimeUs != 300 {
+		t.Errorf("round1 ThinkTimeUs = %v, want &300", recs[1].ThinkTimeUs)
 	}
 	if recs[1].ArrivalTimeUs != 5000 {
 		t.Errorf("round1 ArrivalTimeUs = %d, want 5000", recs[1].ArrivalTimeUs)

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -185,7 +185,14 @@ type TraceRecord struct {
 	FinishReason      string // server-reported finish_reason ("stop", "length", "abort", etc.); empty = not recorded
 	XRequestID        string // client-generated UUID sent as x-request-id header (real-mode only); empty = not recorded
 	Adapter           string // LoRA adapter id serving this request (registry key; #1464); empty = base-model-only
-	ThinkTimeUs       int64  // recorded per-round client think time in µs (gap from previous request's end). Set by agentic-trace converters (#1478); preferred over arrival-gap derivation in closed-loop replay. NOTE: 0 is a LOSSY SENTINEL for "not recorded" — a genuinely-zero recorded think time (e.g. Weka's overlap-clamped rounds) is indistinguishable from an absent column, so an all-zero session falls back to arrival-gap derivation. A non-lossy encoding (distinguishing recorded-0 from absent) is deferred to #1608 (the Weka converter #1604 intentionally kept this lossy 0-sentinel).
+	// ThinkTimeUs is the recorded per-round client think time in µs (gap from the
+	// previous request's end), set by agentic-trace converters (#1478) and preferred
+	// over arrival-gap derivation in closed-loop replay. It is a PRESENCE signal
+	// (#1608): nil = not recorded (CSV cell empty; replay falls back to arrival gaps),
+	// non-nil = recorded — INCLUDING a recorded &0 (CSV cell "0"), which a genuinely-
+	// zero recorded think (e.g. Weka's overlap-clamped rounds) uses so it is no longer
+	// conflated with "absent". A negative recorded value is a load error (INV-3).
+	ThinkTimeUs *int64
 }
 
 // TraceV2 combines header and records for a complete trace.
@@ -262,12 +269,13 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 	}
 
 	// Conditionally include think_time_us column (#1478): present iff any record carries
-	// a non-zero recorded think time. Trailing position (like x_request_id / adapter) keeps
-	// the positional parser's index math untouched. Omitted when no record has it, so
-	// existing traces (e.g. observe, generated) add no column (INV-6 byte-identity).
+	// a RECORDED (non-nil) think time — including a recorded &0 (#1608). Trailing position
+	// (like x_request_id / adapter) keeps the positional parser's index math untouched.
+	// Omitted when no record recorded think, so traces that never set it (e.g. observe,
+	// generated, convert otel) add no column (INV-6 byte-identity).
 	includeThinkTime := false
 	for _, r := range records {
-		if r.ThinkTimeUs != 0 {
+		if r.ThinkTimeUs != nil {
 			includeThinkTime = true
 			break
 		}
@@ -370,9 +378,14 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		if includeAdapter {
 			row = append(row, r.Adapter)
 		}
-		// Append think_time_us at end (#1478).
+		// Append think_time_us at end (#1478). A nil (not-recorded) think writes an
+		// empty cell so it is distinguishable from a recorded &0 on reload (#1608).
 		if includeThinkTime {
-			row = append(row, strconv.FormatInt(r.ThinkTimeUs, 10))
+			if r.ThinkTimeUs != nil {
+				row = append(row, strconv.FormatInt(*r.ThinkTimeUs, 10))
+			} else {
+				row = append(row, "")
+			}
 		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("writing CSV row %d: %w", r.RequestID, err)
@@ -642,18 +655,20 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequest
 	}
 
 	// Optional think_time_us at trailing column (#1478): looked up by absolute header
-	// position so the positional index math above is unaffected. Negative values are
-	// rejected — recorded think time cannot be negative (INV-3).
-	var thinkTimeUs int64
+	// position so the positional index math above is unaffected. An EMPTY cell means
+	// "not recorded" and yields a nil pointer (#1608), distinct from a recorded "0";
+	// negative values are rejected — recorded think time cannot be negative (INV-3).
+	var thinkTimeUs *int64
 	if thinkTimeUsIdx >= 0 && thinkTimeUsIdx < len(row) {
 		if v := strings.TrimSpace(row[thinkTimeUsIdx]); v != "" {
-			thinkTimeUs, err = strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("parsing think_time_us %q: %w", v, err)
+			parsed, perr := strconv.ParseInt(v, 10, 64)
+			if perr != nil {
+				return nil, fmt.Errorf("parsing think_time_us %q: %w", v, perr)
 			}
-			if thinkTimeUs < 0 {
-				return nil, fmt.Errorf("parsing think_time_us: negative value %d not allowed", thinkTimeUs)
+			if parsed < 0 {
+				return nil, fmt.Errorf("parsing think_time_us: negative value %d not allowed", parsed)
 			}
+			thinkTimeUs = &parsed
 		}
 	}
 

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -1137,8 +1137,8 @@ func TestTraceV2_ThinkTimeUs_RoundTrip(t *testing.T) {
 		headerPath := filepath.Join(dir, "h.yaml")
 		dataPath := filepath.Join(dir, "d.csv")
 		records := []TraceRecord{
-			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: 0},
-			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ThinkTimeUs: 5000},
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: i64p(0)},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ThinkTimeUs: i64p(5000)},
 		}
 		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
 			t.Fatalf("ExportTraceV2: %v", err)
@@ -1151,8 +1151,41 @@ func TestTraceV2_ThinkTimeUs_RoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadTraceV2: %v", err)
 		}
-		if loaded.Records[0].ThinkTimeUs != 0 || loaded.Records[1].ThinkTimeUs != 5000 {
-			t.Errorf("ThinkTimeUs round-trip = [%d, %d], want [0, 5000]", loaded.Records[0].ThinkTimeUs, loaded.Records[1].ThinkTimeUs)
+		// A recorded &0 round-trips as non-nil &0 (NOT nil) — the core #1608 distinction.
+		if loaded.Records[0].ThinkTimeUs == nil || *loaded.Records[0].ThinkTimeUs != 0 {
+			t.Errorf("recorded &0 round-trip = %v, want &0 (non-nil)", loaded.Records[0].ThinkTimeUs)
+		}
+		if loaded.Records[1].ThinkTimeUs == nil || *loaded.Records[1].ThinkTimeUs != 5000 {
+			t.Errorf("recorded &5000 round-trip = %v, want &5000", loaded.Records[1].ThinkTimeUs)
+		}
+	})
+
+	t.Run("mixed presence: nil / &0 / &N round-trip distinctly (#1608)", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		// nil = not recorded (empty cell); &0 = recorded zero ("0"); &N = recorded N.
+		// think_time_us is the last trailing column, so a nil is an empty trailing field.
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: nil},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ThinkTimeUs: i64p(0)},
+			{RequestID: 2, SessionID: "A", RoundIndex: 2, InputTokens: 70, OutputTokens: 30, ThinkTimeUs: i64p(9000)},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[0].ThinkTimeUs != nil {
+			t.Errorf("record 0 (nil) round-trip = %v, want nil (empty cell)", loaded.Records[0].ThinkTimeUs)
+		}
+		if loaded.Records[1].ThinkTimeUs == nil || *loaded.Records[1].ThinkTimeUs != 0 {
+			t.Errorf("record 1 (&0) round-trip = %v, want &0 (distinct from nil)", loaded.Records[1].ThinkTimeUs)
+		}
+		if loaded.Records[2].ThinkTimeUs == nil || *loaded.Records[2].ThinkTimeUs != 9000 {
+			t.Errorf("record 2 (&9000) round-trip = %v, want &9000", loaded.Records[2].ThinkTimeUs)
 		}
 	})
 
@@ -1175,8 +1208,34 @@ func TestTraceV2_ThinkTimeUs_RoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadTraceV2: %v", err)
 		}
-		if loaded.Records[1].ThinkTimeUs != 0 {
-			t.Errorf("absent column: ThinkTimeUs = %d, want 0", loaded.Records[1].ThinkTimeUs)
+		if loaded.Records[1].ThinkTimeUs != nil {
+			t.Errorf("absent column: ThinkTimeUs = %v, want nil", loaded.Records[1].ThinkTimeUs)
+		}
+	})
+
+	t.Run("lone recorded &0 emits column (BC-5, was omitted pre-#1608)", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		// A single recorded &0 (with all other records nil) now emits the column —
+		// pre-#1608 the != 0 gate would have omitted it, losing the recorded zero.
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: nil},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, ThinkTimeUs: i64p(0)},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		data, _ := os.ReadFile(dataPath)
+		if !strings.Contains(string(data), "think_time_us") {
+			t.Error("think_time_us column omitted when a record recorded &0 (must be present, BC-5)")
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[1].ThinkTimeUs == nil || *loaded.Records[1].ThinkTimeUs != 0 {
+			t.Errorf("lone &0 round-trip = %v, want &0", loaded.Records[1].ThinkTimeUs)
 		}
 	})
 }
@@ -1189,7 +1248,7 @@ func TestParseTraceRecord_NegativeThinkTime_Errors(t *testing.T) {
 	dataPath := filepath.Join(dir, "d.csv")
 	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
 	records := []TraceRecord{
-		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: 5000},
+		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ThinkTimeUs: i64p(5000)},
 	}
 	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
 		t.Fatalf("ExportTraceV2: %v", err)
@@ -1248,8 +1307,8 @@ func TestExportTraceV2_ThinkTimeUs_CoexistsWithAdapterAndXRequestID(t *testing.T
 	dp := filepath.Join(dir, "d.csv")
 	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "real"} // real → x_request_id emitted
 	records := []TraceRecord{
-		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, Adapter: "sql-lora", XRequestID: "uuid-0", ThinkTimeUs: 0},
-		{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, Adapter: "sql-lora", XRequestID: "uuid-1", ThinkTimeUs: 7000},
+		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, Adapter: "sql-lora", XRequestID: "uuid-0", ThinkTimeUs: i64p(0)},
+		{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40, Adapter: "sql-lora", XRequestID: "uuid-1", ThinkTimeUs: i64p(7000)},
 	}
 	if err := ExportTraceV2(header, records, hp, dp); err != nil {
 		t.Fatalf("ExportTraceV2: %v", err)
@@ -1259,11 +1318,11 @@ func TestExportTraceV2_ThinkTimeUs_CoexistsWithAdapterAndXRequestID(t *testing.T
 		t.Fatalf("LoadTraceV2: %v", err)
 	}
 	r := loaded.Records[1]
-	if r.Adapter != "sql-lora" || r.XRequestID != "uuid-1" || r.ThinkTimeUs != 7000 {
-		t.Errorf("coexistence round-trip: adapter=%q xreq=%q think=%d; want sql-lora/uuid-1/7000", r.Adapter, r.XRequestID, r.ThinkTimeUs)
+	if r.Adapter != "sql-lora" || r.XRequestID != "uuid-1" || r.ThinkTimeUs == nil || *r.ThinkTimeUs != 7000 {
+		t.Errorf("coexistence round-trip: adapter=%q xreq=%q think=%v; want sql-lora/uuid-1/&7000", r.Adapter, r.XRequestID, r.ThinkTimeUs)
 	}
-	if loaded.Records[0].ThinkTimeUs != 0 {
-		t.Errorf("record 0 think_time_us = %d, want 0", loaded.Records[0].ThinkTimeUs)
+	if loaded.Records[0].ThinkTimeUs == nil || *loaded.Records[0].ThinkTimeUs != 0 {
+		t.Errorf("record 0 think_time_us = %v, want &0 (recorded zero, non-nil)", loaded.Records[0].ThinkTimeUs)
 	}
 }
 

--- a/sim/workload/weka_convert.go
+++ b/sim/workload/weka_convert.go
@@ -118,7 +118,11 @@ func ConvertWekaSession(raw []byte, opts WekaConvertOptions) ([]TraceRecord, err
 	// pure client think (#1478), preferred over arrival-gap think at replay.
 	rounds := make([]NormalizedRound, 0, len(turns))
 	for i, tn := range turns {
-		var thinkUs int64
+		// Round 0 has no predecessor → think is not recorded (nil, #1608). Rounds
+		// 1..N carry the recomputed pure client think — including a recorded &0 when
+		// the turn overlapped the previous response, which is now distinguishable
+		// from "not recorded" (no longer degrades an all-overlap session to gaps).
+		var thinkUs *int64
 		if i > 0 {
 			prev := turns[i-1]
 			// Pure client think: wall-clock from the previous turn's RESPONSE
@@ -130,7 +134,7 @@ func ConvertWekaSession(raw []byte, opts WekaConvertOptions) ([]TraceRecord, err
 			if opts.MaxThinkTimeUs > 0 && gapUs > opts.MaxThinkTimeUs {
 				gapUs = opts.MaxThinkTimeUs
 			}
-			thinkUs = gapUs
+			thinkUs = &gapUs
 		}
 		rounds = append(rounds, NormalizedRound{
 			InputTokensAbs: tn.in,

--- a/sim/workload/weka_convert_test.go
+++ b/sim/workload/weka_convert_test.go
@@ -91,22 +91,23 @@ func TestConvertWekaSession_ThinkTimeRecompute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConvertWekaSession: %v", err)
 	}
-	if recs[0].ThinkTimeUs != 0 {
-		t.Errorf("round0 think = %d, want 0 (round 0 has no predecessor)", recs[0].ThinkTimeUs)
+	if recs[0].ThinkTimeUs != nil {
+		t.Errorf("round0 think = %v, want nil (round 0 has no predecessor → not recorded, #1608)", recs[0].ThinkTimeUs)
 	}
 	// Round 1 think absorbs the skipped sub-agent group's wall-clock: 5.0s.
-	if recs[1].ThinkTimeUs != 5_000_000 {
-		t.Errorf("round1 think = %d, want 5e6 (t1−t0−api0 = 6−0−1, absorbs sub-agent wall-clock; == recorded think_time 5.0)", recs[1].ThinkTimeUs)
+	if recs[1].ThinkTimeUs == nil || *recs[1].ThinkTimeUs != 5_000_000 {
+		t.Errorf("round1 think = %v, want &5e6 (t1−t0−api0 = 6−0−1, absorbs sub-agent wall-clock; == recorded think_time 5.0)", recs[1].ThinkTimeUs)
 	}
 	// Round 2 think: consecutive main turns, no sub-agent between: 2.0s.
-	if recs[2].ThinkTimeUs != 2_000_000 {
-		t.Errorf("round2 think = %d, want 2e6 (t2−t1−api1 = 10−6−2; == recorded think_time 2.0)", recs[2].ThinkTimeUs)
+	if recs[2].ThinkTimeUs == nil || *recs[2].ThinkTimeUs != 2_000_000 {
+		t.Errorf("round2 think = %v, want &2e6 (t2−t1−api1 = 10−6−2; == recorded think_time 2.0)", recs[2].ThinkTimeUs)
 	}
 }
 
 // T3 — overlapping main turns (round i arrives before round i-1's response
-// elapsed → negative raw gap, real in these traces) yield ThinkTimeUs == 0,
-// never negative (INV-3, BC-4). Mirrors the input-delta clamp.
+// elapsed → negative raw gap, real in these traces) yield a RECORDED &0
+// (non-nil), never negative and never conflated with "not recorded" (INV-3, BC-4,
+// BC-6 #1608). Mirrors the input-delta clamp.
 func TestConvertWekaSession_NegativeGapThinkClampsToZero(t *testing.T) {
 	// Round 1 arrives at t=1.0 but round 0's response ends at 0.0+2.0=2.0 →
 	// raw gap 1.0−0.0−2.0 = −1.0s → clamp to 0.
@@ -118,8 +119,13 @@ func TestConvertWekaSession_NegativeGapThinkClampsToZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConvertWekaSession: %v", err)
 	}
-	if recs[1].ThinkTimeUs != 0 {
-		t.Errorf("round1 think = %d, want 0 (negative raw gap clamped; never negative)", recs[1].ThinkTimeUs)
+	// The overlap is a RECORDED zero, not an absent think: non-nil &0 (#1608), so an
+	// all-overlap session no longer degrades to arrival-gap think at replay.
+	if recs[1].ThinkTimeUs == nil {
+		t.Fatal("round1 think = nil, want recorded &0 (overlap clamps to a RECORDED zero, #1608)")
+	}
+	if *recs[1].ThinkTimeUs != 0 {
+		t.Errorf("round1 think = %d, want 0 (negative raw gap clamped; never negative)", *recs[1].ThinkTimeUs)
 	}
 }
 
@@ -134,15 +140,15 @@ func TestConvertWekaSession_MaxThinkTimeCapAndUncapped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("capped: %v", err)
 	}
-	if capped[1].ThinkTimeUs != 15_000_000 {
-		t.Errorf("capped think = %d, want 15e6", capped[1].ThinkTimeUs)
+	if capped[1].ThinkTimeUs == nil || *capped[1].ThinkTimeUs != 15_000_000 {
+		t.Errorf("capped think = %v, want &15e6", capped[1].ThinkTimeUs)
 	}
 	uncapped, err := ConvertWekaSession([]byte(j), WekaConvertOptions{MinRounds: 1, MaxThinkTimeUs: 0})
 	if err != nil {
 		t.Fatalf("uncapped: %v", err)
 	}
-	if uncapped[1].ThinkTimeUs != 100_000_000 {
-		t.Errorf("uncapped think = %d, want 100e6 (no cap when MaxThinkTimeUs == 0)", uncapped[1].ThinkTimeUs)
+	if uncapped[1].ThinkTimeUs == nil || *uncapped[1].ThinkTimeUs != 100_000_000 {
+		t.Errorf("uncapped think = %v, want &100e6 (no cap when MaxThinkTimeUs == 0)", uncapped[1].ThinkTimeUs)
 	}
 }
 
@@ -242,8 +248,8 @@ func TestConvertWekaSession_DropsMainTurnMissingTokens(t *testing.T) {
 		t.Errorf("survivor round1 = ri %d in %d, want 1/40", recs[1].RoundIndex, recs[1].InputTokens)
 	}
 	// Think for the kept round spans the dropped turn: t2-t0-api0 = 8-0-1 = 7s.
-	if recs[1].ThinkTimeUs != 7_000_000 {
-		t.Errorf("round1 think = %d, want 7e6 (dropped turn's wall-clock absorbed into the gap)", recs[1].ThinkTimeUs)
+	if recs[1].ThinkTimeUs == nil || *recs[1].ThinkTimeUs != 7_000_000 {
+		t.Errorf("round1 think = %v, want &7e6 (dropped turn's wall-clock absorbed into the gap)", recs[1].ThinkTimeUs)
 	}
 }
 


### PR DESCRIPTION
## Summary

`TraceRecord.ThinkTimeUs` (the `think_time_us` column, #1478) used `0` as a **lossy
sentinel** meaning "not recorded". A closed-loop session whose every round genuinely
recorded `think == 0` — real for the Weka converter's overlap-clamped turns (`blis
convert weka`, #1604/#1605) — was therefore indistinguishable from a session with no
recorded think at all, and `LoadTraceV2SessionBlueprints` fell back to **arrival-gap
derivation** for it. Arrival-gap think bundles service time into the gap — the very
effect `think_time_us` exists to avoid.

This PR makes the encoding **non-lossy** by turning `TraceRecord.ThinkTimeUs` and the
reader→encoder `NormalizedRound.ThinkUs` into `*int64` **presence signals**:

- `nil` = not recorded → CSV cell is empty; replay falls back to arrival gaps.
- non-nil (**including `&0`**) = recorded → CSV cell is the integer (`"0"` for a
  recorded zero); replay prefers it.

The CSV parser *already* distinguished an empty cell from `"0"` (it only parsed a
non-empty cell); the gaps were that the in-memory `int64` could not represent "absent"
and the writer always formatted the integer. `*int64` closes both, and — crucially —
makes the struct's **zero value (`nil`) mean the correct default** ("not recorded"), so
every existing `TraceRecord{…}` literal that omits think stays correct with no edit.

### Design choice (issue offered `-1` sentinel *or* a presence signal)

Chose the presence signal, realized as `*int64`, over a `-1` sentinel because:
- With `-1`, a fresh `TraceRecord{}` defaults to `0` = "recorded zero" — the wrong
  default and an R4 construction-site footgun. With `*int64`, `nil` = "not recorded" is
  the correct default.
- `-1` would need a carve-out in the parser, which currently rejects **all** negative
  think times (INV-3). `*int64` keeps that intact.
- Pointer-for-optional-where-zero-is-valid is the same principle rules.md R9 applies to
  YAML config fields.

**No trace-version bump** — this refines the *cell encoding* of an existing optional CSV
column, not the header schema. It degrades gracefully both directions: old code reading a
new trace reads an empty cell as its old `0` sentinel; new code reading an old trace reads
old `"0"` cells as recorded — which is the corrected behavior. (Consistent with precedent:
the trailing `adapter`/`think_time_us`/`x_request_id` columns were all added without a bump.)

> **Intentional behavior change:** replaying a pre-existing Weka trace whose main turns
> all overlapped (all `"0"`) now uses the recorded zeros (back-to-back rounds) instead of
> degrading to arrival gaps. This is the fix. `blis run` and `convert otel` outputs are
> unchanged (they never set think → nil → no column, INV-6/INV-13).

## Behavioral Contracts

- **BC-1** GIVEN a session whose every non-round-0 round records think == 0 (non-nil `&0`)
  WHEN loaded THEN closed-loop replay uses the recorded zeros, NOT arrival gaps.
- **BC-2 / BC-7** GIVEN a session whose non-round-0 rounds are all `nil` (OTel, generated)
  WHEN loaded THEN replay derives think from arrival gaps (byte-identical to pre-#1608).
- **BC-3** GIVEN records mixing `nil` / `&0` / `&N` WHEN exported then re-loaded THEN each
  round's presence and value round-trip exactly (`nil`↔empty cell, `&0`↔`"0"`, `&N`↔`"N"`).
- **BC-4** GIVEN every record's think is `nil` WHEN exported THEN no `think_time_us` column
  is written (`blis run` / `convert otel` byte-identical, INV-6).
- **BC-5** GIVEN at least one record with non-nil think (incl. `&0`) THEN the column is present.
- **BC-6** GIVEN a Weka session WHEN converted THEN round 0's think is `nil` and an
  overlapping turn is a recorded `&0`.
- **BC-8** A `think_time_us` cell with a negative value is still a hard load error (INV-3).

## Testing

`go build ./...` clean · `go test ./...` all pass (13/13 packages) · `golangci-lint run ./...` 0 issues.

New / updated tests (`sim/workload`, `cmd`):
- `TestLoadTraceV2SessionBlueprints_AllRecordedZeroThink_UsesRecordedZeros` (BC-1; replaces
  the old `…_AllZeroRecordedThink_FallsBackToGap`, which pinned the lossy-sentinel behavior).
- `TestLoadTraceV2SessionBlueprints_AbsentThink_FallsBackToGap` (BC-2, the surviving fallback).
- `TestTraceV2_ThinkTimeUs_RoundTrip` extended: `mixed presence: nil / &0 / &N round-trip
  distinctly` (BC-3) and `lone recorded &0 emits column` (BC-5).
- `TestLoadTraceV2SessionBlueprints_MixedThinkSessions` updated for per-session selection.
- `TestConvertWekaSession_NegativeGapThinkClampsToZero` now asserts the overlap is a recorded
  `&0` (non-nil), not absent (BC-6).

## Affected code

`sim/workload/tracev2.go` (`ThinkTimeUs *int64` + export gate/writer/parser),
`sim/workload/replay.go` (`sessionHasRecordedThinkTime` presence test + sampler deref),
`sim/workload/trace_encode.go` (`NormalizedRound.ThinkUs *int64`),
`sim/workload/weka_convert.go`, `sim/workload/otel_convert.go` (doc), plus `CLAUDE.md`
and `docs/guide/observe-replay-calibrate.md`.

Closes #1608