### PR TITLE
fix(ci): allow the github-actions bot to initiate the verify and correct agents

### DIFF
--- a/.github/workflows/deliver-correct.yml
+++ b/.github/workflows/deliver-correct.yml
@@ -127,6 +127,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
+          # claude-code-action refuses to run when a BOT initiated the workflow, and its
+          # allowed_bots input defaults to "" (no bots at all). This phase is always dispatched by
+          # the preceding phase via `gh workflow run` under GITHUB_TOKEN, so its initiating actor
+          # is always github-actions[bot] — meaning without this the agent step fails every time
+          # and no delivery can reach a verdict (#1681).
+          #
+          # Named rather than "*": the action's docs warn that on a public repo "*" lets external
+          # Apps invoke this action with prompts they control. github-actions is the only
+          # initiator these dispatched phases can legitimately have.
+          allowed_bots: "github-actions"
           claude_args: '--model ${{ env.DELIVER_MODEL }} --allowed-tools Skill Agent Bash Read Edit Write'
           show_full_output: true
           # Same reason as the other two phases: the prompts reference skills that live in

--- a/.github/workflows/deliver-verify.yml
+++ b/.github/workflows/deliver-verify.yml
@@ -406,6 +406,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
+          # claude-code-action refuses to run when a BOT initiated the workflow, and its
+          # allowed_bots input defaults to "" (no bots at all). This phase is always dispatched by
+          # the preceding phase via `gh workflow run` under GITHUB_TOKEN, so its initiating actor
+          # is always github-actions[bot] — meaning without this the agent step fails every time
+          # and no delivery can reach a verdict (#1681).
+          #
+          # Named rather than "*": the action's docs warn that on a public repo "*" lets external
+          # Apps invoke this action with prompts they control. github-actions is the only
+          # initiator these dispatched phases can legitimately have.
+          allowed_bots: "github-actions"
           claude_args: '--model ${{ env.DELIVER_MODEL }} --allowed-tools Skill Agent Bash Read Edit Write'
           show_full_output: true
           # The blis-pr-review skill's entire body is an invocation of


### PR DESCRIPTION
## In plain English

The delivery loop got one step from working. Its review phase died immediately because `claude-code-action` **refuses to run when a bot started the workflow**, and the loop's own phases are started by a bot.

One input fixes it.

`Closes #1681`

## The error, from the first live run

```
##[error]Action failed with error: Workflow initiated by non-human actor:
github-actions (type: Bot). Add bot to allowed_bots list or use '*' to ...
```

`allowed_bots` defaults to `""` — no bots at all. Verify and correct are always dispatched by the preceding phase via `gh workflow run` under `GITHUB_TOKEN`, so their initiating actor is always `github-actions[bot]`. **Both phases would fail at their agent step on every delivery**, so nothing could ever reach a verdict.

This is why it did not surface until a real run: the implement phase is human-triggered and works fine, the hand-off works fine, and the failure is one step into the *second* phase.

## The fix

```yaml
allowed_bots: "github-actions"
```

on the `claude-code-action` step in `deliver-verify.yml` and `deliver-correct.yml`.

**Named, not `*`.** The action's documentation warns: *"On public repos with `'*'`, external Apps may be able to invoke this action with prompts they control."* This repo is public, so `*` would widen the trigger surface to any App. `github-actions` is the only initiator these dispatched phases can legitimately have.

**`deliver-implement.yml` deliberately does not get it** — it is triggered by a human `issue_comment`, so its actor is that human. Adding it there would only widen what can start an agent run.

## Evidence

- failing run: https://github.com/inference-sim/inference-sim/actions/runs/33802179081
- source issue #1679 → delivery PR #1680, which correctly carries `needs-human`

## What that run proved working

Recording this because several of these were unverifiable before #1655 merged:

| | |
|---|---|
| command, collaborator gate, all three preflight guards | ✅ |
| branch creation, agent implementation, PR creation | ✅ — the diff on #1680 meets every acceptance criterion in #1679 |
| `workflow_dispatch` hand-off, implement → verify | ✅ |
| **`ci.yml` dispatch + required-context assertion** | ✅ read all 7 contexts from the ruleset, confirmed green, `CI_STATUS=success` |
| archon build, review, `PLAN_GATE=absent` | ✅ |
| self-verification guard | ✅ "no workflow files touched" |
| **failure reporter** | ✅ commented and applied `needs-human` instead of going silent |

That fourth row was the single largest unverified claim in #1655 — the fix for "ready-for-merge on a PR GitHub will not merge". It works.

## Test plan

- [x] `actionlint` clean on all three deliver workflows (one pre-existing finding in `claude.yml:64` is untouched and unrelated)
- [x] confirmed `allowed_bots` is a real input on `claude-code-action@v1`, with default `""`, rather than assuming
- [x] confirmed `deliver-implement.yml` has zero occurrences — the widening is scoped to the two dispatched phases
- [ ] **re-run the delivery on #1679 after merge** and confirm verify reaches a verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)
