### PR TITLE
feat(latency): inter-node network cost for cross-node TP/EP traffic (#1530)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,18 @@ go build -o blis main.go
 # Run with default model
 ./blis run --model qwen/qwen3-14b
 
+# Run with inter-node network cost (#1530, trained-physics only). --gpus-per-node sets the
+# node size; a TP collective (group=tp) or DEP expert all-to-all (group=TP·DP) larger than it
+# is charged for its cross-node hops at --inter-node-bandwidth (GB/s) + --inter-node-latency
+# (ms), instead of on-package NVLink. Omitting --gpus-per-node (default 0) is inert and
+# byte-identical to a pre-feature build. Same flags on `blis replay` reproduce the StepTime
+# (INV-13). Multi-node TP all-reduce example (tp=8 spanning 2 nodes of 4 over ~50 GB/s IB):
+./blis run --model qwen/qwen3-14b --hardware H100 --tp 8 \
+  --gpus-per-node 4 --inter-node-bandwidth 50 --inter-node-latency 0.005
+# Wide-EP (multi_node_dep) example: TP within node, DP across nodes (moeGroup=TP·DP spans):
+./blis run --model deepseek-ai/deepseek-v2-lite --hardware H100 --tp 4 --dp 2 \
+  --enable-expert-parallel --gpus-per-node 4 --inter-node-bandwidth 50
+
 # Run with goodput SLO targets (#1413). --slo-ttft / --slo-itl / --slo-e2e accept
 # class=duration[,class=duration...] using Go duration syntax. Precedence:
 # CLI > trace header > workload spec. Distinct from --slo-targets (dispatch ordering).
@@ -614,6 +626,8 @@ Two latency model modes (trained-physics, roofline), selected via `--latency-mod
 **Roofline model**: Pure analytical model available via explicit `--latency-model roofline` flag. Useful when you want FLOPs/bandwidth-based estimation without learned corrections.
 
 See [`docs/guide/latency-models.md`](docs/guide/latency-models.md) for details.
+
+**Inter-node network cost (#1530, trained-physics only)**: By default the trained-physics comm terms (`tpAllReduceBasis` TP all-reduce, `moeDispatchBasis` DEP expert all-to-all) divide byte volume by `bwHbmUs` (on-package HBM/NVLink), so cross-node collective traffic is free. `sim.NetworkConfig` (`--gpus-per-node`, `--inter-node-bandwidth` GB/s, `--inter-node-latency` ms) charges it: a collective whose participant group exceeds `--gpus-per-node` (TP group = `tp`; MoE all-to-all group = `moeGroup` = `TP·DP`) is scored as spanning `ceil(group/gpus_per_node)` nodes, and its cross-node fraction `(n-1)/n` of the ring/all-to-all volume is charged at the inter-node bandwidth (an effective rate, like `--pd-transfer-bandwidth`; **no learned β** — β₄ absorbs the NVLink/HBM ratio, which must not re-apply to the fabric) plus a fixed per-collective latency. Injected via the `latency.WithNetworkConfig` option (no `NewModelHardwareConfig` churn). **Inert by default** (`--gpus-per-node 0`): the term is exactly `0.0`, so every config expressible today is byte-identical to a pre-feature build (INV-6/INV-BC-DP1) — the guarantee is conditional on the network model being off or the group fitting in one node. Topology is a **config input, not a placement-derived signal** (mirroring `--tp`/`--dp`): both `blis run` and `blis replay` build it from the same flags, so run/replay parity (INV-13) holds by construction with no TraceV2 round-trip. `--gpus-per-node` requires `--latency-model trained-physics`, and an active config without a positive `--inter-node-bandwidth` (or fabric knobs set without `--gpus-per-node`) is a hard CLI error (R1). This is the foundation the multi-node placement work (#1529) will drive from real GPU spans; until then the node span is declared. `blis observe` takes timing from the real server, so it is unaffected.
 
 **Quantized model support**: Three-tier auto-detection of weight precision: (1) `quantization_config` in HF `config.json` — GPTQ/AWQ (`bits`), FP8 (implicit), compressed-tensors (`config_groups.*.weights.num_bits`); (2) model name conventions (`w4a16` → 0.5, `FP8` → 1.0 via `InferWeightBytesFromModelName`); (3) fallback to `BytesPerParam` from `torch_dtype`. Uses quantized weight precision for weight bandwidth and KV capacity calculations while keeping compute dtype for KV cache and activations. `ModelConfig.WeightBytesPerParam` (0=fallback to `BytesPerParam`) with `EffectiveWeightBytesPerParam()` accessor decouples weight storage precision from compute/KV dtype.
 

--- a/cmd/network_cost_parity_test.go
+++ b/cmd/network_cost_parity_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
+	"github.com/spf13/cobra"
+)
+
+// replayTraceWithNetwork replays a TraceV2 through replayCmd at the given TP and
+// inter-node network config (#1530). When gpusPerNodeVal == 0 the network flags are
+// omitted (inert). Modeled on replaySpecTrace; adds --tp / --gpus-per-node /
+// --inter-node-bandwidth so INV-13 parity can be exercised for a cross-node config.
+//
+// NOTE: mutates package-level CLI vars; not for t.Parallel().
+func replayTraceWithNetwork(t *testing.T, traceHeaderFile, traceDataFile string, tpVal, gpusPerNodeVal int, bwGBps float64) []workload.SimResult {
+	t.Helper()
+	tmpDir := t.TempDir()
+	resultsFile := filepath.Join(tmpDir, "results.json")
+	mcFolder, hwPath, defaultsPath := setupTrainedPhysicsTestFixturesWithDefaults(t)
+
+	orig := captureCmdLevelVars()
+	defer orig.restore()
+
+	origTraceHeader := traceHeaderPath
+	origTraceData := traceDataPath
+	origSessionMode := replaySessionMode
+	origGpusPerNode := gpusPerNode
+	origInterNodeBw := interNodeBandwidth
+	origInterNodeLat := interNodeLatency
+	defer func() {
+		traceHeaderPath = origTraceHeader
+		traceDataPath = origTraceData
+		replaySessionMode = origSessionMode
+		gpusPerNode = origGpusPerNode
+		interNodeBandwidth = origInterNodeBw
+		interNodeLatency = origInterNodeLat
+	}()
+
+	model = "qwen/qwen3-14b"
+	latencyModelBackend = "trained-physics"
+	totalKVBlocks = 1000
+	blockSizeTokens = 16
+	maxNumSeqs = 64
+	maxNumBatchedTokens = 2048
+	numInstances = 1
+	resultsPath = resultsFile
+	longPrefillTokenThreshold = 0
+	kvCPUBlocks = 0
+	kvOffloadThreshold = 0.9
+	kvTransferBandwidth = 100.0
+	kvTransferBaseLatency = 0
+	snapshotRefreshInterval = 0
+	admissionPolicy = "always-admit"
+	routingPolicy = "round-robin"
+	scheduler = "fcfs"
+	policyConfigPath = ""
+	maxModelLen = 0
+	traceLevel = "none"
+	counterfactualK = 0
+	traceHeaderPath = traceHeaderFile
+	traceDataPath = traceDataFile
+	modelConfigFolder = mcFolder
+	hwConfigPath = hwPath
+	gpu = "H100"
+	tensorParallelism = tpVal
+	defaultsFilePath = defaultsPath
+	replaySessionMode = "fixed"
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd) // resets gpusPerNode/interNodeBandwidth/interNodeLatency to 0
+	testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+	testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+	testCmd.Flags().StringVar(&resultsPath, "results-path", "", "")
+	args := []string{
+		"--model", "qwen/qwen3-14b", "--latency-model", "trained-physics",
+		"--total-kv-blocks", "1000", "--hardware", "H100",
+		"--tp", strconv.Itoa(tpVal),
+		"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+		"--trace-header", traceHeaderFile, "--trace-data", traceDataFile,
+		"--results-path", resultsFile,
+		"--num-instances", "1",
+		"--horizon", "120000000",
+		"--defaults-filepath", defaultsPath,
+	}
+	if gpusPerNodeVal > 0 {
+		args = append(args,
+			"--gpus-per-node", strconv.Itoa(gpusPerNodeVal),
+			"--inter-node-bandwidth", strconv.FormatFloat(bwGBps, 'f', -1, 64),
+		)
+	}
+	if err := testCmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	replayCmd.Run(testCmd, nil)
+
+	data, err := os.ReadFile(resultsFile)
+	if err != nil {
+		t.Fatalf("results file not written: %v", err)
+	}
+	var results []workload.SimResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("parse SimResult JSON: %v", err)
+	}
+	return results
+}
+
+// TestResolveNetworkConfig_HappyPaths pins the CLI seam that both run and replay
+// use (BC-6 non-fatal cases): an inert config passes on any backend, and an active,
+// well-formed config on trained-physics returns the configured fabric. The fatal
+// paths (invalid fabric config, active-on-roofline) delegate to NetworkConfig.Validate
+// and the trained-physics backend check, covered by the sim/latency guard tests.
+//
+// NOTE: mutates package-level vars; do NOT use t.Parallel().
+func TestResolveNetworkConfig_HappyPaths(t *testing.T) {
+	o1, o2, o3 := gpusPerNode, interNodeBandwidth, interNodeLatency
+	defer func() { gpusPerNode, interNodeBandwidth, interNodeLatency = o1, o2, o3 }()
+
+	// Inert default: valid on any backend, contributes nothing.
+	gpusPerNode, interNodeBandwidth, interNodeLatency = 0, 0, 0
+	if nc := resolveNetworkConfig("roofline"); nc.IsActive() {
+		t.Errorf("inert config must not be active, got %+v", nc)
+	}
+
+	// Active, well-formed config on trained-physics: returned verbatim.
+	gpusPerNode, interNodeBandwidth, interNodeLatency = 4, 50.0, 0.001
+	nc := resolveNetworkConfig("trained-physics")
+	if !nc.IsActive() || nc.GPUsPerNode != 4 || nc.InterNodeBandwidthGBps != 50.0 || nc.InterNodeLatencyMs != 0.001 {
+		t.Errorf("resolveNetworkConfig returned %+v, want {4, 50, 0.001} active", nc)
+	}
+}
+
+// TestParity_InterNodeNetwork_RunReplay_INV13 is BC-5: replaying a workload trace
+// with a cross-node network config is deterministic (INV-13/INV-6), and replay
+// HONORS the network flags rather than silently dropping them — a cross-node
+// replay differs from an inert one, and never completes faster (the cross-node
+// term only adds cost). Uses TP=2 with --gpus-per-node 1 so the TP all-reduce
+// group (2) spans 2 nodes.
+//
+// NOTE: mutates package-level vars; do NOT use t.Parallel().
+func TestParity_InterNodeNetwork_RunReplay_INV13(t *testing.T) {
+	const seed int64 = 20260826
+	shape := paritySpecShapes()[0] // chatbot
+
+	// A single workload trace (mode: generated); replay recomputes timing from the
+	// latency config, so the same trace drives both the cross-node and inert legs.
+	hdr, data := runSpecToTraceFiles(t, shape.yaml, seed, shape.horizon, false)
+
+	withNet := replayTraceWithNetwork(t, hdr, data, 2, 1, 50.0)
+	withNet2 := replayTraceWithNetwork(t, hdr, data, 2, 1, 50.0)
+	inert := replayTraceWithNetwork(t, hdr, data, 2, 0, 0)
+
+	if len(withNet) == 0 {
+		t.Fatal("cross-node replay produced no completed requests")
+	}
+
+	// Determinism: identical cross-node config ⇒ byte-identical per-request metrics.
+	wTTFT, wE2E := simResultMaps(withNet)
+	w2TTFT, w2E2E := simResultMaps(withNet2)
+	for id, v := range wTTFT {
+		if w2TTFT[id] != v {
+			t.Errorf("INV-6: request %d TTFT non-deterministic across identical cross-node replays: %f vs %f", id, v, w2TTFT[id])
+		}
+		if w2E2E[id] != wE2E[id] {
+			t.Errorf("INV-6: request %d E2E non-deterministic: %f vs %f", id, wE2E[id], w2E2E[id])
+		}
+	}
+
+	// Replay honors the network flags: a cross-node replay must differ from an inert
+	// one (if replay silently dropped --gpus-per-node, they would be identical), and
+	// the cross-node term only ADDS cost, so no request completes earlier.
+	iTTFT, iE2E := simResultMaps(inert)
+	if len(iTTFT) != len(wTTFT) {
+		t.Fatalf("cross-node and inert replays completed different request counts: %d vs %d", len(wTTFT), len(iTTFT))
+	}
+	anyDifferent := false
+	for id, wv := range wE2E {
+		iv, ok := iE2E[id]
+		if !ok {
+			t.Errorf("request %d present in cross-node replay, missing from inert replay", id)
+			continue
+		}
+		if wv != iv {
+			anyDifferent = true
+		}
+		if wv < iv {
+			t.Errorf("request %d: cross-node E2E (%f) < inert E2E (%f) — the network term must only add cost", id, wv, iv)
+		}
+	}
+	if !anyDifferent {
+		t.Error("cross-node replay produced identical metrics to inert replay — replay is not honoring --gpus-per-node/--inter-node-bandwidth (INV-13)")
+	}
+}

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -612,6 +612,7 @@ Example:
 				ModelHardwareConfig:  sim.NewModelHardwareConfig(lr.ModelConfig, lr.HWConfig, model, gpu, tensorParallelism, dataParallelism, enableExpertParallel, moeCommBackend, lr.Backend, maxModelLen),
 				PolicyConfig:         sim.NewPolicyConfig(scheduler, preemptionPolicy),
 				LoRAConfig:           loraCfg,
+				NetworkConfig:        resolveNetworkConfig(lr.Backend),
 				SLOPriorityOverrides: sloPriorityOverrides,
 			},
 			NumInstances:                    numInstances,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,13 @@ var (
 	enableExpertParallel bool   // EP mode (MoE only; trained-physics backend only)
 	moeCommBackend       string // MoE all-to-all comm backend (MoE only; trained-physics backend only)
 
+	// Inter-node network cost (#1530; trained-physics backend only). Inert by default
+	// (gpusPerNode == 0): a collective whose group exceeds gpusPerNode is charged for
+	// its cross-node hops at interNodeBandwidth/interNodeLatency instead of NVLink.
+	gpusPerNode        int     // GPUs per physical node (0 = single-node/off)
+	interNodeBandwidth float64 // Effective inter-node link bandwidth in GB/s (IB/RoCE)
+	interNodeLatency   float64 // Inter-node per-collective base latency in ms
+
 	// cluster config
 	numInstances int // Number of instances in the cluster
 
@@ -817,6 +824,25 @@ func composeLoRAScorer(base []sim.ScorerConfig, weight float64) ([]sim.ScorerCon
 // DeploymentConfig.RoutingScorerConfigs) and the loaded policy bundle (nil if none).
 // Per-pool scorer configs (PD disaggregation) are NOT handled here — they remain inline
 // in runCmd.
+// resolveNetworkConfig builds and validates the inter-node network config from the
+// shared --gpus-per-node / --inter-node-bandwidth / --inter-node-latency flags (#1530).
+// Both `blis run` and `blis replay` call it at SimConfig assembly, so the two paths
+// reject the same misconfigurations identically and — since the config is a plain
+// CLI input, not a placement-derived signal — run/replay parity (INV-13) holds by
+// construction. It fails fast (CLI boundary → logrus.Fatalf) on an invalid fabric
+// config or an active config on a non-trained-physics backend (R1: never a silent
+// no-op). Inert by default (--gpus-per-node 0).
+func resolveNetworkConfig(backend string) sim.NetworkConfig {
+	nc := sim.NewNetworkConfig(gpusPerNode, interNodeBandwidth, interNodeLatency)
+	if err := nc.Validate(); err != nil {
+		logrus.Fatalf("Invalid inter-node network configuration: %v", err)
+	}
+	if nc.IsActive() && backend != "trained-physics" {
+		logrus.Fatalf("--gpus-per-node (inter-node network cost) requires --latency-model trained-physics, got %q", backend)
+	}
+	return nc
+}
+
 func resolvePolicies(cmd *cobra.Command) ([]sim.ScorerConfig, *sim.PolicyBundle) {
 	var bundleScorerConfigs []sim.ScorerConfig
 	var loadedBundle *sim.PolicyBundle
@@ -1131,6 +1157,11 @@ func registerSimConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&dataParallelism, "dp", 1, "Data parallelism degree (MoE models only; --latency-model trained-physics only)")
 	cmd.Flags().BoolVar(&enableExpertParallel, "enable-expert-parallel", false, "Enable expert parallelism for MoE models (mirrors vLLM --enable-expert-parallel; --latency-model trained-physics only)")
 	cmd.Flags().StringVar(&moeCommBackend, "moe-comm-backend", "", "MoE all-to-all comm backend for dispatch/combine cost (mirrors vLLM VLLM_ALL2ALL_BACKEND: naive, allgather_reducescatter [default], pplx, deepep_high_throughput, deepep_low_latency, mori, flashinfer_all2allv; MoE + --latency-model trained-physics + --dp > 1)")
+	// Inter-node network cost (#1530; trained-physics backend only). Default 0 ⇒ inert
+	// (single-node) ⇒ StepTime byte-identical to a pre-feature build.
+	cmd.Flags().IntVar(&gpusPerNode, "gpus-per-node", 0, "GPUs per physical node for inter-node network cost (0 = single-node/off). A TP or MoE (TP·DP) collective larger than this crosses node boundaries and is charged at --inter-node-bandwidth/--inter-node-latency. Requires --latency-model trained-physics.")
+	cmd.Flags().Float64Var(&interNodeBandwidth, "inter-node-bandwidth", 0, "Effective inter-node link bandwidth in GB/s (InfiniBand/RoCE) for cross-node collective traffic (#1530). Required when --gpus-per-node > 0.")
+	cmd.Flags().Float64Var(&interNodeLatency, "inter-node-latency", 0, "Inter-node per-collective base latency in ms for cross-node collective traffic (#1530). 0 = no fixed latency.")
 	cmd.Flags().StringVar(&latencyModelBackend, "latency-model", "trained-physics", "Latency model backend: trained-physics (default), roofline")
 	cmd.Flags().Int64Var(&maxModelLen, "max-model-len", 0, "Max total sequence length (input + output); 0 = unlimited. Auto-derived from HF config for analytical backends when not set.")
 
@@ -2086,6 +2117,7 @@ var runCmd = &cobra.Command{
 				ModelHardwareConfig:  sim.NewModelHardwareConfig(lr.ModelConfig, lr.HWConfig, model, gpu, tensorParallelism, dataParallelism, enableExpertParallel, moeCommBackend, lr.Backend, maxModelLen),
 				PolicyConfig:         sim.NewPolicyConfig(scheduler, preemptionPolicy),
 				LoRAConfig:           loraCfg,
+				NetworkConfig:        resolveNetworkConfig(lr.Backend),
 				SLOPriorityOverrides: sloPriorityOverrides,
 			},
 			NumInstances:                    numInstances,

--- a/cmd/simconfig_shared_test.go
+++ b/cmd/simconfig_shared_test.go
@@ -77,6 +77,7 @@ func TestRunCmd_SimConfigFlagsParity(t *testing.T) {
 		"alpha-coeffs", "beta-coeffs",
 		"total-kv-blocks", "block-size-in-tokens", "max-model-len",
 		"gpu-memory-utilization", "model-config-folder", "hardware-config",
+		"gpus-per-node", "inter-node-bandwidth", "inter-node-latency",
 	}
 	for _, name := range latencyFlags {
 		runFlag := runCmd.Flags().Lookup(name)
@@ -172,6 +173,7 @@ func TestBothCommands_SimConfigFlagsHaveIdenticalDefaults(t *testing.T) {
 		"per-band-capacity", "usage-limit-threshold",
 		"queue-shedding", "dispatch-tick-interval",
 		"in-flight-eviction",
+		"gpus-per-node", "inter-node-bandwidth", "inter-node-latency",
 	}
 	for _, name := range sharedFlags {
 		runFlag := runCmd.Flags().Lookup(name)

--- a/docs/guide/latency-models.md
+++ b/docs/guide/latency-models.md
@@ -203,6 +203,28 @@ The β₄ default assumes the dispatch/combine collective runs at the same per-b
 
 Because the dispatch term is the *only* term gated on `DP > 1`, the residual isolates it cleanly. Fit per comm-backend *family* (all-gather vs all-to-all), not per backend name; see the PR #1433 discussion for why per-backend scalars are the wrong granularity (the within-family differences are prefill/decode shape effects a single scalar cannot represent).
 
+### Inter-node network cost (multi-node TP / DEP) — trained-physics only
+
+By default every collective — the TP all-reduce and the DEP expert all-to-all — is charged against `bwHbmUs` (on-package HBM/NVLink), i.e. as if all its GPUs share one fast intra-node fabric. For a deployment that spans a node boundary (multi-node TP, or Wide-EP with DP replicas on separate nodes) that is optimistic: the cross-node hops actually traverse a much slower InfiniBand/RoCE fabric. #1530 adds a minimal inter-node cost so those hops are charged.
+
+| Flag | Meaning | Default |
+|------|---------|---------|
+| `--gpus-per-node` | GPUs sharing the fast intra-node fabric. A collective whose group exceeds this spans nodes. | `0` (off — single node) |
+| `--inter-node-bandwidth` | Effective cross-node link bandwidth, GB/s (an achievable rate, like `--pd-transfer-bandwidth`). Required when `--gpus-per-node > 0`. | `0` |
+| `--inter-node-latency` | Fixed per-collective cross-node base latency, ms. | `0` |
+
+**How it's charged.** For a collective over a group of `G` GPUs (TP all-reduce: `G = tp`; DEP all-to-all: `G = moeGroup = TP·DP`), if `G > gpus_per_node` the group spans `n = ceil(G / gpus_per_node)` nodes. The cross-node fraction `(n−1)/n` of the ring/all-to-all byte volume is charged at the inter-node bandwidth (instead of NVLink), plus `inter-node-latency` per collective launch. **No learned β multiplies this term** — β₄ absorbs the NVLink/HBM ratio, which must not be re-applied to a different fabric; the inter-node bandwidth you supply is authoritative. The term is a first-cut serial-additive MVP (a hierarchical-overlap refinement is future work).
+
+**When it fires (recipe mapping).**
+
+- `single_node_tp` / `single_node_tep`: `tp ≤ gpus_per_node`, `moeGroup ≤ gpus_per_node` → no cross-node cost.
+- `multi_node_tp`: `tp > gpus_per_node` → TP all-reduce charged.
+- `multi_node_dep` (Wide-EP): TP within node (`tp ≤ gpus_per_node`) but `moeGroup = TP·DP > gpus_per_node` → DEP all-to-all charged, TP all-reduce not.
+
+**Guarantees.** Inert by default (`--gpus-per-node 0`): the term is exactly zero, so output is byte-identical to a pre-feature build (INV-6), and dense `DP=1` still satisfies INV-BC-DP1. Because the topology is a **config input** (not derived from `node_pools` placement), the same flags on `blis run` and `blis replay` reproduce identical `StepTime` (INV-13) with no trace round-trip. `--gpus-per-node` requires `--latency-model trained-physics`; an active config without a positive `--inter-node-bandwidth`, or fabric knobs set without `--gpus-per-node`, is a hard error. `blis observe` takes timing from the real server and is unaffected.
+
+**Relation to #1529.** This is the cost mechanism; the multi-node *placement* work (#1529) will later derive the node span from real GPU assignments and feed the same seam. Until then the node topology is declared via `--gpus-per-node` — a legitimate capacity-planning input (compare IB vs RoCE, or TP-vs-EP-vs-PP tradeoffs, without a real cluster).
+
 ## When to Use Which
 
 | Aspect | Roofline | Trained-Physics (default) |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -146,6 +146,9 @@ Maps to `ModelHardwareConfig`.
 | `--hardware` | string | "" | GPU type. Bundled options: `H100`, `A100-SXM`, `A100-80`. If empty, loaded from `defaults.yaml`. Add new GPUs to `hardware_config.json`. |
 | `--tp` | int | 0 | Tensor parallelism degree. If 0, loaded from `defaults.yaml`. |
 | `--max-model-len` | int64 | 0 | Max total sequence length (input + output) in tokens. 0 = unlimited. Mirrors vLLM's `--max-model-len`. Auto-derived from `max_position_embeddings` in HuggingFace `config.json` for roofline/trained-physics backends. Applies `rope_scaling` factor for types `linear`, `dynamic`, `yarn`, `default`, `mrope`; excludes `su`, `longrope`, `llama3`; skips entirely for `gemma3` models. Capped at KV-feasible maximum. |
+| `--gpus-per-node` | int | 0 | Inter-node network cost (#1530; `--latency-model trained-physics` only). GPUs sharing the fast intra-node fabric. A TP collective (group = `tp`) or DEP expert all-to-all (group = `TP·DP`) larger than this is charged for its cross-node hops at `--inter-node-bandwidth`/`--inter-node-latency`. `0` = single-node/off (inert, byte-identical to a pre-feature build). Requires `--latency-model trained-physics`. Same flags on `blis run` and `blis replay` reproduce `StepTime` (INV-13). |
+| `--inter-node-bandwidth` | float64 | 0 | Effective inter-node link bandwidth in GB/s (InfiniBand/RoCE) for cross-node collective traffic. Required (must be > 0) when `--gpus-per-node > 0`. |
+| `--inter-node-latency` | float64 | 0 | Inter-node per-collective base latency in ms for cross-node collective traffic. `0` = no fixed latency. |
 
 ### Roofline Mode
 

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -23,6 +23,7 @@ inference-sim/
 │   └── default_config.go      # defaults.yaml loading (includes GetHFRepo for HF repo name mapping)
 ├── sim/                       # Core single-instance simulator
 │   ├── config.go              # Module-scoped sub-config types (KVCacheConfig, BatchConfig, LatencyCoeffs, ModelHardwareConfig, PolicyConfig, WorkloadConfig) — composed into SimConfig via embedding (R16)
+│   ├── network_config.go      # NetworkConfig (inter-node interconnect: GPUsPerNode + inter-node bandwidth/latency, #1530); zero value inert; embedded as SimConfig's 8th sub-config; consumed by the trained-physics latency model via latency.WithNetworkConfig
 │   ├── doc.go                 # Package reading guide: start with request.go, event.go, simulator.go
 │   ├── simulator.go           # SimConfig struct (composed of embedded sub-configs + Horizon/Seed), NewSimulator(SimConfig) (*Simulator, error) constructor (validates MaxModelLen vs KV capacity), event loop (Run()), batch formation (delegated to BatchFormation interface), step execution with phased metric recording, EnqueueRequest (MaxModelLen + KV capacity guards), processCompletions (proactive MaxModelLen cap at maxModelLen-1 boundary), observation methods (QueueDepth(), BatchSize(), CurrentClock(), SimHorizon()). All workload generation external via InjectArrival().
 │   ├── admission.go           # AdmissionPolicy interface (accepts *RouterState), AlwaysAdmit, TokenBucket, RejectAll, NewAdmissionPolicy factory

--- a/sim/cluster/instance.go
+++ b/sim/cluster/instance.go
@@ -64,7 +64,13 @@ func NewInstanceSimulator(id InstanceID, cfg sim.SimConfig) *InstanceSimulator {
 	if err != nil {
 		panic(fmt.Sprintf("NewInstanceSimulator(%s): adapter cost model: %v", id, err))
 	}
-	latencyModel, err := latency.NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig, latency.WithAdapterCost(adapterCost))
+	// WithNetworkConfig supplies the inter-node interconnect model (#1530). Inert by
+	// default (cfg.NetworkConfig zero value ⇒ GPUsPerNode==0), so StepTime is
+	// byte-identical to a pre-feature build (INV-6). When active it charges cross-node
+	// collective traffic; the factory validates the fabric config and rejects an
+	// active config on a non-trained-physics backend.
+	latencyModel, err := latency.NewLatencyModel(cfg.LatencyCoeffs, cfg.ModelHardwareConfig,
+		latency.WithAdapterCost(adapterCost), latency.WithNetworkConfig(cfg.NetworkConfig))
 	if err != nil {
 		panic(fmt.Sprintf("NewInstanceSimulator(%s): NewLatencyModel: %v", id, err))
 	}

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -32,9 +32,11 @@ func clampToInt64(v float64) int64 {
 // the same options, so an adapter effect applies identically (R23).
 type Option func(*latencyOptions)
 
-// latencyOptions accumulates the applied Options. Zero value ⇒ no adapter effect.
+// latencyOptions accumulates the applied Options. Zero value ⇒ no adapter effect
+// and an inert (single-node) network model.
 type latencyOptions struct {
 	adapterCost sim.AdapterCost
+	network     sim.NetworkConfig
 }
 
 // WithAdapterCost supplies the LoRA per-step compute-overhead accessor. A nil
@@ -43,6 +45,17 @@ type latencyOptions struct {
 // sim.AdapterCost interface — sim/latency never imports sim/lora.
 func WithAdapterCost(ac sim.AdapterCost) Option {
 	return func(o *latencyOptions) { o.adapterCost = ac }
+}
+
+// WithNetworkConfig supplies the inter-node interconnect model (#1530). An inert
+// config (the zero value / GPUsPerNode == 0, or no option) leaves StepTime
+// byte-identical to a pre-feature build (INV-6, INV-BC-DP1). The network term is
+// modeled only by the trained-physics backend; NewLatencyModel rejects an active
+// config on any other backend (R1 — never silently ignore a cross-node cost the
+// user asked for). The concrete topology/fabric values are validated at
+// construction.
+func WithNetworkConfig(nc sim.NetworkConfig) Option {
+	return func(o *latencyOptions) { o.network = nc }
 }
 
 // applyAdapterOverhead multiplies a base step time by the batch's LoRA
@@ -152,6 +165,16 @@ func NewLatencyModel(coeffs sim.LatencyCoeffs, hw sim.ModelHardwareConfig, opts 
 	if err := validateCoeffs("AlphaCoeffs", coeffs.AlphaCoeffs); err != nil {
 		return nil, err
 	}
+	// Inter-node network model (#1530): validate the fabric config, and reject an
+	// active config on any backend that does not model it (R1 — a cross-node cost
+	// the user configured must never be silently dropped). Only trained-physics
+	// consumes it; an inert config (the common case) is a no-op everywhere.
+	if err := o.network.Validate(); err != nil {
+		return nil, fmt.Errorf("latency model: %w", err)
+	}
+	if o.network.IsActive() && hw.Backend != "trained-physics" {
+		return nil, fmt.Errorf("latency model: inter-node network cost (--gpus-per-node) requires --latency-model trained-physics, got backend %q", hw.Backend)
+	}
 	switch hw.Backend {
 	case "", "roofline":
 		if hw.TP <= 0 {
@@ -176,6 +199,7 @@ func NewLatencyModel(coeffs sim.LatencyCoeffs, hw sim.ModelHardwareConfig, opts 
 			return nil, err
 		}
 		model.adapterCost = o.adapterCost
+		model.network = o.network
 		return model, nil
 	default:
 		return nil, fmt.Errorf("latency model: unknown backend %q; valid options: %s",

--- a/sim/latency/network_cost_test.go
+++ b/sim/latency/network_cost_test.go
@@ -1,0 +1,142 @@
+package latency
+
+import (
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+	"github.com/stretchr/testify/require"
+)
+
+// newNetModel builds a trained-physics model through the production factory
+// (NewLatencyModel + WithNetworkConfig) so the inter-node option-wiring and
+// validation are exercised, then returns the concrete type for StepTime.
+func newNetModel(t *testing.T, mc *sim.ModelConfig, tp, dp int, nc sim.NetworkConfig) *TrainedPhysicsModel {
+	t.Helper()
+	mhw := sim.NewModelHardwareConfig(*mc, dpepTestHW(), "m", "H100", tp, dp, false, "", "trained-physics", 0)
+	lm, err := NewLatencyModel(*testCoeffs(), mhw, WithNetworkConfig(nc))
+	require.NoError(t, err)
+	m, ok := lm.(*TrainedPhysicsModel)
+	require.True(t, ok, "expected *TrainedPhysicsModel")
+	return m
+}
+
+// TestInterNodeCost_BC1_CrossNodeCharged is AC1: for an otherwise-identical config,
+// a topology that spans a node boundary yields a strictly larger StepTime than one
+// contained within a single node — for BOTH delivered legs (TP all-reduce and DEP
+// all-to-all).
+func TestInterNodeCost_BC1_CrossNodeCharged(t *testing.T) {
+	batch := dpepMixedBatch() // has prefill + decode tokens → comm terms nonzero
+
+	t.Run("TP all-reduce leg (dense, tp>gpus-per-node)", func(t *testing.T) {
+		dense := testModelConfig()
+		// tp=8 spanning 2 nodes of 4 vs contained in a node of 8.
+		spanning := newNetModel(t, &dense, 8, 1, sim.NewNetworkConfig(4, 50.0, 0)).StepTime(batch)
+		contained := newNetModel(t, &dense, 8, 1, sim.NewNetworkConfig(8, 50.0, 0)).StepTime(batch)
+		inert := newNetModel(t, &dense, 8, 1, sim.NetworkConfig{}).StepTime(batch)
+		require.Greater(t, spanning, contained, "cross-node TP all-reduce must cost strictly more than single-node")
+		require.Equal(t, inert, contained, "a group that fits within one node must charge zero cross-node cost")
+	})
+
+	t.Run("DEP all-to-all leg (MoE, moeGroup>gpus-per-node)", func(t *testing.T) {
+		moe := dpepMoEModelConfig()
+		// tp=4, dp=2 → moeGroup=8. gpus-per-node=4: TP (4) fits, moeGroup (8) spans → isolates the dispatch leg.
+		spanning := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 50.0, 0)).StepTime(batch)
+		contained := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(8, 50.0, 0)).StepTime(batch)
+		inert := newNetModel(t, moe, 4, 2, sim.NetworkConfig{}).StepTime(batch)
+		require.Greater(t, spanning, contained, "cross-node DEP all-to-all must cost strictly more than single-node")
+		require.Equal(t, inert, contained, "a moeGroup that fits within one node must charge zero cross-node cost")
+	})
+}
+
+// TestInterNodeCost_BC2_MonotonicFabricQuality is AC2: holding topology fixed,
+// decreasing inter-node bandwidth OR increasing inter-node latency never decreases
+// the charged cost (and strictly increases it while comm volume is nonzero).
+func TestInterNodeCost_BC2_MonotonicFabricQuality(t *testing.T) {
+	batch := dpepMixedBatch()
+	moe := dpepMoEModelConfig()
+
+	// Bandwidth: worse fabric (lower GB/s) ⇒ higher StepTime.
+	fast := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 100.0, 0)).StepTime(batch)
+	mid := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 50.0, 0)).StepTime(batch)
+	slow := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 25.0, 0)).StepTime(batch)
+	require.Greater(t, slow, mid, "lower inter-node bandwidth must not decrease cost")
+	require.Greater(t, mid, fast, "lower inter-node bandwidth must not decrease cost")
+
+	// Latency: higher base latency ⇒ higher StepTime, holding bandwidth fixed.
+	noLat := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 50.0, 0)).StepTime(batch)
+	someLat := newNetModel(t, moe, 4, 2, sim.NewNetworkConfig(4, 50.0, 0.01)).StepTime(batch)
+	require.Greater(t, someLat, noLat, "higher inter-node latency must not decrease cost")
+}
+
+// TestInterNodeCost_BC3_NoOpByteIdentical is AC3 / INV-6 / INV-BC-DP1: any config
+// that stays within one node — the inert default, and a declared topology whose
+// groups fit — produces StepTime byte-identical to a model built with NO network
+// option at all (the pre-feature value). Covers a matrix of dense/MoE × TP × DP.
+func TestInterNodeCost_BC3_NoOpByteIdentical(t *testing.T) {
+	dense := testModelConfig()
+	moe := dpepMoEModelConfig()
+	batch := dpepMixedBatch()
+
+	cases := []struct {
+		name string
+		mc   *sim.ModelConfig
+		tp   int
+		dp   int
+	}{
+		{"dense tp1 dp1 (INV-BC-DP1)", &dense, 1, 1},
+		{"dense tp2 dp1 (INV-BC-DP1)", &dense, 2, 1},
+		{"dense tp8 dp1 (INV-BC-DP1)", &dense, 8, 1},
+		{"moe tp2 dp1", moe, 2, 1},
+		{"moe tp4 dp2", moe, 4, 2},
+		{"moe tp8 dp1", moe, 8, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reference: no network option applied at all (pre-feature construction).
+			ref := newDPEPModel(t, tc.mc, tc.tp, tc.dp, false, "").StepTime(batch)
+
+			// Inert network config (default zero value) must be byte-identical.
+			inert := newNetModel(t, tc.mc, tc.tp, tc.dp, sim.NetworkConfig{}).StepTime(batch)
+			require.Equal(t, ref, inert, "inert network config must be byte-identical to no-network")
+
+			// A declared topology whose every group fits in one node (gpus-per-node
+			// >= tp*dp) must also be byte-identical — the term is 0 unless a boundary
+			// is crossed, even when the network model is "active".
+			fits := newNetModel(t, tc.mc, tc.tp, tc.dp, sim.NewNetworkConfig(64, 50.0, 0.01)).StepTime(batch)
+			require.Equal(t, ref, fits, "a topology that fits in one node must charge zero cross-node cost")
+		})
+	}
+}
+
+// TestInterNodeCost_BC4_Deterministic is AC4 / INV-6: the same config produces the
+// same StepTime on repeated calls (the term is a pure function of config + tokens).
+func TestInterNodeCost_BC4_Deterministic(t *testing.T) {
+	batch := dpepMixedBatch()
+	moe := dpepMoEModelConfig()
+	nc := sim.NewNetworkConfig(4, 37.5, 0.003)
+	first := newNetModel(t, moe, 4, 2, nc).StepTime(batch)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, first, newNetModel(t, moe, 4, 2, nc).StepTime(batch), "StepTime must be deterministic")
+	}
+}
+
+// TestInterNodeCost_BC6_BackendAndConfigGuards is BC-6 / R1: an active network
+// config on a non-trained-physics backend is a hard error, and an invalid fabric
+// config is rejected at construction — never a silent no-op.
+func TestInterNodeCost_BC6_BackendAndConfigGuards(t *testing.T) {
+	dense := testModelConfig()
+
+	// Active network config on the roofline backend → error.
+	roof := sim.NewModelHardwareConfig(dense, dpepTestHW(), "m", "H100", 8, 1, false, "", "roofline", 0)
+	_, err := NewLatencyModel(*testCoeffs(), roof, WithNetworkConfig(sim.NewNetworkConfig(4, 50.0, 0)))
+	require.Error(t, err, "active network config on roofline backend must error")
+
+	// Inert network config on roofline is fine (no cross-node cost requested).
+	_, err = NewLatencyModel(*testCoeffs(), roof, WithNetworkConfig(sim.NetworkConfig{}))
+	require.NoError(t, err, "inert network config must not affect the roofline backend")
+
+	// Invalid fabric config (active but zero bandwidth) → error at construction.
+	tp := sim.NewModelHardwareConfig(dense, dpepTestHW(), "m", "H100", 8, 1, false, "", "trained-physics", 0)
+	_, err = NewLatencyModel(*testCoeffs(), tp, WithNetworkConfig(sim.NetworkConfig{GPUsPerNode: 4}))
+	require.Error(t, err, "active network config with zero bandwidth must error")
+}

--- a/sim/latency/trained_physics_model.go
+++ b/sim/latency/trained_physics_model.go
@@ -173,6 +173,14 @@ type TrainedPhysicsModel struct {
 	// when the LoRA subsystem is inert, in which case StepTime is byte-identical to
 	// a pre-feature build (INV-6/INV-BC-DP1). Set via WithAdapterCost at construction.
 	adapterCost sim.AdapterCost
+
+	// network is the inter-node interconnect model (#1530). Its zero value is inert
+	// (GPUsPerNode == 0): the cross-node term contributes exactly zero and StepTime
+	// is byte-identical to a pre-feature build (INV-6/INV-BC-DP1). When active, a
+	// comm collective whose participant group exceeds network.GPUsPerNode is charged
+	// for its cross-node hops at the inter-node bandwidth/latency. Set via
+	// WithNetworkConfig at construction.
+	network sim.NetworkConfig
 }
 
 // bytesPerKVElement is 2 bytes (FP16) for KV cache, matching vLLM's default.
@@ -431,6 +439,11 @@ func (m *TrainedPhysicsModel) StepTime(batch []*sim.Request) int64 {
 		m.Beta[6] +
 		m.Beta[7]*moeScaling*float64(m.numMoELayers) // β₈: per-MoE-layer overhead (interleaved archs only)
 
+	// Inter-node network cost (#1530): additional µs for cross-node collective
+	// traffic. Exactly 0 when the network model is inert or no collective crosses a
+	// node boundary, so intra-node configs stay byte-identical (INV-6/INV-BC-DP1).
+	stepTime += m.interNodeCost(totalTokens)
+
 	return applyAdapterOverhead(max(1, clampToInt64(stepTime)), batch, m.adapterCost)
 }
 
@@ -469,27 +482,108 @@ func (m *TrainedPhysicsModel) sharedExpertCompute(tokens, d, tpdp float64) float
 // efficiency (ring all-reduce, which β_EP defaults to β₄ from, IS reduce-scatter+
 // all-gather), so only the volume basis differs between families.
 func (m *TrainedPhysicsModel) moeDispatchBasis(globalTokens, kEff float64) float64 {
+	return m.moeDispatchBytes(globalTokens, kEff) / m.bwHbmUs
+}
+
+// moeDispatchBytes is the raw per-MoE-layer dispatch/combine byte volume for
+// moeDispatchBasis, before dividing by a link bandwidth. Factored out (#1530) so
+// the same volume feeds both the intra-node basis (÷ bwHbmUs) and the inter-node
+// cross-node term (÷ inter-node bandwidth). The operation order is preserved
+// exactly, so moeDispatchBasis is byte-identical to its pre-#1530 form.
+//
+// Dispatch/combine moves hidden-state ACTIVATIONS, so size them with the
+// compute/activation dtype (BytesPerParam), NOT the quantized weight dtype —
+// matching tpAllReduceBytes and the KV terms (vLLM dispatches the BF16 hidden
+// states: NaiveAll2AllManager.naive_multicast allocates dtype=x.dtype; the
+// quantized post_quant_allgather path is an explicit opt-in, not the default).
+func (m *TrainedPhysicsModel) moeDispatchBytes(globalTokens, kEff float64) float64 {
 	hidden := float64(m.hiddenDim)
 	group := float64(m.moeGroup)
 	dpf := float64(m.dp)
-	// Dispatch/combine moves hidden-state ACTIVATIONS, so size them with the
-	// compute/activation dtype (BytesPerParam), NOT the quantized weight dtype —
-	// matching tpAllReduceBasis and the KV terms (vLLM dispatches the BF16 hidden
-	// states: NaiveAll2AllManager.naive_multicast allocates dtype=x.dtype; the
-	// quantized post_quant_allgather path is an explicit opt-in, not the default).
 	switch m.commFamily {
 	case commFamilyAllGather: // dense hidden-state volume, no top_k
-		return (globalTokens / dpf) * (group - 1) / group * 2 * hidden * m.activationBPP / m.bwHbmUs
+		return (globalTokens / dpf) * (group - 1) / group * 2 * hidden * m.activationBPP
 	case commFamilyAll2All:
 		load := m.placement.Resolve(globalTokens, kEff, m.numExperts, m.moeGroup, m.dp)
-		return load.PerGPUCommTokens * hidden * m.activationBPP / m.bwHbmUs
+		return load.PerGPUCommTokens * hidden * m.activationBPP
 	default:
 		// Unreachable: commFamily is set once at construction from moeCommFamilyFor,
 		// which only yields the two families above. Panic on a future 3rd family so a
 		// new volume model is added here deliberately, rather than silently inheriting
 		// the all-gather (no-kEff) cost — a quiet factor-of-kEff error.
-		panic(fmt.Sprintf("moeDispatchBasis: unhandled commFamily %d", m.commFamily))
+		panic(fmt.Sprintf("moeDispatchBytes: unhandled commFamily %d", m.commFamily))
 	}
+}
+
+// nodesSpanned returns how many physical nodes a collective over groupSize GPUs
+// spans, given the intra-node GPU count (network.GPUsPerNode). Returns 1 (single
+// node ⇒ no cross-node cost) when the network model is inert (GPUsPerNode == 0) or
+// the group fits within one node.
+func (m *TrainedPhysicsModel) nodesSpanned(groupSize int) int {
+	g := m.network.GPUsPerNode
+	if g <= 0 || groupSize <= g {
+		return 1
+	}
+	return (groupSize + g - 1) / g // ceil(groupSize / gpusPerNode)
+}
+
+// interNodeCost returns the additional step-time (µs) charged for cross-node
+// collective traffic (#1530). It is exactly 0 when the network model is inert
+// (GPUsPerNode == 0) or no collective crosses a node boundary, so an intra-node
+// config is byte-identical to a pre-feature build (INV-6/INV-BC-DP1).
+//
+// Mechanism (the issue's "swap bwHbmUs for an effective link bandwidth when the
+// collective crosses a node boundary"): for each comm collective whose participant
+// group spans n > 1 nodes, the cross-node fraction (n-1)/n of its ring/all-to-all
+// byte volume is charged at the inter-node bandwidth (an effective achievable rate,
+// like --pd-transfer-bandwidth) instead of the on-package bwHbmUs, plus a fixed
+// per-collective inter-node base latency. No learned β is applied: β₄ absorbs the
+// NVLink/HBM ratio, which must NOT be re-applied to the inter-node fabric.
+//
+// Two legs, mirroring the intra-node comm terms they shadow:
+//   - TP all-reduce (group = tp): attention (all layers) + dense-FFN (dense layers)
+//     + MoE-FFN reduce (MoE layers, only at dp==1, mirroring tMoEReduce). Charged
+//     /dp because DP groups run in parallel, exactly like tTpAttention/tTpDenseFFN.
+//   - MoE dispatch/combine (group = moeGroup = TP·DP): MoE layers, only at dp>1
+//     (mirroring tMoEDispatch). Its byte volume is already per-rank.
+//
+// This is a first-cut MVP: the cross-node cost is charged additively on top of the
+// intra-node comm term (a conservative serial model), and the per-collective latency
+// is charged per layer. A hierarchical-overlap refinement is future work.
+func (m *TrainedPhysicsModel) interNodeCost(totalTokens float64) float64 {
+	if !m.network.IsActive() || totalTokens <= 0 {
+		// No cross-node modeling requested, or no tokens to communicate this step —
+		// no collective runs, so neither the bandwidth nor the fixed-latency term applies.
+		return 0
+	}
+	bwUs := m.network.InterNodeBandwidthGBps * 1000.0 // GB/s → bytes/µs (matches PD-transfer)
+	latUs := m.network.InterNodeLatencyMs * 1000.0    // ms → µs
+	cost := 0.0
+
+	// TP all-reduce leg (group = tp).
+	if m.tp > 1 {
+		if n := m.nodesSpanned(m.tp); n > 1 {
+			crossFrac := float64(n-1) / float64(n)
+			units := float64(m.numLayers + m.numDenseLayers)
+			if m.isMoE && m.dp == 1 {
+				units += float64(m.numMoELayers) // MoE-FFN reduce, mirroring the tMoEReduce (dp==1) gate
+			}
+			dpf := float64(m.dp)
+			cost += crossFrac * m.tpAllReduceBytes(units, totalTokens) / bwUs / dpf
+			cost += latUs * units // per-collective launch latency (wall-clock; DP ranks run in parallel, so not /dp)
+		}
+	}
+
+	// MoE dispatch/combine leg (group = moeGroup = TP·DP), only at dp>1.
+	if m.isMoE && m.dp > 1 {
+		if n := m.nodesSpanned(m.moeGroup); n > 1 {
+			crossFrac := float64(n-1) / float64(n)
+			bytes := m.moeDispatchBytes(totalTokens, float64(m.kEff)) * float64(m.numMoELayers)
+			cost += crossFrac * bytes / bwUs
+			cost += latUs * float64(m.numMoELayers)
+		}
+	}
+	return cost
 }
 
 // tpAllReduceBasis is the ring-all-reduce communication basis V(units, tokens):
@@ -501,6 +595,19 @@ func (m *TrainedPhysicsModel) moeDispatchBasis(globalTokens, kEff float64) float
 // MoE-FFN reduction). Returns 0 at tp == 1 (no communication). β₄ absorbs the
 // NVLink/HBM bandwidth ratio (~0.27 on H100) and ring-collective efficiency.
 func (m *TrainedPhysicsModel) tpAllReduceBasis(units, tokens float64) float64 {
+	return m.tpAllReduceBytes(units, tokens) / m.bwHbmUs
+}
+
+// tpAllReduceBytes is the raw ring-all-reduce byte volume for tpAllReduceBasis,
+// before dividing by a link bandwidth:
+//
+//	units · tokens · hidden · activationBPP · 2 (ring phases) · (tp-1)/tp
+//
+// Returns 0 at tp == 1 (no communication). Factored out (#1530) so the same volume
+// feeds both the intra-node basis (÷ bwHbmUs) and the inter-node cross-node term
+// (÷ inter-node bandwidth). The operation order is preserved exactly, so
+// tpAllReduceBasis is byte-identical to its pre-#1530 form (INV-BC-DP1).
+func (m *TrainedPhysicsModel) tpAllReduceBytes(units, tokens float64) float64 {
 	if m.tp <= 1 {
 		return 0
 	}
@@ -508,7 +615,7 @@ func (m *TrainedPhysicsModel) tpAllReduceBasis(units, tokens float64) float64 {
 	// activationBPP (compute dtype) sizes the moved hidden states, not the weight dtype
 	// — same convention as moeDispatchBasis and the KV terms. The trailing 2.0 is the
 	// ring all-reduce phase count (reduce-scatter + all-gather), not a byte width.
-	return units * tokens * float64(m.hiddenDim) * m.activationBPP * 2.0 * tpFactor / m.bwHbmUs
+	return units * tokens * float64(m.hiddenDim) * m.activationBPP * 2.0 * tpFactor
 }
 
 // QueueingTime computes request-level overhead (ARRIVED → QUEUED).

--- a/sim/network_config.go
+++ b/sim/network_config.go
@@ -1,0 +1,87 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+)
+
+// NetworkConfig describes the inter-node interconnect for the trained-physics
+// latency model (#1530). It is the topology + fabric input the model uses to
+// charge cross-node collective traffic (multi-node TP all-reduce, DEP expert
+// all-to-all) at an inter-node bandwidth/latency instead of the on-package
+// HBM/NVLink bandwidth.
+//
+// The zero value is inert: with GPUsPerNode == 0 the model treats every collective
+// as intra-node and StepTime is byte-identical to a pre-feature build (INV-6,
+// INV-BC-DP1). The network term contributes exactly zero unless a collective's
+// participant group exceeds GPUsPerNode — i.e. a real node boundary is crossed.
+//
+// Topology is expressed as an explicit config input (mirroring how --tp/--dp are
+// modeling inputs), NOT derived from node_pools placement. This keeps the signal
+// identical across `blis run` and `blis replay` (both build it from the same CLI
+// flags), so run/replay parity (INV-13) holds by construction without any TraceV2
+// round-trip. Deriving GPUsPerNode from real multi-node placement is the #1529
+// follow-up that consumes this same seam.
+type NetworkConfig struct {
+	// GPUsPerNode is the number of GPUs sharing the fast intra-node fabric (NVLink).
+	// A parallel collective whose group size exceeds this spans node boundaries.
+	// 0 = unset ⇒ the network model is inert (single-node, no cross-node cost).
+	GPUsPerNode int
+
+	// InterNodeBandwidthGBps is the effective cross-node link bandwidth in GB/s
+	// (InfiniBand / RoCE). Used only when a collective crosses a node boundary.
+	// Interpreted as an effective achievable rate (like --pd-transfer-bandwidth),
+	// not a theoretical peak. Must be > 0 when GPUsPerNode > 0 (R11 divisor guard).
+	InterNodeBandwidthGBps float64
+
+	// InterNodeLatencyMs is the fixed per-collective cross-node base latency in ms
+	// (switch/hop latency). 0 = no fixed latency. Non-negative.
+	InterNodeLatencyMs float64
+}
+
+// NewNetworkConfig creates a NetworkConfig with all fields explicitly set. This is
+// the canonical constructor — all construction sites must use it (R4).
+func NewNetworkConfig(gpusPerNode int, interNodeBandwidthGBps, interNodeLatencyMs float64) NetworkConfig {
+	return NetworkConfig{
+		GPUsPerNode:            gpusPerNode,
+		InterNodeBandwidthGBps: interNodeBandwidthGBps,
+		InterNodeLatencyMs:     interNodeLatencyMs,
+	}
+}
+
+// IsActive reports whether the network model contributes any cost. It is active
+// exactly when GPUsPerNode > 0; when inactive the latency model is byte-identical
+// to a pre-feature build (INV-6).
+func (c NetworkConfig) IsActive() bool {
+	return c.GPUsPerNode > 0
+}
+
+// Validate checks the NetworkConfig for internal consistency. It is a pure query —
+// the library boundary returns an error and the caller decides fatality (cmd/ →
+// logrus.Fatalf; sim/ factory → error). The zero value is valid and inert (INV-6).
+//
+// Guards (R1/R3/R11):
+//   - GPUsPerNode must be non-negative.
+//   - Bandwidth and latency must be finite and non-negative.
+//   - An active config (GPUsPerNode > 0) requires a positive bandwidth (the
+//     cross-node cost divides by it).
+//   - Fabric knobs set without GPUsPerNode is a misconfiguration — they would have
+//     no effect, so surface it loudly rather than silently ignore (R1).
+func (c NetworkConfig) Validate() error {
+	if c.GPUsPerNode < 0 {
+		return fmt.Errorf("NetworkConfig: GPUsPerNode must be >= 0, got %d", c.GPUsPerNode)
+	}
+	if math.IsNaN(c.InterNodeBandwidthGBps) || math.IsInf(c.InterNodeBandwidthGBps, 0) || c.InterNodeBandwidthGBps < 0 {
+		return fmt.Errorf("NetworkConfig: InterNodeBandwidthGBps must be a finite non-negative number, got %v", c.InterNodeBandwidthGBps)
+	}
+	if math.IsNaN(c.InterNodeLatencyMs) || math.IsInf(c.InterNodeLatencyMs, 0) || c.InterNodeLatencyMs < 0 {
+		return fmt.Errorf("NetworkConfig: InterNodeLatencyMs must be a finite non-negative number, got %v", c.InterNodeLatencyMs)
+	}
+	if c.GPUsPerNode > 0 && c.InterNodeBandwidthGBps <= 0 {
+		return fmt.Errorf("NetworkConfig: InterNodeBandwidthGBps must be > 0 when GPUsPerNode is set (got GPUsPerNode=%d, bandwidth=%v)", c.GPUsPerNode, c.InterNodeBandwidthGBps)
+	}
+	if c.GPUsPerNode == 0 && (c.InterNodeBandwidthGBps > 0 || c.InterNodeLatencyMs > 0) {
+		return fmt.Errorf("NetworkConfig: inter-node bandwidth/latency have no effect without GPUsPerNode > 0 (got bandwidth=%v, latency=%v ms); set --gpus-per-node", c.InterNodeBandwidthGBps, c.InterNodeLatencyMs)
+	}
+	return nil
+}

--- a/sim/network_config_test.go
+++ b/sim/network_config_test.go
@@ -1,0 +1,71 @@
+package sim
+
+import (
+	"math"
+	"testing"
+)
+
+// TestNewNetworkConfig_FieldEquivalence verifies the canonical constructor sets
+// every field (R4) and that the zero value is inert (IsActive false), so an
+// unset network config leaves the latency model byte-identical to a pre-feature
+// build (INV-6).
+func TestNewNetworkConfig_FieldEquivalence(t *testing.T) {
+	nc := NewNetworkConfig(8, 50.0, 0.002)
+	if nc.GPUsPerNode != 8 {
+		t.Errorf("GPUsPerNode = %d, want 8", nc.GPUsPerNode)
+	}
+	if nc.InterNodeBandwidthGBps != 50.0 {
+		t.Errorf("InterNodeBandwidthGBps = %v, want 50.0", nc.InterNodeBandwidthGBps)
+	}
+	if nc.InterNodeLatencyMs != 0.002 {
+		t.Errorf("InterNodeLatencyMs = %v, want 0.002", nc.InterNodeLatencyMs)
+	}
+
+	// Zero value is inert.
+	var zero NetworkConfig
+	if zero.IsActive() {
+		t.Error("zero-value NetworkConfig must be inert (IsActive false)")
+	}
+	if NewNetworkConfig(0, 0, 0).IsActive() {
+		t.Error("NewNetworkConfig(0,0,0) must be inert")
+	}
+	if !NewNetworkConfig(8, 50.0, 0).IsActive() {
+		t.Error("NewNetworkConfig(8,50,0) must be active (GPUsPerNode>0)")
+	}
+}
+
+// TestNetworkConfig_Validate covers the R3 numeric guards and the R11 divisor
+// guard: an active config (GPUsPerNode>0) requires a positive finite bandwidth,
+// fabric knobs set without GPUsPerNode is a misconfiguration (R1), and all fields
+// must be finite and non-negative.
+func TestNetworkConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		nc      NetworkConfig
+		wantErr bool
+	}{
+		{"inert zero value", NetworkConfig{}, false},
+		{"active well-formed", NewNetworkConfig(8, 50.0, 0.002), false},
+		{"active no latency ok", NewNetworkConfig(8, 50.0, 0), false},
+		{"negative gpus-per-node", NetworkConfig{GPUsPerNode: -1}, true},
+		{"active but zero bandwidth", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: 0}, true},
+		{"active but negative bandwidth", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: -1}, true},
+		{"orphan bandwidth (no gpus-per-node)", NetworkConfig{InterNodeBandwidthGBps: 50.0}, true},
+		{"orphan latency (no gpus-per-node)", NetworkConfig{InterNodeLatencyMs: 0.002}, true},
+		{"NaN bandwidth", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: math.NaN()}, true},
+		{"Inf bandwidth", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: math.Inf(1)}, true},
+		{"NaN latency", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: 50.0, InterNodeLatencyMs: math.NaN()}, true},
+		{"negative latency", NetworkConfig{GPUsPerNode: 8, InterNodeBandwidthGBps: 50.0, InterNodeLatencyMs: -0.001}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.nc.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -78,6 +78,13 @@ type SimConfig struct {
 	// zero value is inert: unset => the subsystem is a no-op and output is
 	// byte-identical to a pre-feature build (INV-6). See sim/lora.
 	LoRAConfig
+	// NetworkConfig is the 8th module sub-config (inter-node interconnect cost,
+	// #1530). Its zero value is inert: unset => the trained-physics latency model
+	// charges no cross-node cost and StepTime is byte-identical to a pre-feature
+	// build (INV-6, INV-BC-DP1). Consumed by the latency model via
+	// latency.WithNetworkConfig. Always accessed qualified (cfg.NetworkConfig) —
+	// its Validate() intentionally does not promote onto SimConfig.
+	NetworkConfig
 
 	// SLO priority overrides for preemption victim selection (--preemption-policy priority).
 	// nil = use GAIE defaults (critical=4, standard=3, batch=-1, sheddable=-2, background=-3).


### PR DESCRIPTION
## Summary

- BLIS never charged for cross-node collective traffic: `tpAllReduceBasis` (TP all-reduce) and `moeDispatchBasis` (DEP expert all-to-all) both divide byte volume by `bwHbmUs` (on-package HBM/NVLink), so any multi-node TP or Wide-EP (`multi_node_dep`) deployment carried **zero interconnect penalty** — optimistic in a way that's invisible to the user.
- This PR adds a minimal inter-node network cost to the **trained-physics** latency model. A new `sim.NetworkConfig` (`--gpus-per-node`, `--inter-node-bandwidth` GB/s, `--inter-node-latency` ms) charges a collective whose participant group exceeds `--gpus-per-node`: its cross-node fraction `(n-1)/n` of the ring/all-to-all byte volume is charged at the inter-node bandwidth (an effective rate, like `--pd-transfer-bandwidth`; **no learned β** — β₄ absorbs the NVLink/HBM ratio, which must not re-apply to the fabric) plus a fixed per-collective base latency.
- Delivered boundary: **both** comm legs (they share one mechanism) — multi-node TP all-reduce (group = `tp`) **and** DEP all-to-all (group = `moeGroup` = `TP·DP`).

## Issue

Closes #1530 · Part of #1532 (GLM-5.2 support).

## Design notes (source-document audit)

The issue body says "implement after #1529" (multi-node placement, **not yet merged**), while the parent tracking issue #1532 says "#1530 is the foundation … buildable and unit-testable first … suggested order: #1530 → then #1529/#1531." Resolved toward the parent's guidance:

- **Topology is a config input, not a placement-derived signal.** `--gpus-per-node` + the existing `--tp`/`--dp` degrees determine whether a collective crosses a node boundary — no dependency on #1529's multi-node placement. This makes the mechanism unit- and integration-testable today, and it is the exact seam #1529 will later drive from real GPU spans.
- **No `NewModelHardwareConfig` churn:** injected through a `latency.WithNetworkConfig` functional option (mirroring `WithAdapterCost`), carried on `SimConfig` as an 8th zero-value-inert sub-config (mirroring `LoRAConfig`).
- Two comm bases (`tpAllReduceBasis`, `moeDispatchBasis`) were refactored to expose their raw byte volume (`*Bytes`) so the same volume feeds both the intra-node basis (÷ `bwHbmUs`) and the new cross-node term (÷ inter-node bandwidth); the operation order is preserved exactly, so the existing terms are byte-identical (guarded by the trained-physics golden + INV-BC-DP1 suites, which pass unchanged).

## Cross-Path Parity (run / replay / observe)

| Path | Applies | Implemented | Notes |
|------|---------|-------------|-------|
| `blis run` | yes | yes | `--gpus-per-node` / `--inter-node-bandwidth` / `--inter-node-latency` |
| `blis replay` | yes | yes | Same flags via the shared `registerSimConfigFlags`; INV-13 holds by construction (identical flags → identical config → identical `StepTime`). No TraceV2 round-trip needed (signal is not `node_pools`-derived). |
| `blis observe` | no | N/A | Takes timing from the real server; unaffected. |

## Invariants

- **INV-6 / INV-BC-DP1:** inert by default (`--gpus-per-node 0`) and when a group fits in one node → the term is exactly `0.0` → `StepTime` byte-identical to a pre-feature build; dense `DP=1` unchanged across the TP matrix.
- **INV-13:** run/replay reconstruct the same `StepTime` from identical CLI flags; a run→replay parity test covers a cross-node config.
- **R1:** `--gpus-per-node` requires `--latency-model trained-physics`; an active config without a positive `--inter-node-bandwidth`, or fabric knobs set without `--gpus-per-node`, is a hard error (never a silent no-op).

## Test Plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (all packages green, incl. trained-physics golden + INV-BC-DP1)
- [x] `golangci-lint run ./sim/... ./cmd/...` (0 issues)
- [x] **AC1** `TestInterNodeCost_BC1_CrossNodeCharged` — cross-node > single-node for both legs
- [x] **AC2** `TestInterNodeCost_BC2_MonotonicFabricQuality` — monotonic in bandwidth and latency
- [x] **AC3** `TestInterNodeCost_BC3_NoOpByteIdentical` — inert + fits-in-node byte-identical (incl. dense DP=1)
- [x] **AC4** `TestInterNodeCost_BC4_Deterministic`
- [x] **INV-13** `TestParity_InterNodeNetwork_RunReplay_INV13`
- [x] **R1 guards** `TestInterNodeCost_BC6_BackendAndConfigGuards`, `TestResolveNetworkConfig_HappyPaths`, `NetworkConfig.Validate` table
- [x] End-to-end smoke: `blis run … --tp 8 --gpus-per-node 4 --inter-node-bandwidth 50` raises mean E2E vs the same run without the flags; all three misconfig guards fatal with clear messages.

## Not in scope (documented)

Hierarchical-overlap refinement of the (currently serial-additive, per-layer) cost model; deriving `--gpus-per-node` from real multi-node placement (#1529). `blis observe` does not model the fabric.

---

Generated with [Claude Code](https://claude.com/claude-code)