### PR TITLE
feat(workload): represent context compaction in accumulate replay (#1609)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,17 +227,22 @@ go build -o blis main.go
 # = uncapped, since Weka gaps are genuine away-from-keyboard times). Reads `in` directly
 # (never len(hash_ids)×64). Weka ISL is huge (p50 ≈ 110K, p90 ≈ 395K), so replay MUST raise
 # --max-model-len (the ~41K default drops every request unservable) and scale --total-kv-blocks.
-# Fidelity note (important): real agentic traces compact/trim context heavily — ~30% of
+# Context compaction (#1609): real agentic traces compact/trim context heavily — ~30% of
 # rounds on the full 051926 dataset (219 sessions, 37.7K rounds) have in_N < in_{N-1}+out_{N-1}.
-# Such non-monotone rounds clamp their input delta to 0 (the accumulate buffer can only grow,
-# never shrink), so it OVER-counts the true cumulative input by ≈3–4× on real Claude Code
-# traffic (+312% on this dataset). Replayed input length / KV pressure / hit-rate is therefore
-# a substantial UPPER BOUND — do NOT read it as a faithful reproduction of the recorded ISL.
-# (Property of the PR-A/PR-B accumulate delta law, not this converter; the conversion is exact
-# per that law. Faithful compaction support is tracked in #1609.) The recorded think time is
-# non-lossy (#1608): a genuinely-zero recorded think (an overlapping turn) is a &0 in the
-# think_time_us column, distinct from a not-recorded (empty) cell, so an all-overlap session
-# uses the recorded zeros rather than degrading to arrival-gap think at replay.
+# The shared encoder now emits a per-round input_tokens_reset marker (the recorded absolute)
+# on exactly those non-monotone rounds, and accumulate closed-loop replay RE-SEEDS its growing
+# buffer to that absolute at the boundary — so the reconstructed input tracks the recorded
+# cumulative input (previously it clamped the delta to 0 and over-counted by ≈3–4× / +312% on
+# this dataset). Re-seeding intentionally breaks strict prefix identity across the compaction
+# boundary (the summary is not a literal prefix of the pre-compaction buffer), which also
+# corrects the prefix-cache hit-rate over-estimate. The marker is a trailing conditional CSV
+# column, absent for monotone sessions and for `blis run`, so a trace without any compaction
+# round replays byte-identically to before (INV-6). Traces converted by an OLDER build (no
+# marker column) still over-count — re-run convert to get compaction-aware output.
+# The recorded think time is likewise non-lossy (#1608): a genuinely-zero recorded think (an
+# overlapping turn) is a &0 in the think_time_us column, distinct from a not-recorded (empty)
+# cell, so an all-overlap session uses the recorded zeros rather than degrading to arrival-gap
+# think at replay.
 ./blis convert weka --input traces.jsonl --trace-output corpus \
   --context-growth accumulate --max-think-time 0
 #

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -401,18 +401,24 @@ distinct from a not-recorded (empty) cell, so an all-overlap session replays wit
 recorded zeros rather than degrading to arrival-gap think. The recorded `claude-*`
 model names are dropped during conversion (same routing-safety reason as OTel).
 
-!!! warning "Weka replay ISL is an upper bound (context compaction)"
+!!! note "Context compaction is represented (#1609)"
     Weka input token counts are very large (p50 ≈ 110K, p90 ≈ 395K), so the
     `--max-model-len` / `--total-kv-blocks` sizing warning above applies with extra
-    force. More subtly: real Claude Code traffic **compacts/trims context constantly**
-    — ~30% of rounds on the full `051926` dataset have `in_N < in_{N-1}+out_{N-1}`.
-    The accumulate buffer can only grow, never shrink, so each such round clamps its
-    input delta to 0 and the reconstructed cumulative input **over-counts the recorded
-    total by ≈3–4×** (+312% on that dataset). Treat replayed input length, KV pressure,
-    and hit-rate as a substantial **upper bound**, not a faithful reproduction of the
-    recorded workload. (This is a property of the accumulate delta law, not the
-    converter; faithful compaction support is tracked in #1609. The separate
-    think-time lossy-0 sentinel was resolved in #1608 — see the non-lossy note above.)
+    force. Real Claude Code traffic **compacts/trims context constantly** — ~30% of
+    rounds on the full `051926` dataset have `in_N < in_{N-1}+out_{N-1}` (the model
+    summarized or trimmed). The shared agentic-trace encoder emits a per-round
+    `input_tokens_reset` marker (the recorded absolute) on exactly those non-monotone
+    rounds, and accumulate closed-loop replay **re-seeds its growing buffer to that
+    absolute at the compaction boundary**. The reconstructed cumulative input therefore
+    tracks the recorded total — previously the buffer could only grow, clamped the delta
+    to 0, and **over-counted by ≈3–4×** (+312% on that dataset). The re-seed intentionally
+    breaks strict prefix identity across the boundary (a summary is not a literal prefix of
+    the pre-compaction context), which also corrects the prefix-cache hit-rate over-estimate.
+    The marker is a trailing conditional CSV column: absent for monotone sessions and for
+    `blis run`, so a trace with no compaction round replays byte-identically to before
+    (INV-6). Traces converted by an **older build** (no marker column) still over-count —
+    re-run `convert` to get compaction-aware output. (The separate think-time lossy-0
+    sentinel was resolved in #1608 — see the non-lossy note above.)
 
 ---
 

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -295,7 +295,9 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 	var requests []*sim.Request
 	var blueprints []SessionBlueprint
 
-	// Growth mode from header (design §5): "accumulate" → strict growing prefix.
+	// Growth mode from header (design §5): "accumulate" → growing shared prefix,
+	// shrunk back to the recorded absolute at a context-compaction boundary when the
+	// trace carries input_tokens_reset markers (#1609).
 	// Validate up front: an unrecognized value (e.g. a typo like "Accumulate") would
 	// otherwise fall through to the non-accumulate branch silently, disabling the
 	// feature with no feedback — an operator footgun. Fail loudly instead (R1).

--- a/sim/workload/replay.go
+++ b/sim/workload/replay.go
@@ -319,6 +319,30 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 			outputSeq[i] = rec.OutputTokens
 		}
 
+		// Context-compaction reset targets (#1609), aligned with inputSeq. A round's
+		// input_tokens_reset marker (non-nil) becomes its absolute re-seed length; a
+		// round without one gets the -1 "no reset" sentinel. Only meaningful in
+		// accumulate mode, and only built when at least one round 1..N actually carries
+		// a marker — so a trace with no compaction column (or a monotone session within
+		// a compaction-bearing corpus) leaves InputResetSampler nil and replays
+		// byte-identically to pre-#1609 (INV-6).
+		var inputResetSampler LengthSampler
+		if contextGrowth == "accumulate" {
+			resetSeq := make([]int, len(rounds))
+			anyReset := false
+			for i, rec := range rounds {
+				if i > 0 && rec.InputTokensReset != nil {
+					resetSeq[i] = int(*rec.InputTokensReset)
+					anyReset = true
+				} else {
+					resetSeq[i] = -1 // no reset this round
+				}
+			}
+			if anyReset {
+				inputResetSampler = &SequenceSampler{values: resetSeq[1:]} // rounds 1..N, lockstep with InputSampler
+			}
+		}
+
 		// Build think time. Precedence (#1478):
 		//   1. caller-provided sampler (CLI --think-time-dist / --think-time-ms)
 		//   2. recorded per-round think_time_us column (set by agentic-trace converters):
@@ -409,21 +433,22 @@ func LoadTraceV2SessionBlueprints(trace *TraceV2, seed int64, thinkTimeSampler L
 		requests = append(requests, req)
 
 		bp := SessionBlueprint{
-			SessionID:        sessionID,
-			ClientID:         r0.ClientID,
-			MaxRounds:        len(rounds),
-			ContextGrowth:    contextGrowth,
-			ThinkTimeSampler: sessionThinkTimeSampler,
-			Horizon:          horizon,
-			InputSampler:     &SequenceSampler{values: inputSeq[1:]},  // rounds 1..N
-			OutputSampler:    &SequenceSampler{values: outputSeq[1:]}, // rounds 1..N
-			RNG:              sessionRNG,
-			Prefix:           prefix,
-			TenantID:         r0.TenantID,
-			SLOClass:         r0.SLOClass,
-			Model:            r0.Model,
-			SLOTargetUs:      r0.SLOTargetUs,
-			Adapter:          r0.Adapter, // #1464: adapter threads through session follow-up rounds
+			SessionID:         sessionID,
+			ClientID:          r0.ClientID,
+			MaxRounds:         len(rounds),
+			ContextGrowth:     contextGrowth,
+			ThinkTimeSampler:  sessionThinkTimeSampler,
+			Horizon:           horizon,
+			InputSampler:      &SequenceSampler{values: inputSeq[1:]},  // rounds 1..N
+			OutputSampler:     &SequenceSampler{values: outputSeq[1:]}, // rounds 1..N
+			InputResetSampler: inputResetSampler,                       // #1609; nil unless a round compacts
+			RNG:               sessionRNG,
+			Prefix:            prefix,
+			TenantID:          r0.TenantID,
+			SLOClass:          r0.SLOClass,
+			Model:             r0.Model,
+			SLOTargetUs:       r0.SLOTargetUs,
+			Adapter:           r0.Adapter, // #1464: adapter threads through session follow-up rounds
 		}
 		blueprints = append(blueprints, bp)
 	}

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -1466,6 +1466,62 @@ func TestAccumulateReplay_ZeroReset_EmptyBuffer(t *testing.T) {
 	}
 }
 
+// TestAccumulateReplay_ConsecutiveCompactions covers back-to-back compaction rounds
+// (qa-review G9): a session that compacts on two consecutive turns (abs 200 → 150 → 100)
+// must re-seed the buffer to the recorded absolute EACH round, with the continuity
+// invariant holding across successive resets (each reset installs a fresh buffer; the
+// next completion validates its length before resetting again) and strict prefix identity
+// broken at every compaction boundary.
+func TestAccumulateReplay_ConsecutiveCompactions(t *testing.T) {
+	// abs: 200, then 150 (150 < 200+10), then 100 (100 < 150+5) — two compactions in a row.
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 200, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 0, OutputTokens: 5, ArrivalTimeUs: 1_000_000, InputTokensReset: i64p(150)},
+			{RequestID: 2, SessionID: "s", RoundIndex: 2, InputTokens: 0, OutputTokens: 5, ArrivalTimeUs: 2_000_000, InputTokensReset: i64p(100)},
+		},
+	}
+	r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sm := NewSessionManager(bps)
+	next := func(req *sim.Request, tick int64) *sim.Request {
+		req.State = sim.StateCompleted
+		req.ProgressIndex = int64(req.InputLen()) + int64(len(req.OutputTokens))
+		fu := sm.OnComplete(req, tick)
+		if len(fu) != 1 {
+			t.Fatalf("expected 1 follow-up, got %d", len(fu))
+		}
+		return fu[0]
+	}
+
+	round1 := next(r0[0], 1_000_000)
+	round1In := append([]sim.TokenID{}, round1.FullInputTokens()...)
+	if round1.InputLen() != 150 {
+		t.Fatalf("compaction round1 len = %d, want 150 (re-seed to recorded absolute)", round1.InputLen())
+	}
+	// Second consecutive compaction: buffer must reset AGAIN to the new absolute (100),
+	// not accumulate on top of the first reset (which would give 150+5+0 = 155).
+	round2 := next(round1, 2_000_000)
+	if round2.InputLen() != 100 {
+		t.Fatalf("consecutive compaction round2 len = %d, want 100 (second re-seed, not 155)", round2.InputLen())
+	}
+	// Strict prefix identity broken at the second boundary too (fresh segment).
+	round2In := round2.FullInputTokens()
+	prefixIdentical := true
+	for i := 0; i < 100; i++ {
+		if round2In[i] != round1In[i] {
+			prefixIdentical = false
+			break
+		}
+	}
+	if prefixIdentical {
+		t.Error("round2 is a strict prefix of round1 — each consecutive compaction must break prefix identity")
+	}
+}
+
 // TestAccumulateReplay_NoResetSampler_WhenMonotone pins BC-5: an accumulate trace
 // with no compaction marker builds NO reset sampler, so replay stays on the
 // pre-#1609 append-only path (byte-identical, INV-6).

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -1342,3 +1342,101 @@ func TestAccumulateReplay_TransitivityAndLengthCap(t *testing.T) {
 		}
 	})
 }
+
+// TestAccumulateReplay_CompactionResetsBuffer covers #1609: a round whose trace
+// carries an input_tokens_reset marker (context compaction) re-seeds the accumulate
+// buffer to the recorded absolute — shrinking the reconstructed input to in_N exactly
+// and intentionally breaking strict prefix identity across the boundary — while
+// monotone rounds (before AND after the compaction) keep the growing-prefix behavior.
+func TestAccumulateReplay_CompactionResetsBuffer(t *testing.T) {
+	// Recorded absolutes: 100 → 150(mono) → 50(COMPACTION, 50 < 150+20) → 80(mono).
+	// As delta-encoded records: round2 carries delta 0 + InputTokensReset=&50.
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 1_000_000},
+			{RequestID: 2, SessionID: "s", RoundIndex: 2, InputTokens: 0, OutputTokens: 5, ArrivalTimeUs: 2_000_000, InputTokensReset: i64p(50)},
+			{RequestID: 3, SessionID: "s", RoundIndex: 3, InputTokens: 25, OutputTokens: 5, ArrivalTimeUs: 3_000_000},
+		},
+	}
+	r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// The loader must build a reset sampler for a compaction-bearing session.
+	if bps[0].InputResetSampler == nil {
+		t.Fatal("InputResetSampler = nil, want a sampler (session carries a compaction marker)")
+	}
+	sm := NewSessionManager(bps)
+
+	next := func(req *sim.Request, tick int64) *sim.Request {
+		req.State = sim.StateCompleted
+		req.ProgressIndex = int64(req.InputLen()) + int64(len(req.OutputTokens)) // full output generated
+		fu := sm.OnComplete(req, tick)
+		if len(fu) != 1 {
+			t.Fatalf("expected 1 follow-up, got %d", len(fu))
+		}
+		return fu[0]
+	}
+
+	round1 := next(r0[0], 1_000_000)
+	if round1.InputLen() != 150 { // 100 + 10 output + 40 delta — normal accumulate
+		t.Fatalf("round1 len = %d, want 150 (monotone accumulate)", round1.InputLen())
+	}
+	round1In := append([]sim.TokenID{}, round1.FullInputTokens()...)
+
+	round2 := next(round1, 2_000_000)
+	// BC-2: buffer shrinks to the recorded absolute (50), NOT the over-counted
+	// 150+20+0 = 170 the append-only buffer would have produced.
+	if round2.InputLen() != 50 {
+		t.Fatalf("compaction round2 len = %d, want 50 (re-seeded to recorded absolute, not 170)", round2.InputLen())
+	}
+	// BC-3: strict prefix identity is broken across the compaction boundary —
+	// round2 is a fresh segment, not a token-prefix of round1.
+	round2In := round2.FullInputTokens()
+	prefixIdentical := true
+	for i := 0; i < 50; i++ {
+		if round2In[i] != round1In[i] {
+			prefixIdentical = false
+			break
+		}
+	}
+	if prefixIdentical {
+		t.Error("round2 is a strict prefix of round1 — compaction must break prefix identity (#1609)")
+	}
+
+	// BC-3 (other direction): a monotone round AFTER the compaction resumes the
+	// growing-prefix behavior from the re-seeded segment. round3 = 50 + 5 out + 25 delta.
+	round2FullIn := append([]sim.TokenID{}, round2In...)
+	round3 := next(round2, 3_000_000)
+	if round3.InputLen() != 80 {
+		t.Fatalf("post-compaction round3 len = %d, want 80 (50 + 5 output + 25 delta)", round3.InputLen())
+	}
+	got := round3.FullInputTokens()
+	for i := 0; i < 50; i++ {
+		if got[i] != round2FullIn[i] {
+			t.Fatalf("round3 token[%d] diverged from round2 — post-compaction prefix must be preserved", i)
+		}
+	}
+}
+
+// TestAccumulateReplay_NoResetSampler_WhenMonotone pins BC-5: an accumulate trace
+// with no compaction marker builds NO reset sampler, so replay stays on the
+// pre-#1609 append-only path (byte-identical, INV-6).
+func TestAccumulateReplay_NoResetSampler_WhenMonotone(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 40, OutputTokens: 20, ArrivalTimeUs: 1_000_000},
+		},
+	}
+	_, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if bps[0].InputResetSampler != nil {
+		t.Error("InputResetSampler != nil for a monotone accumulate session — must be nil (INV-6)")
+	}
+}

--- a/sim/workload/replay_test.go
+++ b/sim/workload/replay_test.go
@@ -1421,6 +1421,51 @@ func TestAccumulateReplay_CompactionResetsBuffer(t *testing.T) {
 	}
 }
 
+// TestAccumulateReplay_ZeroReset_EmptyBuffer exercises the degenerate `&0` reset
+// end-to-end through OnComplete (blis-pr-review coverage note): a compaction to an
+// absolute of 0 (full context discarded) makes the buffer empty. The follow-up round
+// then carries a 0-length input, and the buffer-continuity invariant still holds on the
+// NEXT round (req.InputLen()==buf.Len()==0). No shipped converter emits a 0-token round
+// (nil/0 in/out rounds are dropped at conversion), but the loader accepts &0, so this
+// pins that the reset path handles it without panicking rather than assuming InputLen()>0.
+func TestAccumulateReplay_ZeroReset_EmptyBuffer(t *testing.T) {
+	trace := &TraceV2{
+		Header: TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"},
+		Records: []TraceRecord{
+			{RequestID: 0, SessionID: "s", RoundIndex: 0, InputTokens: 100, OutputTokens: 10, ArrivalTimeUs: 0},
+			// round 1 compacts to an absolute of 0 (full context discarded).
+			{RequestID: 1, SessionID: "s", RoundIndex: 1, InputTokens: 0, OutputTokens: 5, ArrivalTimeUs: 1_000_000, InputTokensReset: i64p(0)},
+			// round 2 grows again from the empty buffer.
+			{RequestID: 2, SessionID: "s", RoundIndex: 2, InputTokens: 30, OutputTokens: 5, ArrivalTimeUs: 2_000_000},
+		},
+	}
+	r0, bps, err := LoadTraceV2SessionBlueprints(trace, 42, nil, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sm := NewSessionManager(bps)
+	next := func(req *sim.Request, tick int64) *sim.Request {
+		req.State = sim.StateCompleted
+		req.ProgressIndex = int64(req.InputLen()) + int64(len(req.OutputTokens))
+		fu := sm.OnComplete(req, tick)
+		if len(fu) != 1 {
+			t.Fatalf("expected 1 follow-up, got %d", len(fu))
+		}
+		return fu[0]
+	}
+
+	round1 := next(r0[0], 1_000_000)
+	if round1.InputLen() != 0 {
+		t.Fatalf("zero-reset round1 InputLen = %d, want 0 (buffer fully reset)", round1.InputLen())
+	}
+	// Continuity must still hold on the next round: growing from an empty buffer.
+	// round2 = 0 (buffer) + 5 (round1 actual output) + 30 (delta) = 35.
+	round2 := next(round1, 2_000_000)
+	if round2.InputLen() != 35 {
+		t.Fatalf("post-zero-reset round2 InputLen = %d, want 35 (0 + 5 output + 30 delta)", round2.InputLen())
+	}
+}
+
 // TestAccumulateReplay_NoResetSampler_WhenMonotone pins BC-5: an accumulate trace
 // with no compaction marker builds NO reset sampler, so replay stays on the
 // pre-#1609 append-only path (byte-identical, INV-6).

--- a/sim/workload/session.go
+++ b/sim/workload/session.go
@@ -27,24 +27,32 @@ const (
 // SessionBlueprint describes a session's full shape. Created during workload generation,
 // immutable after creation. Each session has its own deterministic RNG (INV-6).
 type SessionBlueprint struct {
-	SessionID        string
-	ClientID         string
-	MaxRounds        int
-	UnlimitedRounds  bool   // when true, session continues past MaxRounds until budget/horizon/timeout/drop
-	ContextGrowth    string // "accumulate" or ""
-	ThinkTimeUs      int64
-	Timeout          *int64 // per-request timeout from ClientSpec (nil = default 300s)
-	Horizon          int64  // simulation horizon for BC-19 guard
-	InputSampler     LengthSampler
-	OutputSampler    LengthSampler
-	RNG              *rand.Rand    // per-session, seeded deterministically from client RNG
-	ThinkTimeSampler LengthSampler // optional: per-round think time in µs; nil = use constant ThinkTimeUs
-	Prefix           []sim.TokenID // shared system prompt tokens
-	TenantID         string
-	SLOClass         string
-	Model            string
-	Adapter          string // LoRA adapter id (registry key; #1464). "" = base-model-only.
-	SLOTargetUs      int64  // per-request SLO TTFT target in µs; 0 = no target
+	SessionID       string
+	ClientID        string
+	MaxRounds       int
+	UnlimitedRounds bool   // when true, session continues past MaxRounds until budget/horizon/timeout/drop
+	ContextGrowth   string // "accumulate" or ""
+	ThinkTimeUs     int64
+	Timeout         *int64 // per-request timeout from ClientSpec (nil = default 300s)
+	Horizon         int64  // simulation horizon for BC-19 guard
+	InputSampler    LengthSampler
+	OutputSampler   LengthSampler
+	// InputResetSampler yields a per-follow-up-round context-compaction reset target
+	// (#1609), in lockstep with InputSampler: a value >= 0 means "re-seed the accumulate
+	// buffer to this absolute input length at this round" (a compaction boundary from the
+	// trace's input_tokens_reset column); a value < 0 (the -1 sentinel) means "no reset,
+	// use the delta". nil (the common case: monotone sessions, spec-built `blis run`
+	// blueprints) means no round resets, so the accumulate path is byte-identical to
+	// pre-#1609 (INV-6). Only consulted in ContextGrowth == "accumulate" mode.
+	InputResetSampler LengthSampler
+	RNG               *rand.Rand    // per-session, seeded deterministically from client RNG
+	ThinkTimeSampler  LengthSampler // optional: per-round think time in µs; nil = use constant ThinkTimeUs
+	Prefix            []sim.TokenID // shared system prompt tokens
+	TenantID          string
+	SLOClass          string
+	Model             string
+	Adapter           string // LoRA adapter id (registry key; #1464). "" = base-model-only.
+	SLOTargetUs       int64  // per-request SLO TTFT target in µs; 0 = no target
 }
 
 // activeSession tracks mutable per-session lifecycle state.
@@ -180,6 +188,13 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 	// Generate round N+1
 	inputLen := bp.InputSampler.Sample(bp.RNG)
 	outputLen := bp.OutputSampler.Sample(bp.RNG)
+	// Context-compaction reset target for this round (#1609): accumulate mode only,
+	// -1 = no reset. SequenceSampler.Sample ignores the RNG, so sampling it consumes
+	// no randomness and cannot perturb byte-identity of the non-compaction path (INV-6).
+	resetTarget := -1
+	if bp.ContextGrowth == "accumulate" && bp.InputResetSampler != nil {
+		resetTarget = bp.InputResetSampler.Sample(bp.RNG)
+	}
 	newInputTokens := sim.GenerateRandomTokenIDs(bp.RNG, inputLen)
 	outputTokens := sim.GenerateRandomTokenIDs(bp.RNG, outputLen)
 
@@ -238,30 +253,46 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 			panic(fmt.Sprintf("SessionManager.OnComplete: session %s req.InputLen=%d != buf.Len=%d — buffer continuity broken; expected req.InputTokens to alias buf[0:buf.Len()]",
 				req.SessionID, req.InputLen(), sess.buf.Len()))
 		}
-		// Append the round's actual output and the new round's input.
-		if actualOutputLen > 0 && len(req.OutputTokens) > 0 {
-			outTokens := req.OutputTokens
-			switch {
-			case actualOutputLen > len(outTokens):
-				// Over-cap defense: ProgressIndex accounting should never produce
-				// an actualOutputLen exceeding the oracle output length. If it
-				// does, cancel the session — the upstream computation has
-				// drifted and continuing would propagate the corruption to every
-				// subsequent round. Better to terminate one session loudly than
-				// silently corrupt many.
-				logrus.Errorf("SessionManager.OnComplete: session %s round %d actualOutputLen=%d > len(OutputTokens)=%d — cancelling session to contain corruption (ProgressIndex accounting drift)",
-					req.SessionID, req.RoundIndex, actualOutputLen, len(outTokens))
-				sess.state = sessionCancelled
-				return nil
-			case actualOutputLen < len(outTokens):
-				outTokens = outTokens[:actualOutputLen]
-				logrus.Debugf("SessionManager.OnComplete: session %s round %d length-capped — accumulating %d/%d output tokens",
-					req.SessionID, req.RoundIndex, actualOutputLen, len(req.OutputTokens))
+		if resetTarget >= 0 {
+			// Context compaction (#1609): the recorded absolute input for this round
+			// dropped below the accumulated length (the model summarized/trimmed), so
+			// the trace carries an input_tokens_reset marker. Re-seed the buffer to a
+			// fresh segment of exactly resetTarget tokens: this restores exact
+			// reconstruction (buf.Len() == recorded in_N, no over-count) and
+			// intentionally breaks strict prefix identity across the boundary — real
+			// compaction replaces the history with a summary, which is not a literal
+			// prefix of the pre-compaction buffer. The just-completed round's output is
+			// deliberately NOT carried forward: it was folded into the compaction the
+			// trace already recorded as in_N.
+			resetToks := sim.GenerateRandomTokenIDs(bp.RNG, resetTarget)
+			_, inputEnd := sess.buf.Reset(resetToks)
+			inputTokens = sess.buf.Slice(0, inputEnd)
+		} else {
+			// Append the round's actual output and the new round's input.
+			if actualOutputLen > 0 && len(req.OutputTokens) > 0 {
+				outTokens := req.OutputTokens
+				switch {
+				case actualOutputLen > len(outTokens):
+					// Over-cap defense: ProgressIndex accounting should never produce
+					// an actualOutputLen exceeding the oracle output length. If it
+					// does, cancel the session — the upstream computation has
+					// drifted and continuing would propagate the corruption to every
+					// subsequent round. Better to terminate one session loudly than
+					// silently corrupt many.
+					logrus.Errorf("SessionManager.OnComplete: session %s round %d actualOutputLen=%d > len(OutputTokens)=%d — cancelling session to contain corruption (ProgressIndex accounting drift)",
+						req.SessionID, req.RoundIndex, actualOutputLen, len(outTokens))
+					sess.state = sessionCancelled
+					return nil
+				case actualOutputLen < len(outTokens):
+					outTokens = outTokens[:actualOutputLen]
+					logrus.Debugf("SessionManager.OnComplete: session %s round %d length-capped — accumulating %d/%d output tokens",
+						req.SessionID, req.RoundIndex, actualOutputLen, len(req.OutputTokens))
+				}
+				sess.buf.Append(outTokens)
 			}
-			sess.buf.Append(outTokens)
+			_, inputEnd := sess.buf.Append(newInputTokens)
+			inputTokens = sess.buf.Slice(0, inputEnd)
 		}
-		_, inputEnd := sess.buf.Append(newInputTokens)
-		inputTokens = sess.buf.Slice(0, inputEnd)
 	} else {
 		inputTokens = newInputTokens
 		// Non-accumulate: prepend prefix freshly (no shared buffer in this mode).

--- a/sim/workload/session.go
+++ b/sim/workload/session.go
@@ -264,6 +264,10 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 			// prefix of the pre-compaction buffer. The just-completed round's output is
 			// deliberately NOT carried forward: it was folded into the compaction the
 			// trace already recorded as in_N.
+			//
+			// newInputTokens (generated above) is intentionally unused here: a compaction
+			// round's encoded delta is 0, so it is an empty slice — the reset segment below
+			// replaces the whole buffer instead of appending it.
 			resetToks := sim.GenerateRandomTokenIDs(bp.RNG, resetTarget)
 			_, inputEnd := sess.buf.Reset(resetToks)
 			inputTokens = sess.buf.Slice(0, inputEnd)

--- a/sim/workload/session.go
+++ b/sim/workload/session.go
@@ -268,6 +268,11 @@ func (sm *SessionManager) OnComplete(req *sim.Request, tick int64) []*sim.Reques
 			// newInputTokens (generated above) is intentionally unused here: a compaction
 			// round's encoded delta is 0, so it is an empty slice — the reset segment below
 			// replaces the whole buffer instead of appending it.
+			//
+			// The append branch's over-cap corruption defense (actualOutputLen >
+			// len(OutputTokens) => cancel session) is deliberately bypassed here: the reset
+			// discards the completed round's output entirely (it was folded into the recorded
+			// in_N), so ProgressIndex/actualOutputLen drift cannot propagate into the buffer.
 			resetToks := sim.GenerateRandomTokenIDs(bp.RNG, resetTarget)
 			_, inputEnd := sess.buf.Reset(resetToks)
 			inputTokens = sess.buf.Slice(0, inputEnd)

--- a/sim/workload/session_buffer.go
+++ b/sim/workload/session_buffer.go
@@ -88,6 +88,25 @@ func (s *sessionTokenBuffer) Slice(start, end int64) []sim.TokenID {
 	return s.b[start:end]
 }
 
+// Reset discards the buffer's accumulated context and re-seeds it with a copy of
+// toks, returning the new absolute [start, end) = [0, len(toks)). It is the shrink
+// operation the append-only buffer previously lacked (#1609): at a context-compaction
+// boundary the growing prefix is replaced by a fresh, shorter segment.
+//
+// A brand-new backing array is allocated (never an in-place s.b[:0] reuse) so slices
+// previously returned by Slice() — e.g. the just-completed round's Request.InputTokens —
+// keep pointing at the old array and remain content-correct, matching the reallocation-
+// hazard safety model documented on sessionTokenBuffer (a Slice result is read-only for
+// the simulator, and the old array's data is never mutated). The caller passes a
+// freshly-generated slice; copying keeps Reset's contract independent of caller aliasing,
+// mirroring Append.
+func (s *sessionTokenBuffer) Reset(toks []sim.TokenID) (start, end int64) {
+	nb := make([]sim.TokenID, len(toks))
+	copy(nb, toks)
+	s.b = nb
+	return 0, int64(len(nb))
+}
+
 // Len returns the number of tokens currently in the buffer.
 func (s *sessionTokenBuffer) Len() int64 {
 	return int64(len(s.b))

--- a/sim/workload/session_buffer_test.go
+++ b/sim/workload/session_buffer_test.go
@@ -116,6 +116,45 @@ func TestNewSessionTokenBufferWithCapacityRejectsNegative(t *testing.T) {
 // unchanged, even though further appends are no longer visible through
 // them. This locks in the "intentional, bounded" hazard documented in
 // session_buffer.go (susiejojo human review, #1445).
+// TestSessionTokenBufferResetShrinksAndPreservesOrphan verifies the #1609 shrink
+// operation: Reset replaces the accumulated contents with a shorter fresh segment
+// (returning the new [0,len) range), and — like Append's reallocation hazard — a
+// slice returned by a prior Slice() (e.g. the just-completed round's InputTokens)
+// stays content-correct because Reset allocates a NEW backing array rather than
+// mutating the old one in place.
+func TestSessionTokenBufferResetShrinksAndPreservesOrphan(t *testing.T) {
+	b := newSessionTokenBuffer()
+	b.Append([]sim.TokenID{1, 2, 3, 4, 5, 6})
+	prior := b.Slice(0, 6) // a view a completed round would hold
+	priorFirstAddr := &prior[0]
+
+	start, end := b.Reset([]sim.TokenID{7, 8})
+	if start != 0 || end != 2 {
+		t.Fatalf("Reset returned [%d,%d), want [0,2)", start, end)
+	}
+	if b.Len() != 2 {
+		t.Fatalf("buffer len after Reset = %d, want 2 (shrunk)", b.Len())
+	}
+	if got := b.Slice(0, 2); got[0] != 7 || got[1] != 8 {
+		t.Fatalf("buffer after Reset = %v, want [7 8]", got)
+	}
+
+	// Fresh backing array: the reset view must not alias the orphaned prior view.
+	if newView := b.Slice(0, 2); &newView[0] == priorFirstAddr {
+		t.Fatal("Reset reused the old backing array — orphaned prior view would be corrupted")
+	}
+	// Orphan stays content-correct (the pre-Reset round's input is unchanged).
+	want := []sim.TokenID{1, 2, 3, 4, 5, 6}
+	if !reflect.DeepEqual(prior, want) {
+		t.Fatalf("orphan slice content drifted after Reset: got %v, want %v", prior, want)
+	}
+
+	// The buffer keeps growing normally after a Reset.
+	if _, e := b.Append([]sim.TokenID{9}); e != 3 {
+		t.Fatalf("append after Reset ended at %d, want 3", e)
+	}
+}
+
 func TestSessionTokenBufferForcedReallocOrphanContentCorrect(t *testing.T) {
 	// Start with cap=4. The first Slice() returns a view of [1,2,3,4].
 	b := newSessionTokenBufferWithCapacity(4)

--- a/sim/workload/session_pool.go
+++ b/sim/workload/session_pool.go
@@ -55,6 +55,10 @@ func cloneBlueprintForDup(src SessionBlueprint, srcR0 *sim.Request, dupIdx int, 
 	bp.InputSampler = cloneSampler(src.InputSampler)
 	bp.OutputSampler = cloneSampler(src.OutputSampler)
 	bp.ThinkTimeSampler = cloneSampler(src.ThinkTimeSampler)
+	// #1609: the context-compaction reset sampler is a stateful *SequenceSampler in
+	// lockstep with InputSampler, so each clone needs its own cursor (cloneSampler
+	// passes nil through unchanged for monotone sessions).
+	bp.InputResetSampler = cloneSampler(src.InputResetSampler)
 
 	// Cache-busting token prepended to the clone's round-0 input so the block
 	// hash chain diverges immediately from the source session (design §6).

--- a/sim/workload/session_pool_test.go
+++ b/sim/workload/session_pool_test.go
@@ -214,11 +214,13 @@ func TestSessionPool_RefillAndConservation(t *testing.T) {
 // what a shared cursor would produce.
 func TestBuildSessionPool_ClonesHaveIndependentSamplers(t *testing.T) {
 	src := SessionBlueprint{
-		SessionID:     "s0",
-		MaxRounds:     3,
-		Horizon:       1 << 62,
-		InputSampler:  &SequenceSampler{values: []int{10, 20, 30}},
-		OutputSampler: &SequenceSampler{values: []int{1, 2, 3}},
+		SessionID:         "s0",
+		MaxRounds:         3,
+		Horizon:           1 << 62,
+		ContextGrowth:     "accumulate",
+		InputSampler:      &SequenceSampler{values: []int{10, 20, 30}},
+		OutputSampler:     &SequenceSampler{values: []int{1, 2, 3}},
+		InputResetSampler: &SequenceSampler{values: []int{-1, 50, -1}}, // #1609: round-1 compaction reset
 	}
 	srcR0 := &sim.Request{ID: "r_s0", SessionID: "s0", RoundIndex: 0, State: sim.StateQueued}
 
@@ -228,6 +230,18 @@ func TestBuildSessionPool_ClonesHaveIndependentSamplers(t *testing.T) {
 	// Pointer identity must differ: the clone must not alias the source's sampler.
 	if clone.InputSampler == src.InputSampler {
 		t.Fatalf("clone.InputSampler shares the same object as src.InputSampler")
+	}
+	// The #1609 reset sampler must likewise be cloned to an independent cursor —
+	// otherwise a source session and its duplicate corrupt each other's per-round
+	// compaction sequence.
+	if clone.InputResetSampler == src.InputResetSampler {
+		t.Fatalf("clone.InputResetSampler shares the same object as src.InputResetSampler")
+	}
+	// Advance the source's reset cursor one step (-1), then the clone must still
+	// yield the FIRST value (-1), not the source's advanced position.
+	_ = src.InputResetSampler.Sample(nil) // -1
+	if got := clone.InputResetSampler.Sample(nil); got != -1 {
+		t.Fatalf("clone InputResetSampler sample #1 = %d, want -1 (independent cursor)", got)
 	}
 
 	// Advance the source's cursor two steps: 10, then 20.

--- a/sim/workload/trace_encode.go
+++ b/sim/workload/trace_encode.go
@@ -21,9 +21,18 @@ type NormalizedRound struct {
 //
 // The delta law: round 0 carries the full first prompt; round N+1 carries
 // max(0, in_{N+1} − in_N − out_N). In accumulate replay the buffer appends
-// out_N then this delta, reconstructing the recorded absolute input (exactly for
-// monotonically-growing, non-length-capped sessions; non-monotone rounds clamp
-// to 0 and over-count by the clamped deficit — an accepted, documented deviation).
+// out_N then this delta, reconstructing the recorded absolute input exactly for
+// monotonically-growing, non-length-capped sessions.
+//
+// Context compaction (#1609): when in_{N+1} < in_N + out_N (the model summarized
+// or trimmed context, so the delta would go negative) the delta still clamps to
+// 0, but the record ALSO carries the recorded absolute input in InputTokensReset
+// (a *int64 presence marker; nil otherwise). Accumulate replay re-seeds its
+// growing buffer to that absolute at the boundary — restoring exact reconstruction
+// on non-monotone rounds and intentionally breaking strict prefix identity across
+// the compaction boundary (the summary is not a literal prefix of the pre-compaction
+// buffer). The marker is absent for monotone sessions and for spec-built `blis run`
+// blueprints, so a trace without it replays byte-identically to before (INV-6).
 //
 // TraceRecord.Model is left empty deliberately: it is routing-significant at
 // replay (buildRouterState filters instances by it), so writing a recorded
@@ -38,20 +47,28 @@ func EncodeSessionToTraceRecords(sessionID string, rounds []NormalizedRound) []T
 	prevIn, prevOut := 0, 0
 	for round, r := range rounds {
 		inputDelta := r.InputTokensAbs
+		var resetAbs *int64 // #1609: recorded absolute on a compaction round; nil otherwise
 		if round > 0 {
 			inputDelta = r.InputTokensAbs - prevIn - prevOut
 			if inputDelta < 0 {
-				inputDelta = 0 // clamp: non-monotone context (e.g. compaction/trimming)
+				// Non-monotone context (compaction/trimming): the delta would go
+				// negative. Clamp it to 0 as before (so an old reader still replays,
+				// over-counting) AND emit the recorded absolute so a compaction-aware
+				// accumulate replay re-seeds the buffer to it (#1609).
+				inputDelta = 0
+				abs := int64(r.InputTokensAbs)
+				resetAbs = &abs
 			}
 		}
 		recs = append(recs, TraceRecord{
-			SessionID:     sessionID,
-			RoundIndex:    round,
-			InputTokens:   inputDelta,
-			OutputTokens:  r.OutputTokens,
-			ArrivalTimeUs: r.ArrivalUs,
-			ThinkTimeUs:   r.ThinkUs,
-			Status:        r.Status,
+			SessionID:        sessionID,
+			RoundIndex:       round,
+			InputTokens:      inputDelta,
+			InputTokensReset: resetAbs,
+			OutputTokens:     r.OutputTokens,
+			ArrivalTimeUs:    r.ArrivalUs,
+			ThinkTimeUs:      r.ThinkUs,
+			Status:           r.Status,
 			// Model: intentionally empty — see doc comment.
 		})
 		prevIn, prevOut = r.InputTokensAbs, r.OutputTokens

--- a/sim/workload/trace_encode_test.go
+++ b/sim/workload/trace_encode_test.go
@@ -34,6 +34,22 @@ func TestEncodeSessionToTraceRecords_DeltaLaw(t *testing.T) {
 		t.Errorf("round2 delta = %d, want 0 (non-monotone clamp)", recs[2].InputTokens)
 	}
 
+	// Compaction marker (#1609): the non-monotone round (delta would clamp to a
+	// negative) carries the recorded absolute input as a reset target; every
+	// other round leaves it nil. Round 0 never carries a reset.
+	if recs[0].InputTokensReset != nil {
+		t.Errorf("round0 InputTokensReset = %v, want nil", *recs[0].InputTokensReset)
+	}
+	if recs[1].InputTokensReset != nil {
+		t.Errorf("round1 (monotone) InputTokensReset = %v, want nil", *recs[1].InputTokensReset)
+	}
+	if recs[2].InputTokensReset == nil {
+		t.Fatalf("round2 (compaction) InputTokensReset = nil, want &120")
+	}
+	if *recs[2].InputTokensReset != 120 {
+		t.Errorf("round2 InputTokensReset = %d, want 120 (recorded absolute)", *recs[2].InputTokensReset)
+	}
+
 	for i, r := range recs {
 		if r.RoundIndex != i {
 			t.Errorf("record %d RoundIndex = %d, want %d", i, r.RoundIndex, i)
@@ -62,5 +78,26 @@ func TestEncodeSessionToTraceRecords_DeltaLaw(t *testing.T) {
 	}
 	if recs[2].OutputTokens != 10 || recs[2].Status != "error" {
 		t.Errorf("round2 out/status = %d/%q, want 10/error", recs[2].OutputTokens, recs[2].Status)
+	}
+}
+
+// TestEncodeSessionToTraceRecords_MonotoneNoReset verifies a strictly-growing
+// session emits NO reset markers (#1609): every reconstruction is exact via the
+// delta law alone, so the compaction column stays absent (INV-6 byte-identity).
+func TestEncodeSessionToTraceRecords_MonotoneNoReset(t *testing.T) {
+	rounds := []NormalizedRound{
+		{InputTokensAbs: 100, OutputTokens: 50, Status: "ok"},
+		{InputTokensAbs: 200, OutputTokens: 80, Status: "ok"}, // 200 >= 100+50
+		{InputTokensAbs: 300, OutputTokens: 10, Status: "ok"}, // 300 >= 200+80
+	}
+	recs := EncodeSessionToTraceRecords("sess", rounds)
+	for i, r := range recs {
+		if r.InputTokensReset != nil {
+			t.Errorf("round%d InputTokensReset = %d, want nil (monotone)", i, *r.InputTokensReset)
+		}
+	}
+	// Deltas: 100, 50 (200-100-50), 20 (300-200-80).
+	if recs[1].InputTokens != 50 || recs[2].InputTokens != 20 {
+		t.Errorf("deltas = [%d, %d], want [50, 20]", recs[1].InputTokens, recs[2].InputTokens)
 	}
 }

--- a/sim/workload/tracev2.go
+++ b/sim/workload/tracev2.go
@@ -193,6 +193,15 @@ type TraceRecord struct {
 	// zero recorded think (e.g. Weka's overlap-clamped rounds) uses so it is no longer
 	// conflated with "absent". A negative recorded value is a load error (INV-3).
 	ThinkTimeUs *int64
+	// InputTokensReset is a context-compaction marker (#1609): the recorded ABSOLUTE
+	// input for a non-monotone round (in_N < in_{N-1} + out_{N-1}, where the delta law
+	// clamps to 0). Set only by the shared agentic-trace encoder, only on such rounds.
+	// nil (not recorded / monotone round) is the common case and writes no CSV cell, so
+	// a trace without any compaction round is byte-identical to a pre-#1609 trace (INV-6).
+	// In accumulate closed-loop replay the buffer re-seeds to this absolute at the
+	// boundary (see EncodeSessionToTraceRecords / SessionManager.OnComplete). *int64
+	// presence (nil = absent) mirrors the think_time_us non-lossy encoding (#1608/#1612).
+	InputTokensReset *int64
 }
 
 // TraceV2 combines header and records for a complete trace.
@@ -281,6 +290,19 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 		}
 	}
 
+	// Conditionally include input_tokens_reset column (#1609): present iff any record
+	// carries a compaction reset marker (non-nil). Trailing position (like adapter /
+	// think_time_us) keeps the positional parser's index math untouched. Omitted for
+	// traces with no compaction round, so run/observe/monotone traces add no column
+	// (INV-6 byte-identity).
+	includeInputTokensReset := false
+	for _, r := range records {
+		if r.InputTokensReset != nil {
+			includeInputTokensReset = true
+			break
+		}
+	}
+
 	// Conditionally include vllm_priority column: present iff priority was actually computed.
 	// Include when either:
 	// 1. Any record has non-zero priority (batch, standard, sheddable, background from observe)
@@ -320,6 +342,10 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 	// Append think_time_us at end (#1478): also trailing; parsed by header-position lookup.
 	if includeThinkTime {
 		columns = append(columns, "think_time_us")
+	}
+	// Append input_tokens_reset at end (#1609): also trailing; parsed by header-position lookup.
+	if includeInputTokensReset {
+		columns = append(columns, "input_tokens_reset")
 	}
 
 	// Write header row
@@ -387,6 +413,15 @@ func ExportTraceV2(header *TraceHeader, records []TraceRecord, headerPath, dataP
 				row = append(row, "")
 			}
 		}
+		// Append input_tokens_reset at end (#1609): empty cell for nil (no compaction
+		// this round), integer for a recorded absolute reset target.
+		if includeInputTokensReset {
+			if r.InputTokensReset != nil {
+				row = append(row, strconv.FormatInt(*r.InputTokensReset, 10))
+			} else {
+				row = append(row, "")
+			}
+		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("writing CSV row %d: %w", r.RequestID, err)
 		}
@@ -427,9 +462,10 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 	// Detect optional columns from header
 	hasVLLMPriority := false
 	hasSLOTarget := false
-	xRequestIDIdx := -1  // header-position lookup; -1 = absent (issue #1428)
-	adapterIdx := -1     // header-position lookup; -1 = absent (#1464)
-	thinkTimeUsIdx := -1 // header-position lookup; -1 = absent (#1478)
+	xRequestIDIdx := -1       // header-position lookup; -1 = absent (issue #1428)
+	adapterIdx := -1          // header-position lookup; -1 = absent (#1464)
+	thinkTimeUsIdx := -1      // header-position lookup; -1 = absent (#1478)
+	inputTokensResetIdx := -1 // header-position lookup; -1 = absent (#1609)
 	for i, col := range headerRow {
 		switch col {
 		case "vllm_priority":
@@ -442,6 +478,8 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 			adapterIdx = i
 		case "think_time_us":
 			thinkTimeUsIdx = i
+		case "input_tokens_reset":
+			inputTokensResetIdx = i
 		}
 	}
 
@@ -470,11 +508,14 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 		if thinkTimeUsIdx >= 0 {
 			minCols++
 		}
+		if inputTokensResetIdx >= 0 {
+			minCols++
+		}
 		if len(row) < minCols {
 			return nil, fmt.Errorf("CSV row has %d columns, expected at least %d", len(row), minCols)
 		}
 
-		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget, xRequestIDIdx, adapterIdx, thinkTimeUsIdx)
+		r, err := parseTraceRecord(row, hasVLLMPriority, hasSLOTarget, xRequestIDIdx, adapterIdx, thinkTimeUsIdx, inputTokensResetIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -486,10 +527,10 @@ func LoadTraceV2(headerPath, dataPath string) (*TraceV2, error) {
 
 // parseTraceRecord parses a CSV row. Handles optional columns vllm_priority
 // (after slo_class), slo_target_us (after deadline_us), and the trailing
-// columns x_request_id, adapter, and think_time_us. xRequestIDIdx, adapterIdx,
-// and thinkTimeUsIdx are absolute column indices in the row, or -1 if the
-// respective column is absent.
-func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx, adapterIdx, thinkTimeUsIdx int) (*TraceRecord, error) {
+// columns x_request_id, adapter, think_time_us, and input_tokens_reset.
+// xRequestIDIdx, adapterIdx, thinkTimeUsIdx, and inputTokensResetIdx are absolute
+// column indices in the row, or -1 if the respective column is absent.
+func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequestIDIdx, adapterIdx, thinkTimeUsIdx, inputTokensResetIdx int) (*TraceRecord, error) {
 	// Column offset: optional columns shift subsequent indices.
 	// vllm_priority appears after slo_class (index 3) → shifts everything after by +1.
 	// slo_target_us appears after deadline_us → shifts everything after by +1.
@@ -681,6 +722,24 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequest
 		}
 	}
 
+	// Optional input_tokens_reset at trailing column (#1609): looked up by absolute
+	// header position. An empty cell means "no compaction this round" → nil (the common
+	// case); a value is the recorded absolute input the accumulate buffer re-seeds to.
+	// Negative values are rejected — an input length cannot be negative.
+	var inputTokensReset *int64
+	if inputTokensResetIdx >= 0 && inputTokensResetIdx < len(row) {
+		if v := strings.TrimSpace(row[inputTokensResetIdx]); v != "" {
+			parsed, perr := strconv.ParseInt(v, 10, 64)
+			if perr != nil {
+				return nil, fmt.Errorf("parsing input_tokens_reset %q: %w", v, perr)
+			}
+			if parsed < 0 {
+				return nil, fmt.Errorf("parsing input_tokens_reset: negative value %d not allowed", parsed)
+			}
+			inputTokensReset = &parsed
+		}
+	}
+
 	return &TraceRecord{
 		RequestID:         requestID,
 		ClientID:          row[1],
@@ -714,6 +773,7 @@ func parseTraceRecord(row []string, hasVLLMPriority, hasSLOTarget bool, xRequest
 		XRequestID:        xRequestID,
 		Adapter:           adapter,
 		ThinkTimeUs:       thinkTimeUs,
+		InputTokensReset:  inputTokensReset,
 	}, nil
 }
 

--- a/sim/workload/tracev2_test.go
+++ b/sim/workload/tracev2_test.go
@@ -313,7 +313,7 @@ func TestParseTraceRecord_InvalidInteger_ReturnsError(t *testing.T) {
 	}
 
 	// WHEN parsing
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -332,7 +332,7 @@ func TestParseTraceRecord_InvalidDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "not_a_number" // deadline_us column (shifted +1 by prefix_length)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric deadline_us, got nil")
@@ -350,7 +350,7 @@ func TestParseTraceRecord_InvalidServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "not_a_number" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for non-numeric server_input_tokens, got nil")
@@ -370,7 +370,7 @@ func TestParseTraceRecord_InvalidVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "not_a_number" // vllm_priority column (index 4)
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, true, false, -1, -1, -1, -1)
 
 	// THEN error about invalid value
 	if err == nil {
@@ -391,7 +391,7 @@ func TestParseTraceRecord_NegativeVLLMPriority_ReturnsError(t *testing.T) {
 	row[4] = "-1" // negative vllm_priority
 
 	// WHEN parsing with hasVLLMPriority=true
-	_, err := parseTraceRecord(row, true, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, true, false, -1, -1, -1, -1)
 
 	// THEN error about negative value
 	if err == nil {
@@ -413,7 +413,7 @@ func TestParseTraceRecord_NegativeDeadlineUs_ReturnsError(t *testing.T) {
 	}
 	row[17] = "-1" // negative deadline_us (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative deadline_us, got nil")
@@ -435,7 +435,7 @@ func TestParseTraceRecord_NegativeArrivalTimeUs_ReturnsError(t *testing.T) {
 	}
 	row[19] = "-1" // arrival_time_us column (offset 0 when vllm_priority absent)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative arrival_time_us, got nil")
@@ -459,7 +459,7 @@ func TestParseTraceRecord_NegativeSendTimeUs_Tolerated(t *testing.T) {
 	}
 	row[20] = "-100" // send_time_us column; must be tolerated
 
-	rec, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	rec, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 	if err != nil {
 		t.Fatalf("negative send_time_us must be tolerated (falls back to arrival), got error: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestParseTraceRecord_NegativeInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[9] = "-1" // input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative input_tokens, got nil")
@@ -496,7 +496,7 @@ func TestParseTraceRecord_NegativeOutputTokens_ReturnsError(t *testing.T) {
 	}
 	row[10] = "-1" // output_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative output_tokens, got nil")
@@ -515,7 +515,7 @@ func TestParseTraceRecord_NegativeServerInputTokens_ReturnsError(t *testing.T) {
 	}
 	row[18] = "-1" // server_input_tokens column (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for negative server_input_tokens, got nil")
@@ -535,7 +535,7 @@ func TestParseTraceRecord_DeadlineBeforeArrival_ReturnsError(t *testing.T) {
 	row[17] = "1000" // deadline_us = 1000 (shifted +1)
 	row[19] = "5000" // arrival_time_us = 5000 (shifted +1)
 
-	_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+	_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 	if err == nil {
 		t.Fatal("expected error for deadline before arrival, got nil")
@@ -564,7 +564,7 @@ func TestParseTraceRecord_InvalidReasonRatio_ReturnsError(t *testing.T) {
 		}
 		row[15] = tc.value // reason_ratio column (shifted +1)
 
-		_, err := parseTraceRecord(row, false, false, -1, -1, -1)
+		_, err := parseTraceRecord(row, false, false, -1, -1, -1, -1)
 
 		if err == nil {
 			t.Errorf("reason_ratio=%q: expected error, got nil", tc.value)
@@ -1283,6 +1283,113 @@ func TestTraceV2_ThinkTimeUs_RoundTrip(t *testing.T) {
 			t.Errorf("lone &0 round-trip = %v, want &0", loaded.Records[1].ThinkTimeUs)
 		}
 	})
+}
+
+func TestTraceV2_InputTokensReset_RoundTrip(t *testing.T) {
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
+	i64 := func(v int64) *int64 { return &v }
+
+	t.Run("present: marker round-trips and column is emitted", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},                           // no reset
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 0, OutputTokens: 40, InputTokensReset: i64(120)}, // compaction
+			{RequestID: 2, SessionID: "A", RoundIndex: 2, InputTokens: 30, OutputTokens: 10},                            // monotone
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		data, _ := os.ReadFile(dataPath)
+		if !strings.Contains(string(data), "input_tokens_reset") {
+			t.Error("input_tokens_reset column missing from CSV when a record carries it")
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[0].InputTokensReset != nil {
+			t.Errorf("record0 InputTokensReset = %d, want nil (empty cell)", *loaded.Records[0].InputTokensReset)
+		}
+		if loaded.Records[1].InputTokensReset == nil || *loaded.Records[1].InputTokensReset != 120 {
+			t.Errorf("record1 InputTokensReset round-trip = %v, want &120", loaded.Records[1].InputTokensReset)
+		}
+		if loaded.Records[2].InputTokensReset != nil {
+			t.Errorf("record2 InputTokensReset = %d, want nil (monotone)", *loaded.Records[2].InputTokensReset)
+		}
+	})
+
+	t.Run("absent: no column when no record carries it (INV-6 byte-identity)", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 60, OutputTokens: 40},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		data, _ := os.ReadFile(dataPath)
+		if strings.Contains(string(data), "input_tokens_reset") {
+			t.Error("input_tokens_reset column emitted when no record carries it (must be omitted, INV-6)")
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		if loaded.Records[1].InputTokensReset != nil {
+			t.Errorf("absent column: InputTokensReset = %d, want nil", *loaded.Records[1].InputTokensReset)
+		}
+	})
+
+	t.Run("zero is a valid recorded absolute (distinct from absent)", func(t *testing.T) {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "h.yaml")
+		dataPath := filepath.Join(dir, "d.csv")
+		records := []TraceRecord{
+			{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},
+			{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 0, OutputTokens: 40, InputTokensReset: i64(0)},
+		}
+		if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			t.Fatalf("ExportTraceV2: %v", err)
+		}
+		loaded, err := LoadTraceV2(headerPath, dataPath)
+		if err != nil {
+			t.Fatalf("LoadTraceV2: %v", err)
+		}
+		// Presence encoding (#1612 precedent): recorded &0 survives as non-nil,
+		// distinct from an absent (nil) cell.
+		if loaded.Records[1].InputTokensReset == nil || *loaded.Records[1].InputTokensReset != 0 {
+			t.Errorf("recorded &0 round-trip = %v, want &0 (presence, not absence)", loaded.Records[1].InputTokensReset)
+		}
+	})
+}
+
+func TestParseTraceRecord_NegativeInputTokensReset_Errors(t *testing.T) {
+	// input_tokens_reset carrying a negative value must be rejected (an input
+	// length cannot be negative).
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "h.yaml")
+	dataPath := filepath.Join(dir, "d.csv")
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
+	i64 := func(v int64) *int64 { return &v }
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "A", RoundIndex: 0, InputTokens: 100, OutputTokens: 50},
+		{RequestID: 1, SessionID: "A", RoundIndex: 1, InputTokens: 0, OutputTokens: 40, InputTokensReset: i64(120)},
+	}
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatalf("ExportTraceV2: %v", err)
+	}
+	data, _ := os.ReadFile(dataPath)
+	corrupt := strings.Replace(string(data), "120", "-120", 1)
+	if err := os.WriteFile(dataPath, []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadTraceV2(headerPath, dataPath); err == nil || !strings.Contains(err.Error(), "input_tokens_reset") {
+		t.Errorf("expected negative input_tokens_reset to error, got %v", err)
+	}
 }
 
 func TestParseTraceRecord_NegativeThinkTime_Errors(t *testing.T) {


### PR DESCRIPTION
## Summary

Accumulate context-growth replay (`session_context_growth: accumulate`) reconstructed a session's per-round input as a **strictly-growing** shared token buffer. Real agentic traffic (Claude Code) **compacts** context: when the model summarizes/trims, the recorded absolute `in_N < in_{N-1} + out_{N-1}`, the delta encoder clamps the negative delta to `0`, and the append-only buffer cannot shrink. On real Weka data this **over-counts** the reconstructed cumulative input by ≈3–4× (+312%, ~30% of rounds), and the surviving over-long shared prefix inflates prefix-cache hit-rate.

**Fix:** the shared agentic-trace encoder emits an optional per-round `input_tokens_reset` marker (the recorded absolute) on **exactly** the compaction rounds (pre-clamp delta `< 0` — the precise over-count trigger). Accumulate closed-loop replay **re-seeds** its growing buffer to that absolute at the boundary, which:
1. shrinks the reconstructed input to the recorded absolute — reconstruction becomes **exact at every round**, not merely bounded; and
2. **intentionally breaks strict prefix identity across the boundary** (a summary is not a literal prefix of the pre-compaction buffer — faithful; also fixes the hit-rate over-estimate direction).

The marker is a trailing conditional CSV column (`adapter` / `think_time_us` precedent), `*int64` presence (nil = absent, mirroring #1608/#1612), round-tripping losslessly. It is **absent** for monotone sessions and for spec-built `blis run` blueprints, so a trace with no compaction round replays **byte-identically** to before (INV-6).

### Design decision (the issue asked for one)

Chose issue candidates **1+2** (optional absolute-reset column consumed as a per-round buffer re-seed) over candidate 3 (an explicit compaction event type): no new `sim.Event`, no schema-version bump, mirrors the merged `think_time_us` `*int64` presence column exactly. **Re-seed (fresh tokens), not truncate-keeping-prefix** — the acceptance criteria require strict-prefix identity to be *intentionally (and only)* broken across a compaction boundary; truncating `buf[0:in_N]` keeps a literal prefix and still over-estimates reuse.

Because both converters (`convert otel`, `convert weka`) feed the shared `EncodeSessionToTraceRecords` (#1479), the compaction signal is emitted in **one place** — **no converter-file change**. The behavioral shrink lands in `SessionManager.OnComplete`, shared by `blis replay` (closed-loop) and `blis observe` (corpus-mode) → both apply the shrink for calibration parity; `blis run` is inert.

## Behavioral contracts

- **BC-1 (encoder emits marker):** GIVEN rounds with `in_N < in_{N-1} + out_{N-1}` (N≥1), WHEN `EncodeSessionToTraceRecords` runs, THEN that record's delta stays `0` AND its `InputTokensReset` is non-nil `= in_N`; all other records (incl. round 0) leave it nil with unchanged deltas.
- **BC-2 (exact reconstruction):** GIVEN an accumulate trace with compaction markers, WHEN replayed closed-loop, THEN each round's reconstructed input length equals the recorded absolute at every round.
- **BC-3 (prefix break is boundary-local):** a compaction round's input is NOT a token-prefix of the previous round's; a monotone round preserves strict prefix identity (unchanged).
- **BC-4 (round-trip / INV-13):** records with/without `InputTokensReset` survive write→read identically (nil↔empty cell, non-nil↔integer, recorded `&0` distinct from absent); the column is present iff any record carries it.
- **BC-5 (INV-6 inert):** no `input_tokens_reset` column (or a monotone per-session sequence) ⇒ replay byte-identical to today; `blis run` never emits the column. `SequenceSampler.Sample` ignores the RNG, so sampling the reset target consumes no randomness.
- **BC-6 (pool parity):** a compaction session duplicated by `BuildSessionPool` re-seeds identically (the reset sampler is cloned with a fresh cursor).
- **INV-9:** the reset target is a trace-provided **input length** consumed by token assembly, never a servability/admission signal reading `OutputTokens`.

## End-to-end validation

Crafted a 4-round Weka session with a compaction round (absolutes `100 → 150 → 50 → 80`), `convert weka` → `replay --session-mode closed-loop`:

| | pre-fix (upstream/main) | with this PR | recorded |
|---|---|---|---|
| `total_input_tokens` | **614** (over-count) | **378** | ~380 |

`convert weka` emits `input_tokens_reset=50` on the compaction row (delta 0), empty elsewhere. Replay is deterministic run-to-run (matching stdout md5). The small residual offset (614 vs 620 / 378 vs 380) is an aggregation nuance identical in both binaries.

## Testing

- `go build ./...`, `go test ./... -count=1`, `golangci-lint run ./...` (v2.9.0) — all green.
- New/extended tests: encoder marker + monotone-no-marker (`trace_encode_test`); CSV round-trip incl. present/absent/recorded-`&0`/negative-rejected (`tracev2_test`); buffer `Reset` shrink + orphan-view safety (`session_buffer_test`); compaction re-seed + prefix-break + post-compaction transitivity + no-sampler-when-monotone (`replay_test`); reset-sampler clone independence (`session_pool_test`).
- Pinned `TestAccumulateReplay_StrictPrefixIdentity` / `_TransitivityAndLengthCap` unchanged (no markers → unchanged behavior).

## Files

`sim/workload/{trace_encode,tracev2,session_buffer,session,replay,session_pool}.go` (+ tests), `CLAUDE.md`, `docs/guide/observe-replay-calibrate.md`.

### Known boundary
Re-exporting a *replayed* compaction trace via `--trace-output` does not reconstruct the marker (as `RequestsToTraceRecords` emits absolute suffix lengths, the same pre-existing limitation as delta re-export) — not an INV-13 scenario the issue requires (`blis run` export → replay carries no markers and is identical).

Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)