### PR TITLE
feat(ci): auto-detect archon-plan for dist tracking in PR reviews

### DIFF
--- a/.github/workflows/archon.yml
+++ b/.github/workflows/archon.yml
@@ -96,6 +96,7 @@ jobs:
             });
             core.setOutput('base_sha', pr.base.sha);
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('body', pr.body || '');
 
       - name: Fetch PR head ref
         run: git fetch origin "pull/${{ github.event.issue.number }}/head"
@@ -103,19 +104,18 @@ jobs:
       - name: Collect plan declarations
         id: decl
         uses: actions/github-script@v8
+        env:
+          PR_BODY: ${{ steps.refs.outputs.body }}
         with:
           script: |
             const fs = require('fs');
             const os = require('os');
             const path = require('path');
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
             // PR body first: the earliest declaration wins, so a PR's own declaration
-            // outranks one in a third-party issue it happens to close.
-            const parts = [pr.body || ''];
+            // outranks one in a third-party issue it happens to close. In practice the PR
+            // body is usually the ONLY source: GitHub links closing issues only for a PR
+            // targeting the default branch, so a hole PR against a feature branch links none.
+            const parts = [process.env.PR_BODY || ''];
             const res = await github.graphql(
               `query($owner: String!, $repo: String!, $num: Int!) {
                  repository(owner: $owner, name: $repo) {
@@ -126,8 +126,13 @@ jobs:
                }`,
               { owner: context.repo.owner, repo: context.repo.repo, num: context.issue.number }
             );
-            for (const node of res.repository.pullRequest.closingIssuesReferences.nodes) {
-              parts.push(node.body || '');
+            // Tolerate a partial response rather than failing the step: losing the fallback
+            // costs a warning on the PR, whereas failing here costs the whole review.
+            const nodes = res?.repository?.pullRequest?.closingIssuesReferences?.nodes;
+            if (nodes) {
+              for (const node of nodes) parts.push(node.body || '');
+            } else {
+              core.warning('Could not read closing issues; using the PR body alone.');
             }
             // Written as file CONTENTS, never handed to a shell as an argument.
             const dir = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'archon-'));
@@ -141,22 +146,27 @@ jobs:
           BASE_SHA: ${{ steps.refs.outputs.base_sha }}
           HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
           DECL_FILE: ${{ steps.decl.outputs.file }}
-          OUTPUT_FILE: /tmp/archon-output.md
+          OUTPUT_FILE: ${{ runner.temp }}/archon-output.md
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/archon-review.sh
 
-      # always(): the review script exits 0 for every reviewed outcome, but an environment
-      # error exits non-zero, and a trigger that silently posts nothing is the failure mode
-      # this feature exists to avoid. The script truncates the output file up front, so an
-      # aborted run leaves it empty and the guard below skips rather than posting a stale body.
+      # always(): the review script reports every reviewed outcome through its output file and
+      # exits 0, but an environment error exits non-zero, and a trigger that silently posts
+      # nothing is the failure mode this feature exists to avoid.
+      #
+      # The body lives under runner.temp, which the runner empties at the start of every job.
+      # A fixed /tmp path would not be safe here: when a step BEFORE the review fails, the
+      # review script never runs to truncate it, and this step would post whatever the
+      # previous job on this self-hosted runner left behind — possibly another PR's review.
       - name: Post PR comment
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          OUTPUT_FILE: ${{ runner.temp }}/archon-output.md
         run: |
-          if [[ ! -s /tmp/archon-output.md ]]; then
+          if [[ ! -s "$OUTPUT_FILE" ]]; then
             echo "::warning::Archon produced no output. Skipping PR comment."
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --body-file /tmp/archon-output.md
+          gh pr comment "$PR_NUMBER" --body-file "$OUTPUT_FILE"

--- a/.github/workflows/archon.yml
+++ b/.github/workflows/archon.yml
@@ -116,23 +116,33 @@ jobs:
             // body is usually the ONLY source: GitHub links closing issues only for a PR
             // targeting the default branch, so a hole PR against a feature branch links none.
             const parts = [process.env.PR_BODY || ''];
-            const res = await github.graphql(
-              `query($owner: String!, $repo: String!, $num: Int!) {
-                 repository(owner: $owner, name: $repo) {
-                   pullRequest(number: $num) {
-                     closingIssuesReferences(first: 10) { nodes { body } }
+            // Losing this fallback costs at most a warning on the PR, whereas failing the
+            // step costs the whole review — so neither a thrown error (transient API failure,
+            // missing scope) nor a malformed response is allowed to propagate.
+            let nodes;
+            let failure;
+            try {
+              const res = await github.graphql(
+                `query($owner: String!, $repo: String!, $num: Int!) {
+                   repository(owner: $owner, name: $repo) {
+                     pullRequest(number: $num) {
+                       closingIssuesReferences(first: 10) { nodes { body } }
+                     }
                    }
-                 }
-               }`,
-              { owner: context.repo.owner, repo: context.repo.repo, num: context.issue.number }
-            );
-            // Tolerate a partial response rather than failing the step: losing the fallback
-            // costs a warning on the PR, whereas failing here costs the whole review.
-            const nodes = res?.repository?.pullRequest?.closingIssuesReferences?.nodes;
+                 }`,
+                { owner: context.repo.owner, repo: context.repo.repo, num: context.issue.number }
+              );
+              nodes = res?.repository?.pullRequest?.closingIssuesReferences?.nodes;
+              if (!nodes) { failure = 'the response contained no closingIssuesReferences'; }
+            } catch (error) {
+              // A GraphQL error can still carry partial data alongside it.
+              nodes = error?.data?.repository?.pullRequest?.closingIssuesReferences?.nodes;
+              if (!nodes) { failure = error.message; }
+            }
             if (nodes) {
               for (const node of nodes) parts.push(node.body || '');
             } else {
-              core.warning('Could not read closing issues; using the PR body alone.');
+              core.warning(`Could not read closing issues (${failure}); using the PR body alone.`);
             }
             // Written as file CONTENTS, never handed to a shell as an argument.
             const dir = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'archon-'));

--- a/.github/workflows/archon.yml
+++ b/.github/workflows/archon.yml
@@ -2,6 +2,9 @@ name: Archon PR Review
 
 permissions:
   contents: read
+  # closingIssuesReferences returns issue objects, which the pull-request scope does not
+  # cover. Without this the declaration-collection step fails and nothing is posted.
+  issues: read
   pull-requests: write
 
 on:
@@ -97,54 +100,57 @@ jobs:
       - name: Fetch PR head ref
         run: git fetch origin "pull/${{ github.event.issue.number }}/head"
 
+      - name: Collect plan declarations
+        id: decl
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const os = require('os');
+            const path = require('path');
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            // PR body first: the earliest declaration wins, so a PR's own declaration
+            // outranks one in a third-party issue it happens to close.
+            const parts = [pr.body || ''];
+            const res = await github.graphql(
+              `query($owner: String!, $repo: String!, $num: Int!) {
+                 repository(owner: $owner, name: $repo) {
+                   pullRequest(number: $num) {
+                     closingIssuesReferences(first: 10) { nodes { body } }
+                   }
+                 }
+               }`,
+              { owner: context.repo.owner, repo: context.repo.repo, num: context.issue.number }
+            );
+            for (const node of res.repository.pullRequest.closingIssuesReferences.nodes) {
+              parts.push(node.body || '');
+            }
+            // Written as file CONTENTS, never handed to a shell as an argument.
+            const dir = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'archon-'));
+            const out = path.join(dir, 'plan-decl.txt');
+            fs.writeFileSync(out, parts.join('\n'));
+            core.setOutput('file', out);
+
       - name: Run archon pr-review
-        id: archon
         env:
           ARCHON_BIN: ${{ steps.build.outputs.archon_bin }}
           BASE_SHA: ${{ steps.refs.outputs.base_sha }}
           HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
+          DECL_FILE: ${{ steps.decl.outputs.file }}
+          OUTPUT_FILE: /tmp/archon-output.md
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null) || {
-            OUTPUT="## Archon Error
+        run: scripts/archon-review.sh
 
-          Could not compute merge-base between base ($BASE_SHA) and head ($HEAD_SHA). The PR head may not be reachable — check that the fetch step succeeded."
-            echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
-            echo "$OUTPUT" > /tmp/archon-output.md
-            exit 0
-          }
-
-          "$ARCHON_BIN" pr-review . "$MERGE_BASE" "$HEAD_SHA" --out .archon || {
-            OUTPUT="## Archon Error
-
-          archon-go pr-review failed. Check the workflow logs."
-            echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
-            echo "$OUTPUT" > /tmp/archon-output.md
-            exit 0
-          }
-
-          if [[ ! -f .archon/review.md ]]; then
-            OUTPUT="## Archon Error
-
-          archon-go exited 0 but did not produce .archon/review.md."
-            echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
-            echo "$OUTPUT" > /tmp/archon-output.md
-            exit 0
-          fi
-
-          OUTPUT=$(cat .archon/review.md)
-          echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
-
-          # GitHub PR comments have a 65536 char limit. Truncate if needed.
-          if [[ ${#OUTPUT} -gt 60000 ]]; then
-            FULL_LEN=${#OUTPUT}
-            OUTPUT="${OUTPUT:0:60000}
-
-          _Output truncated (${FULL_LEN} chars). See the [workflow run](${RUN_URL}) for the full report._"
-          fi
-          echo "$OUTPUT" > /tmp/archon-output.md
-
+      # always(): the review script exits 0 for every reviewed outcome, but an environment
+      # error exits non-zero, and a trigger that silently posts nothing is the failure mode
+      # this feature exists to avoid. The script truncates the output file up front, so an
+      # aborted run leaves it empty and the guard below skips rather than posting a stale body.
       - name: Post PR comment
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           - name: "root & internals"
             packages: ". ./sim/internal/..."
             timeout: "5m"
+          # The CI shell scripts are driven by a test-only package. The matrix lists
+          # packages explicitly rather than ./..., so this entry is what makes them run.
+          - name: "scripts"
+            packages: "./scripts"
+            timeout: "5m"
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ blis
 blis_iter*
 inference-sim
 
+# archon-go pr-review --out
+.archon/
+
 # results
 results/
 largesweep/

--- a/docs/contributing/archon/encode-plan.md
+++ b/docs/contributing/archon/encode-plan.md
@@ -23,6 +23,12 @@ Every sub-issue body must include this line so `/archon-pr-review` can find the 
 archon-plan: specs/NNN-feature/feature.plan.json
 ```
 
+The same line must appear in every **PR body** as well, including the final PR to main. CI
+reads the PR body first and falls back to the bodies of the issues the PR closes, but GitHub
+only links closing issues for a PR targeting the default branch: a hole PR targets the feature
+branch, so nothing is linked, and the final PR closes only the tracking issue, which has no
+such line. Without it in the PR body the dist ratchet is skipped with a warning.
+
 The path must end in `.json`, and the plan must be **committed** to the branch — CI reads it
 out of git, not the working tree, so an untracked plan is invisible to it. (`.gitignore`
 ignores `*.json` repo-wide; `!specs/**/*.json` is the negation that lets the compiled plan be

--- a/docs/contributing/archon/encode-plan.md
+++ b/docs/contributing/archon/encode-plan.md
@@ -23,6 +23,12 @@ Every sub-issue body must include this line so `/archon-pr-review` can find the 
 archon-plan: specs/NNN-feature/feature.plan.json
 ```
 
+The path must end in `.json`, and the plan must be **committed** to the branch — CI reads it
+out of git, not the working tree, so an untracked plan is invisible to it. (`.gitignore`
+ignores `*.json` repo-wide; `!specs/**/*.json` is the negation that lets the compiled plan be
+tracked.) A declared path CI cannot read produces a warning on the PR rather than a silent
+delta-only review.
+
 ## Where to persist
 
 ```

--- a/docs/contributing/archon/pr-review-context.md
+++ b/docs/contributing/archon/pr-review-context.md
@@ -8,16 +8,22 @@ How to incorporate archon's PR review output during code review.
 
 ## When it runs
 
-`/archon-pr-review` runs when triggered via a comment on the PR (manually by a contributor or maintainer). It is NOT automatic — someone must type `/archon-pr-review` on the PR. It runs the standard delta review (boundary moves, surface changes, edge deltas). Additionally, if the PR body (or its closing issue body) contains an `archon-plan:` line with a path to a `.plan.json`, it also runs `--plan` for dist tracking.
+`/archon-pr-review` runs when triggered via a comment on the PR (manually by a contributor or maintainer). It is NOT automatic — someone must type `/archon-pr-review` on the PR. It always runs the standard delta review (boundary moves, surface changes, edge deltas). If a plan is declared and readable, `--plan` is added to that same invocation, which appends `### G5 — Plan distance ratchet` for dist tracking and a plan verdict.
 
 ```
 # When triggered (pseudocode):
-archon-go pr-review . $BASE $HEAD --out .archon           # always: delta view
-if archon-plan path found AND file exists on base branch:
-  archon-go pr-review . $BASE $HEAD --plan <path> --out .archon  # additionally: dist tracking
+plan = first `archon-plan: <path>` line in the PR body, else in a closing issue body
+if <path> is a committed .json file at the base branch tip, else at the PR head:
+  archon-go pr-review . $BASE $HEAD --plan <extracted> --out .archon   # 3 views + dist
+else:
+  archon-go pr-review . $BASE $HEAD --out .archon                      # 3 views
 ```
 
-Both outputs are posted. No failure if the plan path is missing or wrong — falls back to delta-only.
+**One invocation, one comment, in every case.** The `--plan` `review.md` is the delta one plus the ratchet section, so posting both would duplicate every diagram.
+
+**Where the plan is read from.** The base branch tip is preferred over the PR head, so a hole PR cannot be graded against a plan it rewrote. The final feature-branch-to-`main` PR has the plan only on its head; that copy is used, and the comment labels it as not independently verified, since a fork PR controls its own head. Either way the comment names the plan path and the commit it came from.
+
+**When it does not run.** A PR that declares no plan is reviewed delta-only with no note and no warning — the normal case for a bug fix. A PR that *declares* a plan CI cannot read gets a visible warning saying so, because a silent delta-only review would be indistinguishable from a PR with no plan and would quietly remove dist as the merge gate.
 
 ## Convention: `archon-plan:` in sub-issues
 
@@ -25,7 +31,9 @@ When sub-issues are created via `rfc-to-plan.md`, each includes a standard line:
 ```
 archon-plan: specs/NNN-feature/feature.plan.json
 ```
-CI greps for this. If absent, dist tracking is skipped (safe default).
+Requirements: the path must end in `.json`, be repository-relative, and be **committed** to the branch — CI reads it out of git, not the working tree, since the workflow runs with the default branch checked out. If the line is absent, dist tracking is skipped silently (safe default). If it is present but unreadable, the review says so.
+
+Implementation: `scripts/archon-plan-resolve.sh` (detection and extraction) and `scripts/archon-review.sh` (the review itself), both driven by tests in `scripts/`.
 
 ## Verdicts
 

--- a/docs/contributing/archon/pr-review-context.md
+++ b/docs/contributing/archon/pr-review-context.md
@@ -6,34 +6,19 @@ How to incorporate archon's PR review output during code review.
 
 **Getting archon (for manual runs):** Run `scripts/archon-build.sh` from the repo root. It builds the version pinned in `.archon-version` and prints the binary path. See [archon README](https://github.com/AI-native-Systems-Research/archon) for verdict definitions and full examples.
 
-## When it runs
+## What the comment contains
 
-`/archon-pr-review` runs when triggered via a comment on the PR (manually by a contributor or maintainer). It is NOT automatic — someone must type `/archon-pr-review` on the PR. It always runs the standard delta review (boundary moves, surface changes, edge deltas). If a plan is declared and readable, `--plan` is added to that same invocation, which appends `### G5 — Plan distance ratchet` for dist tracking and a plan verdict.
+One comment per `/archon-pr-review`, in one of two shapes:
 
-```
-# When triggered (pseudocode):
-plan = first `archon-plan: <path>` line in the PR body, else in a closing issue body
-if <path> is a committed .json file at the base branch tip, else at the PR head:
-  archon-go pr-review . $BASE $HEAD --plan <extracted> --out .archon   # 3 views + dist
-else:
-  archon-go pr-review . $BASE $HEAD --out .archon                      # 3 views
-```
+- **three views** — component, witness delta, interface-contract
+- **three views plus plan checks** — the same, with `### G5 — Plan distance ratchet` and a plan verdict appended
 
-**One invocation, one comment, in every case.** The `--plan` `review.md` is the delta one plus the ratchet section, so posting both would duplicate every diagram.
+The second shape appears when the PR belongs to a planned multi-PR feature. Nothing here needs to know how CI decides that; if a section is present, read it.
 
-**Where the plan is read from.** The base branch tip is preferred over the PR head, so a hole PR cannot be graded against a plan it rewrote. The final feature-branch-to-`main` PR has the plan only on its head; that copy is used, and the comment labels it as not independently verified, since a fork PR controls its own head. Either way the comment names the plan path and the commit it came from.
+Two lines may precede the review:
 
-**When it does not run.** A PR that declares no plan is reviewed delta-only with no note and no warning — the normal case for a bug fix. A PR that *declares* a plan CI cannot read gets a visible warning saying so, because a silent delta-only review would be indistinguishable from a PR with no plan and would quietly remove dist as the merge gate.
-
-## Convention: `archon-plan:` in sub-issues
-
-When sub-issues are created via `rfc-to-plan.md`, each includes a standard line:
-```
-archon-plan: specs/NNN-feature/feature.plan.json
-```
-Requirements: the path must end in `.json`, be repository-relative, and be **committed** to the branch — CI reads it out of git, not the working tree, since the workflow runs with the default branch checked out. If the line is absent, dist tracking is skipped silently (safe default). If it is present but unreadable, the review says so.
-
-Implementation: `scripts/archon-plan-resolve.sh` (detection and extraction) and `scripts/archon-review.sh` (the review itself), both driven by tests in `scripts/`.
+- a note naming the plan the checks ran against, and the commit it came from. When that commit is the PR's own head it says the plan is not independently verified — expected on the final feature-branch-to-`main` PR, since `main` carries no plan.
+- a `> [!WARNING]` saying the plan check was skipped. The PR asked to be checked against a plan and was not, so there is no ratchet or verdict in that comment — treat it as missing evidence, not as a passing gate.
 
 ## Verdicts
 
@@ -50,3 +35,4 @@ Implementation: `scripts/archon-plan-resolve.sh` (detection and extraction) and 
 2. **FAST-TRACK** → no architectural concern, proceed with normal review
 3. **REALIZES** → verify dist reduction matches sub-issue expectation
 4. **EXCEEDS/CONFLICTS** → flag to maintainer, may need plan-update PR
+5. **Plan check skipped** (the warning above) → the dist gate did not run. Say so; do not read the comment as evidence the plan was satisfied.

--- a/docs/contributing/pr-workflow.md
+++ b/docs/contributing/pr-workflow.md
@@ -1,6 +1,6 @@
 # PR Development Workflow
 
-**Status:** Active (v4.2 — updated 2026-03-17)
+**Status:** Active (v4.3 — updated 2026-08-28)
 
 This document describes the complete workflow for implementing a PR from any source: an RFC sub-issue, GitHub issues, a design document, or a feature request. The same steps apply whether you use Claude Code or standard git tools.
 
@@ -398,6 +398,8 @@ gh pr create --title "<title>" --body "<description with behavioral contracts>"
 
 The PR description should include a summary, behavioral contracts (GIVEN/WHEN/THEN), testing verification, and GitHub closing keywords from the plan's `Closes:` field (e.g., `Fixes #183, fixes #189`).
 
+**Multi-PR features:** if the sub-issue body carries an `archon-plan:` line, copy it verbatim into the PR body. CI reads the PR body to find the plan; a hole PR targets a feature branch, so GitHub links no closing issue and the sub-issue is never read. Without the line, the dist ratchet is skipped. The same applies to the final PR to `main`, which closes the tracking issue — an issue that carries no such line.
+
 !!! tip "Automation"
     `/commit-commands:commit-push-pr` handles staging, committing, pushing, and PR creation in one command. It analyzes current git state, creates an appropriate commit message referencing behavioral contracts, and opens the PR.
 
@@ -546,5 +548,6 @@ When to use: When Step 2.5 or Step 4.5 hits context limits. Not needed for most 
 **v4.0 (2026-02-27):** Human-first rewrite (#464). Steps describe human actions; skills in admonition callouts. Manual path is primary; automation is additive. Templates split into human-readable format descriptions + agent prompt companions.
 **v4.1 (2026-03-17):** Added Step 1.5 (Source Document Audit) between Steps 1 and 2 — structured pre-audit of source documents for ambiguities, contradictions, and missing information before planning begins. Added `CLARIFICATION` as a Deviation Log reason (#664).
 **v4.2 (2026-03-17):** Added Express Lane tier for ≤3-line mechanical changes (implement → self-audit → commit, no plan/review/human gate). Eliminated pre-pass for Small PRs — single convergence round sufficient. Medium/Large unchanged (#673).
+**v4.3 (2026-08-28):** Step 5 now requires copying the sub-issue's `archon-plan:` line into the PR body for multi-PR features. CI reads the PR body; GitHub links closing issues only for PRs targeting the default branch, so a hole PR against a feature branch links none and the sub-issue body is never read (#1631).
 
 </details>

--- a/docs/contributing/templates/archon-issue-examples.md
+++ b/docs/contributing/templates/archon-issue-examples.md
@@ -134,6 +134,10 @@ Self-reviewed by developer: `@claude /blis-pr-review` + `/archon-pr-review`
 archon-plan: specs/[NNN-feature]/[feature].plan.json
 ```
 
+Substitute the bracketed placeholders. `/archon-pr-review` rejects a literal
+`specs/[NNN-feature]/...` and posts a warning instead of running the dist ratchet, and it
+reads the plan out of git, so the file must be committed to the branch.
+
 ---
 
 ## Final PR (feature branch → main)

--- a/docs/contributing/templates/archon-issue-examples.md
+++ b/docs/contributing/templates/archon-issue-examples.md
@@ -138,6 +138,11 @@ Substitute the bracketed placeholders. `/archon-pr-review` rejects a literal
 `specs/[NNN-feature]/...` and posts a warning instead of running the dist ratchet, and it
 reads the plan out of git, so the file must be committed to the branch.
 
+**Copy this line into the PR body too.** CI reads the PR body first and falls back to the
+bodies of the issues the PR closes — but GitHub only links closing issues for a PR that
+targets the **default branch**. A hole PR targets the feature branch, so nothing is linked
+and the sub-issue body is never read. The PR body is the only place the line can be seen.
+
 ---
 
 ## Final PR (feature branch → main)
@@ -187,7 +192,15 @@ Closes: #[tracking issue number]
 ## Review
 
 Maintainer reviews this PR (the whole feature in one diff against main).
+
+---
+
+archon-plan: specs/NNN-feature/feature.plan.json
 ```
+
+The line is required **in the PR body**, not just in the tracking issue. This PR closes the
+tracking issue, which carries no `archon-plan:` line of its own, so without it the dist
+ratchet is silently skipped on the one PR where `dist = 0` is the merge gate.
 
 ---
 

--- a/docs/contributing/templates/rfc-to-plan.md
+++ b/docs/contributing/templates/rfc-to-plan.md
@@ -44,6 +44,14 @@ Read the tracking issue discussions and final decisions. Then:
    placeholders: a literal `specs/[NNN-feature]/...` is rejected and the
    review posts a warning instead of running the dist ratchet.
 
+   The line must also be copied into each PR body, including the final
+   PR to main. CI reads the PR body first and falls back to the bodies of
+   the issues the PR closes, but GitHub only links closing issues for a PR
+   targeting the default branch — a hole PR targets the feature branch, so
+   nothing is linked. The final PR does close the tracking issue, which
+   carries no such line. In both cases the PR body is the only place CI
+   can find it.
+
 4. Report: summary of baseline dist, number of holes, delivery order.
 
 Use the sub-issue format from docs/contributing/templates/archon-issue-examples.md.

--- a/docs/contributing/templates/rfc-to-plan.md
+++ b/docs/contributing/templates/rfc-to-plan.md
@@ -36,8 +36,13 @@ Read the tracking issue discussions and final decisions. Then:
        (CI uses this to auto-detect the plan for dist tracking)
 
    IMPORTANT: Every sub-issue (including sub-issue 0) must contain the
-   `archon-plan:` line with the same path. This is how CI knows to run
-   both the standard delta review AND the plan-based dist tracking.
+   `archon-plan:` line with the same path. This is how CI knows to add
+   plan-based dist tracking to the review.
+
+   The path must end in `.json` and the plan must be committed to the
+   branch — CI reads it out of git, not the working tree. Substitute the
+   placeholders: a literal `specs/[NNN-feature]/...` is rejected and the
+   review posts a warning instead of running the dist ratchet.
 
 4. Report: summary of baseline dist, number of holes, delivery order.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,66 @@ Reproducible analysis scripts for BLIS. Each script runs `blis` end-to-end and
 emits a single CSV summary alongside per-run raw outputs, so anyone can
 re-validate a published claim without manually reconstructing the command set.
 
+## archon-review.sh — `/archon-pr-review` review step
+
+Runs `archon-go pr-review` and composes the PR comment. Called by
+`.github/workflows/archon.yml`; it lives here rather than inline in the workflow so its
+behaviour can be tested (`scripts/archon_review_test.go` drives it against a stub
+`archon-go` and throwaway git repositories).
+
+```bash
+ARCHON_BIN=... BASE_SHA=... HEAD_SHA=... DECL_FILE=... OUTPUT_FILE=... RUN_URL=... \
+  scripts/archon-review.sh
+```
+
+| Variable | Meaning |
+|---|---|
+| `ARCHON_BIN` | archon-go binary, from `archon-build.sh` |
+| `BASE_SHA` | the PR's base branch tip (where the plan is looked for first) |
+| `HEAD_SHA` | the PR's head commit, already fetched into the object store |
+| `DECL_FILE` | file holding plan-declaration candidate text (PR body, then closing-issue bodies) |
+| `OUTPUT_FILE` | where the comment body is written; truncated up front |
+| `RUN_URL` | workflow run URL, used in the truncation notice |
+| `GITHUB_STEP_SUMMARY` | optional; the untruncated body is appended when set |
+
+Exits 0 for every reviewed outcome, including archon failure, so the caller always has a
+body to post. Exit 2 only on a usage or environment error. Adds `--plan` to the single
+`archon-go` invocation when a plan resolves; retries once without it if that invocation
+fails, so a bad plan file never costs the three views.
+
+## archon-plan-resolve.sh — find and extract a declared archon plan
+
+Finds the first `archon-plan: <path>` line in the declaration text and extracts that file
+out of git. Tested by `scripts/archon_plan_resolve_test.go`.
+
+```bash
+scripts/archon-plan-resolve.sh <base-ref> <head-ref> <decl-file> <out-file>
+```
+
+Prints one `key=value` per line and exits 0 in all three cases (exit 2 only on a usage error):
+
+| Output | Meaning |
+|---|---|
+| `status=none` | no declaration found — the normal case for a bug fix |
+| `status=resolved` + `plan_path`, `plan_source` (`base`/`head`), `plan_commit` | `<out-file>` written |
+| `status=error` + `plan_path`, `message` | declared but unusable |
+
+The declared path comes from a PR or issue body, so it is untrusted. It must be
+repository-relative, end in `.json`, be at most 256 characters, and match
+`[A-Za-z0-9._/-]+` with no `..`; anything echoed back has out-of-allowlist characters
+replaced, so a rejected path cannot inject markdown or a workflow command into the comment.
+
+Extraction uses git plumbing against an explicit commit — never the filesystem. The
+workflow is `issue_comment`-triggered, so the working tree holds the default branch rather
+than the PR: a filesystem read would find the wrong file and would let a traversal escape
+the repository. The object's type, mode, and size are gated (regular-file blob, non-empty,
+at most 1 MiB) before any bytes are written.
+
+Base is tried before head so a hole PR cannot be graded against a plan it rewrote. A base
+copy that exists but is unusable, and a commit that is not reachable locally, are both hard
+errors rather than a fall-through to the head copy — `git ls-tree` is silent for both, and
+either one would quietly hand grading back to the PR.
+
 ## find-saturation.sh — Rate-sweep saturation finder
 
 Drives `blis run` across a configurable rate sweep against a chosen

--- a/scripts/archon-plan-resolve.sh
+++ b/scripts/archon-plan-resolve.sh
@@ -59,9 +59,12 @@ cd "$repo_root" || fail "" "could not enter the repository root"
 
 # --- detect -----------------------------------------------------------------
 
-# A declaration file that was never written is an error, not "no declaration": treating it
-# as absent would drop the plan gate exactly when the collecting step misbehaved.
+# A declaration file that was never written, or cannot be read, is an error rather than "no
+# declaration": treating it as absent would drop the plan gate exactly when the collecting
+# step misbehaved. Readability is checked too, since `tr` failing below is swallowed by the
+# `|| true` that lets grep report "no match".
 [[ -f "$DECL_FILE" ]] || fail "" "declaration file was not produced; plan detection could not run"
+[[ -r "$DECL_FILE" ]] || fail "" "declaration file is not readable; plan detection could not run"
 
 # GitHub API bodies use CRLF; an unstripped \r survives into the path and fails validation
 # on every real PR while passing every LF-only test.
@@ -110,8 +113,11 @@ for candidate in "base:$BASE_REF" "head:$HEAD_REF"; do
     || fail "$PLAN_PATH" "the $source_name commit ($source_ref) is not available locally"
 
   # `git ls-tree -l` prints: <mode> SP <type> SP <sha> SP <size> TAB <path>
-  # Empty output now means only one thing: the path is absent at this commit.
-  meta=$(git ls-tree -l "$source_ref" -- "$PLAN_PATH")
+  # Its exit status is checked so that empty output means only one thing: the path is absent
+  # at this commit. A failure here (unreadable object store, damaged tree) would otherwise
+  # also read as absent and fall through to the head copy.
+  meta=$(git ls-tree -l "$source_ref" -- "$PLAN_PATH") \
+    || fail "$PLAN_PATH" "could not read the tree at $source_name ($source_ref)"
   [[ -n "$meta" ]] || continue
 
   read -r obj_mode obj_type obj_sha obj_size _ <<< "$meta"

--- a/scripts/archon-plan-resolve.sh
+++ b/scripts/archon-plan-resolve.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# archon-plan-resolve.sh — resolve the archon plan a PR declares.
+#
+# Usage: scripts/archon-plan-resolve.sh <base-ref> <head-ref> <decl-file> <out-file>
+#
+# <decl-file> holds candidate declaration text: the PR body, then the body of each issue
+# the PR closes, in that order. The first `archon-plan: <path>` line wins, so a PR's own
+# declaration outranks one in a third-party issue it happens to close.
+#
+# The declared path is UNTRUSTED — anyone can write a PR or issue body — so it is validated
+# before any use and dereferenced only with git plumbing against an explicit commit. Never
+# through the filesystem: on an issue_comment runner the working tree holds the default
+# branch, not the PR, so a filesystem read would find the wrong file and would let a
+# traversal escape the repository.
+#
+# Prints one key=value per line on stdout:
+#   status=none
+#   status=resolved  plan_path=… plan_source=base|head plan_commit=…   (<out-file> written)
+#   status=error     plan_path=… message=…
+# Exits 0 in all three cases; exit 2 only on a usage error.
+#
+# `set -e` is deliberately off: a failure is a reported status, and non-zero git exits are
+# expected control flow. Every state-changing command is therefore checked explicitly.
+
+set -uo pipefail
+
+readonly MAX_PLAN_BYTES=1048576   # 1 MiB; a compiled archon plan is orders of magnitude smaller
+readonly MAX_PATH_CHARS=256       # a longer path could crowd the verdict out of the PR comment
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <base-ref> <head-ref> <decl-file> <out-file>" >&2
+  exit 2
+fi
+
+BASE_REF="$1"
+HEAD_REF="$2"
+DECL_FILE="$3"
+OUT_FILE="$4"
+
+# Reduce an untrusted path to the allowlist, so it is safe to embed in a comment posted to
+# GitHub. `:` becomes `?`, so a rejected path cannot smuggle a ::workflow:: command either.
+neuter() { printf '%s' "$1" | tr -c 'A-Za-z0-9._/-' '?'; }
+
+fail() {
+  printf 'status=error\nplan_path=%s\nmessage=%s\n' "$(neuter "$1")" "$2"
+  exit 0
+}
+
+# git ls-tree takes a pathspec relative to the current directory, so anchor to the root.
+# Absolutise the caller's file arguments first, since they may be relative to its own cwd.
+abspath() { case "$1" in /*) printf '%s' "$1" ;; *) printf '%s/%s' "$PWD" "$1" ;; esac; }
+DECL_FILE=$(abspath "$DECL_FILE")
+OUT_FILE=$(abspath "$OUT_FILE")
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
+  || fail "" "not inside a git repository; plan detection could not run"
+cd "$repo_root" || fail "" "could not enter the repository root"
+
+# --- detect -----------------------------------------------------------------
+
+# A declaration file that was never written is an error, not "no declaration": treating it
+# as absent would drop the plan gate exactly when the collecting step misbehaved.
+[[ -f "$DECL_FILE" ]] || fail "" "declaration file was not produced; plan detection could not run"
+
+# GitHub API bodies use CRLF; an unstripped \r survives into the path and fails validation
+# on every real PR while passing every LF-only test.
+# The anchor admits leading whitespace and markdown list, quote, bold, and backtick markers
+# but not prose, so a sentence mentioning archon-plan: in passing is not a declaration.
+RAW=$(tr -d '\r' < "$DECL_FILE" | grep -m1 -E '^[^A-Za-z0-9]*archon-plan:' || true)
+
+if [[ -z "$RAW" ]]; then
+  echo "status=none"
+  exit 0
+fi
+
+REST=${RAW#*archon-plan:}            # everything after the first colon
+REST=${REST//[\`*]/}                 # tolerate `path` and **archon-plan:** path
+read -r PLAN_PATH _ <<< "$REST"      # first whitespace-delimited token ("" if none)
+
+# --- validate ---------------------------------------------------------------
+
+[[ -n "$PLAN_PATH" ]] || fail "" "an archon-plan: line was declared with no path"
+
+if (( ${#PLAN_PATH} > MAX_PATH_CHARS )); then
+  fail "${PLAN_PATH:0:64}" "declared plan path is longer than ${MAX_PATH_CHARS} characters"
+fi
+if [[ "$PLAN_PATH" != *.json ]]; then
+  fail "$PLAN_PATH" "declared plan path is not a .json file: $(neuter "$PLAN_PATH")"
+fi
+if [[ "$PLAN_PATH" == /* || "$PLAN_PATH" == -* || "$PLAN_PATH" == *..* \
+      || ! "$PLAN_PATH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  fail "$PLAN_PATH" "declared plan path is not a safe repository-relative path: $(neuter "$PLAN_PATH")"
+fi
+
+# --- extract: base branch tip first, then the PR head -----------------------
+
+TMP_FILE=$(mktemp "${OUT_FILE}.XXXXXX") || fail "$PLAN_PATH" "could not create a temporary file"
+trap 'rm -f "$TMP_FILE"' EXIT INT TERM
+
+for candidate in "base:$BASE_REF" "head:$HEAD_REF"; do
+  source_name=${candidate%%:*}
+  source_ref=${candidate#*:}
+  [[ -n "$source_ref" ]] || continue
+
+  # An unknown commit and an absent path BOTH make git ls-tree print nothing, so check
+  # reachability separately. Conflating them would let an unfetched base tip degrade
+  # silently to the PR's own head copy — the thing preferring base exists to prevent.
+  git rev-parse --verify --quiet "${source_ref}^{commit}" >/dev/null \
+    || fail "$PLAN_PATH" "the $source_name commit ($source_ref) is not available locally"
+
+  # `git ls-tree -l` prints: <mode> SP <type> SP <sha> SP <size> TAB <path>
+  # Empty output now means only one thing: the path is absent at this commit.
+  meta=$(git ls-tree -l "$source_ref" -- "$PLAN_PATH")
+  [[ -n "$meta" ]] || continue
+
+  read -r obj_mode obj_type obj_sha obj_size _ <<< "$meta"
+
+  # Present but unusable is TERMINAL, not a fall-through: letting a broken plan on the base
+  # branch hand grading to the PR's own copy would undo the reason base is preferred.
+  # Order matters — a tree's size field is `-`, so the type gate must precede the arithmetic.
+  [[ "$obj_type" == "blob" ]] \
+    || fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") is a $obj_type, not a file, at $source_name ($source_ref)"
+  [[ "$obj_mode" == "100644" || "$obj_mode" == "100755" ]] \
+    || fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") is not a regular file (mode $obj_mode) at $source_name ($source_ref)"
+  (( obj_size > 0 )) \
+    || fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") is empty at $source_name ($source_ref)"
+  (( obj_size <= MAX_PLAN_BYTES )) \
+    || fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") is $obj_size bytes at $source_name ($source_ref), over the ${MAX_PLAN_BYTES}-byte limit"
+
+  # By object sha, not by `ref:path`: the bytes written are then provably the object whose
+  # size was just checked, with no second path resolution in between.
+  git cat-file blob "$obj_sha" > "$TMP_FILE" \
+    || fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") could not be read at $source_name ($source_ref)"
+
+  plan_commit=$(git rev-parse --verify "$source_ref") \
+    || fail "$PLAN_PATH" "could not resolve the $source_name commit ($source_ref)"
+
+  mv "$TMP_FILE" "$OUT_FILE" || fail "$PLAN_PATH" "could not write the extracted plan"
+
+  printf 'status=resolved\nplan_path=%s\nplan_source=%s\nplan_commit=%s\n' \
+    "$PLAN_PATH" "$source_name" "$plan_commit"
+  exit 0
+done
+
+fail "$PLAN_PATH" "declared plan $(neuter "$PLAN_PATH") is not committed at the base branch tip ($BASE_REF) or the PR head ($HEAD_REF)"

--- a/scripts/archon-review.sh
+++ b/scripts/archon-review.sh
@@ -27,20 +27,26 @@ set -uo pipefail
 
 readonly MAX_COMMENT_CHARS=60000   # GitHub's limit is 65536; leave room for the notice
 
-for var in ARCHON_BIN BASE_SHA HEAD_SHA DECL_FILE OUTPUT_FILE RUN_URL; do
-  if [[ -z "${!var:-}" ]]; then
-    echo "usage: $0 (required environment variable $var is unset)" >&2
-    exit 2
-  fi
+usage() { echo "usage: $0 (required environment variable $1 is unset)" >&2; exit 2; }
+
+# Absolutise the caller's file arguments before anchoring to the repository root.
+abspath() { case "$1" in /*) printf '%s' "$1" ;; *) printf '%s/%s' "$PWD" "$1" ;; esac; }
+
+# OUTPUT_FILE is handled first so it can be truncated before anything else can fail. The
+# runner is self-hosted and the path is fixed, so a body left by an earlier run must not be
+# posted if this one exits before composing its own.
+[[ -n "${OUTPUT_FILE:-}" ]] || usage OUTPUT_FILE
+OUTPUT_FILE=$(abspath "$OUTPUT_FILE")
+: > "$OUTPUT_FILE" || { echo "could not write to $OUTPUT_FILE" >&2; exit 2; }
+
+for var in ARCHON_BIN BASE_SHA HEAD_SHA DECL_FILE RUN_URL; do
+  [[ -n "${!var:-}" ]] || usage "$var"
 done
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) \
   || { echo "could not locate the script directory" >&2; exit 2; }
 
-# Absolutise the caller's file arguments before anchoring to the repository root.
-abspath() { case "$1" in /*) printf '%s' "$1" ;; *) printf '%s/%s' "$PWD" "$1" ;; esac; }
 DECL_FILE=$(abspath "$DECL_FILE")
-OUTPUT_FILE=$(abspath "$OUTPUT_FILE")
 
 repo_root=$(git rev-parse --show-toplevel) \
   || { echo "not inside a git repository" >&2; exit 2; }

--- a/scripts/archon-review.sh
+++ b/scripts/archon-review.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# archon-review.sh — run archon's PR review and compose the comment body.
+#
+# Environment (all required):
+#   ARCHON_BIN   path to the archon-go binary
+#   BASE_SHA     the PR's base branch tip
+#   HEAD_SHA     the PR's head commit (already fetched into the object store)
+#   DECL_FILE    file holding plan-declaration candidate text
+#   OUTPUT_FILE  where to write the comment body
+#   RUN_URL      workflow run URL, used in the truncation notice
+# Optional:
+#   GITHUB_STEP_SUMMARY  appended to when set
+#
+# Exits 0 for every reviewed outcome, including archon failure, so the caller always has a
+# body to post. Exit 2 only on a usage or environment error.
+#
+# This script is executed from the DEFAULT BRANCH checkout: the workflow fetches the PR head
+# into the object store but never checks it out. A pull request therefore cannot get its own
+# copy of this script, the resolver, or .archon-version executed. Adding a `ref:` to the
+# checkout step would turn that property into arbitrary code execution on the runner.
+#
+# `set -e` is deliberately off: archon's non-zero exit is an outcome to report, not a crash.
+# Every state-changing command is therefore checked explicitly.
+
+set -uo pipefail
+
+readonly MAX_COMMENT_CHARS=60000   # GitHub's limit is 65536; leave room for the notice
+
+for var in ARCHON_BIN BASE_SHA HEAD_SHA DECL_FILE OUTPUT_FILE RUN_URL; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "usage: $0 (required environment variable $var is unset)" >&2
+    exit 2
+  fi
+done
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) \
+  || { echo "could not locate the script directory" >&2; exit 2; }
+
+# Absolutise the caller's file arguments before anchoring to the repository root.
+abspath() { case "$1" in /*) printf '%s' "$1" ;; *) printf '%s/%s' "$PWD" "$1" ;; esac; }
+DECL_FILE=$(abspath "$DECL_FILE")
+OUTPUT_FILE=$(abspath "$OUTPUT_FILE")
+
+repo_root=$(git rev-parse --show-toplevel) \
+  || { echo "not inside a git repository" >&2; exit 2; }
+cd "$repo_root" || { echo "could not enter the repository root" >&2; exit 2; }
+
+# emit <body> — write the comment body and the job summary, then stop. The single exit point
+# for a composed body, so neither the summary append nor the truncation can be skipped.
+emit() {
+  local body="$1"
+  local full_len=${#1}
+  [[ -z "${GITHUB_STEP_SUMMARY:-}" ]] || printf '%s\n' "$body" >> "$GITHUB_STEP_SUMMARY"
+  if (( full_len > MAX_COMMENT_CHARS )); then
+    body="${body:0:MAX_COMMENT_CHARS}
+
+_Output truncated (${full_len} chars). See the [workflow run](${RUN_URL}) for the full report._"
+  fi
+  printf '%s\n' "$body" > "$OUTPUT_FILE" \
+    || { echo "could not write the comment body to $OUTPUT_FILE" >&2; exit 2; }
+  exit 0
+}
+
+MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null) || emit "$(printf '## Archon Error\n\nCould not compute merge-base between base (%s) and head (%s). The PR head may not be reachable — check that the fetch step succeeded.' "$BASE_SHA" "$HEAD_SHA")"
+
+WORK_DIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/archon-review.XXXXXX") \
+  || { echo "could not create a work directory" >&2; exit 2; }
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+PLAN_FILE="$WORK_DIR/plan.json"
+STATUS_FILE="$WORK_DIR/plan-status.txt"
+
+# Guarded: a missing, non-executable, or crashing resolver must degrade to a delta review
+# with a warning, never abort the step and leave the trigger with no comment. Resolver
+# stderr is left on the job log, since the synthesised message points a reader there.
+"$script_dir/archon-plan-resolve.sh" "$BASE_SHA" "$HEAD_SHA" "$DECL_FILE" "$PLAN_FILE" > "$STATUS_FILE" \
+  || printf 'status=error\nplan_path=\nmessage=plan resolution failed to run; see the workflow logs\n' > "$STATUS_FILE"
+
+plan_field() { sed -n "s/^$1=//p" "$STATUS_FILE"; }
+PLAN_STATUS=$(plan_field status)
+PLAN_NOTE=""
+
+# A fresh output directory per invocation: a partial bundle from a failed plan-aware run
+# must never be posted as though it were the delta review.
+run_review() {
+  rm -rf .archon || return 1
+  "$ARCHON_BIN" pr-review . "$MERGE_BASE" "$HEAD_SHA" --out .archon "$@"
+}
+
+case "$PLAN_STATUS" in
+  resolved)
+    if [[ "$(plan_field plan_source)" == "head" ]]; then
+      PLAN_NOTE=$(printf '> [!NOTE]\n> Plan check used `%s` taken from this PR'"'"'s own head (`%s`). The base branch carries no copy, so the plan itself is not independently verified.' \
+        "$(plan_field plan_path)" "$(plan_field plan_commit)")
+    else
+      PLAN_NOTE=$(printf '_Plan check: `%s` from the base branch tip (`%s`)._' \
+        "$(plan_field plan_path)" "$(plan_field plan_commit)")
+    fi
+    if ! run_review --plan "$PLAN_FILE"; then
+      PLAN_NOTE=$(printf '> [!WARNING]\n> Plan-aware review failed for `%s`; reporting the delta review only. No dist ratchet or plan verdict in this comment.' \
+        "$(plan_field plan_path)")
+      PLAN_STATUS=fallback
+    fi
+    ;;
+  none) ;;
+  error)
+    PLAN_NOTE=$(printf '> [!WARNING]\n> Archon plan check skipped: %s. Reviewed without `--plan`, so this comment carries no dist ratchet or plan verdict.' \
+      "$(plan_field message)")
+    ;;
+  *)
+    echo "::error::archon-plan-resolve.sh returned an unknown status: ${PLAN_STATUS:-<empty>}" >&2
+    PLAN_NOTE=$(printf '> [!WARNING]\n> Archon plan detection returned an unrecognised result and was skipped. Reviewed without `--plan`, so this comment carries no dist ratchet or plan verdict.')
+    PLAN_STATUS=error
+    ;;
+esac
+
+# with_note <body> — prepend the plan note when there is one. Applied to the failure bodies
+# too, so the reason a declared plan was not checked is never dropped.
+with_note() {
+  if [[ -z "$PLAN_NOTE" ]]; then printf '%s' "$1"; else printf '%s\n\n%s' "$PLAN_NOTE" "$1"; fi
+}
+
+if [[ "$PLAN_STATUS" != "resolved" ]]; then
+  run_review || emit "$(with_note "$(printf '## Archon Error\n\narchon-go pr-review failed. Check the workflow logs.')")"
+fi
+
+[[ -f .archon/review.md ]] \
+  || emit "$(with_note "$(printf '## Archon Error\n\narchon-go exited 0 but did not produce .archon/review.md.')")"
+
+emit "$(with_note "$(cat .archon/review.md)")"

--- a/scripts/archon_plan_resolve_test.go
+++ b/scripts/archon_plan_resolve_test.go
@@ -460,6 +460,31 @@ func TestResolve_ProseMention_ReportsNone(t *testing.T) {
 	}
 }
 
+// Prose that BEGINS a line with the convention is treated as a malformed declaration, not as
+// no declaration. The anchor cannot distinguish the two, and erring toward a visible warning
+// is the safe direction: reporting `none` here would let a genuinely broken declaration pass
+// as a PR that never asked for a plan check.
+func TestResolve_LineInitialProse_ReportsErrorNotNone(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+
+	for _, decl := range []string{
+		"- archon-plan: is what we call it",
+		"archon-plan: see the sub-issue for the path",
+	} {
+		t.Run(decl, func(t *testing.T) {
+			got := runResolve(t, repo, base, base, writeDecl(t, decl+"\n"))
+
+			if got.status() != "error" {
+				t.Fatalf("status = %q, want error (fields %v)", got.status(), got.fields)
+			}
+			if got.outExists(t) {
+				t.Error("a plan file was produced from prose")
+			}
+		})
+	}
+}
+
 func TestResolve_PlanInNeitherCommit_ReportsError(t *testing.T) {
 	repo := newRepo(t)
 	base := gitCmd(t, repo, "rev-parse", "HEAD")

--- a/scripts/archon_plan_resolve_test.go
+++ b/scripts/archon_plan_resolve_test.go
@@ -1,0 +1,564 @@
+// Package scripts_test drives the repository's CI shell scripts against throwaway git
+// repositories. The scripts run inside a GitHub Actions workflow where nothing else can
+// exercise them, so their behaviour is pinned here instead.
+package scripts_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const declaredPlan = "specs/008-x/feature.plan.json"
+
+// scriptPath returns the absolute path of a script in this directory. Go runs tests with
+// the package directory as the working directory.
+func scriptPath(t *testing.T, name string) string {
+	t.Helper()
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		t.Fatalf("resolving %s: %v", name, err)
+	}
+	return abs
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not on PATH")
+	}
+}
+
+// gitCmd runs git with an identity and signing config of its own, so neither a missing nor
+// a signing-enabled global config changes the result.
+func gitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.name=blis-test",
+		"-c", "user.email=blis-test@example.invalid",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newRepo creates a repository with a single seed commit. Callers build every further
+// commit explicitly, so no returned SHA can go stale.
+func newRepo(t *testing.T) string {
+	t.Helper()
+	requireGit(t)
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("writing seed: %v", err)
+	}
+	gitCmd(t, dir, "add", "seed.txt")
+	gitCmd(t, dir, "commit", "-m", "seed")
+	return dir
+}
+
+func commitAll(t *testing.T, dir, message string) string {
+	t.Helper()
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", message)
+	return gitCmd(t, dir, "rev-parse", "HEAD")
+}
+
+func writeInRepo(t *testing.T, dir, path string, content []byte) {
+	t.Helper()
+	full := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(full, content, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// commitFileAt commits a regular file at path and returns the new commit SHA.
+func commitFileAt(t *testing.T, dir, path, content string) string {
+	t.Helper()
+	writeInRepo(t, dir, path, []byte(content))
+	return commitAll(t, dir, "add "+path)
+}
+
+func commitRemovalAt(t *testing.T, dir, path string) string {
+	t.Helper()
+	gitCmd(t, dir, "rm", "-q", path)
+	return commitAll(t, dir, "remove "+path)
+}
+
+// commitSymlinkAt commits a symlink at path, which git records with mode 120000.
+func commitSymlinkAt(t *testing.T, dir, path, target string) string {
+	t.Helper()
+	full := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.Symlink(target, full); err != nil {
+		t.Fatalf("symlinking %s: %v", path, err)
+	}
+	return commitAll(t, dir, "symlink "+path)
+}
+
+// commitTreeAt makes the declared path itself a directory, by committing a file inside it.
+// The .json suffix rule cannot short-circuit the object-type gate this way.
+func commitTreeAt(t *testing.T, dir, path string) string {
+	t.Helper()
+	writeInRepo(t, dir, filepath.Join(path, "inner.txt"), []byte("inner\n"))
+	return commitAll(t, dir, "tree at "+path)
+}
+
+func writeDecl(t *testing.T, text string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plan-decl.txt")
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		t.Fatalf("writing declaration: %v", err)
+	}
+	return path
+}
+
+type resolveResult struct {
+	fields   map[string]string
+	outPath  string
+	exitCode int
+	stderr   string
+}
+
+func (r resolveResult) status() string { return r.fields["status"] }
+
+func (r resolveResult) outExists(t *testing.T) bool {
+	t.Helper()
+	_, err := os.Stat(r.outPath)
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, fs.ErrNotExist):
+		return false
+	default:
+		t.Fatalf("stat %s: %v", r.outPath, err)
+		return false
+	}
+}
+
+func (r resolveResult) outBytes(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(r.outPath)
+	if err != nil {
+		t.Fatalf("reading extracted plan: %v", err)
+	}
+	return string(b)
+}
+
+// runResolve runs the resolver with repoDir as the working directory. Without that the
+// script would anchor to the BLIS repository itself and the extraction tests would be
+// meaningless.
+func runResolve(t *testing.T, repoDir, baseRef, headRef, declPath string, extraArgs ...string) resolveResult {
+	t.Helper()
+	outPath := filepath.Join(t.TempDir(), "plan.json")
+	args := []string{baseRef, headRef, declPath, outPath}
+	if extraArgs != nil {
+		args = extraArgs
+	}
+	cmd := exec.Command(scriptPath(t, "archon-plan-resolve.sh"), args...)
+	cmd.Dir = repoDir
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+
+	res := resolveResult{fields: map[string]string{}, outPath: outPath, stderr: stderr.String()}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		res.exitCode = exitErr.ExitCode()
+	default:
+		t.Fatalf("running resolver: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(stdout)), "\n") {
+		if key, value, ok := strings.Cut(line, "="); ok {
+			res.fields[key] = value
+		}
+	}
+	return res
+}
+
+func TestResolve_NoDeclaration_ReportsNone(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":2}`)
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "Fixes #1631\n\nNo plan here.\n"))
+
+	if got.status() != "none" {
+		t.Fatalf("status = %q, want none (fields %v)", got.status(), got.fields)
+	}
+	if got.outExists(t) {
+		t.Error("a plan file was produced for a PR that declared none")
+	}
+}
+
+// A declaration file that was never written must not look like "no declaration": that
+// would drop the plan gate exactly when the collecting step misbehaved.
+func TestResolve_MissingDeclarationFile_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+
+	got := runResolve(t, repo, base, base, filepath.Join(t.TempDir(), "absent.txt"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.fields["message"] == "" {
+		t.Error("no message explaining the failure")
+	}
+}
+
+func TestResolve_WrongArgCount_ExitsTwo(t *testing.T) {
+	repo := newRepo(t)
+
+	got := runResolve(t, repo, "", "", "", "only-one-argument")
+
+	if got.exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", got.exitCode)
+	}
+	if !strings.Contains(got.stderr, "usage:") {
+		t.Errorf("stderr = %q, want a usage message", got.stderr)
+	}
+}
+
+func TestResolve_UnsafePath_Rejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"absolute", "/etc/passwd"},
+		{"traversal", "../../etc/passwd"},
+		{"embedded traversal", "specs/../../x.json"},
+		{"leading dash", "-rf.json"},
+		{"space", "specs/a b.json"},
+		{"shell metacharacter", "specs/a;b.json"},
+		{"command substitution", "specs/a$(id).json"},
+		{"unsubstituted placeholder", "specs/[NNN-feature]/[feature].plan.json"},
+		{"wrong extension", "specs/plan.txt"},
+		{"over length", "specs/" + strings.Repeat("a", 300) + ".json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newRepo(t)
+			base := gitCmd(t, repo, "rev-parse", "HEAD")
+
+			got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+tc.path+"\n"))
+
+			if got.status() != "error" {
+				t.Fatalf("status = %q, want error (fields %v)", got.status(), got.fields)
+			}
+			if got.outExists(t) {
+				t.Error("a plan file was produced for a rejected path")
+			}
+			if got.fields["message"] == "" {
+				t.Error("no message explaining the rejection")
+			}
+			// Whatever is echoed back must be reduced to the allowlist, so a rejected
+			// path cannot smuggle markdown or a workflow command into the comment.
+			if p := got.fields["plan_path"]; strings.ContainsAny(p, "$;() []`\n") {
+				t.Errorf("plan_path = %q still contains unsafe characters", p)
+			}
+		})
+	}
+}
+
+func TestResolve_DeclarationWithNoPath_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan:\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("a plan file was produced for a declaration with no path")
+	}
+}
+
+func TestResolve_PlanOnBase_ResolvesFromBase(t *testing.T) {
+	repo := newRepo(t)
+	const content = `{"holes":["h1","h2"]}`
+	base := commitFileAt(t, repo, declaredPlan, content)
+	head := commitFileAt(t, repo, "sim/thing.go", "package sim\n")
+
+	got := runResolve(t, repo, base, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved (fields %v)", got.status(), got.fields)
+	}
+	if got.fields["plan_source"] != "base" {
+		t.Errorf("plan_source = %q, want base", got.fields["plan_source"])
+	}
+	if got.fields["plan_commit"] != base {
+		t.Errorf("plan_commit = %q, want %q", got.fields["plan_commit"], base)
+	}
+	if got.outBytes(t) != content {
+		t.Errorf("extracted plan = %q, want %q", got.outBytes(t), content)
+	}
+}
+
+func TestResolve_PlanOnlyOnHead_ResolvesFromHead(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	const content = `{"holes":[]}`
+	head := commitFileAt(t, repo, declaredPlan, content)
+
+	got := runResolve(t, repo, base, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved (fields %v)", got.status(), got.fields)
+	}
+	if got.fields["plan_source"] != "head" {
+		t.Errorf("plan_source = %q, want head", got.fields["plan_source"])
+	}
+	if got.fields["plan_commit"] != head {
+		t.Errorf("plan_commit = %q, want %q", got.fields["plan_commit"], head)
+	}
+	if got.outBytes(t) != content {
+		t.Errorf("extracted plan = %q, want %q", got.outBytes(t), content)
+	}
+}
+
+// A hole PR must not be able to grade itself against a plan it rewrote.
+func TestResolve_PlanOnBoth_PrefersBase(t *testing.T) {
+	repo := newRepo(t)
+	const onBase = `{"holes":["still-open"]}`
+	const onHead = `{"holes":[]}`
+	base := commitFileAt(t, repo, declaredPlan, onBase)
+	head := commitFileAt(t, repo, declaredPlan, onHead)
+
+	got := runResolve(t, repo, base, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved", got.status())
+	}
+	if got.fields["plan_source"] != "base" {
+		t.Errorf("plan_source = %q, want base", got.fields["plan_source"])
+	}
+	if got.outBytes(t) != onBase {
+		t.Errorf("extracted the head copy (%q); the base copy must win", got.outBytes(t))
+	}
+}
+
+func TestResolve_DeclarationInSecondSection_Resolves(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+
+	// The PR body comes first and declares nothing; the closing issue's body follows.
+	decl := writeDecl(t, "Implements hole 2.\n\nCloses #99\n"+"\n"+"### Hole 2\n\narchon-plan: "+declaredPlan+"\n")
+	got := runResolve(t, repo, base, base, decl)
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved (fields %v)", got.status(), got.fields)
+	}
+	if got.fields["plan_path"] != declaredPlan {
+		t.Errorf("plan_path = %q, want %q", got.fields["plan_path"], declaredPlan)
+	}
+}
+
+// The PR body is collected first, so its declaration outranks one in a third-party issue.
+func TestResolve_MultipleDeclarations_FirstWins(t *testing.T) {
+	repo := newRepo(t)
+	const other = "specs/999-other/other.plan.json"
+	commitFileAt(t, repo, other, `{"holes":"other"}`)
+	const mine = `{"holes":"mine"}`
+	base := commitFileAt(t, repo, declaredPlan, mine)
+
+	decl := writeDecl(t, "archon-plan: "+declaredPlan+"\n\n---\n\narchon-plan: "+other+"\n")
+	got := runResolve(t, repo, base, base, decl)
+
+	if got.fields["plan_path"] != declaredPlan {
+		t.Fatalf("plan_path = %q, want the first declaration %q", got.fields["plan_path"], declaredPlan)
+	}
+	if got.outBytes(t) != mine {
+		t.Errorf("extracted %q, want the first declaration's content", got.outBytes(t))
+	}
+}
+
+// GitHub API bodies use CRLF; an unstripped \r fails validation on every real PR.
+func TestResolve_CRLFDeclaration_Resolves(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "## Summary\r\n\r\narchon-plan: "+declaredPlan+"\r\n"))
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved (fields %v)", got.status(), got.fields)
+	}
+}
+
+// The templates wrap the declaration in backticks and bold markers.
+func TestResolve_MarkdownWrappedDeclaration_Resolves(t *testing.T) {
+	for _, decl := range []string{
+		"`archon-plan: " + declaredPlan + "`",
+		"- archon-plan: " + declaredPlan,
+		"> archon-plan: " + declaredPlan,
+		"**archon-plan:** " + declaredPlan,
+	} {
+		t.Run(decl, func(t *testing.T) {
+			repo := newRepo(t)
+			base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+
+			got := runResolve(t, repo, base, base, writeDecl(t, decl+"\n"))
+
+			if got.status() != "resolved" {
+				t.Fatalf("status = %q, want resolved (fields %v)", got.status(), got.fields)
+			}
+			if got.fields["plan_path"] != declaredPlan {
+				t.Errorf("plan_path = %q, want %q", got.fields["plan_path"], declaredPlan)
+			}
+		})
+	}
+}
+
+// Prose mentioning the convention must not be read as a declaration.
+func TestResolve_ProseMention_ReportsNone(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "This PR has no archon-plan: line yet.\n"))
+
+	if got.status() != "none" {
+		t.Fatalf("status = %q, want none (fields %v)", got.status(), got.fields)
+	}
+}
+
+func TestResolve_PlanInNeitherCommit_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if !strings.Contains(got.fields["message"], declaredPlan) {
+		t.Errorf("message %q does not name the declared path", got.fields["message"])
+	}
+	if got.outExists(t) {
+		t.Error("a plan file was produced for a path committed nowhere")
+	}
+}
+
+// The declared path exists in the working tree and is committed nowhere. Any
+// implementation that reads the filesystem instead of git resolves it and fails here.
+func TestResolve_PlanOnlyInWorkingTree_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	writeInRepo(t, repo, declaredPlan, []byte(`{"holes":"uncommitted"}`))
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error; the plan is not committed", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("the working-tree copy was read; extraction must go through git")
+	}
+}
+
+// A broken base copy must not hand grading back to the PR's own head copy.
+func TestResolve_EmptyBlobOnBase_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, "")
+	head := commitFileAt(t, repo, declaredPlan, `{"holes":[]}`)
+
+	got := runResolve(t, repo, base, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("the head copy was used to replace an unusable base copy")
+	}
+}
+
+func TestResolve_PathIsDirectory_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := commitTreeAt(t, repo, declaredPlan)
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("a plan file was produced for a directory")
+	}
+}
+
+func TestResolve_PathIsSymlink_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := commitSymlinkAt(t, repo, declaredPlan, "/etc/passwd")
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("a symlink was dereferenced")
+	}
+}
+
+func TestResolve_OversizePlan_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, strings.Repeat("x", 1024*1024+1))
+
+	got := runResolve(t, repo, base, base, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("an oversized blob was extracted")
+	}
+}
+
+// git ls-tree prints nothing both for an absent path and for an unknown commit. Without a
+// reachability check an unfetched base tip would silently degrade to the head copy.
+func TestResolve_UnknownBaseCommit_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	const unknown = "0123456789abcdef0123456789abcdef01234567"
+	head := commitFileAt(t, repo, declaredPlan, `{"holes":[]}`)
+
+	got := runResolve(t, repo, unknown, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error", got.status())
+	}
+	if got.outExists(t) {
+		t.Error("an unreachable base commit fell through to the head copy")
+	}
+}
+
+// A plan removed on the head is still resolved from the base.
+func TestResolve_PlanRemovedOnHead_ResolvesFromBase(t *testing.T) {
+	repo := newRepo(t)
+	const content = `{"holes":["h1"]}`
+	base := commitFileAt(t, repo, declaredPlan, content)
+	head := commitRemovalAt(t, repo, declaredPlan)
+
+	got := runResolve(t, repo, base, head, writeDecl(t, "archon-plan: "+declaredPlan+"\n"))
+
+	if got.status() != "resolved" {
+		t.Fatalf("status = %q, want resolved", got.status())
+	}
+	if got.outBytes(t) != content {
+		t.Errorf("extracted plan = %q, want %q", got.outBytes(t), content)
+	}
+}

--- a/scripts/archon_plan_resolve_test.go
+++ b/scripts/archon_plan_resolve_test.go
@@ -44,9 +44,13 @@ func gitCmd(t *testing.T, dir string, args ...string) string {
 	}, args...)
 	cmd := exec.Command("git", full...)
 	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	// Output, not CombinedOutput: a git warning on stderr would otherwise be returned as
+	// part of a commit SHA.
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(string(out))
 }
@@ -222,6 +226,24 @@ func TestResolve_MissingDeclarationFile_ReportsError(t *testing.T) {
 	}
 }
 
+// Existence is not readability: an unreadable declaration file must not read as "no
+// declaration", which would drop the plan gate silently.
+func TestResolve_UnreadableDeclarationFile_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := commitFileAt(t, repo, declaredPlan, `{"holes":1}`)
+	decl := writeDecl(t, "archon-plan: "+declaredPlan+"\n")
+	if err := os.Chmod(decl, 0o000); err != nil {
+		t.Fatalf("making the declaration unreadable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(decl, 0o644) })
+
+	got := runResolve(t, repo, base, base, decl)
+
+	if got.status() != "error" {
+		t.Fatalf("status = %q, want error (fields %v)", got.status(), got.fields)
+	}
+}
+
 func TestResolve_WrongArgCount_ExitsTwo(t *testing.T) {
 	repo := newRepo(t)
 
@@ -244,6 +266,7 @@ func TestResolve_UnsafePath_Rejected(t *testing.T) {
 		{"traversal", "../../etc/passwd"},
 		{"embedded traversal", "specs/../../x.json"},
 		{"leading dash", "-rf.json"},
+		// `read` stops at the space, so this is rejected for not ending in .json.
 		{"space", "specs/a b.json"},
 		{"shell metacharacter", "specs/a;b.json"},
 		{"command substitution", "specs/a$(id).json"},

--- a/scripts/archon_review_test.go
+++ b/scripts/archon_review_test.go
@@ -434,6 +434,37 @@ func TestReview_ArchonFailsWithPlanWarning_KeepsWarning(t *testing.T) {
 	}
 }
 
+// The runner is self-hosted and the output path is fixed, so a body left by an earlier run
+// must not survive into a run that aborts before composing its own.
+func TestReview_AbortedRun_LeavesNoStaleBody(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	scratch := t.TempDir()
+	outputFile := filepath.Join(scratch, "archon-output.md")
+	if err := os.WriteFile(outputFile, []byte("## Stale review from an earlier run\n"), 0o644); err != nil {
+		t.Fatalf("seeding a stale body: %v", err)
+	}
+
+	// An unset RUN_URL aborts the script after the truncation but before any body exists.
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":    base,
+		"HEAD_SHA":    base,
+		"OUTPUT_FILE": outputFile,
+		"RUN_URL":     "",
+	}, nil)
+
+	if got.exitCode == 0 {
+		t.Fatalf("exit code = 0, want non-zero for a missing RUN_URL")
+	}
+	body, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("reading the output file: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("stale body survived an aborted run: %q", body)
+	}
+}
+
 func TestReview_MissingRequiredEnv_ExitsTwo(t *testing.T) {
 	repo, _, head := planRepo(t, "base")
 

--- a/scripts/archon_review_test.go
+++ b/scripts/archon_review_test.go
@@ -2,6 +2,7 @@ package scripts_test
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -114,7 +115,7 @@ func runReview(t *testing.T, repoDir string, env map[string]string, mutate func(
 	cmd.Stderr = &stderr
 	cmd.Stdout = &strings.Builder{}
 
-	res := reviewResult{stderr: stderr.String()}
+	var res reviewResult
 	err := cmd.Run()
 	res.stderr = stderr.String()
 	var exitErr *exec.ExitError
@@ -126,12 +127,16 @@ func runReview(t *testing.T, repoDir string, env map[string]string, mutate func(
 		t.Fatalf("running review script: %v", err)
 	}
 
-	if b, readErr := os.ReadFile(outputFile); readErr == nil {
-		res.body = string(b)
+	body, readErr := os.ReadFile(outputFile)
+	if readErr != nil && !errors.Is(readErr, fs.ErrNotExist) {
+		t.Fatalf("reading the comment body: %v", readErr)
 	}
-	if b, readErr := os.ReadFile(summaryFile); readErr == nil {
-		res.summary = string(b)
+	res.body = string(body)
+	summary, readErr := os.ReadFile(summaryFile)
+	if readErr != nil && !errors.Is(readErr, fs.ErrNotExist) {
+		t.Fatalf("reading the job summary: %v", readErr)
 	}
+	res.summary = string(summary)
 	if b, readErr := os.ReadFile(stubLog); readErr == nil {
 		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
 			if line != "" {

--- a/scripts/archon_review_test.go
+++ b/scripts/archon_review_test.go
@@ -1,0 +1,475 @@
+package scripts_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// reviewMarker is written into the stub's review.md so a test can tell which invocation
+// produced the bundle that ended up in the comment.
+const reviewMarker = "STUB REVIEW"
+
+// stubArchon writes a fake archon-go. It records each invocation's argv on one line of
+// $STUB_LOG, writes a review bundle naming whether --plan was in that argv, and exits with
+// $STUB_EXIT. When $STUB_EXIT_ONCE is set only the first invocation fails, which is what
+// the retry contract needs.
+func stubArchon(t *testing.T, dir string) (binPath, logPath string) {
+	t.Helper()
+	binPath = filepath.Join(dir, "archon-go-stub")
+	logPath = filepath.Join(dir, "stub.log")
+	script := `#!/usr/bin/env bash
+set -uo pipefail
+echo "$*" >> "$STUB_LOG"
+invocation=$(wc -l < "$STUB_LOG" | tr -d '[:space:]')
+
+plan_flag=absent
+for arg in "$@"; do [[ "$arg" == "--plan" ]] && plan_flag=present; done
+
+exit_code=${STUB_EXIT:-0}
+# STUB_EXIT_ONCE fails only the first invocation, which is what the retry contract needs.
+if [[ -n "${STUB_EXIT_ONCE:-}" && "$invocation" == "1" ]]; then exit_code=1; fi
+
+# STUB_WRITE_ONCE makes only the first invocation produce a bundle, so a caller that does
+# not clear .archon between runs would post the first invocation's output.
+if [[ -z "${STUB_WRITE_ONCE:-}" || "$invocation" == "1" ]]; then
+  mkdir -p .archon
+  printf '# ` + reviewMarker + ` (--plan %s)\n\nBody of the review.\n' "$plan_flag" > .archon/review.md
+  if [[ -n "${STUB_PAD:-}" ]]; then
+    head -c "$STUB_PAD" /dev/zero | tr '\0' 'x' >> .archon/review.md
+  fi
+fi
+exit "$exit_code"
+`
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing stub archon: %v", err)
+	}
+	return binPath, logPath
+}
+
+type reviewResult struct {
+	body     string
+	summary  string
+	stubArgs []string
+	exitCode int
+	stderr   string
+}
+
+func (r reviewResult) invocations() int { return len(r.stubArgs) }
+
+// runReview executes archon-review.sh with repoDir as the working directory.
+//
+// Both scripts are copied into a scratch directory and the copy is executed, because
+// archon-review.sh locates the resolver next to itself. A test that needs a broken
+// resolver can then break the copy instead of the repository's own file.
+func runReview(t *testing.T, repoDir string, env map[string]string, mutate func(scriptDir string)) reviewResult {
+	t.Helper()
+	requireGit(t)
+
+	scratch := t.TempDir()
+	scriptDir := filepath.Join(scratch, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("creating script dir: %v", err)
+	}
+	for _, name := range []string{"archon-review.sh", "archon-plan-resolve.sh"} {
+		src, err := os.ReadFile(scriptPath(t, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(scriptDir, name), src, 0o755); err != nil {
+			t.Fatalf("copying %s: %v", name, err)
+		}
+	}
+	if mutate != nil {
+		mutate(scriptDir)
+	}
+
+	outputFile := filepath.Join(scratch, "archon-output.md")
+	summaryFile := filepath.Join(scratch, "step-summary.md")
+	stubBin, stubLog := stubArchon(t, scratch)
+
+	full := map[string]string{
+		"ARCHON_BIN":          stubBin,
+		"DECL_FILE":           writeDecl(t, ""),
+		"OUTPUT_FILE":         outputFile,
+		"RUN_URL":             "https://example.invalid/run/1",
+		"GITHUB_STEP_SUMMARY": summaryFile,
+		"STUB_LOG":            stubLog,
+		"RUNNER_TEMP":         scratch,
+	}
+	for k, v := range env {
+		full[k] = v
+	}
+
+	cmd := exec.Command(filepath.Join(scriptDir, "archon-review.sh"))
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "PATH="+os.Getenv("PATH"))
+	for k, v := range full {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	cmd.Stdout = &strings.Builder{}
+
+	res := reviewResult{stderr: stderr.String()}
+	err := cmd.Run()
+	res.stderr = stderr.String()
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		res.exitCode = exitErr.ExitCode()
+	default:
+		t.Fatalf("running review script: %v", err)
+	}
+
+	if b, readErr := os.ReadFile(outputFile); readErr == nil {
+		res.body = string(b)
+	}
+	if b, readErr := os.ReadFile(summaryFile); readErr == nil {
+		res.summary = string(b)
+	}
+	if b, readErr := os.ReadFile(stubLog); readErr == nil {
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			if line != "" {
+				res.stubArgs = append(res.stubArgs, line)
+			}
+		}
+	}
+	return res
+}
+
+// planRepo builds a repository whose base and head share a merge-base, with the plan
+// committed wherever the caller asks.
+func planRepo(t *testing.T, planAt string) (dir, base, head string) {
+	t.Helper()
+	dir = newRepo(t)
+	switch planAt {
+	case "base":
+		base = commitFileAt(t, dir, declaredPlan, `{"holes":["h1"]}`)
+		head = commitFileAt(t, dir, "sim/thing.go", "package sim\n")
+	case "head":
+		base = gitCmd(t, dir, "rev-parse", "HEAD")
+		head = commitFileAt(t, dir, declaredPlan, `{"holes":["h1"]}`)
+	case "nowhere":
+		base = gitCmd(t, dir, "rev-parse", "HEAD")
+		head = commitFileAt(t, dir, "sim/thing.go", "package sim\n")
+	default:
+		t.Fatalf("unknown planAt %q", planAt)
+	}
+	return dir, base, head
+}
+
+func TestReview_NoDeclaration_DeltaOnly(t *testing.T) {
+	repo, base, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "Fixes #1631\n\nNo plan declared.\n"),
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 1 {
+		t.Fatalf("archon invoked %d times, want 1: %v", got.invocations(), got.stubArgs)
+	}
+	if strings.Contains(got.stubArgs[0], "--plan") {
+		t.Errorf("--plan was passed for a PR that declared no plan: %q", got.stubArgs[0])
+	}
+	if !strings.Contains(got.body, reviewMarker) {
+		t.Errorf("comment body does not contain the review: %q", got.body)
+	}
+	// A PR with no plan must read exactly as it did before this feature existed.
+	if strings.Contains(got.body, "[!WARNING]") || strings.Contains(got.body, "Plan check") {
+		t.Errorf("comment body carries a plan note or warning:\n%s", got.body)
+	}
+	if !strings.Contains(got.summary, reviewMarker) {
+		t.Errorf("job summary does not contain the review: %q", got.summary)
+	}
+}
+
+func TestReview_PlanOnBase_PassesPlanOnce(t *testing.T) {
+	repo, base, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 1 {
+		t.Fatalf("archon invoked %d times, want 1: %v", got.invocations(), got.stubArgs)
+	}
+	if n := strings.Count(got.stubArgs[0], "--plan"); n != 1 {
+		t.Errorf("--plan appears %d times in %q, want 1", n, got.stubArgs[0])
+	}
+	if !strings.Contains(got.body, declaredPlan) {
+		t.Errorf("comment body does not name the plan:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, base) {
+		t.Errorf("comment body does not name the commit the plan came from:\n%s", got.body)
+	}
+	if strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body carries a warning for a successful plan check:\n%s", got.body)
+	}
+}
+
+// A fork PR controls its own head, so a head-sourced plan is not an independent gate and
+// the comment has to say so.
+func TestReview_PlanFromHead_LabelsUnverified(t *testing.T) {
+	repo, base, head := planRepo(t, "head")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+	}, nil)
+
+	if got.invocations() != 1 || !strings.Contains(got.stubArgs[0], "--plan") {
+		t.Fatalf("want one plan-aware invocation, got %v", got.stubArgs)
+	}
+	if !strings.Contains(got.body, "not independently verified") {
+		t.Errorf("comment body does not flag the head-sourced plan:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, head) {
+		t.Errorf("comment body does not name the head commit:\n%s", got.body)
+	}
+}
+
+// A PR that asks to be checked against a plan and silently is not would be
+// indistinguishable from a PR with no plan, which removes the gate without telling anyone.
+func TestReview_UnusablePlan_WarnsAndReviewsWithoutPlan(t *testing.T) {
+	repo, base, head := planRepo(t, "nowhere")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 1 {
+		t.Fatalf("archon invoked %d times, want 1: %v", got.invocations(), got.stubArgs)
+	}
+	if strings.Contains(got.stubArgs[0], "--plan") {
+		t.Errorf("--plan was passed for an unresolvable plan: %q", got.stubArgs[0])
+	}
+	if !strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body carries no warning:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, declaredPlan) {
+		t.Errorf("warning does not name the declared path:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, reviewMarker) {
+		t.Errorf("comment body lost the delta review:\n%s", got.body)
+	}
+}
+
+// The three views must survive a plan file archon rejects.
+func TestReview_PlanAwareRunFails_RetriesWithoutPlan(t *testing.T) {
+	repo, base, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":       base,
+		"HEAD_SHA":       head,
+		"DECL_FILE":      writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+		"STUB_EXIT_ONCE": "1",
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 2 {
+		t.Fatalf("archon invoked %d times, want 2: %v", got.invocations(), got.stubArgs)
+	}
+	if !strings.Contains(got.stubArgs[0], "--plan") {
+		t.Errorf("first invocation should have carried --plan: %q", got.stubArgs[0])
+	}
+	if strings.Contains(got.stubArgs[1], "--plan") {
+		t.Errorf("retry should not carry --plan: %q", got.stubArgs[1])
+	}
+	if !strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body carries no warning about the failed plan check:\n%s", got.body)
+	}
+	// The failed invocation's bundle must not be what gets posted.
+	if !strings.Contains(got.body, "--plan absent") {
+		t.Errorf("comment body is not the retry's output:\n%s", got.body)
+	}
+	if strings.Contains(got.body, "--plan present") {
+		t.Errorf("comment body contains the failed invocation's output:\n%s", got.body)
+	}
+}
+
+// The plan-aware invocation can leave a partial bundle behind. If the output directory is
+// not cleared before the retry, that bundle gets posted as though it were the delta review —
+// a plan-aware verdict presented under a "plan check failed" warning.
+func TestReview_RetryProducesNoBundle_DoesNotPostTheFailedRun(t *testing.T) {
+	repo, base, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":        base,
+		"HEAD_SHA":        head,
+		"DECL_FILE":       writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+		"STUB_EXIT_ONCE":  "1",
+		"STUB_WRITE_ONCE": "1",
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 2 {
+		t.Fatalf("archon invoked %d times, want 2: %v", got.invocations(), got.stubArgs)
+	}
+	if strings.Contains(got.body, "--plan present") {
+		t.Errorf("the failed plan-aware bundle was posted:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, "did not produce") {
+		t.Errorf("comment body does not report the missing bundle:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body dropped the plan warning:\n%s", got.body)
+	}
+}
+
+// The workflow shell is `bash -eo pipefail`, so an unguarded resolver failure would abort
+// the step and post nothing at all.
+func TestReview_ResolverNotExecutable_WarnsAndReviews(t *testing.T) {
+	repo, base, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+	}, func(scriptDir string) {
+		if err := os.Chmod(filepath.Join(scriptDir, "archon-plan-resolve.sh"), 0o000); err != nil {
+			t.Fatalf("breaking the resolver copy: %v", err)
+		}
+	})
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 1 || strings.Contains(got.stubArgs[0], "--plan") {
+		t.Fatalf("want one delta-only invocation, got %v", got.stubArgs)
+	}
+	if !strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body carries no warning about plan resolution:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, reviewMarker) {
+		t.Errorf("comment body lost the delta review:\n%s", got.body)
+	}
+}
+
+func TestReview_UnreachableMergeBase_ReportsError(t *testing.T) {
+	repo := newRepo(t)
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	// An orphan root shares no history, so git merge-base genuinely fails.
+	gitCmd(t, repo, "checkout", "-q", "--orphan", "unrelated")
+	gitCmd(t, repo, "rm", "-q", "-rf", ".")
+	writeInRepo(t, repo, "other.txt", []byte("other\n"))
+	head := commitAll(t, repo, "unrelated root")
+
+	got := runReview(t, repo, map[string]string{"BASE_SHA": base, "HEAD_SHA": head}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if got.invocations() != 0 {
+		t.Errorf("archon was invoked despite an unreachable merge-base: %v", got.stubArgs)
+	}
+	if !strings.Contains(got.body, "Archon Error") || !strings.Contains(got.body, "merge-base") {
+		t.Errorf("comment body does not report the merge-base failure:\n%s", got.body)
+	}
+	if !strings.Contains(got.summary, "merge-base") {
+		t.Errorf("job summary does not report the merge-base failure:\n%s", got.summary)
+	}
+}
+
+func TestReview_ArchonFails_ReportsError(t *testing.T) {
+	repo, base, head := planRepo(t, "nowhere")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"STUB_EXIT": "1",
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if !strings.Contains(got.body, "Archon Error") {
+		t.Errorf("comment body does not report the failure:\n%s", got.body)
+	}
+}
+
+// A plan warning must survive a failing review, or the reason the gate did not run is lost.
+func TestReview_ArchonFailsWithPlanWarning_KeepsWarning(t *testing.T) {
+	repo, base, head := planRepo(t, "nowhere")
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA":  base,
+		"HEAD_SHA":  head,
+		"DECL_FILE": writeDecl(t, "archon-plan: "+declaredPlan+"\n"),
+		"STUB_EXIT": "1",
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if !strings.Contains(got.body, "Archon Error") {
+		t.Errorf("comment body does not report the archon failure:\n%s", got.body)
+	}
+	if !strings.Contains(got.body, "[!WARNING]") {
+		t.Errorf("comment body dropped the plan warning:\n%s", got.body)
+	}
+}
+
+func TestReview_MissingRequiredEnv_ExitsTwo(t *testing.T) {
+	repo, _, head := planRepo(t, "base")
+
+	got := runReview(t, repo, map[string]string{"BASE_SHA": "", "HEAD_SHA": head}, nil)
+
+	if got.exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "BASE_SHA") {
+		t.Errorf("stderr does not name the missing variable: %q", got.stderr)
+	}
+}
+
+// GitHub caps a comment at 65536 characters, so an oversize review is truncated for the
+// comment while the job summary keeps the whole thing.
+func TestReview_OversizeReview_TruncatesWithRunLink(t *testing.T) {
+	repo, base, head := planRepo(t, "nowhere")
+	const runURL = "https://example.invalid/run/42"
+
+	got := runReview(t, repo, map[string]string{
+		"BASE_SHA": base,
+		"HEAD_SHA": head,
+		"STUB_PAD": "70000",
+		"RUN_URL":  runURL,
+	}, nil)
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr %q)", got.exitCode, got.stderr)
+	}
+	if len(got.body) > 65536 {
+		t.Errorf("comment body is %d characters, over GitHub's 65536 limit", len(got.body))
+	}
+	if !strings.Contains(got.body, "Output truncated") || !strings.Contains(got.body, runURL) {
+		t.Errorf("truncated body does not link the workflow run:\n%s", got.body[max(0, len(got.body)-300):])
+	}
+	if len(got.summary) < 70000 {
+		t.Errorf("job summary is %d characters; it should keep the untruncated review", len(got.summary))
+	}
+}


### PR DESCRIPTION
## Summary

`/archon-pr-review` reviewed every PR as an isolated diff. Now, when a PR declares which archon plan it belongs to, `--plan` is added to that same invocation — so a planned multi-PR feature gets a dist ratchet and a plan verdict.

One command, one comment, in every case.

```
plan = first `archon-plan: <path>` line in the PR body, else in a closing issue body
if <path> is a committed .json file at the base branch tip, else at the PR head:
  archon-go pr-review . $BASE $HEAD --plan <extracted> --out .archon   # 3 views + dist
else:
  archon-go pr-review . $BASE $HEAD --out .archon                      # 3 views
```

| Case | Target | Plan file | CI does |
|---|---|---|---|
| PR0 — create branch + persist plan | no PR (direct push) | — | nothing; there is no PR to review |
| Hole PR (PR1..N) | feature branch | on the base | 3 views + plan checks |
| Final PR | `main` | on the head only | 3 views + plan checks |
| Normal PR (bug fix) | `main` | none | 3 views only, silently |

Builds on #1625 (merged), which pinned archon at v0.5.0 and added the `!specs/**/*.json` negation without which a compiled plan cannot be committed (#1633).

## Behavioral contracts

**Positive** — BC-1 quiet by default (no note, no warning, unchanged output). BC-2/BC-3 plan resolved from the base branch tip, else the PR head. BC-4 the base copy wins. BC-5 declaration found in a closing issue. BC-6 the earliest declaration wins. BC-7 one invocation, one comment. BC-8 a head-sourced plan is labelled as not independently verified.

**Negative** — BC-9 unsafe paths refused (absolute, `..`, leading `-`, over 256 chars, outside `[A-Za-z0-9._/-]`, not `.json`). BC-10 a declared path is never dereferenced through the filesystem.

**Error handling** — BC-11 declared but unusable is loud. BC-12 an unusable base copy is not silently replaced by the head copy. BC-13 a failing plan-aware review still yields the three views. BC-14 an unreachable commit is an error, not an absent plan. BC-15 pre-existing failure reporting survives. BC-16 a resolver that cannot run does not swallow the review.

## Why the review step moved into a script

Over half those contracts describe *what gets posted*, which no test can reach inside a YAML `run:` block. `scripts/archon-review.sh` is the same logic in a file a stub `archon-go` can drive, so the pre-existing merge-base and missing-bundle paths are now tested too — they never were before.

## Three things worth a reviewer's attention

**The declared path is untrusted.** It comes from a PR or issue body, and this workflow runs on a self-hosted runner with `pull-requests: write`. The text crosses as file *contents*, never a shell argument; the path is validated before any use; it is dereferenced only with git plumbing against an explicit commit, with object type, mode, and size gated before a byte is written; and anything echoed back has out-of-allowlist characters replaced.

**Base is preferred over head, and there are three ways that could have silently collapsed.** A hole PR racing the base (BC-4), a base copy that exists but is broken (BC-12), and a base commit git has never fetched (BC-14). `git ls-tree` prints nothing for the last two, exactly as it does for an absent file, so each needed an explicit check. Each has a test that fails if the check is removed.

**The workflow never checks out the PR head**, so a PR cannot get its own copy of these scripts executed. That property is load-bearing and now documented in `archon-review.sh`: adding a `ref:` to the checkout step would turn it into arbitrary code execution on the runner.

## Testing

`scripts/` gains a test-only Go package driving both scripts against throwaway git repositories and a stub archon. `ci.yml` lists packages explicitly rather than `./...`, so a `./scripts` matrix entry was needed or none of it would run.

```
go build ./...          exit 0
go test ./... -count=1  exit 0   (all packages ok; ./scripts 40 cases)
```

Six mutations were applied to confirm the tests discriminate rather than merely pass:

| Mutation | Test that caught it |
|---|---|
| prefer head over base | `TestResolve_PlanOnBoth_PrefersBase` |
| read the path from the filesystem instead of git | `TestResolve_PlanOnlyInWorkingTree_ReportsError` |
| drop the commit-reachability check | `TestResolve_UnknownBaseCommit_ReportsError` |
| drop the retry without `--plan` | `TestReview_PlanAwareRunFails_RetriesWithoutPlan` |
| stop clearing `.archon` between invocations | `TestReview_RetryProducesNoBundle_DoesNotPostTheFailedRun` |
| drop the plan warning from failure bodies | `TestReview_UnusablePlan_WarnsAndReviewsWithoutPlan` |

The first pass of the `.archon`-clearing test did *not* catch its mutation — the stub rewrote the bundle on every call, masking it. That is why a second test exists for it.

`golangci-lint` was not run locally: the installed binary is v1.53.3 (built with Go 1.20) and cannot read Go 1.24 export data. CI runs it.

## Docs corrected

`pr-review-context.md` documented a design that was never built — two invocations with both outputs posted, base-branch-only lookup, and a silent fall back to delta-only. All three are wrong and are fixed here. The `.json` and must-be-committed requirements were implicit at all four sites that define the convention; `archon-issue-examples.md` and `rfc-to-plan.md` now also say the bracketed placeholders must be substituted, since a literal `specs/[NNN-feature]/...` is rejected.

## Also fixed here

`archon.yml` posted the comment from a fixed `/tmp/archon-output.md`. Adding `if: always()` to the comment step made that reachable in a new way: when a step *before* the review fails, the review script never runs to truncate the file, so a body left by an earlier job on that host would be posted — possibly another PR's review. The path now lives under `${{ runner.temp }}`, referenced from both steps (env does not carry between steps). Closes #1643.

Fixes #1631


