### PR TITLE
fix(ci): dedupe the archon comment, check out the PR head, guard report-status

### DIFF
--- a/.github/workflows/archon.yml
+++ b/.github/workflows/archon.yml
@@ -179,13 +179,15 @@ jobs:
             echo "::warning::Archon produced no output. Skipping PR comment."
             exit 0
           fi
-          # --edit-last keeps ONE archon comment per PR instead of appending a ~27 KB
-          # report on every push. A long-running PR otherwise accumulates hundreds of KB
-          # of near-identical comments, which the Claude review action later folds into its
-          # prompt until it exceeds the model context window and the review dies with
-          # "Prompt is too long" (run 33772637816: 244,554 tokens against a 200,000 limit).
-          # Per-round history is preserved: emit() in scripts/archon-review.sh also appends
-          # every body to $GITHUB_STEP_SUMMARY, so each round stays on its own run page.
+          # --edit-last keeps ONE archon comment per PR instead of appending a ~21 KB report
+          # on every trigger (this workflow fires on a comment, never directly on a push).
+          # On #1667 archon dumps were 365,295 of the thread's 470,270 bytes (77.7%), and the
+          # Claude review action folded two BYTE-IDENTICAL copies into a single prompt.
+          # Scope: this bounds archon's contribution to the thread. It does NOT by itself
+          # prove a review fits the model context window — see #1676.
+          # History is retained per run, not permanently: emit() in scripts/archon-review.sh
+          # appends every body to $GITHUB_STEP_SUMMARY, which lives as long as the workflow
+          # run is retained.
           # --edit-last scopes to the authenticated user (github-actions[bot]); the Claude
           # action comments under a separate App identity, so this cannot edit those.
           gh pr comment "$PR_NUMBER" --body-file "$OUTPUT_FILE" \

--- a/.github/workflows/archon.yml
+++ b/.github/workflows/archon.yml
@@ -179,4 +179,14 @@ jobs:
             echo "::warning::Archon produced no output. Skipping PR comment."
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --body-file "$OUTPUT_FILE"
+          # --edit-last keeps ONE archon comment per PR instead of appending a ~27 KB
+          # report on every push. A long-running PR otherwise accumulates hundreds of KB
+          # of near-identical comments, which the Claude review action later folds into its
+          # prompt until it exceeds the model context window and the review dies with
+          # "Prompt is too long" (run 33772637816: 244,554 tokens against a 200,000 limit).
+          # Per-round history is preserved: emit() in scripts/archon-review.sh also appends
+          # every body to $GITHUB_STEP_SUMMARY, so each round stays on its own run page.
+          # --edit-last scopes to the authenticated user (github-actions[bot]); the Claude
+          # action comments under a separate App identity, so this cannot edit those.
+          gh pr comment "$PR_NUMBER" --body-file "$OUTPUT_FILE" \
+            --edit-last --create-if-none

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,6 +60,21 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # For issue_comment/pull_request_review_comment, github.ref is the DEFAULT
+          # branch — GitHub does not associate the event with the PR head. Without an
+          # explicit ref the action's own prompt assembly runs `git hash-object` against
+          # main and fails for every file the PR ADDS, dropping those SHAs from the prompt
+          # and emitting dozens of misleading "could not open ... No such file" lines
+          # (12 files on PR #1667). claude-code-action re-checks-out refs/pull/N/head
+          # afterwards, so the review itself was never on main — but the noise reads as
+          # though it were. Empty string falls back to checkout's default, which the
+          # `issues:` trigger needs: a plain issue has no refs/pull/N/head to check out.
+          ref: >-
+            ${{ github.event_name == 'pull_request_review_comment'
+                && format('refs/pull/{0}/head', github.event.pull_request.number)
+             || (github.event.issue.pull_request
+                && format('refs/pull/{0}/head', github.event.issue.number))
+             || '' }}
 
       - uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -96,7 +96,15 @@ jobs:
 
   report-status:
     needs: claude
-    if: always() && github.event_name == 'issue_comment' && github.event.issue.pull_request
+    # needs.claude.result != 'skipped' is load-bearing. claude[bot]'s own review comment
+    # fires issue_comment, so the claude job correctly skips — but with a bare always()
+    # this job still ran and wrote "pending / Claude Code: skipped" OVER the real result.
+    # Verified on head 4be14710: failure @ 15:17:20 then pending @ 15:21:11, stale last and
+    # sticking, masking a genuine failure behind a required check that never resolves
+    # (run 33770188054: claude skipped, report-status success, 34 s after the real run).
+    if: |
+      always() && needs.claude.result != 'skipped' &&
+      github.event_name == 'issue_comment' && github.event.issue.pull_request
     runs-on: ubuntu-latest
     permissions:
       statuses: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,13 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    outputs:
+      # Both are EMPTY when the action returns early ("No trigger found, skipping remaining
+      # steps") — the outer trigger below is a broad substring test, so a comment that merely
+      # mentions @claude in prose admits the job and the action then no-ops. The job still
+      # concludes 'success', so report-status must not read the job result alone (see #1675).
+      execution_file: ${{ steps.claude.outputs.execution_file }}
+      conclusion: ${{ steps.claude.outputs.conclusion }}
 
     steps:
       - uses: actions/checkout@v5
@@ -77,6 +84,7 @@ jobs:
              || '' }}
 
       - uses: anthropics/claude-code-action@v1
+        id: claude
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
           CLAUDE_CODE_DISABLE_THINKING: "1"
@@ -96,15 +104,29 @@ jobs:
 
   report-status:
     needs: claude
-    # needs.claude.result != 'skipped' is load-bearing. claude[bot]'s own review comment
-    # fires issue_comment, so the claude job correctly skips — but with a bare always()
-    # this job still ran and wrote "pending / Claude Code: skipped" OVER the real result.
-    # Verified on head 4be14710: failure @ 15:17:20 then pending @ 15:21:11, stale last and
-    # sticking, masking a genuine failure behind a required check that never resolves
-    # (run 33770188054: claude skipped, report-status success, 34 s after the real run).
+    # Publish a verdict ONLY when Claude actually ran. Two no-op paths otherwise corrupt the
+    # status, and the job RESULT alone cannot tell them apart:
+    #
+    #  - claude SKIPPED (permissions denied, or claude[bot]'s own comment fired the event).
+    #    A bare always() wrote "pending / Claude Code: skipped" OVER the real result. Verified
+    #    on head 4be14710: failure @ 15:17:20 then pending @ 15:21:11 — stale lands last and
+    #    sticks, hiding a genuine failure behind a check that never resolves (run 33770188054).
+    #
+    #  - claude SUCCEEDED WITHOUT RUNNING. The outer trigger is a broad substring test, so a
+    #    comment mentioning @claude in prose admits the job; the action logs "No trigger found,
+    #    skipping remaining steps" and returns, and the job still concludes 'success'. That
+    #    published a FALSE GREEN: run 33785598570 put "Claude Code: success" on head 6c7c3a81
+    #    with no review having run. execution_file is empty on that early return, so it — not
+    #    the job result — is the signal that work happened.
+    #
+    # Stated positively so a new job result cannot silently fall through to a status. A real
+    # success that somehow reported no execution_file publishes NOTHING rather than a verdict:
+    # a missing status is visible and honest, a wrong one is neither.
     if: |
-      always() && needs.claude.result != 'skipped' &&
-      github.event_name == 'issue_comment' && github.event.issue.pull_request
+      always() &&
+      github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      (needs.claude.result == 'failure' || needs.claude.result == 'cancelled' ||
+       (needs.claude.result == 'success' && needs.claude.outputs.execution_file != ''))
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -137,11 +159,14 @@ jobs:
           script: |
             const result = process.env.CLAUDE_RESULT;
             const sha = process.env.PR_HEAD_SHA;
+            // No 'skipped' entry: the job condition above excludes skipped runs, so a
+            // skipped result reaching here means that gate regressed. Fall through to the
+            // warning + 'error' path rather than silently re-publishing a stale 'pending'
+            // over a real verdict.
             const stateMap = {
               success: 'success',
               failure: 'failure',
-              cancelled: 'error',
-              skipped: 'pending'
+              cancelled: 'error'
             };
             const state = stateMap[result];
             if (!state) {

--- a/docs/contributing/archon/pr-review-context.md
+++ b/docs/contributing/archon/pr-review-context.md
@@ -9,7 +9,9 @@ How to incorporate archon's PR review output during code review.
 ## What the comment contains
 
 One archon comment per PR — re-running `/archon-pr-review` edits it in place, so what you
-read is always the latest round. It comes in one of two shapes:
+read is always the latest round. Earlier rounds are not in the thread; they are in each
+workflow run's job summary, for as long as that run is retained. It comes in one of two
+shapes:
 
 - **three views** — component, witness delta, interface-contract
 - **three views plus plan checks** — the same, with `### G5 — Plan distance ratchet` and a plan verdict appended

--- a/docs/contributing/archon/pr-review-context.md
+++ b/docs/contributing/archon/pr-review-context.md
@@ -8,7 +8,8 @@ How to incorporate archon's PR review output during code review.
 
 ## What the comment contains
 
-One comment per `/archon-pr-review`, in one of two shapes:
+One archon comment per PR — re-running `/archon-pr-review` edits it in place, so what you
+read is always the latest round. It comes in one of two shapes:
 
 - **three views** — component, witness delta, interface-contract
 - **three views plus plan checks** — the same, with `### G5 — Plan distance ratchet` and a plan verdict appended

--- a/docs/guide/archon-pr-review.md
+++ b/docs/guide/archon-pr-review.md
@@ -12,8 +12,11 @@ Comment on any PR:
 
 The GitHub Action runs automatically and posts the results as a PR comment. Re-running
 `/archon-pr-review` **updates that same comment in place** rather than adding a new one, so
-a long-running PR keeps one current report instead of a stack of near-identical ones. Every
-round's full body is still kept on its own workflow run page (job summary).
+a long-running PR keeps one current report instead of a stack of near-identical ones.
+
+Each round's full body is also written to its own workflow run's job summary. That is
+retention-bound, not an archive: it disappears when the run is aged out under the
+repository's retention policy. If you need a round preserved, quote it in a PR comment.
 
 ## What It Reports
 

--- a/docs/guide/archon-pr-review.md
+++ b/docs/guide/archon-pr-review.md
@@ -10,7 +10,10 @@ Comment on any PR:
 /archon-pr-review
 ```
 
-The GitHub Action runs automatically and posts a comment with the results.
+The GitHub Action runs automatically and posts the results as a PR comment. Re-running
+`/archon-pr-review` **updates that same comment in place** rather than adding a new one, so
+a long-running PR keeps one current report instead of a stack of near-identical ones. Every
+round's full body is still kept on its own workflow run page (job summary).
 
 ## What It Reports
 
@@ -44,7 +47,7 @@ If the PR changes package boundaries, Archon reports three sections:
 2. Runs `archon-go delta --json` to detect structural changes
 3. If empty: posts fast-track message
 4. If non-empty: runs `archon-go delta` (human report), `archon-go impact` (blast radius per changed package), and `archon-go evidence` (contract test coverage)
-5. Posts combined output as a PR comment
+5. Posts combined output as a PR comment, editing the existing archon comment if one exists
 
 ## Key Properties
 


### PR DESCRIPTION
## Summary

Three CI defects found while triaging why `@claude /blis-pr-review` died on #1667 ([run 33772637816](https://github.com/inference-sim/inference-sim/actions/runs/33772637816)).

**Scope note (revised after review):** this PR does **not** claim to fix the context-window overflow. Only **two** archon dumps ever reached that failing prompt — `grep -c "^### Component view"` over the assembled `FINAL PROMPT` returns `2` — and they were the byte-identical pair. The other 12 were never in it. The whole prompt block is ~74 KB of a **244,554-token** request, so the thread is a *minority* of the window. Deduping ~21 KB is strictly good and **not sufficient**. The overflow proper, including the `CLAUDE.md` growth data, is **#1676**.

## Fix 1 — archon appended a report on every trigger

`gh pr comment` appends. On #1667 archon dumps were **365,295 of the thread's 470,270 bytes (77.7%)**, and the Claude action folded two **byte-identical** copies into one prompt (verified with `diff`). `--edit-last --create-if-none` keeps one archon comment per PR.

Checked before proposing it:

- `gh 2.83.2` supports both flags.
- `archon.yml:182` was the only `gh pr comment` in `.github/workflows/` — no `createComment`, no `gh api .../comments`, no `peter-evans/create-or-update-comment` either.
- `--edit-last` scopes to `github-actions[bot]`; the Claude action comments under a separate App identity. Identity scoping is a known future fragility → **#1677**.
- History is retained **per run, not permanently** — `emit()` in `scripts/archon-review.sh:60` appends every body to `$GITHUB_STEP_SUMMARY`, which lives as long as the run is retained. Docs say so explicitly.

## Fix 2 — `claude.yml` checked out the default branch

For `issue_comment`, `github.ref` is `main`, so `actions/checkout` landed there. The action's prompt assembly then ran `git hash-object` against main and failed for all **12 files #1667 adds**, dropping those SHAs and emitting ~48 lines of `could not open ... No such file`.

**The review itself was never on main** — `claude-code-action` re-checks-out `refs/pull/N/head` 13 lines later, before the prompt is built. But the noise reads as though it were, and it produced exactly that wrong diagnosis during triage. The ref is **conditional** because the `issues:` trigger has no `refs/pull/N/head`; empty string falls back to checkout's default.

## Fix 3 — `report-status` overwrote real results with a stale `pending` *(added after review)*

An independent defect in a file this PR already edits. The job ran under a bare `always()`, so when `claude[bot]`'s own review comment fired `issue_comment` and the `claude` job correctly **skipped**, this job still wrote `pending / Claude Code: skipped` over the good status.

Verified on head `4be14710`:

```
15:17:20  failure  Claude Code: failure
15:21:11  pending  Claude Code: skipped   ← lands last, sticks
```

Plus run `33770188054`: `claude: skipped`, `report-status: success`, 34 s after the real run `33770122756`. Result is a required check that never resolves, masking a genuine failure. Guarded with `needs.claude.result != 'skipped'`. A denied permission check now also writes no status — better than a stuck `pending`.

## Out of scope by design

```
Restoring .claude, CLAUDE.md, .mcp.json, ... from origin/main (PR head is untrusted)
```

A fork PR must not execute its own config, so a PR editing `CLAUDE.md` (#1667 does, +26/-2) or `.claude/skills/blis-pr-review/SKILL.md` is always reviewed by main's copy. Noted so it is not rediscovered as a bug.

## Follow-ups filed rather than scope-crept

- **#1675** — archon triggers on prose **mentions** of `/archon-pr-review`. `contains()` cannot tell a mention from an invocation, so a comment *discussing* the command re-reviews the PR. Two comments on this very PR each fired a run ~4 s later, producing byte-identical reports for the same head. Explains #1667's 14 comments for 9 real triggers. `--edit-last` hides the bloat but not the runs.
- **#1676** — the context-window problem, with `CLAUDE.md` growth (65,478 → 80,500 B in 10 days; 79% of it is four reference sections that already name a canonical source elsewhere).
- **#1677** — marker-scoped comment lookup and a test for the event→ref mapping, plus `actionlint`.

## Testing

- `go build ./...` passes (no Go files changed).
- All five workflow YAMLs parse; the archon step body passes `bash -n`.
- Ref expression traced over all four trigger shapes: `pull_request_review_comment` → `refs/pull/<pr.number>/head`; `issue_comment` on a PR → `refs/pull/<issue.number>/head`; `issue_comment` on a plain issue → `''`; `issues` → `''`.
- `report-status` guard traced: `success`/`failure`/`cancelled` still report; `skipped` does not.

**Neither workflow fix is testable before merge.** `issue_comment` workflows always run from the default branch — both archon runs on this PR report `branch=main`, and the two byte-identical 5,548 B comments here are the **old appending code**. Merge, then watch the first `/archon-pr-review` and the first `@claude` run. Both changes are one-line reverts if they misbehave.

**Tier:** Small — 4 files, CI config + docs, no Go behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
