### PR TITLE
feat(latency): parse Kimi-K3 MoE key aliases (num_experts_per_token / num_shared_experts)

### DIFF
--- a/sim/latency/config.go
+++ b/sim/latency/config.go
@@ -68,6 +68,20 @@ func (c *HFConfig) MustGetInt(key string, def int) int {
 	return def
 }
 
+// MustGetIntFallback returns the first of keys that resolves to a non-zero int
+// (tried in order), else def. It centralizes multi-spelling field resolution
+// (e.g. vendor-specific MoE activation-count names) so GetModelConfigFromHF and
+// ExtractKVCapacityParams resolve identical spellings and cannot desync (R23
+// code-path parity).
+func (c *HFConfig) MustGetIntFallback(def int, keys ...string) int {
+	for _, k := range keys {
+		if v, ok := c.GetInt(k); ok && v != 0 {
+			return v
+		}
+	}
+	return def
+}
+
 // moeExpertCountFields lists the HF config field names that carry the total
 // routed-expert count, in the resolution order used by vLLM's get_num_experts
 // (vllm/transformers_utils/model_arch_config_convertor.py): num_experts (Jamba),
@@ -82,6 +96,15 @@ var moeExpertCountFields = []string{
 	"num_local_experts", // Mixtral
 	"num_routed_experts", // BLIS-historical alias
 }
+
+// moeActiveExpertFields and moeSharedExpertFields list the accepted HF spellings
+// for the MoE *activation* counts (experts active per token; shared experts),
+// tried in order. DeepSeek/GLM spell them num_experts_per_tok / n_shared_experts;
+// Kimi-K3 (transformers/vLLM) spells them num_experts_per_token / num_shared_experts
+// (#1634). Shared as package vars so GetModelConfigFromHF and ExtractKVCapacityParams
+// resolve the same spellings and cannot desync (R23 code-path parity).
+var moeActiveExpertFields = []string{"num_experts_per_tok", "num_experts_per_token"}
+var moeSharedExpertFields = []string{"n_shared_experts", "num_shared_experts"}
 
 // ResolveNumExperts returns the total routed-expert count for the model, trying the
 // known architecture-specific field names (moeExpertCountFields) in order and
@@ -288,7 +311,7 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	// (transformers/vLLM) spells it num_experts_per_token (#1634). Missing this on a
 	// detected-MoE model is fatal (trips the MoE-consistency guard at latency-model
 	// construction), not merely inaccurate.
-	numExpertsPerTok := getIntWithFallbacks("num_experts_per_tok", "num_experts_per_token")
+	numExpertsPerTok := getIntWithFallbacks(moeActiveExpertFields...)
 
 	// MoE per-expert FFN dimension (design Section 4.2)
 	// When present and nonzero, takes precedence over general intermediate dim.
@@ -299,7 +322,7 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	var sharedExpertFFNDim int
 	if v := getInt("shared_expert_intermediate_size"); v > 0 {
 		sharedExpertFFNDim = v
-	} else if nShared := getIntWithFallbacks("n_shared_experts", "num_shared_experts"); nShared > 0 {
+	} else if nShared := getIntWithFallbacks(moeSharedExpertFields...); nShared > 0 {
 		// DeepSeek/GLM spell it n_shared_experts; Kimi-K3 spells it
 		// num_shared_experts (#1634). Missing this is a silent weight under-count
 		// (shared experts are optional, so no guard trips).

--- a/sim/latency/config.go
+++ b/sim/latency/config.go
@@ -284,7 +284,11 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	// MoE expert count: resolved via the shared chain (R23 code-path parity with
 	// ExtractKVCapacityParams). Single-expert models are dense-equivalent.
 	numLocalExperts := hf.ResolveNumExperts()
-	numExpertsPerTok := getInt("num_experts_per_tok")
+	// Active experts per token: DeepSeek/GLM spell it num_experts_per_tok; Kimi-K3
+	// (transformers/vLLM) spells it num_experts_per_token (#1634). Missing this on a
+	// detected-MoE model is fatal (trips the MoE-consistency guard at latency-model
+	// construction), not merely inaccurate.
+	numExpertsPerTok := getIntWithFallbacks("num_experts_per_tok", "num_experts_per_token")
 
 	// MoE per-expert FFN dimension (design Section 4.2)
 	// When present and nonzero, takes precedence over general intermediate dim.
@@ -295,7 +299,10 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	var sharedExpertFFNDim int
 	if v := getInt("shared_expert_intermediate_size"); v > 0 {
 		sharedExpertFFNDim = v
-	} else if nShared := getInt("n_shared_experts"); nShared > 0 {
+	} else if nShared := getIntWithFallbacks("n_shared_experts", "num_shared_experts"); nShared > 0 {
+		// DeepSeek/GLM spell it n_shared_experts; Kimi-K3 spells it
+		// num_shared_experts (#1634). Missing this is a silent weight under-count
+		// (shared experts are optional, so no guard trips).
 		// Compute total shared dim from count × per-expert dim
 		perExpert := moeExpertFFNDim
 		if perExpert == 0 {

--- a/sim/latency/config.go
+++ b/sim/latency/config.go
@@ -68,12 +68,12 @@ func (c *HFConfig) MustGetInt(key string, def int) int {
 	return def
 }
 
-// MustGetIntFallback returns the first of keys that resolves to a non-zero int
+// mustGetIntFallback returns the first of keys that resolves to a non-zero int
 // (tried in order), else def. It centralizes multi-spelling field resolution
 // (e.g. vendor-specific MoE activation-count names) so GetModelConfigFromHF and
 // ExtractKVCapacityParams resolve identical spellings and cannot desync (R23
-// code-path parity).
-func (c *HFConfig) MustGetIntFallback(def int, keys ...string) int {
+// code-path parity). Unexported — used only within package latency.
+func (c *HFConfig) mustGetIntFallback(def int, keys ...string) int {
 	for _, k := range keys {
 		if v, ok := c.GetInt(k); ok && v != 0 {
 			return v
@@ -261,14 +261,7 @@ func GetModelConfigFromHF(hf *HFConfig) (*sim.ModelConfig, error) {
 	}
 
 	// getIntWithFallbacks tries multiple field names, returning the first non-zero value.
-	getIntWithFallbacks := func(keys ...string) int {
-		for _, k := range keys {
-			if v := getInt(k); v != 0 {
-				return v
-			}
-		}
-		return 0
-	}
+	getIntWithFallbacks := func(keys ...string) int { return hf.mustGetIntFallback(0, keys...) }
 
 	// Extract heads first to handle the KV heads default logic.
 	// Fallback field names: Falcon uses "num_kv_heads", GLM uses "multi_query_group_num".

--- a/sim/latency/config_test.go
+++ b/sim/latency/config_test.go
@@ -1,6 +1,7 @@
 package latency_test
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -681,6 +682,130 @@ func TestGetModelConfig_Qwen2MoEStyle_SharedExpertDimExplicit(t *testing.T) {
 	// Explicit shared_expert_intermediate_size takes precedence
 	if cfg.SharedExpertFFNDim != 5632 {
 		t.Errorf("expected SharedExpertFFNDim=5632 (explicit field), got %d", cfg.SharedExpertFFNDim)
+	}
+}
+
+// TestGetModelConfig_MoEKeyAliases_BothSpellings covers the Kimi-K3 MoE
+// activation-count key aliases (#1634). K3's HF config spells the active-expert
+// count `num_experts_per_token` and the shared-expert count `num_shared_experts`,
+// whereas the DeepSeek/GLM configs BLIS already reads use `num_experts_per_tok` /
+// `n_shared_experts`. Both spellings must resolve to the same parsed values.
+//
+// GIVEN an 896-expert MoE config that spells the activation counts either way
+// WHEN GetModelConfig parses it
+// THEN NumExpertsPerTok reflects the active-expert count (16) and SharedExpertFFNDim
+//
+//	reflects shared_count × per-expert dim (2 × 2048 = 4096), regardless of spelling.
+func TestGetModelConfig_MoEKeyAliases_BothSpellings(t *testing.T) {
+	tests := []struct {
+		name      string
+		perTokKey string // active-experts-per-token field name
+		sharedKey string // shared-experts field name
+	}{
+		{"deepseek_glm_spelling", "num_experts_per_tok", "n_shared_experts"},
+		{"kimi_k3_spelling", "num_experts_per_token", "num_shared_experts"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, "config.json")
+			content := fmt.Sprintf(`{
+				"num_hidden_layers": 4,
+				"hidden_size": 4096,
+				"num_attention_heads": 32,
+				"num_key_value_heads": 8,
+				"vocab_size": 32000,
+				"intermediate_size": 14336,
+				"moe_intermediate_size": 2048,
+				"num_experts": 896,
+				"%s": 16,
+				"%s": 2,
+				"torch_dtype": "bfloat16"
+			}`, tc.perTokKey, tc.sharedKey)
+			if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			cfg, err := latency.GetModelConfig(configFile)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Detected as MoE via num_experts (unchanged by this PR).
+			if cfg.NumLocalExperts != 896 {
+				t.Errorf("expected NumLocalExperts=896, got %d", cfg.NumLocalExperts)
+			}
+			// Active experts per token resolved from the spelling under test.
+			if cfg.NumExpertsPerTok != 16 {
+				t.Errorf("expected NumExpertsPerTok=16 from %q, got %d", tc.perTokKey, cfg.NumExpertsPerTok)
+			}
+			// SharedExpertFFNDim = shared count (2) × per-expert dim (2048) = 4096.
+			if cfg.SharedExpertFFNDim != 4096 {
+				t.Errorf("expected SharedExpertFFNDim=4096 (2 shared × 2048 per-expert) from %q, got %d", tc.sharedKey, cfg.SharedExpertFFNDim)
+			}
+		})
+	}
+}
+
+// TestGetModelConfig_KimiK3_ConstructsTrainedPhysics is the #1634 regression: a
+// K3-shaped MoE config (896 experts, `num_experts_per_token`, `num_shared_experts`)
+// is detected as MoE, so a missing per-token count trips the MoE-consistency guard
+// at latency-model construction (trained_physics_model.go: "NumExpertsPerTok must
+// be > 0"). With the aliases parsed, the default trained-physics model constructs
+// without that error.
+//
+// GIVEN a K3-spelled 896-expert / num_experts_per_token:16 config
+// WHEN the default trained-physics latency model is constructed from the parsed config
+// THEN construction succeeds (the MoE-consistency guard does not trip).
+func TestGetModelConfig_KimiK3_ConstructsTrainedPhysics(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.json")
+	content := `{
+		"num_hidden_layers": 4,
+		"hidden_size": 4096,
+		"num_attention_heads": 32,
+		"num_key_value_heads": 8,
+		"vocab_size": 32000,
+		"intermediate_size": 14336,
+		"moe_intermediate_size": 2048,
+		"num_experts": 896,
+		"num_experts_per_token": 16,
+		"num_shared_experts": 2,
+		"torch_dtype": "bfloat16"
+	}`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg, err := latency.GetModelConfig(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error parsing config: %v", err)
+	}
+	if cfg.NumLocalExperts != 896 {
+		t.Fatalf("precondition: expected NumLocalExperts=896 (MoE detected), got %d", cfg.NumLocalExperts)
+	}
+	if cfg.NumExpertsPerTok != 16 {
+		t.Fatalf("precondition: expected NumExpertsPerTok=16 from num_experts_per_token, got %d", cfg.NumExpertsPerTok)
+	}
+
+	hw := sim.ModelHardwareConfig{
+		Backend:     "trained-physics", // BLIS default backend
+		TP:          1,
+		ModelConfig: *cfg,
+		HWConfig: sim.HardwareCalib{
+			TFlopsPeak: 989.0,
+			BwPeakTBs:  3.35,
+			MfuPrefill: 0.55,
+			MfuDecode:  0.30,
+		},
+	}
+	coeffs := sim.LatencyCoeffs{
+		AlphaCoeffs: []float64{15563.199579, 777.3455, 45.907545},
+		BetaCoeffs:  []float64{0.152128, 0.0, 1.36252915, 0.752037, 32.09546717, 4.41684444, 126.024825, 481.8613888, 0.0, 1.94710771},
+	}
+
+	if _, err := latency.NewLatencyModel(coeffs, hw); err != nil {
+		t.Fatalf("expected trained-physics model to construct for K3 config, got error: %v", err)
 	}
 }
 

--- a/sim/latency/kv_capacity.go
+++ b/sim/latency/kv_capacity.go
@@ -512,7 +512,7 @@ func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 		var sharedExpertFFNDim int
 		if v := hf.MustGetInt("shared_expert_intermediate_size", 0); v > 0 {
 			sharedExpertFFNDim = v
-		} else if nShared := hf.MustGetIntFallback(0, moeSharedExpertFields...); nShared > 0 {
+		} else if nShared := hf.mustGetIntFallback(0, moeSharedExpertFields...); nShared > 0 {
 			perExpert := moeExpertFFNDim
 			if perExpert == 0 {
 				perExpert = hf.MustGetInt("intermediate_size", 0)

--- a/sim/latency/kv_capacity.go
+++ b/sim/latency/kv_capacity.go
@@ -489,8 +489,11 @@ func ExtractKVCapacityParamsFromFile(hfConfigPath string) (KVCapacityParams, err
 // ExtractKVCapacityParams extracts KVCapacityParams from a parsed HFConfig.
 // MoE detection uses the shared (*HFConfig).ResolveNumExperts (>= MoEMinExperts);
 // see that method for the field set and resolution order. Returns an error if MoE
-// is detected via activation-count fields (n_shared_experts, num_experts_per_tok)
-// without a total expert count — weight estimation requires the count.
+// is detected via activation-count fields (n_shared_experts / num_experts_per_tok,
+// and their Kimi-K3 aliases num_shared_experts / num_experts_per_token; #1634)
+// without a total expert count — weight estimation requires the count. Shared-expert
+// resolution uses moeSharedExpertFields so this path matches GetModelConfigFromHF
+// (R23 code-path parity).
 func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 	hiddenAct := hf.MustGetString("hidden_act", "")
 	tieWordEmbeddings := false
@@ -509,7 +512,7 @@ func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 		var sharedExpertFFNDim int
 		if v := hf.MustGetInt("shared_expert_intermediate_size", 0); v > 0 {
 			sharedExpertFFNDim = v
-		} else if nShared := hf.MustGetInt("n_shared_experts", 0); nShared > 0 {
+		} else if nShared := hf.MustGetIntFallback(0, moeSharedExpertFields...); nShared > 0 {
 			perExpert := moeExpertFFNDim
 			if perExpert == 0 {
 				perExpert = hf.MustGetInt("intermediate_size", 0)
@@ -523,7 +526,8 @@ func ExtractKVCapacityParams(hf *HFConfig) (KVCapacityParams, error) {
 	// a reliable total expert count. Without the total count, weight estimation
 	// would use dense MLP weights — massively underestimating MoE model size.
 	// Return an error so the caller can fall back to --total-kv-blocks.
-	for _, key := range []string{"n_shared_experts", "num_experts_per_tok"} {
+	signalFields := append(append([]string{}, moeSharedExpertFields...), moeActiveExpertFields...)
+	for _, key := range signalFields {
 		if v := hf.MustGetInt(key, 0); v > 0 {
 			return KVCapacityParams{}, fmt.Errorf(
 				"model appears to be MoE (%s=%d) but num_local_experts is missing; "+

--- a/sim/latency/kv_capacity_test.go
+++ b/sim/latency/kv_capacity_test.go
@@ -1497,6 +1497,56 @@ func TestExtractKVCapacityParams_Qwen2MoE_ExplicitSharedDim(t *testing.T) {
 	}
 }
 
+func TestExtractKVCapacityParams_MoEKeyAliases(t *testing.T) {
+	// #1640: the KV-capacity path (ExtractKVCapacityParams) must resolve shared
+	// experts under BOTH the DeepSeek/GLM spelling (n_shared_experts) and the
+	// Kimi-K3 alias (num_shared_experts), matching GetModelConfigFromHF so the two
+	// paths cannot desync (R23 code-path parity). Before the fix, the K3 alias
+	// yielded SharedExpertFFNDim=0 (silent shared-expert weight under-count).
+	const perExpert = 3072
+	tests := []struct {
+		name          string
+		sharedKey     string
+		activeKey     string
+		wantSharedFFN int
+	}{
+		{"deepseek_glm_spelling", "n_shared_experts", "num_experts_per_tok", 2 * perExpert},
+		{"kimi_k3_spelling", "num_shared_experts", "num_experts_per_token", 2 * perExpert},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempConfigJSON(t, map[string]any{
+				"hidden_act":            "silu",
+				"num_hidden_layers":     93,
+				"hidden_size":           7168,
+				"num_attention_heads":   96,
+				"num_key_value_heads":   96,
+				"intermediate_size":     33792,
+				"moe_intermediate_size": perExpert,
+				"num_experts":           896,
+				tc.activeKey:            16,
+				tc.sharedKey:            2,
+				"torch_dtype":           "bfloat16",
+			})
+
+			params, err := latency.ExtractKVCapacityParamsFromFile(path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !params.IsMoE {
+				t.Error("expected IsMoE=true for an 896-expert config")
+			}
+			if params.NumLocalExperts != 896 {
+				t.Errorf("expected NumLocalExperts=896, got %d", params.NumLocalExperts)
+			}
+			if params.SharedExpertFFNDim != tc.wantSharedFFN {
+				t.Errorf("expected SharedExpertFFNDim=%d (2 shared × %d), got %d — %q alias not resolved on the KV-capacity path",
+					tc.wantSharedFFN, perExpert, params.SharedExpertFFNDim, tc.sharedKey)
+			}
+		})
+	}
+}
+
 // --- Quantized model KV capacity tests (BC-7, BC-10) ---
 
 func TestCalculateKVBlocks_W4A16_MoreBlocksThanFP16(t *testing.T) {

--- a/sim/latency/kv_capacity_test.go
+++ b/sim/latency/kv_capacity_test.go
@@ -1217,6 +1217,29 @@ func TestExtractKVCapacityParams_MoEFallback_NumExpertsPerTokOnly_ReturnsError(t
 	}
 }
 
+func TestExtractKVCapacityParams_MoEFallback_KimiK3Aliases_ReturnError(t *testing.T) {
+	// #1640: the Kimi-K3 activation-count spellings (num_shared_experts /
+	// num_experts_per_token) must also signal MoE in the fallback guard, so a
+	// K3-shaped config without a total expert count errors (naming the field)
+	// instead of being silently treated as dense.
+	for _, key := range []string{"num_shared_experts", "num_experts_per_token"} {
+		t.Run(key, func(t *testing.T) {
+			path := writeTempConfigJSON(t, map[string]any{
+				"hidden_act": "silu",
+				key:          2,
+			})
+
+			_, err := latency.ExtractKVCapacityParamsFromFile(path)
+			if err == nil {
+				t.Fatalf("expected error for MoE detected via %s without total expert count", key)
+			}
+			if !strings.Contains(err.Error(), key) {
+				t.Errorf("expected error mentioning %s, got: %v", key, err)
+			}
+		})
+	}
+}
+
 func TestExtractKVCapacityParams_TiedEmbeddings(t *testing.T) {
 	path := writeTempConfigJSON(t, map[string]any{
 		"hidden_act":          "silu",


### PR DESCRIPTION
## Summary

Kimi-K3's HF config (under `text_config`) spells its MoE **activation** counts differently from the DeepSeek/GLM spellings BLIS reads:

| meaning | K3 key (value) | key BLIS read |
|---|---|---|
| active experts / token | `num_experts_per_token` (16) | `num_experts_per_tok` |
| shared experts | `num_shared_experts` (2) | `n_shared_experts` |

K3's total routed-expert count (`num_experts: 896`) already resolves via `moeExpertCountFields`, so **K3 is detected as MoE**. That is exactly what makes the missing per-token count *fatal* rather than merely inaccurate: with `NumLocalExperts=896` and `NumExpertsPerTok=0`, the MoE-consistency guard trips at latency-model construction on the default trained-physics backend (`trained_physics_model.go`: `"NumExpertsPerTok must be > 0"`) and identically on roofline (`ValidateRooflineConfig`), so `blis run --model moonshotai/Kimi-K3` aborts before any simulation. The missed shared-expert count is a separate *silent* weight under-count (shared experts are optional, so no guard trips).

## Fix

Resolve both counts through the existing `getIntWithFallbacks` pattern (the same mechanism already used for KV-head spellings at `config.go` — `num_key_value_heads`/`num_kv_heads`/`multi_query_group_num`):

- active experts: `num_experts_per_tok` → also try `num_experts_per_token`
- shared experts: `n_shared_experts` → also try `num_shared_experts`

These are the transformers/vLLM K3 field names (vLLM parity, same policy as the existing per-architecture aliases). The canonical spelling is tried **first**, so existing configs are unchanged.

Two files: `sim/latency/config.go` (2-line resolution change + comments), `sim/latency/config_test.go` (tests).

## Behavioral contracts

**BC-1 — both spellings resolve identically (table test)**
- GIVEN an 896-expert MoE config that spells the activation counts either the DeepSeek/GLM way or the Kimi-K3 way
- WHEN `GetModelConfig` parses it
- THEN `NumExpertsPerTok == 16` and `SharedExpertFFNDim == 4096` (2 shared × 2048 per-expert), regardless of spelling.

**BC-2 — K3 config constructs the default backend (regression)**
- GIVEN a K3-spelled 896-expert / `num_experts_per_token: 16` / `num_shared_experts: 2` config
- WHEN the default trained-physics latency model is constructed from the parsed config
- THEN construction succeeds — the MoE-consistency guard does not trip (no `"NumExpertsPerTok must be > 0"` error).

## Invariants

- **INV-6 byte-identity**: the canonical spelling is tried first, so DeepSeek / GLM / Mixtral configs resolve to the same values as before — the full test suite (goldens included) and the `deepseek_glm_spelling` table sub-case confirm no behavior change.
- **INV-13 run/replay parity**: config parsing feeds both `blis run` and `blis replay` through the shared `GetModelConfig`/`GetModelConfigFromHF` → latency-model constructor path, so both are fixed together. **observe is unaffected** (black-box dispatcher; does not derive MoE step-time/weight from the config).
- No new struct fields / constructor sites; no `logrus.Fatalf` in `sim/`; no map iteration added.

## Verification

```
go build ./...            → exit 0
go test ./... -count=1     → all packages ok (cmd, sim, sim/cluster, sim/latency, … all PASS)
golangci-lint run ./...    → 0 issues (v2.9.0, matches CI)
```

New tests (red before the fix, green after):
```
--- PASS: TestGetModelConfig_MoEKeyAliases_BothSpellings
    --- PASS: .../deepseek_glm_spelling
    --- PASS: .../kimi_k3_spelling
--- PASS: TestGetModelConfig_KimiK3_ConstructsTrainedPhysics
```

Part of #1638 (Kimi K3 support tracker). Bare-minimum, standalone; hard prerequisite for any K3 end-to-end run (⇄ #1635).

Closes #1634


---
**Update (push 2):** folded in #1640 — extended the shared-expert alias (`num_shared_experts`) to the parallel KV-capacity path (`ExtractKVCapacityParams`), and centralized both MoE activation-count alias lists as package vars + a shared `(*HFConfig).MustGetIntFallback` resolver so `GetModelConfigFromHF` and `ExtractKVCapacityParams` cannot desync (R23 code-path parity). Added `TestExtractKVCapacityParams_MoEKeyAliases` (verified red→green: without the fix the K3 subcase gets `SharedExpertFFNDim=0`).

Closes #1640