### PR TITLE
fix(replay): guard --trace-output against lossy closed-loop accumulate re-export

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -148,6 +148,21 @@ Example:
 		if replayConcurrentSessions > 0 && replayTraceOutput != "" {
 			logrus.Fatalf("--trace-output is not supported with --concurrent-sessions (pool mode): a re-export would capture only the initial %d-session wave, not all pooled sessions. Re-run without --trace-output.", replayConcurrentSessions)
 		}
+		// Plain closed-loop + accumulate + output artifacts: the same silent-truncation
+		// hazard the pool guard above rejects (R1 / INV-13), for --concurrent-sessions == 0
+		// (#1621). A closed-loop re-export sources only the round-0 request slice (the
+		// export block below builds records from `requests`, never the generated
+		// follow-up rounds collected in followUpRequests); RequestsToTraceRecords then
+		// re-emits each per-round input_tokens as an absolute suffix length rather than
+		// the delta an accumulate loader expects; and the re-export header never carries
+		// session_context_growth. The exported trace therefore could NOT be re-replayed
+		// to reproduce the original per-round input. Reject it outright until faithful
+		// re-export (issue #1621, option (a)) lands. Accumulate implies closed-loop here
+		// (guaranteed by the gate above), and pool mode is already handled by the guard
+		// above, so this covers the remaining plain closed-loop case.
+		if traceData.Header.SessionContextGrowth == "accumulate" && replayConcurrentSessions == 0 && replayTraceOutput != "" {
+			logrus.Fatalf("--trace-output is not supported with --session-mode closed-loop on a session_context_growth=accumulate trace: the re-export would source only the round-0 requests (dropping the generated follow-up rounds), emit absolute per-round input_tokens instead of deltas, and omit session_context_growth from the header, so the result could not be re-replayed to reproduce the original per-round input. Re-run without --trace-output; to re-export, replay the original converter corpus (e.g. from `blis convert otel`) instead.")
+		}
 		if replayConcurrentSessions > 0 && resultsPath != "" {
 			logrus.Warnf("--results-path with --concurrent-sessions (pool mode): per-request results cover only the original corpus sessions' round-0; duplicated (clone) sessions and follow-up rounds are excluded (non-numeric request ids).")
 		}

--- a/cmd/replay_test.go
+++ b/cmd/replay_test.go
@@ -3199,3 +3199,210 @@ func TestReplayCmd_PoolRejectsNonSessionRecords(t *testing.T) {
 		t.Errorf("guard should pre-empt BuildSessionPool's internal 'count mismatch' error, but it surfaced:\n%s", out)
 	}
 }
+
+// TestReplayCmd_ClosedLoopAccumulateTraceOutputFatal is a regression test for the
+// plain closed-loop accumulate re-export guard (issue #1621). Re-exporting a
+// closed-loop replay via --trace-output sources only the round-0 `requests` slice
+// (the export block never sees the generated follow-up rounds), and
+// RequestsToTraceRecords re-emits per-round input_tokens as absolute suffix
+// lengths (not the deltas an accumulate loader expects) and does not carry
+// session_context_growth onto the re-export header. The exported trace therefore
+// could not be re-replayed to reproduce the original per-round input, so — rather
+// than write a silently-unfaithful trace (INV-13, R1) — cmd/replay.go Fatalfs.
+//
+// This mirrors the sibling pool-mode guard (--concurrent-sessions + --trace-output,
+// TestReplayCmd_PoolTraceOutputFatal); the guard fires up front, before session
+// blueprints are built, so a minimal accumulate corpus reaches it. Fatalf os.Exit's,
+// so — following TestReplayCmd_AccumulateHeaderRequiresClosedLoop — the case runs in
+// a subprocess re-run (BLIS_TEST_SUBPROCESS=1) and is asserted via exit code + stderr.
+func TestReplayCmd_ClosedLoopAccumulateTraceOutputFatal(t *testing.T) {
+	if os.Getenv("BLIS_TEST_SUBPROCESS") == "1" {
+		// Subprocess: an accumulate-header, multi-round session corpus replayed in
+		// plain closed-loop mode (--concurrent-sessions 0) WITH --trace-output set.
+		// Must Fatalf before completing.
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "trace.yaml")
+		dataPath := filepath.Join(dir, "trace.csv")
+		header := &workload.TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
+		records := []workload.TraceRecord{
+			{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 10, OutputTokens: 5, ArrivalTimeUs: 0, Status: "ok"},
+			{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 4, OutputTokens: 5, ArrivalTimeUs: 100_000, Status: "ok"},
+		}
+		if err := workload.ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			os.Exit(2)
+		}
+
+		mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		totalKVBlocks = 1000
+		blockSizeTokens = 16
+		maxNumSeqs = 64
+		maxNumBatchedTokens = 2048
+		numInstances = 1
+		seed = 42
+		longPrefillTokenThreshold = 0
+		kvCPUBlocks = 0
+		kvOffloadThreshold = 0.9
+		kvTransferBandwidth = 100.0
+		kvTransferBaseLatency = 0
+		snapshotRefreshInterval = 0
+		admissionPolicy = "always-admit"
+		routingPolicy = "round-robin"
+		scheduler = "fcfs"
+		policyConfigPath = ""
+		maxModelLen = 0
+		traceLevel = "none"
+		counterfactualK = 0
+		traceHeaderPath = headerPath
+		traceDataPath = dataPath
+		modelConfigFolder = mcFolder
+		hwConfigPath = hwPath
+		gpu = "H100"
+		tensorParallelism = 1
+		defaultsFilePath = defaultsPath
+		replaySessionMode = "closed-loop"
+		replayConcurrentSessions = 0
+		replayTotalSessions = 0
+		replayThinkTimeMs = 0
+		replayThinkTimeDist = ""
+		resultsPath = ""
+		replayTraceOutput = filepath.Join(dir, "reexport")
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+		testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+		if err := testCmd.ParseFlags([]string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--total-kv-blocks", "1000", "--hardware", "H100", "--tp", "1",
+			"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+			"--trace-header", headerPath, "--trace-data", dataPath,
+			"--defaults-filepath", defaultsPath,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "ParseFlags failed (test setup error): %v\n", err)
+			os.Exit(2) // distinct from logrus.Fatalf exit code (1)
+		}
+		replayCmd.Run(testCmd, nil) // must Fatalf before here
+		os.Exit(0)                  // reached only if no fatal = parent test failure
+	}
+
+	// Parent: re-run this test as subprocess and expect exit code 1 (logrus.Fatalf).
+	cmd := exec.Command(os.Args[0], "-test.run=TestReplayCmd_ClosedLoopAccumulateTraceOutputFatal", "-test.v")
+	cmd.Env = append(os.Environ(), "BLIS_TEST_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when re-exporting a closed-loop accumulate replay (--trace-output), got exit 0")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 (logrus.Fatalf), got %d; output:\n%s", exitErr.ExitCode(), out)
+	}
+	// Message must name the flag, the mode, and the header field so the operator
+	// knows exactly which combination is rejected and why.
+	for _, want := range []string{"--trace-output", "closed-loop", "accumulate"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("fatal message should mention %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestReplayCmd_PoolTraceOutputFatal is the companion regression test the sibling
+// pool-mode guard (--concurrent-sessions > 0 + --trace-output) never had (issue
+// #1621 notes it was untested). Pool-mode re-export would capture only the initial
+// wave of round-0 requests — follow-ups/clones are never collected — so the guard
+// in cmd/replay.go rejects it outright (INV-13, R1). Fatalf os.Exit's, so the case
+// runs in a subprocess re-run and is asserted via exit code + stderr content.
+func TestReplayCmd_PoolTraceOutputFatal(t *testing.T) {
+	if os.Getenv("BLIS_TEST_SUBPROCESS") == "1" {
+		// Subprocess: a pure-session corpus replayed with --concurrent-sessions 1
+		// (pool mode) AND --trace-output set. Must Fatalf before completing.
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "trace.yaml")
+		dataPath := filepath.Join(dir, "trace.csv")
+		header := &workload.TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated"}
+		records := []workload.TraceRecord{
+			{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 10, OutputTokens: 5, ArrivalTimeUs: 0, Status: "ok"},
+		}
+		if err := workload.ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+			os.Exit(2)
+		}
+
+		mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		totalKVBlocks = 1000
+		blockSizeTokens = 16
+		maxNumSeqs = 64
+		maxNumBatchedTokens = 2048
+		numInstances = 1
+		seed = 42
+		longPrefillTokenThreshold = 0
+		kvCPUBlocks = 0
+		kvOffloadThreshold = 0.9
+		kvTransferBandwidth = 100.0
+		kvTransferBaseLatency = 0
+		snapshotRefreshInterval = 0
+		admissionPolicy = "always-admit"
+		routingPolicy = "round-robin"
+		scheduler = "fcfs"
+		policyConfigPath = ""
+		maxModelLen = 0
+		traceLevel = "none"
+		counterfactualK = 0
+		traceHeaderPath = headerPath
+		traceDataPath = dataPath
+		modelConfigFolder = mcFolder
+		hwConfigPath = hwPath
+		gpu = "H100"
+		tensorParallelism = 1
+		defaultsFilePath = defaultsPath
+		replaySessionMode = "closed-loop"
+		replayConcurrentSessions = 1
+		replayTotalSessions = 0
+		replayThinkTimeMs = 0
+		replayThinkTimeDist = ""
+		resultsPath = ""
+		replayTraceOutput = filepath.Join(dir, "reexport")
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+		testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+		if err := testCmd.ParseFlags([]string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--total-kv-blocks", "1000", "--hardware", "H100", "--tp", "1",
+			"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+			"--trace-header", headerPath, "--trace-data", dataPath,
+			"--defaults-filepath", defaultsPath,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "ParseFlags failed (test setup error): %v\n", err)
+			os.Exit(2) // distinct from logrus.Fatalf exit code (1)
+		}
+		replayCmd.Run(testCmd, nil) // must Fatalf before here
+		os.Exit(0)                  // reached only if no fatal = parent test failure
+	}
+
+	// Parent: re-run this test as subprocess and expect exit code 1 (logrus.Fatalf).
+	cmd := exec.Command(os.Args[0], "-test.run=TestReplayCmd_PoolTraceOutputFatal", "-test.v")
+	cmd.Env = append(os.Environ(), "BLIS_TEST_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when re-exporting a pool-mode replay (--trace-output), got exit 0")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 (logrus.Fatalf), got %d; output:\n%s", exitErr.ExitCode(), out)
+	}
+	for _, want := range []string{"--trace-output", "--concurrent-sessions", "pool mode"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("fatal message should mention %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -232,7 +232,25 @@ Replay also accepts all shared simulation config flags (`--latency-model`, `--to
 | **Horizon** | From `--horizon` flag or spec | Auto-computed as 2x max arrival time (override with `--horizon`) |
 | **Output format** | Full `MetricsOutput` JSON | `SimResult` JSON array (request_id, ttft_us, e2e_us, input_tokens, output_tokens) |
 | **Session support** | Session manager creates follow-ups | Session structure encoded in trace (no manager needed) |
-| **Trace export** | `--trace-output` (header `mode: "generated"`) | `--trace-output` (header `mode: "replayed"`) |
+| **Trace export** | `--trace-output` (header `mode: "generated"`) | `--trace-output` (header `mode: "replayed"`); see restrictions below |
+
+!!! warning "`--trace-output` cannot re-export closed-loop follow-up rounds"
+    Replay **rejects `--trace-output` (fails fast, non-zero exit)** in two cases,
+    because a re-export sources only the round-0 request slice — the follow-up rounds
+    generated during a closed-loop run are never in the exported set:
+
+    - **Pool mode** (`--concurrent-sessions > 0`): the export would capture only the
+      initial round-0 wave, not the pooled/cloned sessions.
+    - **Plain closed-loop replay of an accumulate corpus** (`--session-mode
+      closed-loop` on a header with `session_context_growth: accumulate` — e.g. a
+      `blis convert otel` / `blis convert weka` corpus): besides dropping the
+      follow-ups, the export would emit absolute per-round `input_tokens` instead of
+      the deltas an accumulate loader expects and omit `session_context_growth`, so it
+      could not be re-replayed faithfully.
+
+    To re-export, replay the **original converter corpus** rather than a prior
+    closed-loop replay's output. (Faithful closed-loop re-export is a planned
+    follow-up.)
 
 !!! warning "Latency model matters"
     The replay command simulates token generation using the configured latency model. For accurate calibration, choose the latency model that best matches the server's behavior. See [Latency Models](latency-models.md) for guidance on selecting between roofline and trained-physics modes.
@@ -339,7 +357,7 @@ To calibrate real vs simulated over the same corpus:
 ```bash
 blis replay --trace-header corpus.yaml --trace-data corpus.csv \
   --model qwen/qwen3-14b --concurrent-sessions 8 --total-sessions 200 \
-  --trace-output sim
+  --results-path sim.results.json
 blis calibrate --trace-header observed.yaml --trace-data observed.csv \
   --sim-results sim.results.json --report calibration.json
 ```


### PR DESCRIPTION
## Summary

- Plain closed-loop replay (`--session-mode closed-loop`, `--concurrent-sessions 0`) of a `session_context_growth=accumulate` corpus **silently wrote an unfaithful trace** when `--trace-output` was set. The re-export sourced only the round-0 `requests` slice (dropping the `SessionManager`-generated follow-up rounds), `RequestsToTraceRecords` emitted **absolute** per-round `input_tokens` instead of the **deltas** an accumulate loader expects, and the re-export header omitted `session_context_growth`. Re-replaying such an export could not reproduce the original per-round input.
- **Option (b) stopgap** (the issue's recommended first step): fail fast instead of writing a lossy trace, mirroring the **existing sibling pool-mode guard** (`--concurrent-sessions > 0` + `--trace-output`). The new guard sits immediately after that pool guard and covers the remaining plain closed-loop case.
- Adds the **companion test the sibling pool-mode guard never had** (the issue flagged `cmd/replay.go`'s pool `--trace-output` guard as untested).
- **Docs:** documents both `--trace-output` re-export restrictions (pool mode + plain closed-loop accumulate) in the replay guide, and fixes a pre-existing broken calibration example that used `--trace-output` with `--concurrent-sessions` (rejected by the pool guard) and mismatched `--sim-results` — resolving #1622.

## Issue

Closes #1621
Fixes #1622

## Behavioral Contracts

- **BC-1** — GIVEN a header with `session_context_growth: accumulate`, WHEN `blis replay --session-mode closed-loop --trace-output <prefix>` runs with `--concurrent-sessions 0` (default), THEN the command exits non-zero (code 1) with a message naming `--trace-output`, `closed-loop`, and `accumulate`; no trace files are written.
- **BC-2** (companion / regression) — GIVEN any loadable trace, WHEN `blis replay --concurrent-sessions N>0 --trace-output <prefix>`, THEN it exits code 1 naming `--concurrent-sessions` / `pool mode` — locking in the previously-untested sibling guard.

## Cross-Path Parity

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | no | N/A | Sources records from `SetArrivalHook` (captures every round incl. follow-ups) and never emits accumulate corpora — its absolute per-round encoding is correct. `RequestsToTraceRecords` (`cmd/root.go`) intentionally **not** touched. |
| `blis replay` | yes | yes | Fix site — the static round-0 re-export is the sole lossy path. |
| `blis observe` | no | N/A | The `Recorder` captures dispatched rounds directly with real token counts; no `sim.Request → TraceRecord` round-trip. |

## Invariants Affected

- **INV-13 (run/replay parity, 'never silent degradation')** — enforced: the lossy re-export now fails fast with a clear error, matching how node pools / autoscaler / the pool path already reject unsupported replay features, rather than silently writing an unfaithful trace.
- **INV-6 (determinism)** — unaffected: the guard fires only on the exact `accumulate` + plain-closed-loop + `--trace-output` combination; all other runs are byte-identical.

## Scope note (why Option (b), not (a))

The issue recommends Option (b) (fail fast) as the first step; faithful re-export (Option (a) — capture the full round sequence, re-derive per-round deltas, set the header) remains a follow-up. This PR closes the silent-degradation hole immediately with a few lines next to the existing guard.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (full suite green)
- [x] `golangci-lint run ./cmd/...` (0 issues)
- [x] `TestReplayCmd_ClosedLoopAccumulateTraceOutputFatal` — new guard (red→green verified)
- [x] `TestReplayCmd_PoolTraceOutputFatal` — companion for the previously-untested pool guard

---

Generated with [Claude Code](https://claude.ai/claude-code)
