### PR TITLE
hardening(scripts): find-saturation.sh should fail fast when jq or bc is missing

### DIFF
--- a/scripts/find-saturation.sh
+++ b/scripts/find-saturation.sh
@@ -38,6 +38,21 @@ SEED="${SEED:-42}"
 CFG_ARGS=()
 [[ -n "$MODEL_CONFIG_FOLDER" ]] && CFG_ARGS=(--model-config-folder "$MODEL_CONFIG_FOLDER")
 
+# Required tools, checked before anything expensive happens. Both are used only inside the
+# rate loop (jq to read each report, bc for the goodput ratio), so without this the script
+# builds blis and runs at least one full simulation before failing on something knowable at
+# startup. `column` is deliberately NOT checked: the summary print falls back gracefully when
+# it is missing, so requiring it would break a working setup.
+missing=()
+for tool in jq bc; do
+  command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "error: required tool(s) not found on PATH: ${missing[*]}" >&2
+  echo "       install them and re-run; see scripts/README.md for the dependency list." >&2
+  exit 1
+fi
+
 OUT_DIR="${OUT_DIR:-results/saturation-$(date +%Y%m%d-%H%M%S)-$$}"
 mkdir -p "$OUT_DIR"
 SUMMARY="$OUT_DIR/summary.csv"


### PR DESCRIPTION
> **Dry-run artifact.** This PR was produced by hand to validate the L1 delivery loop from #1655, because those workflows cannot be dispatched until they are on `main`. Each phase below was executed manually exactly as the workflow would. **Not intended to merge as-is** — see the dry-run report in the comments.

## Summary

`scripts/find-saturation.sh` used `jq` and `bc` only inside the rate loop, so a machine missing either one built `blis` and ran at least one full simulation before failing on something knowable at startup. Now checked up front.

`column` is deliberately **not** required — the summary print already falls back gracefully without it, so demanding it would break a setup that works today.

Closes #1671

## Contract-by-contract

| Acceptance criterion | Status | How it was verified |
|---|---|---|
| `jq` missing → exits non-zero before building or simulating, message names `jq` | met | `exit=1`, `error: required tool(s) not found on PATH: jq`, and no `Building blis...` line was reached |
| `bc` missing → same, names `bc` | met | `exit=1`, message names `bc` |
| missing `column` does **not** fail | met | preflight passed; execution reached `Building blis...` and the model banner |
| both missing → names both | met | `error: ... on PATH: jq bc` |
| behaviour unchanged when all present | met | preflight is a no-op; no other line altered |

Verified by running the script against a synthetic `PATH` containing only the tools under test, removing one at a time. No repo files were harmed — the probe directory lived in `/tmp`.

## Deliberately not done

The preflight does not check `go`, `git` or `column`. `column` is documented optional; `go` failing is already loud and immediate at the build step; and widening the list beyond what the issue asked for would be scope creep on a hardening fix.
