### PR TITLE
feat(replay): --session-mode fixed-accumulate for faithful high-concurrency agentic replay (#1692)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,8 +297,10 @@ go build -o blis main.go
 # (unmodeled enforce-eager + MTP-without-contention, #1627), so queue depth is under-predicted
 # until decode is calibrated — this mode is a NECESSARY precondition for high-conc fidelity, not
 # sufficient alone. Same huge-ISL caveat: raise --max-model-len and scale --total-kv-blocks.
+# (Example uses a committed MoE config + a hardware key present in hardware_config.json so
+# it runs out of the box; the motivating shape is a large MLA MoE like Kimi-K3 on H200.)
 ./blis replay --trace-header corpus.yaml --trace-data corpus.csv \
-  --model kimi-k3 --hardware H200 --tp 16 --dp 2 --enable-expert-parallel \
+  --model qwen/qwen3-30b-a3b --hardware H100 --tp 2 --dp 2 --enable-expert-parallel \
   --session-mode fixed-accumulate --max-model-len 1000000
 
 # Observe corpus-mode: drive the SAME corpus as a fixed session pool against a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,23 @@ go build -o blis main.go
 # to closed-loop). Same huge-ISL caveat — raise --max-model-len and scale --total-kv-blocks.
 ./blis replay --trace-header corpus.yaml --trace-data corpus.csv \
   --model qwen/qwen3-14b --concurrent-sessions 8 --total-sessions 200 --max-model-len 1000000
+# FAITHFUL replay of a high-concurrency agentic run (#1692): --session-mode fixed-accumulate
+# injects each round at its RECORDED arrival time (open-loop, like fixed) WHILE reconstructing
+# the growing accumulate-delta input (like closed-loop). Closed-loop regenerates arrivals as
+# completion+think, a self-throttling feedback loop that drains the queue and collapses TTFT to
+# compute-only (30–100× low at conc≥8); fixed mode is hard-rejected on an accumulate corpus (it
+# would misread the deltas as absolutes). fixed-accumulate is the only mode that reproduces the
+# real cross-session overlap, so N large prefills pile into the scheduler at the real clock and
+# produce genuine queue wait. Requires an accumulate corpus; mutually exclusive with
+# --concurrent-sessions (open-loop, no pool) and --think-time-* (arrivals are recorded, not
+# regenerated). INV-10 (session causality) is scoped to closed-loop and does not apply here.
+# Second-order caveat: BLIS's decode/step model still runs ~5–10× fast on this workload
+# (unmodeled enforce-eager + MTP-without-contention, #1627), so queue depth is under-predicted
+# until decode is calibrated — this mode is a NECESSARY precondition for high-conc fidelity, not
+# sufficient alone. Same huge-ISL caveat: raise --max-model-len and scale --total-kv-blocks.
+./blis replay --trace-header corpus.yaml --trace-data corpus.csv \
+  --model kimi-k3 --hardware H200 --tp 16 --dp 2 --enable-expert-parallel \
+  --session-mode fixed-accumulate --max-model-len 1000000
 
 # Observe corpus-mode: drive the SAME corpus as a fixed session pool against a
 # LIVE server (observe-side twin of `blis replay --concurrent-sessions`), so

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -1068,7 +1068,7 @@ func init() {
 	replayCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "Path to TraceV2 header YAML file (required)")
 	replayCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "Path to TraceV2 data CSV file (required)")
 	replayCmd.Flags().StringVar(&resultsPath, "results-path", "", "File to write []SimResult JSON (request_id, ttft_us, e2e_us, input_tokens, output_tokens, slo_class, model, itl_mean_us) for blis calibrate consumption.")
-	replayCmd.Flags().StringVar(&replayTraceOutput, "trace-output", "", "Export replay results as TraceV2 files (<prefix>.yaml + <prefix>.csv); header mode is \"replayed\"")
+	replayCmd.Flags().StringVar(&replayTraceOutput, "trace-output", "", "Export replay results as TraceV2 files (<prefix>.yaml + <prefix>.csv); header mode is \"replayed\". Under --session-mode fixed-accumulate the export records reconstructed ABSOLUTE per-round inputs (no session_context_growth header) — re-replay it with --session-mode fixed, not fixed-accumulate.")
 	replayCmd.Flags().StringVar(&replayMetricsPath, "metrics-path", "", "File to write aggregate MetricsOutput JSON (incl. cache_hit_rate for `blis calibrate --sim-metrics`, #1583). Symmetric with `blis run --metrics-path`; stdout is unaffected.")
 
 	// Saturation trace flags (#1516): --detectors + --saturation-config + --saturation-report.

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -112,14 +112,26 @@ Example:
 		}
 
 		// Validate session mode flags (BC-11)
-		if replaySessionMode != "fixed" && replaySessionMode != "closed-loop" {
-			logrus.Fatalf("--session-mode must be \"fixed\" or \"closed-loop\", got %q", replaySessionMode)
+		// fixed-accumulate (#1692): recorded (open-loop) arrivals like "fixed", but with
+		// the growing accumulate-delta input reconstructed like "closed-loop". It is the
+		// only faithful replay mode for a high-concurrency agentic corpus — see the guards
+		// and request-building branch below.
+		if replaySessionMode != "fixed" && replaySessionMode != "closed-loop" && replaySessionMode != "fixed-accumulate" {
+			logrus.Fatalf("--session-mode must be \"fixed\", \"closed-loop\", or \"fixed-accumulate\", got %q", replaySessionMode)
 		}
 		if replayThinkTimeMs < 0 {
 			logrus.Fatalf("--think-time-ms must be non-negative, got %d", replayThinkTimeMs)
 		}
 		if replayConcurrentSessions < 0 {
 			logrus.Fatalf("--concurrent-sessions must be >= 0, got %d", replayConcurrentSessions)
+		}
+		// fixed-accumulate is an open-loop mode: it injects every round at its recorded
+		// arrival, so there is no session pool to maintain. --concurrent-sessions (which
+		// auto-promotes to closed-loop below) is incompatible — reject it here, BEFORE
+		// the auto-promote block, so the conflict is reported rather than silently
+		// overridden into closed-loop (R1).
+		if replaySessionMode == "fixed-accumulate" && replayConcurrentSessions > 0 {
+			logrus.Fatalf("--concurrent-sessions is incompatible with --session-mode fixed-accumulate (fixed-accumulate injects every round at its recorded arrival time; use --concurrent-sessions with --session-mode closed-loop for a pooled prediction instead)")
 		}
 		if replayTotalSessions < 0 {
 			logrus.Fatalf("--total-sessions must be >= 0, got %d", replayTotalSessions)
@@ -142,8 +154,18 @@ Example:
 		// produce wrong-but-plausible-looking metrics. Fail fast instead. This
 		// check runs after the auto-promote block above, so a pool run
 		// (--concurrent-sessions > 0, already promoted to closed-loop) passes.
-		if traceData.Header.SessionContextGrowth == "accumulate" && replaySessionMode != "closed-loop" {
-			logrus.Fatalf("trace header has session_context_growth=accumulate (per-round input_tokens are deltas that only reconstruct correctly in closed-loop replay), but --session-mode is %q. Re-run with --session-mode closed-loop, or use --concurrent-sessions N for pooled replay.", replaySessionMode)
+		// fixed-accumulate (#1692) is the third way to reconstruct the deltas correctly:
+		// it walks the same accumulate delta law on the request-building path while
+		// keeping recorded (open-loop) arrivals, so it is EXEMPT from this reject.
+		if traceData.Header.SessionContextGrowth == "accumulate" && replaySessionMode != "closed-loop" && replaySessionMode != "fixed-accumulate" {
+			logrus.Fatalf("trace header has session_context_growth=accumulate (per-round input_tokens are deltas that only reconstruct correctly in closed-loop or fixed-accumulate replay), but --session-mode is %q. Re-run with --session-mode closed-loop (load-adaptive arrivals), --session-mode fixed-accumulate (recorded arrivals — faithful for high-concurrency runs), or use --concurrent-sessions N for pooled replay.", replaySessionMode)
+		}
+		// fixed-accumulate only makes sense on an accumulate corpus: on a non-accumulate
+		// trace the per-round inputs are already absolute, so plain --session-mode fixed
+		// is correct and fixed-accumulate would needlessly walk an inert delta law. Reject
+		// rather than silently behave like fixed (R1).
+		if replaySessionMode == "fixed-accumulate" && traceData.Header.SessionContextGrowth != "accumulate" {
+			logrus.Fatalf("--session-mode fixed-accumulate requires an accumulate corpus (trace header session_context_growth=accumulate), but this trace's session_context_growth is %q. Use --session-mode fixed for a trace with absolute per-round inputs.", traceData.Header.SessionContextGrowth)
 		}
 		if replayTotalSessions > 0 && replayConcurrentSessions == 0 {
 			logrus.Fatalf("--total-sessions requires --concurrent-sessions > 0")
@@ -198,7 +220,8 @@ Example:
 		var requests []*sim.Request
 		var sessionMgr *workload.SessionManager
 		var poolDriver *workload.SessionPoolDriver
-		if replaySessionMode == "closed-loop" {
+		switch replaySessionMode {
+		case "closed-loop":
 			// Closed-loop: inject only round-0 requests; SessionManager drives follow-ups.
 			// Compute the preliminary horizon from trace records directly (O(n)) so we can
 			// call LoadTraceV2SessionBlueprints exactly once with correct parameters.
@@ -249,7 +272,20 @@ Example:
 				sessionMgr = workload.NewSessionManager(blueprints)
 				logrus.Infof("Closed-loop mode: %d session blueprints, %d round-0 requests", len(blueprints), len(requests))
 			}
-		} else {
+		case "fixed-accumulate":
+			// fixed-accumulate (#1692): pre-bake every session round as a request at its
+			// RECORDED arrival time (open-loop, breaks the closed-loop self-throttling
+			// feedback loop) while reconstructing the growing accumulate-delta input purely
+			// from trace data. The real cross-session arrival overlap is preserved, so N
+			// large prefills pile into the scheduler at the real clock and produce genuine
+			// queueing delay — the whole point for high-concurrency agentic corpora.
+			var bErr error
+			requests, bErr = workload.LoadTraceV2FixedAccumulateRequests(traceData, seed)
+			if bErr != nil {
+				logrus.Fatalf("Failed to build fixed-accumulate requests from trace: %v", bErr)
+			}
+			logrus.Infof("Built %d fixed-accumulate requests for replay (recorded arrivals, reconstructed accumulate inputs)", len(requests))
+		default:
 			// Fixed mode (default): pre-baked arrivals, existing behavior (BC-8)
 			var bErr error
 			requests, bErr = workload.LoadTraceV2Requests(traceData, seed)
@@ -1038,7 +1074,7 @@ func init() {
 	// Saturation trace flags (#1516): --detectors + --saturation-config + --saturation-report.
 	registerDetectorFlags(replayCmd)
 
-	replayCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", `Session replay mode: "fixed" (pre-baked arrivals from trace) or "closed-loop" (load-adaptive follow-ups via SessionManager)`)
+	replayCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", `Session replay mode: "fixed" (pre-baked arrivals from trace), "closed-loop" (load-adaptive follow-ups via SessionManager), or "fixed-accumulate" (recorded arrivals + reconstructed accumulate-delta inputs; faithful replay of high-concurrency agentic corpora, #1692)`)
 	replayCmd.Flags().IntVar(&replayThinkTimeMs, "think-time-ms", 0, "Override think time between session rounds in milliseconds (0 = derive from trace inter-round arrival gaps; mutually exclusive with --think-time-dist; requires --session-mode closed-loop)")
 	replayCmd.Flags().StringVar(&replayThinkTimeDist, "think-time-dist", "", `Think-time distribution spec for closed-loop replay (e.g. "lognormal:mu=2.0,sigma=0.6,min=3s,max=30s" or "constant:value=500ms"). Mutually exclusive with --think-time-ms. Requires --session-mode closed-loop.`)
 	replayCmd.Flags().IntVar(&replayConcurrentSessions, "concurrent-sessions", 0, "Replay a fixed pool of N concurrent closed-loop sessions drawn from the trace corpus (0 = disabled). Implies closed-loop session semantics.")

--- a/cmd/replay_fixed_accumulate_test.go
+++ b/cmd/replay_fixed_accumulate_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/inference-sim/inference-sim/sim/workload"
 )
 
 // accumulateCorpusCSV is a 2-session accumulate corpus (deltas, with a
@@ -50,18 +52,25 @@ func writeAccumulateCorpus(t *testing.T) (headerPath, dataPath string) {
 }
 
 // runFixedAccumulateReplay runs replayCmd.Run with --session-mode fixed-accumulate over
-// the given corpus and captures stdout. Returns the captured stdout bytes.
+// the given corpus and captures stdout. Returns the captured stdout bytes. When
+// traceOutPrefix != "", it also sets --trace-output to re-export the replay.
 func runFixedAccumulateReplay(t *testing.T, headerPath, dataPath string, seedVal int64) []byte {
+	return runFixedAccumulateReplayWithOutput(t, headerPath, dataPath, seedVal, "")
+}
+
+func runFixedAccumulateReplayWithOutput(t *testing.T, headerPath, dataPath string, seedVal int64, traceOutPrefix string) []byte {
 	t.Helper()
 	restore := captureCmdLevelVars()
 	origSession := replaySessionMode
 	origHeader := traceHeaderPath
 	origData := traceDataPath
+	origTraceOut := replayTraceOutput // captureCmdLevelVars covers run's traceOutput, not replay's
 	defer func() {
 		restore.restore()
 		replaySessionMode = origSession
 		traceHeaderPath = origHeader
 		traceDataPath = origData
+		replayTraceOutput = origTraceOut
 	}()
 
 	mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
@@ -95,7 +104,7 @@ func runFixedAccumulateReplay(t *testing.T, headerPath, dataPath string, seedVal
 	tensorParallelism = 1
 	defaultsFilePath = "../defaults.yaml"
 	replaySessionMode = "fixed-accumulate"
-	replayTraceOutput = ""
+	replayTraceOutput = traceOutPrefix
 
 	testCmd := &cobra.Command{}
 	registerSimConfigFlags(testCmd)
@@ -152,6 +161,44 @@ func TestReplayFixedAccumulate_Deterministic(t *testing.T) {
 	}
 	if len(a) == 0 {
 		t.Fatal("stdout is empty; determinism test must produce output to be meaningful")
+	}
+}
+
+// TestReplayFixedAccumulate_TraceOutput_AbsoluteCorpus documents and pins the
+// re-export behavior flagged in PR review: fixed-accumulate reconstructs the growing
+// context in memory, so --trace-output writes the ALREADY-RECONSTRUCTED ABSOLUTE
+// per-round inputs. The exported header carries NO session_context_growth and the CSV
+// records absolute input_tokens (not deltas), so the export is a faithful absolute-mode
+// corpus: re-replay it with --session-mode fixed, NOT fixed-accumulate.
+func TestReplayFixedAccumulate_TraceOutput_AbsoluteCorpus(t *testing.T) {
+	headerPath, dataPath := writeAccumulateCorpus(t)
+	outPrefix := filepath.Join(t.TempDir(), "reexport")
+	_ = runFixedAccumulateReplayWithOutput(t, headerPath, dataPath, 42, outPrefix)
+
+	// Load the re-exported trace and assert it is an absolute (non-accumulate) corpus.
+	trace, err := workload.LoadTraceV2(outPrefix+".yaml", outPrefix+".csv")
+	if err != nil {
+		t.Fatalf("re-exported trace failed to load: %v", err)
+	}
+	if trace.Header.SessionContextGrowth != "" {
+		t.Errorf("re-export header session_context_growth = %q, want empty (absolute corpus)", trace.Header.SessionContextGrowth)
+	}
+	// The reconstructed absolute inputs for session s1 are 100, 180, 245 (deltas
+	// 100/30/25 + prev outputs 50/40). The re-export must record those absolutes, not deltas.
+	byRound := map[int]int{}
+	for _, rec := range trace.Records {
+		if rec.SessionID == "s1" {
+			byRound[rec.RoundIndex] = rec.InputTokens
+		}
+		if rec.InputTokensReset != nil {
+			t.Errorf("re-export should carry no input_tokens_reset markers (absolute corpus), round %d has one", rec.RoundIndex)
+		}
+	}
+	want := map[int]int{0: 100, 1: 180, 2: 245}
+	for r, w := range want {
+		if byRound[r] != w {
+			t.Errorf("re-export s1 round %d input_tokens = %d, want absolute %d", r, byRound[r], w)
+		}
 	}
 }
 

--- a/cmd/replay_fixed_accumulate_test.go
+++ b/cmd/replay_fixed_accumulate_test.go
@@ -148,6 +148,11 @@ func TestReplayFixedAccumulate_EndToEnd(t *testing.T) {
 	if !strings.Contains(s, "\"completed_requests\": 5") && !strings.Contains(s, "\"completed_requests\":5") {
 		t.Errorf("expected 5 completed_requests in output (all rounds), got:\n%s", s)
 	}
+	// INV-1 conservation companion: all 5 rounds injected, and all 5 completed
+	// (nothing queued/dropped) — the corpus arrivals span 2s, well within the horizon.
+	if !strings.Contains(s, "\"injected_requests\": 5") && !strings.Contains(s, "\"injected_requests\":5") {
+		t.Errorf("expected 5 injected_requests (INV-1 conservation), got:\n%s", s)
+	}
 }
 
 // TestReplayFixedAccumulate_Deterministic (BC-4, INV-6): two fixed-accumulate replays at

--- a/cmd/replay_fixed_accumulate_test.go
+++ b/cmd/replay_fixed_accumulate_test.go
@@ -200,6 +200,15 @@ func TestReplayFixedAccumulate_TraceOutput_AbsoluteCorpus(t *testing.T) {
 			t.Errorf("re-export s1 round %d input_tokens = %d, want absolute %d", r, byRound[r], w)
 		}
 	}
+	// The re-export must be arrival-ordered: the run above completed without the
+	// arrival-hook monotonicity panic (the writeAccumulateCorpus corpus interleaves
+	// s1 and s2 in time), and the exported records are non-decreasing in arrival.
+	for i := 1; i < len(trace.Records); i++ {
+		if trace.Records[i].ArrivalTimeUs < trace.Records[i-1].ArrivalTimeUs {
+			t.Errorf("re-export record %d arrival %d < record %d arrival %d — not arrival-ordered",
+				i, trace.Records[i].ArrivalTimeUs, i-1, trace.Records[i-1].ArrivalTimeUs)
+		}
+	}
 }
 
 // TestReplayFixedAccumulate_RejectsConcurrentSessions (BC-5): --concurrent-sessions is
@@ -344,5 +353,78 @@ func TestReplayFixedAccumulate_RejectsNonAccumulateTrace(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "fixed-accumulate requires an accumulate corpus") {
 		t.Errorf("fatal message should explain the accumulate requirement, got:\n%s", out)
+	}
+}
+
+// TestReplayFixedAccumulate_RejectsThinkTime (BC-5): --think-time-ms requires closed-loop;
+// fixed-accumulate uses recorded arrivals (not regenerated), so it must be rejected.
+func TestReplayFixedAccumulate_RejectsThinkTime(t *testing.T) {
+	if os.Getenv("BLIS_TEST_SUBPROCESS") == "1" {
+		headerPath, dataPath := writeAccumulateCorpus(t)
+		restore := captureCmdLevelVars()
+		origThink := replayThinkTimeMs
+		defer func() { restore.restore(); replayThinkTimeMs = origThink }()
+		mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		totalKVBlocks = 100000
+		blockSizeTokens = 16
+		maxNumSeqs = 64
+		maxNumBatchedTokens = 4096
+		numInstances = 1
+		seed = 1
+		admissionPolicy = "always-admit"
+		routingPolicy = "round-robin"
+		scheduler = "fcfs"
+		maxModelLen = 1000000
+		traceLevel = "none"
+		traceHeaderPath = headerPath
+		traceDataPath = dataPath
+		modelConfigFolder = mcFolder
+		hwConfigPath = hwPath
+		gpu = "H100"
+		tensorParallelism = 1
+		defaultsFilePath = "../defaults.yaml"
+		replaySessionMode = "fixed-accumulate"
+		replayThinkTimeMs = 500
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+		testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+		testCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", "")
+		testCmd.Flags().IntVar(&replayConcurrentSessions, "concurrent-sessions", 0, "")
+		testCmd.Flags().IntVar(&replayThinkTimeMs, "think-time-ms", 0, "")
+		if err := testCmd.ParseFlags([]string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--total-kv-blocks", "100000", "--hardware", "H100", "--tp", "1",
+			"--max-model-len", "1000000",
+			"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+			"--trace-header", headerPath, "--trace-data", dataPath,
+			"--defaults-filepath", "../defaults.yaml",
+			"--session-mode", "fixed-accumulate", "--think-time-ms", "500",
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "ParseFlags failed (test setup error): %v\n", err)
+			os.Exit(2)
+		}
+		replayCmd.Run(testCmd, nil) // must Fatalf before here
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestReplayFixedAccumulate_RejectsThinkTime", "-test.v")
+	cmd.Env = append(os.Environ(), "BLIS_TEST_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit for --think-time-ms + fixed-accumulate, got exit 0")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 (logrus.Fatalf), got %d; output:\n%s", exitErr.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "think-time-ms requires --session-mode closed-loop") {
+		t.Errorf("fatal message should explain think-time requires closed-loop, got:\n%s", out)
 	}
 }

--- a/cmd/replay_fixed_accumulate_test.go
+++ b/cmd/replay_fixed_accumulate_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+// CLI-level tests for `blis replay --session-mode fixed-accumulate` (#1692).
+//
+// fixed-accumulate injects every session round at its recorded arrival time
+// (open-loop, like --session-mode fixed) while reconstructing the growing
+// accumulate-delta input (like --session-mode closed-loop). These tests pin the
+// mode's guards (BC-5), end-to-end reconstruction (BC-1), and determinism (BC-4).
+//
+// NOTE: these tests mutate package-level CLI vars and MUST NOT use t.Parallel().
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// accumulateCorpusCSV is a 2-session accumulate corpus (deltas, with a
+// session_context_growth=accumulate header) written to a temp dir. Session s1
+// grows 100→180→245; session s2 grows 60→95. Arrivals overlap across sessions
+// (the cross-session contention fixed-accumulate exists to preserve).
+func writeAccumulateCorpus(t *testing.T) (headerPath, dataPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	headerPath = filepath.Join(dir, "corpus.yaml")
+	dataPath = filepath.Join(dir, "corpus.csv")
+	header := "trace_version: 3\ntime_unit: microseconds\nmode: generated\nsession_context_growth: accumulate\nwarm_up_requests: 0\n"
+	if err := os.WriteFile(headerPath, []byte(header), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// deltas: s1 r0=100; s1 r1 = 180-100-50 = 30; s1 r2 = 245-180-40 = 25; s2 r0=60; s2 r1 = 95-60-15 = 20.
+	csv := "request_id,client_id,tenant_id,slo_class,session_id,round_index,prefix_group,prefix_length,streaming,input_tokens,output_tokens,text_tokens,image_tokens,audio_tokens,video_tokens,reason_ratio,model,deadline_us,server_input_tokens,arrival_time_us,send_time_us,first_chunk_time_us,last_chunk_time_us,num_chunks,status,error_message,finish_reason\n" +
+		"0,c1,t1,standard,s1,0,,0,false,100,50,100,0,0,0,0.0,,0,0,0,0,0,0,0,ok,,\n" +
+		"1,c1,t1,standard,s1,1,,0,false,30,40,30,0,0,0,0.0,,0,0,1000000,1000000,0,0,0,ok,,\n" +
+		"2,c1,t1,standard,s1,2,,0,false,25,20,25,0,0,0,0.0,,0,0,2000000,2000000,0,0,0,ok,,\n" +
+		"3,c2,t1,standard,s2,0,,0,false,60,15,60,0,0,0,0.0,,0,0,500000,500000,0,0,0,ok,,\n" +
+		"4,c2,t1,standard,s2,1,,0,false,20,10,20,0,0,0,0.0,,0,0,1500000,1500000,0,0,0,ok,,\n"
+	if err := os.WriteFile(dataPath, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return headerPath, dataPath
+}
+
+// runFixedAccumulateReplay runs replayCmd.Run with --session-mode fixed-accumulate over
+// the given corpus and captures stdout. Returns the captured stdout bytes.
+func runFixedAccumulateReplay(t *testing.T, headerPath, dataPath string, seedVal int64) []byte {
+	t.Helper()
+	restore := captureCmdLevelVars()
+	origSession := replaySessionMode
+	origHeader := traceHeaderPath
+	origData := traceDataPath
+	defer func() {
+		restore.restore()
+		replaySessionMode = origSession
+		traceHeaderPath = origHeader
+		traceDataPath = origData
+	}()
+
+	mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
+	model = "test-model"
+	latencyModelBackend = "trained-physics"
+	totalKVBlocks = 100000
+	blockSizeTokens = 16
+	maxNumSeqs = 64
+	maxNumBatchedTokens = 4096
+	numInstances = 1
+	seed = seedVal
+	resultsPath = ""
+	longPrefillTokenThreshold = 0
+	kvCPUBlocks = 0
+	kvOffloadThreshold = 0.9
+	kvTransferBandwidth = 100.0
+	kvTransferBaseLatency = 0
+	snapshotRefreshInterval = 0
+	admissionPolicy = "always-admit"
+	routingPolicy = "round-robin"
+	scheduler = "fcfs"
+	policyConfigPath = ""
+	maxModelLen = 1000000
+	traceLevel = "none"
+	counterfactualK = 0
+	traceHeaderPath = headerPath
+	traceDataPath = dataPath
+	modelConfigFolder = mcFolder
+	hwConfigPath = hwPath
+	gpu = "H100"
+	tensorParallelism = 1
+	defaultsFilePath = "../defaults.yaml"
+	replaySessionMode = "fixed-accumulate"
+	replayTraceOutput = ""
+
+	testCmd := &cobra.Command{}
+	registerSimConfigFlags(testCmd)
+	testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+	testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+	testCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", "")
+	testCmd.Flags().IntVar(&replayConcurrentSessions, "concurrent-sessions", 0, "")
+	if err := testCmd.ParseFlags([]string{
+		"--model", "test-model", "--latency-model", "trained-physics",
+		"--total-kv-blocks", "100000", "--hardware", "H100", "--tp", "1",
+		"--max-model-len", "1000000",
+		"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+		"--trace-header", headerPath, "--trace-data", dataPath,
+		"--defaults-filepath", "../defaults.yaml",
+		"--session-mode", "fixed-accumulate",
+	}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	// Capture stdout.
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	replayCmd.Run(testCmd, nil)
+	_ = w.Close()
+	os.Stdout = origStdout
+	out, _ := io.ReadAll(r)
+	return out
+}
+
+// TestReplayFixedAccumulate_EndToEnd (BC-1): a fixed-accumulate replay of an accumulate
+// corpus completes every round and reports non-vacuous completions (conservation companion).
+func TestReplayFixedAccumulate_EndToEnd(t *testing.T) {
+	headerPath, dataPath := writeAccumulateCorpus(t)
+	out := runFixedAccumulateReplay(t, headerPath, dataPath, 42)
+	s := string(out)
+	if len(s) == 0 {
+		t.Fatal("expected non-empty stdout")
+	}
+	// The aggregate metrics JSON reports completed requests; all 5 rounds should complete.
+	if !strings.Contains(s, "\"completed_requests\": 5") && !strings.Contains(s, "\"completed_requests\":5") {
+		t.Errorf("expected 5 completed_requests in output (all rounds), got:\n%s", s)
+	}
+}
+
+// TestReplayFixedAccumulate_Deterministic (BC-4, INV-6): two fixed-accumulate replays at
+// the same seed produce byte-identical stdout.
+func TestReplayFixedAccumulate_Deterministic(t *testing.T) {
+	headerPath, dataPath := writeAccumulateCorpus(t)
+	a := runFixedAccumulateReplay(t, headerPath, dataPath, 777)
+	b := runFixedAccumulateReplay(t, headerPath, dataPath, 777)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("fixed-accumulate stdout non-deterministic across runs\nRUN A:\n%s\nRUN B:\n%s", a, b)
+	}
+	if len(a) == 0 {
+		t.Fatal("stdout is empty; determinism test must produce output to be meaningful")
+	}
+}
+
+// TestReplayFixedAccumulate_RejectsConcurrentSessions (BC-5): --concurrent-sessions is
+// incompatible with fixed-accumulate; replay must Fatalf.
+func TestReplayFixedAccumulate_RejectsConcurrentSessions(t *testing.T) {
+	if os.Getenv("BLIS_TEST_SUBPROCESS") == "1" {
+		headerPath, dataPath := writeAccumulateCorpus(t)
+		restore := captureCmdLevelVars()
+		defer restore.restore()
+		mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		totalKVBlocks = 100000
+		blockSizeTokens = 16
+		maxNumSeqs = 64
+		maxNumBatchedTokens = 4096
+		numInstances = 1
+		seed = 1
+		admissionPolicy = "always-admit"
+		routingPolicy = "round-robin"
+		scheduler = "fcfs"
+		maxModelLen = 1000000
+		traceLevel = "none"
+		traceHeaderPath = headerPath
+		traceDataPath = dataPath
+		modelConfigFolder = mcFolder
+		hwConfigPath = hwPath
+		gpu = "H100"
+		tensorParallelism = 1
+		defaultsFilePath = "../defaults.yaml"
+		replaySessionMode = "fixed-accumulate"
+		replayConcurrentSessions = 4
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+		testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+		testCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", "")
+		testCmd.Flags().IntVar(&replayConcurrentSessions, "concurrent-sessions", 0, "")
+		if err := testCmd.ParseFlags([]string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--total-kv-blocks", "100000", "--hardware", "H100", "--tp", "1",
+			"--max-model-len", "1000000",
+			"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+			"--trace-header", headerPath, "--trace-data", dataPath,
+			"--defaults-filepath", "../defaults.yaml",
+			"--session-mode", "fixed-accumulate", "--concurrent-sessions", "4",
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "ParseFlags failed (test setup error): %v\n", err)
+			os.Exit(2)
+		}
+		replayCmd.Run(testCmd, nil) // must Fatalf before here
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestReplayFixedAccumulate_RejectsConcurrentSessions", "-test.v")
+	cmd.Env = append(os.Environ(), "BLIS_TEST_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit for --concurrent-sessions + fixed-accumulate, got exit 0")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 (logrus.Fatalf), got %d; output:\n%s", exitErr.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "concurrent-sessions") {
+		t.Errorf("fatal message should mention 'concurrent-sessions', got:\n%s", out)
+	}
+}
+
+// TestReplayFixedAccumulate_RejectsNonAccumulateTrace (BC-5): fixed-accumulate on a
+// non-accumulate trace must Fatalf (fixed mode is correct there).
+func TestReplayFixedAccumulate_RejectsNonAccumulateTrace(t *testing.T) {
+	if os.Getenv("BLIS_TEST_SUBPROCESS") == "1" {
+		dir := t.TempDir()
+		headerPath := filepath.Join(dir, "trace.yaml")
+		dataPath := filepath.Join(dir, "trace.csv")
+		// No session_context_growth → non-accumulate.
+		_ = os.WriteFile(headerPath, []byte("trace_version: 3\ntime_unit: microseconds\nmode: generated\nwarm_up_requests: 0\n"), 0644)
+		_ = os.WriteFile(dataPath, []byte("request_id,client_id,tenant_id,slo_class,session_id,round_index,prefix_group,prefix_length,streaming,input_tokens,output_tokens,text_tokens,image_tokens,audio_tokens,video_tokens,reason_ratio,model,deadline_us,server_input_tokens,arrival_time_us,send_time_us,first_chunk_time_us,last_chunk_time_us,num_chunks,status,error_message,finish_reason\n0,c1,t1,standard,s1,0,,0,false,10,5,10,0,0,0,0.0,,0,0,0,0,0,0,0,ok,,\n"), 0644)
+		restore := captureCmdLevelVars()
+		defer restore.restore()
+		mcFolder, hwPath := setupTrainedPhysicsTestFixtures(t)
+		model = "test-model"
+		latencyModelBackend = "trained-physics"
+		totalKVBlocks = 1000
+		blockSizeTokens = 16
+		maxNumSeqs = 64
+		maxNumBatchedTokens = 2048
+		numInstances = 1
+		seed = 1
+		admissionPolicy = "always-admit"
+		routingPolicy = "round-robin"
+		scheduler = "fcfs"
+		maxModelLen = 0
+		traceLevel = "none"
+		traceHeaderPath = headerPath
+		traceDataPath = dataPath
+		modelConfigFolder = mcFolder
+		hwConfigPath = hwPath
+		gpu = "H100"
+		tensorParallelism = 1
+		defaultsFilePath = "../defaults.yaml"
+		replaySessionMode = "fixed-accumulate"
+
+		testCmd := &cobra.Command{}
+		registerSimConfigFlags(testCmd)
+		testCmd.Flags().StringVar(&traceHeaderPath, "trace-header", "", "")
+		testCmd.Flags().StringVar(&traceDataPath, "trace-data", "", "")
+		testCmd.Flags().StringVar(&replaySessionMode, "session-mode", "fixed", "")
+		testCmd.Flags().IntVar(&replayConcurrentSessions, "concurrent-sessions", 0, "")
+		if err := testCmd.ParseFlags([]string{
+			"--model", "test-model", "--latency-model", "trained-physics",
+			"--total-kv-blocks", "1000", "--hardware", "H100", "--tp", "1",
+			"--model-config-folder", mcFolder, "--hardware-config", hwPath,
+			"--trace-header", headerPath, "--trace-data", dataPath,
+			"--defaults-filepath", "../defaults.yaml",
+			"--session-mode", "fixed-accumulate",
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "ParseFlags failed (test setup error): %v\n", err)
+			os.Exit(2)
+		}
+		replayCmd.Run(testCmd, nil) // must Fatalf before here
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestReplayFixedAccumulate_RejectsNonAccumulateTrace", "-test.v")
+	cmd.Env = append(os.Environ(), "BLIS_TEST_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit for fixed-accumulate on non-accumulate trace, got exit 0")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 (logrus.Fatalf), got %d; output:\n%s", exitErr.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "fixed-accumulate requires an accumulate corpus") {
+		t.Errorf("fatal message should explain the accumulate requirement, got:\n%s", out)
+	}
+}

--- a/docs/contributing/standards/invariants.md
+++ b/docs/contributing/standards/invariants.md
@@ -139,7 +139,9 @@ Invariants are properties that must hold at all times during and after simulatio
 
 ## INV-10: Session Causality
 
-**Statement:** For all rounds N in a closed-loop session: `round[N+1].ArrivalTime >= round[N].CompletionTime + ThinkTimeUs`. Boundary: ThinkTimeUs = 0 produces equality.
+**Statement:** For all rounds N in a **closed-loop** session: `round[N+1].ArrivalTime >= round[N].CompletionTime + ThinkTimeUs`. Boundary: ThinkTimeUs = 0 produces equality.
+
+**Scope (#1692):** INV-10 is scoped to closed-loop arrival *regeneration* — it constrains arrivals the `SessionManager` derives from sim completion. The `fixed-accumulate` replay mode (`blis replay --session-mode fixed-accumulate`) is **exempt by design**: it injects every round at its *recorded* arrival time (open-loop, like `--session-mode fixed`) regardless of sim completion, precisely so N large prefills pile into the scheduler at the real clock and produce genuine queueing delay. Chaining arrivals to sim completion (INV-10) is the self-throttling feedback loop that mode exists to break, so INV-10 does not apply to it. `fixed-accumulate` still reconstructs the growing accumulate-delta input (the closed-loop reconstruction) — only the arrival source differs.
 
 **Verification:** `sim/workload/session_test.go` — `TestSession_RoundGeneration_CorrectArrivalTime` verifies the arrival time formula. The ThinkTimeUs=0 boundary is inherent in the formula.
 

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -510,9 +510,11 @@ concurrency > 1:
 
 ```bash
 # Convert once, then replay with recorded arrivals AND reconstructed growing context.
+# (This uses a committed MoE config and a hardware key present in hardware_config.json,
+# so it runs as-is; the motivating shape is a large MLA MoE such as Kimi-K3 on H200.)
 blis convert weka --input traces.jsonl --trace-output corpus --context-growth accumulate
 blis replay --trace-header corpus.yaml --trace-data corpus.csv \
-  --model kimi-k3 --hardware H200 --tp 16 --dp 2 --enable-expert-parallel \
+  --model qwen/qwen3-30b-a3b --hardware H100 --tp 2 --dp 2 --enable-expert-parallel \
   --session-mode fixed-accumulate --max-model-len 1000000
 ```
 
@@ -531,6 +533,25 @@ mode breaks.
     calibrated. Treat `fixed-accumulate` as a **necessary precondition** for high-
     concurrency fidelity — land and validate it alongside (or ahead of) the decode-side
     work, not as a standalone fix.
+
+!!! warning "Intra-session overlap: recorded arrivals ignore sim completion"
+    Each round is injected at its recorded arrival regardless of when the previous round
+    of the **same** session finishes in the sim. A real agentic client is serial (round N
+    waits for round N−1's response), but the recorded inter-round gap includes the *real*
+    server time; the moment sim service time exceeds that real time — exactly the
+    queueing regime this mode creates — round N is injected while round N−1 is still
+    decoding. Two consequences to keep in mind when reading results:
+
+    1. **Measured concurrency is inflated** above what a real serial client produces,
+       because same-session rounds can be in flight at once.
+    2. **Prefix-cache hit rate is partly fictional**: round N's prompt contains round
+       N−1's output tokens, which (under overlap) round N−1 has not finished emitting —
+       so part of the modeled prefix hit corresponds to tokens that did not yet exist.
+
+    This is a distinct effect from the (faithful) *cross*-session overlap the mode
+    reproduces, and it is not covered by the INV-10 exemption (which is about the arrival
+    *source*). It is inherent to open-loop replay of a serial workload; closed-loop avoids
+    it but at the cost of the self-throttling feedback loop this mode exists to break.
 
 !!! note "`--trace-output` produces an absolute (non-accumulate) corpus"
     fixed-accumulate reconstructs each round's growing context in memory, so

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -497,6 +497,41 @@ model names are dropped during conversion (same routing-safety reason as OTel).
     re-run `convert` to get compaction-aware output. (The separate think-time lossy-0
     sentinel was resolved in #1608 — see the non-lossy note above.)
 
+### Faithful high-concurrency replay: `--session-mode fixed-accumulate` (#1692)
+
+An accumulate corpus can be replayed three ways. Only the third is faithful at
+concurrency > 1:
+
+| Mode | Arrivals | Accumulate inputs | Faithful high-conc? |
+|------|----------|-------------------|---------------------|
+| `--session-mode closed-loop` | regenerated (`completion + think`) | ✅ reconstructed | ❌ self-throttles — arrivals chain to sim completion, so the queue drains instead of piling up and TTFT collapses to compute-only (30–100× low at conc ≥ 8) |
+| `--session-mode fixed` | recorded | ❌ **hard-rejected** on an accumulate corpus (reads deltas as absolutes) | ❌ not usable |
+| `--session-mode fixed-accumulate` | **recorded** | ✅ reconstructed | ✅ recorded arrivals carry the real cross-session overlap, so N large prefills pile into the scheduler at the real clock and produce genuine queue wait |
+
+```bash
+# Convert once, then replay with recorded arrivals AND reconstructed growing context.
+blis convert weka --input traces.jsonl --trace-output corpus --context-growth accumulate
+blis replay --trace-header corpus.yaml --trace-data corpus.csv \
+  --model kimi-k3 --hardware H200 --tp 16 --dp 2 --enable-expert-parallel \
+  --session-mode fixed-accumulate --max-model-len 1000000
+```
+
+The arrival timestamps are already in the corpus (`ArrivalTimeUs`, written per round by
+the converter) — this mode consumes data that exists today; no trace-format change. It
+requires an accumulate corpus, and is mutually exclusive with `--concurrent-sessions`
+(open-loop, so there is no session pool to maintain) and `--think-time-*` (arrivals are
+recorded, not regenerated). INV-10 (session causality) is **scoped to closed-loop** and
+does not apply — chaining arrivals to sim completion is exactly the feedback loop this
+mode breaks.
+
+!!! warning "Necessary, not sufficient (decode-side gap, #1627)"
+    Even with faithful arrivals, BLIS's decode/step model currently runs ~5–10× fast on
+    this workload (the unmodeled `--enforce-eager` regime plus MTP-speedup-without-
+    contention, #1627), so queue depth is still under-predicted until decode is
+    calibrated. Treat `fixed-accumulate` as a **necessary precondition** for high-
+    concurrency fidelity — land and validate it alongside (or ahead of) the decode-side
+    work, not as a standalone fix.
+
 ---
 
 ## `blis calibrate`

--- a/docs/guide/observe-replay-calibrate.md
+++ b/docs/guide/observe-replay-calibrate.md
@@ -532,6 +532,16 @@ mode breaks.
     concurrency fidelity — land and validate it alongside (or ahead of) the decode-side
     work, not as a standalone fix.
 
+!!! note "`--trace-output` produces an absolute (non-accumulate) corpus"
+    fixed-accumulate reconstructs each round's growing context in memory, so
+    `--trace-output` re-exports the **already-reconstructed absolute** per-round inputs —
+    the exported header carries **no** `session_context_growth`, and the CSV records
+    absolute `input_tokens` (not deltas). This export is a faithful absolute-mode corpus:
+    re-replay it with `--session-mode fixed` (the default). It is **not** an accumulate
+    corpus, so `--session-mode fixed-accumulate` will reject it (the accumulate-corpus
+    guard) — re-run the original `convert` step if you need to re-export deltas. This is
+    lossless: the absolute inputs are exactly what fixed-accumulate reconstructed.
+
 ---
 
 ## `blis calibrate`

--- a/sim/workload/fixed_accumulate.go
+++ b/sim/workload/fixed_accumulate.go
@@ -25,12 +25,20 @@ import (
 //
 // The insight: the growing buffer needs no live sim output. The trace's delta chain
 // (abs_N = abs_{N-1} + out_{N-1} + delta_N) plus input_tokens_reset compaction markers
-// fully determines every round's absolute input from trace data alone. So we walk the
-// delta law here — appending each round's generated output then its delta (or Reset-ing
-// to a recorded absolute on a compaction round) into a session-scoped buffer, exactly as
-// SessionManager.OnComplete does — and pre-bake every round as a request at its recorded
-// arrival. The result carries the real cross-session overlap, so N large prefills pile
-// into the scheduler per the real clock and produce genuine queueing delay.
+// fully determines every round's absolute input from trace data alone. So we invert the
+// ENCODER's delta law here (EncodeSessionToTraceRecords) — appending each round's
+// generated output then its delta (or Reset-ing to the recorded absolute on a compaction
+// round) into a session-scoped buffer — and pre-bake every round as a request at its
+// recorded arrival. The result carries the real cross-session overlap, so N large
+// prefills pile into the scheduler per the real clock and produce genuine queueing delay.
+//
+// This mirrors SessionManager.OnComplete's buffer mechanics but feeds it the RECORDED
+// output (rec.OutputTokens), whereas OnComplete appends the ACTUAL sim output
+// (ProgressIndex − InputLen, which a length cap can truncate). The two are the same
+// absent capping; feeding the recorded output is the correct choice here because the
+// encoder's law is written over the recorded output, so this is its exact inverse (no
+// INV-13 claim spans the two modes, and token CONTENT also differs from closed-loop on
+// compaction rounds due to RNG draw order — harmless).
 //
 // # Contract with the encoder (INV-13 with the accumulate closed-loop path)
 //
@@ -119,7 +127,14 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 		// Seed the growing buffer with round 0's input: prefix (if any) + a generated
 		// suffix of effectiveInputTokenCount tokens. Layout mirrors the closed-loop
 		// buffer: [prefix | r0_conversation | r0_output | r1_delta | r1_output | ...].
-		buf := newSessionTokenBuffer()
+		//
+		// Pre-allocate to the session's EXACT peak buffer length (computed from the delta
+		// chain) so the growth phase never reallocates — every round's Slice() view then
+		// aliases ONE backing array, and the session retains O(peak) tokens, not the
+		// O(Σ absolute inputs) an eager per-round copy would retain. On the motivating
+		// Weka corpus (ISL p50 ≈ 110K over ~37K rounds) that is the difference between
+		// ~0.4 GB and ~16–24 GB. Matches the reasoning.go accumulate pattern (#1445).
+		buf := newSessionTokenBufferWithCapacity(accumulatePeakBufferLen(rounds, len(prefix)))
 		if len(prefix) > 0 {
 			buf.Append(prefix)
 		}
@@ -152,10 +167,16 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 				inputTokens = buf.Slice(0, inputEnd)
 			} else {
 				// Normal growth: append prev round's output, then this round's delta.
+				// A round>0 in an accumulate corpus stores its per-round DELTA directly in
+				// rec.InputTokens — read it as-is. (Do NOT route through
+				// effectiveInputTokenCount here: that helper returns the ABSOLUTE
+				// ServerInputTokens when set, which would be a large silent over-count when
+				// consumed as a delta. ServerInputTokens/PrefixGroup are round-0 concerns;
+				// the prefix is already folded into the buffer.)
 				if len(prevOutputTokens) > 0 {
 					buf.Append(prevOutputTokens)
 				}
-				deltaToks := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
+				deltaToks := sim.GenerateRandomTokenIDs(sessionRNG, rec.InputTokens)
 				_, inputEnd := buf.Append(deltaToks)
 				inputTokens = buf.Slice(0, inputEnd)
 			}
@@ -163,14 +184,17 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 			outputTokens := sim.GenerateRandomTokenIDs(sessionRNG, rec.OutputTokens)
 			prevOutputTokens = outputTokens
 
-			// Copy the buffer view into an independent slice: distinct rounds must not
-			// alias one growable backing array (a later Append/Reset would shift or
-			// orphan an earlier round's view). Copying makes each request's InputTokens
-			// stable and content-frozen at its recorded absolute length.
-			frozen := make([]sim.TokenID, len(inputTokens))
-			copy(frozen, inputTokens)
-
-			requests = append(requests, buildFixedAccumulateRequest(rec, sessionID, frozen, outputTokens, originShift))
+			// inputTokens is a VIEW into the shared session buffer (no copy). This is the
+			// #1445 shared-buffer pattern (see reasoning.go): the simulator treats
+			// Request.InputTokens as read-only (Request.FullInputTokens/InputTokenSlice
+			// hand out capped three-index slices, so a stray append can't overwrite the
+			// buffer), and the buffer's reallocation hazard is documented-safe — Append only
+			// grows (indices [0,end_i) of an earlier view never move) and Reset allocates a
+			// fresh array (earlier views keep pointing at the old, content-correct array).
+			// Because the buffer was pre-sized to the peak above, the no-compaction path
+			// never reallocates, so all views alias one array; a compaction Reset shrinks it
+			// and the pre-reset views remain valid on the old array.
+			requests = append(requests, buildFixedAccumulateRequest(rec, sessionID, inputTokens, outputTokens, originShift))
 		}
 	}
 
@@ -201,6 +225,41 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 	})
 
 	return requests, nil
+}
+
+// accumulatePeakBufferLen returns the maximum shared-buffer length the growth loop in
+// LoadTraceV2FixedAccumulateRequests will reach for a session, so the buffer can be
+// pre-allocated once and never reallocate (keeping every round's Slice() view aliased to
+// one backing array).
+//
+// The buffer length after round i's input is that round's ABSOLUTE input in_i, and it
+// never exceeds in_i mid-round (the transient append of out_{i-1} brings it to
+// in_{i-1}+out_{i-1} = in_i − delta_i ≤ in_i). So the peak is max_i(in_i), reconstructed
+// from the same delta law the loop applies:
+//   - round 0: in_0 = prefixLen + delta_0 (the seeded prefix + round-0 suffix)
+//   - reset round: in_i = *InputTokensReset (the recorded absolute)
+//   - normal round i>0: in_i = in_{i-1} + out_{i-1} + delta_i
+// rounds is assumed sorted ascending and consecutive (validated by the caller).
+func accumulatePeakBufferLen(rounds []TraceRecord, prefixLen int) int64 {
+	var peak, prevAbs, prevOut int64
+	for i, rec := range rounds {
+		var abs int64
+		switch {
+		case i == 0:
+			abs = int64(prefixLen) + int64(effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
+		case rec.InputTokensReset != nil:
+			abs = *rec.InputTokensReset
+		default:
+			// round>0 delta is rec.InputTokens directly (see the growth branch in
+			// LoadTraceV2FixedAccumulateRequests — not effectiveInputTokenCount).
+			abs = prevAbs + prevOut + int64(rec.InputTokens)
+		}
+		if abs > peak {
+			peak = abs
+		}
+		prevAbs, prevOut = abs, int64(rec.OutputTokens)
+	}
+	return peak
 }
 
 // buildFixedAccumulateRequest assembles a sim.Request from a trace record with the

--- a/sim/workload/fixed_accumulate.go
+++ b/sim/workload/fixed_accumulate.go
@@ -128,16 +128,30 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 		// suffix of effectiveInputTokenCount tokens. Layout mirrors the closed-loop
 		// buffer: [prefix | r0_conversation | r0_output | r1_delta | r1_output | ...].
 		//
-		// Pre-allocate to the session's EXACT peak buffer length (computed from the delta
-		// chain) so the growth phase never reallocates — every round's Slice() view then
-		// aliases ONE backing array, and the session retains O(peak) tokens, not the
-		// O(Σ absolute inputs) an eager per-round copy would retain. On the motivating
-		// Weka corpus (ISL p50 ≈ 110K over ~37K rounds) that is the difference between
-		// ~0.4 GB and ~16–24 GB. Matches the reasoning.go accumulate pattern (#1445).
-		buf := newSessionTokenBufferWithCapacity(accumulatePeakBufferLen(rounds, len(prefix)))
+		// Pre-allocate to the FIRST EPOCH's peak (rounds up to the first compaction reset),
+		// computed from the delta chain, so the growth phase never reallocates within the
+		// epoch — every round's Slice() view then aliases ONE backing array. At each reset
+		// we re-size to the NEXT epoch's peak (see ResetWithCapacity below). Per-epoch (not
+		// global-peak) sizing is deliberate: sizing to the global peak would pin every
+		// earlier round's small view inside one giant array, retaining more than an eager
+		// copy on a shrinking-then-growing corpus (PR #1696 review F1). Retained memory is
+		// therefore O(Σ per-epoch peaks): for a monotone (no-compaction) session that is a
+		// single O(peak) array (~0.4 GB vs ~16–24 GB of eager copies on the Weka corpus);
+		// for a compacting session it is one right-sized array per live epoch. Matches the
+		// reasoning.go shared-buffer pattern (#1445).
+		buf := newSessionTokenBufferWithCapacity(accumulateEpochPeakLen(rounds, 0, len(prefix)))
 		if len(prefix) > 0 {
 			buf.Append(prefix)
 		}
+		// Round 0 seeds from effectiveInputTokenCount (server-reported count wins when set),
+		// but rounds>0 read rec.InputTokens raw as the DELTA. CAVEAT (latent): if a corpus
+		// ever carried a round-0 ServerInputTokens that differed from InputTokens, seeding
+		// abs_0 from the server count while the encoder wrote deltas over the InputTokens
+		// column would shift every later reconstructed absolute by (server − input).
+		// Unreachable today — no converter (weka/otel) or re-exporter sets ServerInputTokens
+		// on an accumulate corpus, and observe (the only ServerInputTokens producer) never
+		// emits session_context_growth=accumulate, so such a trace is rejected by the CLI
+		// guard before reaching here. Left as a documented boundary rather than a guard.
 		r0Suffix := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(r0.InputTokens, r0.ServerInputTokens, r0.PrefixGroup))
 		buf.Append(r0Suffix)
 
@@ -163,7 +177,10 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 				// just-completed round's output is intentionally NOT carried forward — it
 				// was folded into the compaction the trace recorded as this round's abs.
 				resetToks := sim.GenerateRandomTokenIDs(sessionRNG, resetTarget)
-				_, inputEnd := buf.Reset(resetToks)
+				// Size the fresh array to THIS epoch's peak (rounds i..next-reset) so the
+				// new epoch's appends don't reallocate and don't keep the prior epoch's
+				// array alive beyond its own live views (PR #1696 review F1).
+				_, inputEnd := buf.ResetWithCapacity(resetToks, accumulateEpochPeakLen(rounds, i, 0))
 				inputTokens = buf.Slice(0, inputEnd)
 			} else {
 				// Normal growth: append prev round's output, then this round's delta.
@@ -227,27 +244,37 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 	return requests, nil
 }
 
-// accumulatePeakBufferLen returns the maximum shared-buffer length the growth loop in
-// LoadTraceV2FixedAccumulateRequests will reach for a session, so the buffer can be
-// pre-allocated once and never reallocate (keeping every round's Slice() view aliased to
-// one backing array).
+// accumulateEpochPeakLen returns the maximum shared-buffer length reached within ONE
+// context epoch of a session — the run of rounds from epochStart up to (but not
+// including) the next context-compaction reset. The loader sizes each backing array to
+// exactly its epoch's peak so no epoch reallocates, and — critically — a later epoch's
+// growth does NOT enlarge (and thus keep alive) an earlier epoch's array. Sizing to the
+// GLOBAL peak instead would pin every earlier round's small view inside one giant array,
+// which can be worse than an eager copy on a shrinking-then-growing corpus (PR #1696
+// review F1).
 //
-// The buffer length after round i's input is that round's ABSOLUTE input in_i, and it
+// The buffer length after a round's input is that round's ABSOLUTE input in_i, and it
 // never exceeds in_i mid-round (the transient append of out_{i-1} brings it to
-// in_{i-1}+out_{i-1} = in_i − delta_i ≤ in_i). So the peak is max_i(in_i), reconstructed
-// from the same delta law the loop applies:
-//   - round 0: in_0 = prefixLen + delta_0 (the seeded prefix + round-0 suffix)
-//   - reset round: in_i = *InputTokensReset (the recorded absolute)
-//   - normal round i>0: in_i = in_{i-1} + out_{i-1} + delta_i
-// rounds is assumed sorted ascending and consecutive (validated by the caller).
-func accumulatePeakBufferLen(rounds []TraceRecord, prefixLen int) int64 {
+// in_{i-1}+out_{i-1} = in_i − delta_i ≤ in_i). Within the epoch, the delta law is:
+//   - epoch's first round: in = prefixLen + delta (round 0, via effectiveInputTokenCount)
+//     OR *InputTokensReset (a reset round that opens a new epoch)
+//   - subsequent round j: in_j = in_{j-1} + out_{j-1} + delta_j (delta = rec.InputTokens)
+//
+// prefixLen is added only when epochStart == 0 (the seeded prefix); a reset epoch carries
+// no prefix. rounds is assumed sorted ascending and consecutive (validated by the caller).
+func accumulateEpochPeakLen(rounds []TraceRecord, epochStart, prefixLen int) int64 {
 	var peak, prevAbs, prevOut int64
-	for i, rec := range rounds {
+	for i := epochStart; i < len(rounds); i++ {
+		rec := rounds[i]
+		isResetRound := i > 0 && rec.InputTokensReset != nil
+		if i > epochStart && isResetRound {
+			break // next epoch begins here
+		}
 		var abs int64
 		switch {
 		case i == 0:
 			abs = int64(prefixLen) + int64(effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
-		case rec.InputTokensReset != nil:
+		case isResetRound: // i == epochStart, a reset round opening this epoch
 			abs = *rec.InputTokensReset
 		default:
 			// round>0 delta is rec.InputTokens directly (see the growth branch in

--- a/sim/workload/fixed_accumulate.go
+++ b/sim/workload/fixed_accumulate.go
@@ -186,6 +186,20 @@ func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Requ
 		requests = append(requests, buildFixedAccumulateRequest(rec, rec.SessionID, inputTokens, outputTokens, originShift))
 	}
 
+	// Sort by arrival time to satisfy the RequestSource contract (cluster.Run
+	// requires non-decreasing ArrivalTime; SliceRequestSource does not re-sort).
+	// This loader emits requests in SESSION-major order (all of session A's rounds,
+	// then all of session B's), but a high-concurrency corpus interleaves sessions
+	// in time — session B's round 0 may arrive between session A's rounds 0 and 1 —
+	// so session order is not arrival order. A stable sort here (matching generator.go)
+	// preserves the per-session round order for equal-arrival ties, keeping INV-6
+	// determinism. Safe because every request is already fully materialized with a
+	// frozen InputTokens slice, so reordering cannot disturb the accumulate
+	// reconstruction (which happened above, per session).
+	sort.SliceStable(requests, func(i, j int) bool {
+		return requests[i].ArrivalTime < requests[j].ArrivalTime
+	})
+
 	return requests, nil
 }
 

--- a/sim/workload/fixed_accumulate.go
+++ b/sim/workload/fixed_accumulate.go
@@ -221,9 +221,18 @@ func buildFixedAccumulateRequest(rec TraceRecord, sessionID string, inputTokens,
 		Streaming:        rec.Streaming,
 		Adapter:          rec.Adapter,
 	}
-	// Non-session records carry their prefix metadata (suffix-only input); session
-	// rounds do not (prefix already folded into the reconstructed absolute).
-	if sessionID == "" {
+	// Prefix metadata parity with the other loaders (router prefix-affinity scoring
+	// reads PrefixGroup/PrefixLength; the tokens themselves are already baked into
+	// InputTokens):
+	//   - Non-session records: carry it (suffix-only input), like LoadTraceV2Requests.
+	//   - Session ROUND 0: carry it, matching LoadTraceV2SessionBlueprints' round-0
+	//     request — so two sessions sharing a system-prompt group still get cross-session
+	//     prefix-cache affinity. No-op for converter corpora (PrefixGroup == "").
+	//   - Session follow-up rounds (RoundIndex > 0): DO NOT carry it — accumulate folds
+	//     the prefix into the growing buffer, so a PrefixLength here would double-count
+	//     (mirrors SessionManager.OnComplete, which prepends the prefix but leaves the
+	//     follow-up's PrefixGroup/PrefixLength unset).
+	if sessionID == "" || rec.RoundIndex == 0 {
 		req.PrefixGroup = rec.PrefixGroup
 		req.PrefixLength = rec.PrefixLength
 	}

--- a/sim/workload/fixed_accumulate.go
+++ b/sim/workload/fixed_accumulate.go
@@ -1,0 +1,231 @@
+package workload
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// LoadTraceV2FixedAccumulateRequests builds a flat slice of pre-baked requests from
+// an accumulate corpus (header session_context_growth == "accumulate"), one request
+// per session round, injected at its RECORDED arrival time (open-loop, like fixed
+// mode) while reconstructing the GROWING accumulate-delta input for each round (like
+// closed-loop). This is the loader behind `blis replay --session-mode fixed-accumulate`
+// (#1692).
+//
+// # Why this decoupling is possible
+//
+// Closed-loop replay reconstructs the growing context inside SessionManager.OnComplete,
+// which chains each round's arrival to the sim's own completion time — a self-throttling
+// feedback loop that never lets the queue reach its real depth at high concurrency.
+// Fixed mode replays the recorded arrivals (breaking the feedback loop) but reads
+// input_tokens as ABSOLUTE, so it misreads the deltas of an accumulate corpus.
+//
+// The insight: the growing buffer needs no live sim output. The trace's delta chain
+// (abs_N = abs_{N-1} + out_{N-1} + delta_N) plus input_tokens_reset compaction markers
+// fully determines every round's absolute input from trace data alone. So we walk the
+// delta law here — appending each round's generated output then its delta (or Reset-ing
+// to a recorded absolute on a compaction round) into a session-scoped buffer, exactly as
+// SessionManager.OnComplete does — and pre-bake every round as a request at its recorded
+// arrival. The result carries the real cross-session overlap, so N large prefills pile
+// into the scheduler per the real clock and produce genuine queueing delay.
+//
+// # Contract with the encoder (INV-13 with the accumulate closed-loop path)
+//
+// The reconstruction is the EXACT inverse of EncodeSessionToTraceRecords' delta law:
+// round 0 carries the full first prompt; round N+1's recorded delta is
+// max(0, in_{N+1} - in_N - out_N), so appending out_N then delta reproduces in_{N+1}.
+// On a compaction round (in_{N+1} < in_N + out_N) the encoder clamps the delta to 0 and
+// stamps InputTokensReset = in_{N+1}; here we Reset the buffer to a fresh segment of that
+// absolute length, matching SessionManager.OnComplete (#1609).
+//
+// Determinism (INV-6): sessions are processed in insertion order, each with its own RNG
+// seeded from a master RNG derived from seed — identical to LoadTraceV2SessionBlueprints —
+// so token streams are reproducible.
+//
+// Non-session (single-shot) records pass through with recorded absolute input at their
+// recorded arrival, identical to LoadTraceV2Requests.
+//
+// Errors (never Fatalf — this is library code, R6): an empty trace, an unknown
+// session_context_growth value, or a session with non-consecutive round indices.
+func LoadTraceV2FixedAccumulateRequests(trace *TraceV2, seed int64) ([]*sim.Request, error) {
+	if trace == nil || len(trace.Records) == 0 {
+		return nil, fmt.Errorf("empty trace")
+	}
+	// This loader is only meaningful for an accumulate corpus. An empty growth value
+	// is tolerated (the deltas then equal absolutes for single-round sessions), but an
+	// unknown value is a typo footgun — fail loudly, mirroring LoadTraceV2SessionBlueprints.
+	contextGrowth := trace.Header.SessionContextGrowth
+	if contextGrowth != "" && contextGrowth != "accumulate" {
+		return nil, fmt.Errorf("session_context_growth: unknown value %q (valid: \"accumulate\" or empty)", contextGrowth)
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+
+	// Injection-origin shift (#1606): re-base injection onto the arrival/deadline origin.
+	// 0 for generated traces (send == arrival) ⇒ arrivals equal the recorded ArrivalTimeUs.
+	originShift := injectionOriginShift(trace.Records)
+
+	// Shared prefix tokens per prefix group (same as LoadTraceV2Requests).
+	prefixTokens := make(map[string][]sim.TokenID)
+	for _, rec := range trace.Records {
+		if rec.PrefixGroup != "" && rec.PrefixLength > 0 {
+			if _, exists := prefixTokens[rec.PrefixGroup]; !exists {
+				prefixTokens[rec.PrefixGroup] = sim.GenerateRandomTokenIDs(rng, rec.PrefixLength)
+			}
+		}
+	}
+
+	// Group records by session, preserving insertion order (INV-6).
+	sessionMap := make(map[string][]TraceRecord)
+	var nonSessionRecords []TraceRecord
+	var sessionOrder []string
+	for _, rec := range trace.Records {
+		if rec.SessionID == "" {
+			nonSessionRecords = append(nonSessionRecords, rec)
+			continue
+		}
+		if _, exists := sessionMap[rec.SessionID]; !exists {
+			sessionOrder = append(sessionOrder, rec.SessionID)
+		}
+		sessionMap[rec.SessionID] = append(sessionMap[rec.SessionID], rec)
+	}
+
+	var requests []*sim.Request
+
+	for _, sessionID := range sessionOrder {
+		rounds := sessionMap[sessionID]
+		sort.SliceStable(rounds, func(i, j int) bool {
+			return rounds[i].RoundIndex < rounds[j].RoundIndex
+		})
+		for i, rec := range rounds {
+			if rec.RoundIndex != i {
+				return nil, fmt.Errorf("session %q has non-consecutive round indices (expected %d, got %d)", sessionID, i, rec.RoundIndex)
+			}
+		}
+
+		// Per-session RNG for deterministic token IDs (INV-6), seeded from the master
+		// RNG exactly as LoadTraceV2SessionBlueprints does.
+		sessionRNG := rand.New(rand.NewSource(rng.Int63()))
+
+		r0 := rounds[0]
+		var prefix []sim.TokenID
+		if r0.PrefixGroup != "" {
+			prefix = prefixTokens[r0.PrefixGroup]
+		}
+
+		// Seed the growing buffer with round 0's input: prefix (if any) + a generated
+		// suffix of effectiveInputTokenCount tokens. Layout mirrors the closed-loop
+		// buffer: [prefix | r0_conversation | r0_output | r1_delta | r1_output | ...].
+		buf := newSessionTokenBuffer()
+		if len(prefix) > 0 {
+			buf.Append(prefix)
+		}
+		r0Suffix := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(r0.InputTokens, r0.ServerInputTokens, r0.PrefixGroup))
+		buf.Append(r0Suffix)
+
+		// prevOutputTokens holds the previous round's generated output, appended to the
+		// buffer BEFORE the current round's delta (the accumulate growth step).
+		var prevOutputTokens []sim.TokenID
+
+		for i, rec := range rounds {
+			// Reset target for compaction rounds (#1609): a round>0 with an
+			// input_tokens_reset marker re-seeds the buffer to that absolute length.
+			resetTarget := -1
+			if i > 0 && rec.InputTokensReset != nil {
+				resetTarget = int(*rec.InputTokensReset)
+			}
+
+			var inputTokens []sim.TokenID
+			if i == 0 {
+				// Round 0 already seeded above.
+				inputTokens = buf.Slice(0, buf.Len())
+			} else if resetTarget >= 0 {
+				// Context compaction: replace the whole buffer with a fresh segment of
+				// exactly resetTarget tokens (mirrors SessionManager.OnComplete). The
+				// just-completed round's output is intentionally NOT carried forward — it
+				// was folded into the compaction the trace recorded as this round's abs.
+				resetToks := sim.GenerateRandomTokenIDs(sessionRNG, resetTarget)
+				_, inputEnd := buf.Reset(resetToks)
+				inputTokens = buf.Slice(0, inputEnd)
+			} else {
+				// Normal growth: append prev round's output, then this round's delta.
+				if len(prevOutputTokens) > 0 {
+					buf.Append(prevOutputTokens)
+				}
+				deltaToks := sim.GenerateRandomTokenIDs(sessionRNG, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
+				_, inputEnd := buf.Append(deltaToks)
+				inputTokens = buf.Slice(0, inputEnd)
+			}
+
+			outputTokens := sim.GenerateRandomTokenIDs(sessionRNG, rec.OutputTokens)
+			prevOutputTokens = outputTokens
+
+			// Copy the buffer view into an independent slice: distinct rounds must not
+			// alias one growable backing array (a later Append/Reset would shift or
+			// orphan an earlier round's view). Copying makes each request's InputTokens
+			// stable and content-frozen at its recorded absolute length.
+			frozen := make([]sim.TokenID, len(inputTokens))
+			copy(frozen, inputTokens)
+
+			requests = append(requests, buildFixedAccumulateRequest(rec, sessionID, frozen, outputTokens, originShift))
+		}
+	}
+
+	// Non-session records: identical construction to LoadTraceV2Requests.
+	for _, rec := range nonSessionRecords {
+		inputTokens := sim.GenerateRandomTokenIDs(rng, effectiveInputTokenCount(rec.InputTokens, rec.ServerInputTokens, rec.PrefixGroup))
+		if rec.PrefixGroup != "" {
+			if prefix, ok := prefixTokens[rec.PrefixGroup]; ok {
+				inputTokens = append(append([]sim.TokenID{}, prefix...), inputTokens...)
+			}
+		}
+		outputTokens := sim.GenerateRandomTokenIDs(rng, rec.OutputTokens)
+		requests = append(requests, buildFixedAccumulateRequest(rec, rec.SessionID, inputTokens, outputTokens, originShift))
+	}
+
+	return requests, nil
+}
+
+// buildFixedAccumulateRequest assembles a sim.Request from a trace record with the
+// already-reconstructed input/output token slices. Field set matches
+// LoadTraceV2Requests (R4). PrefixGroup/PrefixLength are deliberately NOT carried on
+// session rounds: accumulate folds the prefix into round 0's reconstructed input, so
+// re-prepending it would double-count. Non-session records keep them (their input is
+// suffix-only, exactly as fixed mode).
+func buildFixedAccumulateRequest(rec TraceRecord, sessionID string, inputTokens, outputTokens []sim.TokenID, originShift int64) *sim.Request {
+	req := &sim.Request{
+		ID:               fmt.Sprintf("request_%d", rec.RequestID),
+		ArrivalTime:      injectionTime(rec) - originShift, // #1606: on the arrival/deadline origin
+		InputTokens:      inputTokens,
+		OutputTokens:     outputTokens,
+		MaxOutputLen:     len(outputTokens),
+		State:            sim.StateQueued,
+		ScheduledStepIdx: 0,
+		FinishedStepIdx:  0,
+		TenantID:         rec.TenantID,
+		SLOClass:         rec.SLOClass,
+		SessionID:        sessionID,
+		RoundIndex:       rec.RoundIndex,
+		TextTokenCount:   rec.TextTokens,
+		ImageTokenCount:  rec.ImageTokens,
+		AudioTokenCount:  rec.AudioTokens,
+		VideoTokenCount:  rec.VideoTokens,
+		ReasonRatio:      rec.ReasonRatio,
+		Model:            rec.Model,
+		Deadline:         rec.DeadlineUs,
+		SLOTargetUs:      rec.SLOTargetUs,
+		ClientID:         rec.ClientID,
+		Streaming:        rec.Streaming,
+		Adapter:          rec.Adapter,
+	}
+	// Non-session records carry their prefix metadata (suffix-only input); session
+	// rounds do not (prefix already folded into the reconstructed absolute).
+	if sessionID == "" {
+		req.PrefixGroup = rec.PrefixGroup
+		req.PrefixLength = rec.PrefixLength
+	}
+	return req
+}

--- a/sim/workload/fixed_accumulate_test.go
+++ b/sim/workload/fixed_accumulate_test.go
@@ -122,6 +122,62 @@ func TestFixedAccumulate_CompactionReset(t *testing.T) {
 	}
 }
 
+// TestFixedAccumulate_SingleRoundSession: a session with exactly one round is just its
+// round-0 absolute input at its recorded arrival (no growth, no follow-up).
+func TestFixedAccumulate_SingleRoundSession(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 70, OutputTokens: 12, ArrivalTimeUs: 300_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 11)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if int(reqs[0].InputLen()) != 70 {
+		t.Errorf("single-round input len = %d, want 70", reqs[0].InputLen())
+	}
+	if reqs[0].ArrivalTime != 300_000 {
+		t.Errorf("single-round arrival = %d, want 300000", reqs[0].ArrivalTime)
+	}
+	if len(reqs[0].OutputTokens) != 12 {
+		t.Errorf("single-round output len = %d, want 12", len(reqs[0].OutputTokens))
+	}
+}
+
+// TestFixedAccumulate_CompactionReset_Content: after a reset round the input tokens are
+// a FRESH segment, NOT a continuation of the pre-compaction buffer — the reset round's
+// input must not share the pre-reset round-0 prefix (real compaction replaces history
+// with a summary, mirroring SessionManager.OnComplete's Reset semantics, #1609).
+func TestFixedAccumulate_CompactionReset_Content(t *testing.T) {
+	reset := int64(120)
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 200, OutputTokens: 100, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 0, InputTokensReset: &reset, OutputTokens: 30, ArrivalTimeUs: 1_000_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r0 := reqs[0].FullInputTokens() // 200 tokens
+	r1 := reqs[1].FullInputTokens() // 120 tokens (reset), NOT 200+100+delta
+	if len(r1) != 120 {
+		t.Fatalf("reset round input len = %d, want 120", len(r1))
+	}
+	// The reset segment is freshly generated: it must NOT be a prefix continuation of
+	// round 0 (otherwise the buffer wasn't reset — it just kept growing).
+	sharedPrefix := 0
+	for sharedPrefix < len(r0) && sharedPrefix < len(r1) && r0[sharedPrefix] == r1[sharedPrefix] {
+		sharedPrefix++
+	}
+	if sharedPrefix == len(r1) {
+		t.Error("reset round input is a prefix of round 0 — buffer was not reset (compaction ignored)")
+	}
+}
+
 // TestFixedAccumulate_NonSessionPassThrough (BC-6): non-session single-shot records
 // inject at their recorded arrival with their recorded absolute input.
 func TestFixedAccumulate_NonSessionPassThrough(t *testing.T) {
@@ -177,6 +233,50 @@ func TestFixedAccumulate_PrefixMetadataParity(t *testing.T) {
 	}
 	if reqs[1].PrefixGroup != "" || reqs[1].PrefixLength != 0 {
 		t.Errorf("follow-up prefix = %q/%d, want empty (prefix folded into buffer)", reqs[1].PrefixGroup, reqs[1].PrefixLength)
+	}
+}
+
+// TestFixedAccumulate_MultiSessionArrivalOrder: the returned slice must be
+// non-decreasing in ArrivalTime (the RequestSource contract) even when sessions
+// interleave in time. Sessions are built session-major (all of s1, then s2), but a
+// high-concurrency corpus interleaves arrivals — s2's round 0 lands between s1's rounds.
+func TestFixedAccumulate_MultiSessionArrivalOrder(t *testing.T) {
+	// s1 arrivals 0, 1_000_000, 2_000_000; s2 arrivals 500_000, 1_500_000 — interleaved.
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 30, OutputTokens: 40, ArrivalTimeUs: 1_000_000, Status: "ok"},
+		{RequestID: 2, SessionID: "s1", RoundIndex: 2, InputTokens: 25, OutputTokens: 20, ArrivalTimeUs: 2_000_000, Status: "ok"},
+		{RequestID: 3, SessionID: "s2", RoundIndex: 0, InputTokens: 60, OutputTokens: 15, ArrivalTimeUs: 500_000, Status: "ok"},
+		{RequestID: 4, SessionID: "s2", RoundIndex: 1, InputTokens: 20, OutputTokens: 10, ArrivalTimeUs: 1_500_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 5 {
+		t.Fatalf("expected 5 requests, got %d", len(reqs))
+	}
+	for i := 1; i < len(reqs); i++ {
+		if reqs[i].ArrivalTime < reqs[i-1].ArrivalTime {
+			t.Errorf("request %d arrival %d < request %d arrival %d — RequestSource order violated",
+				i, reqs[i].ArrivalTime, i-1, reqs[i-1].ArrivalTime)
+		}
+	}
+	// Reconstruction must survive the sort: each session's rounds keep their absolute
+	// inputs regardless of interleaving. Verify via a session_id → round → len map.
+	got := map[string]map[int]int{}
+	for _, r := range reqs {
+		if got[r.SessionID] == nil {
+			got[r.SessionID] = map[int]int{}
+		}
+		got[r.SessionID][r.RoundIndex] = int(r.InputLen())
+	}
+	if got["s1"][0] != 100 || got["s1"][1] != 180 || got["s1"][2] != 245 {
+		t.Errorf("s1 absolute inputs = %v, want 100/180/245", got["s1"])
+	}
+	if got["s2"][0] != 60 || got["s2"][1] != 95 {
+		t.Errorf("s2 absolute inputs = %v, want 60/95", got["s2"])
 	}
 }
 

--- a/sim/workload/fixed_accumulate_test.go
+++ b/sim/workload/fixed_accumulate_test.go
@@ -65,6 +65,71 @@ func TestFixedAccumulate_ReconstructsAbsoluteInputs(t *testing.T) {
 	}
 }
 
+// TestFixedAccumulate_EncoderRoundTrip (BC-1, BC-3): pins the reconstruction to the REAL
+// EncodeSessionToTraceRecords law rather than to hand-computed deltas. Every other test in
+// this file hand-computes the delta (e.g. 180-100-50=30), so all would pass even if the
+// loader and encoder disagreed. This drives known absolutes (including shrinking rounds
+// that trigger compaction) through the actual encoder, then asserts the loader
+// reconstructs each round's exact recorded absolute. Randomized over many trials — the RNG
+// only varies the shape (seeded off the trial index; no Math.rand/time), keeping it
+// deterministic and INV-6-safe.
+func TestFixedAccumulate_EncoderRoundTrip(t *testing.T) {
+	for trial := 0; trial < 200; trial++ {
+		// Deterministic pseudo-random shape from the trial index (no wall-clock/global rng).
+		rng := deterministicShapeRNG(int64(trial))
+		nRounds := 1 + rng(8) // 1..8 rounds
+		abs := make([]int, nRounds)
+		out := make([]int, nRounds)
+		prev := 20 + rng(200)
+		for i := 0; i < nRounds; i++ {
+			out[i] = rng(50)
+			if i == 0 {
+				abs[i] = prev
+			} else if rng(3) == 0 {
+				// ~1/3 compaction rounds: shrink below prev+out (forces InputTokensReset).
+				abs[i] = 5 + rng(prev)
+			} else {
+				abs[i] = abs[i-1] + out[i-1] + rng(100) // monotone growth
+			}
+		}
+		rounds := make([]NormalizedRound, nRounds)
+		for i := range rounds {
+			rounds[i] = NormalizedRound{InputTokensAbs: abs[i], OutputTokens: out[i], ArrivalUs: int64(i * 1000), Status: "ok"}
+		}
+		recs := EncodeSessionToTraceRecords("s1", rounds)
+		for i := range recs {
+			recs[i].RequestID = i
+		}
+		trace := buildAccumulateTrace(t, recs)
+		reqs, err := LoadTraceV2FixedAccumulateRequests(trace, int64(trial))
+		if err != nil {
+			t.Fatalf("trial %d: %v", trial, err)
+		}
+		if len(reqs) != nRounds {
+			t.Fatalf("trial %d: got %d requests, want %d", trial, len(reqs), nRounds)
+		}
+		for i, r := range reqs {
+			if int(r.InputLen()) != abs[i] {
+				t.Fatalf("trial %d round %d: reconstructed input = %d, want recorded absolute %d (encoder/loader law drift)", trial, i, r.InputLen(), abs[i])
+			}
+		}
+	}
+}
+
+// deterministicShapeRNG returns a closure yielding a pseudo-random int in [0, n) from a
+// seeded LCG — deterministic (INV-6) and free of Math.rand/time so the round-trip test's
+// shapes are reproducible across runs.
+func deterministicShapeRNG(seed int64) func(n int) int {
+	state := uint64(seed)*2862933555777941757 + 3037000493
+	return func(n int) int {
+		state = state*6364136223846793005 + 1442695040888963407
+		if n <= 0 {
+			return 0
+		}
+		return int((state >> 33) % uint64(n))
+	}
+}
+
 // TestFixedAccumulate_GrowingPrefixConsistent (BC-2): round N's input token IDs are
 // a strict prefix of round N+1's input token IDs (the growing conversation), so a
 // prefix-cache probe across consecutive rounds hits.
@@ -283,6 +348,39 @@ func TestFixedAccumulate_ViewsStableAfterGrowthAndReset(t *testing.T) {
 				t.Fatalf("round %d view token %d mutated after session build (%d != %d)", i, j, live[j], snaps[i][j])
 			}
 		}
+	}
+}
+
+// TestFixedAccumulate_EpochScopedCapacity pins PR-review F1: the backing array of each
+// round's view is sized to its EPOCH's peak, not the session's GLOBAL peak. The failure
+// mode: a tiny first epoch followed by a huge later epoch — sizing to the global peak
+// would pin round 0's tiny view inside a giant array, retaining more than an eager copy.
+func TestFixedAccumulate_EpochScopedCapacity(t *testing.T) {
+	// Epoch 0: round 0 tiny (10 tokens). Round 1 compacts (reset to 5), opening epoch 1,
+	// which then grows huge (delta 5000). Global peak ≈ 5000+; epoch-0 peak is 10.
+	reset := int64(5)
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 10, OutputTokens: 2, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 0, InputTokensReset: &reset, OutputTokens: 3, ArrivalTimeUs: 1000, Status: "ok"},
+		{RequestID: 2, SessionID: "s1", RoundIndex: 2, InputTokens: 5000, OutputTokens: 4, ArrivalTimeUs: 2000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(reqs))
+	}
+	// Round 0's view (epoch 0, peak 10) must NOT be backed by an array sized for the huge
+	// later epoch. cap of the round-0 InputTokens slice reflects its backing array size.
+	r0cap := cap(reqs[0].InputTokens)
+	if int64(r0cap) > 100 { // generous slack over epoch-0 peak (10); the bug gives ~5008
+		t.Errorf("round 0 view cap = %d, want ~10 (epoch-scoped); a global-peak alloc would pin ~5008 (F1 regression)", r0cap)
+	}
+	// Round 2 (epoch 1) is correctly the large one — sanity that reconstruction still works.
+	if int(reqs[2].InputLen()) != 5008 { // reset 5 + out 3 + delta 5000
+		t.Errorf("round 2 input len = %d, want 5008 (reset 5 + prev out 3 + delta 5000)", reqs[2].InputLen())
 	}
 }
 

--- a/sim/workload/fixed_accumulate_test.go
+++ b/sim/workload/fixed_accumulate_test.go
@@ -152,6 +152,34 @@ func TestFixedAccumulate_NonSessionPassThrough(t *testing.T) {
 	}
 }
 
+// TestFixedAccumulate_PrefixMetadataParity: round 0 carries PrefixGroup/PrefixLength
+// (for cross-session prefix-affinity routing, parity with LoadTraceV2SessionBlueprints),
+// but follow-up rounds do NOT (accumulate folds the prefix into the growing buffer).
+func TestFixedAccumulate_PrefixMetadataParity(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, PrefixGroup: "sys", PrefixLength: 8, InputTokens: 20, OutputTokens: 5, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 4, OutputTokens: 3, ArrivalTimeUs: 1000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(reqs))
+	}
+	if reqs[0].PrefixGroup != "sys" || reqs[0].PrefixLength != 8 {
+		t.Errorf("round 0 prefix = %q/%d, want sys/8", reqs[0].PrefixGroup, reqs[0].PrefixLength)
+	}
+	// round 0 input = prefix(8) + suffix(20) = 28 tokens.
+	if int(reqs[0].InputLen()) != 28 {
+		t.Errorf("round 0 input len = %d, want 28 (prefix 8 + suffix 20)", reqs[0].InputLen())
+	}
+	if reqs[1].PrefixGroup != "" || reqs[1].PrefixLength != 0 {
+		t.Errorf("follow-up prefix = %q/%d, want empty (prefix folded into buffer)", reqs[1].PrefixGroup, reqs[1].PrefixLength)
+	}
+}
+
 // TestFixedAccumulate_NonConsecutiveRounds_Error (R1): a session with a round gap
 // must error rather than silently misreconstruct.
 func TestFixedAccumulate_NonConsecutiveRounds_Error(t *testing.T) {

--- a/sim/workload/fixed_accumulate_test.go
+++ b/sim/workload/fixed_accumulate_test.go
@@ -1,0 +1,197 @@
+package workload
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/inference-sim/inference-sim/sim"
+)
+
+// buildAccumulateTrace writes a two-session accumulate corpus to a temp dir and
+// loads it back, returning the parsed TraceV2. Records carry per-round DELTAS
+// (the encoder's law), so the absolute inputs are reconstructed at replay.
+func buildAccumulateTrace(t *testing.T, records []TraceRecord) *TraceV2 {
+	t.Helper()
+	header := &TraceHeader{Version: 3, TimeUnit: "microseconds", Mode: "generated", SessionContextGrowth: "accumulate"}
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "header.yaml")
+	dataPath := filepath.Join(dir, "data.csv")
+	if err := ExportTraceV2(header, records, headerPath, dataPath); err != nil {
+		t.Fatal(err)
+	}
+	trace, err := LoadTraceV2(headerPath, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return trace
+}
+
+// TestFixedAccumulate_ReconstructsAbsoluteInputs (BC-1): a session whose recorded
+// absolute inputs grow across rounds must produce requests whose InputTokens count
+// equals the recorded absolute per round, injected at the recorded arrival time.
+func TestFixedAccumulate_ReconstructsAbsoluteInputs(t *testing.T) {
+	// Session "s1": abs inputs 100, 100+50+30=180, 180+40+25=245.
+	// Deltas: round0=100; round1 = 180-100-50 = 30; round2 = 245-180-40 = 25.
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 100, OutputTokens: 50, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 30, OutputTokens: 40, ArrivalTimeUs: 1_000_000, Status: "ok"},
+		{RequestID: 2, SessionID: "s1", RoundIndex: 2, InputTokens: 25, OutputTokens: 20, ArrivalTimeUs: 2_000_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(reqs))
+	}
+	wantAbs := []int{100, 180, 245}
+	wantArrival := []int64{0, 1_000_000, 2_000_000}
+	for i, r := range reqs {
+		if int(r.InputLen()) != wantAbs[i] {
+			t.Errorf("round %d input len = %d, want absolute %d", i, r.InputLen(), wantAbs[i])
+		}
+		if r.ArrivalTime != wantArrival[i] {
+			t.Errorf("round %d arrival = %d, want %d", i, r.ArrivalTime, wantArrival[i])
+		}
+		if r.RoundIndex != i {
+			t.Errorf("round %d RoundIndex = %d, want %d", i, r.RoundIndex, i)
+		}
+		if r.SessionID != "s1" {
+			t.Errorf("round %d SessionID = %q, want s1", i, r.SessionID)
+		}
+	}
+}
+
+// TestFixedAccumulate_GrowingPrefixConsistent (BC-2): round N's input token IDs are
+// a strict prefix of round N+1's input token IDs (the growing conversation), so a
+// prefix-cache probe across consecutive rounds hits.
+func TestFixedAccumulate_GrowingPrefixConsistent(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 60, OutputTokens: 10, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 15, OutputTokens: 8, ArrivalTimeUs: 500_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(reqs))
+	}
+	r0 := reqs[0].FullInputTokens()
+	r1 := reqs[1].FullInputTokens()
+	if len(r1) <= len(r0) {
+		t.Fatalf("round 1 input (%d) should be longer than round 0 (%d)", len(r1), len(r0))
+	}
+	for i := range r0 {
+		if r1[i] != r0[i] {
+			t.Fatalf("round 1 input token %d = %d, want round-0 prefix token %d", i, r1[i], r0[i])
+		}
+	}
+	// round 1 input must begin with round-0 input (60) then round-0 output (10).
+	r0out := reqs[0].OutputTokens
+	for i := range r0out {
+		if r1[len(r0)+i] != r0out[i] {
+			t.Fatalf("round 1 input token %d (after r0 input) = %d, want round-0 output token %d", len(r0)+i, r1[len(r0)+i], r0out[i])
+		}
+	}
+}
+
+// TestFixedAccumulate_CompactionReset (BC-3): a round carrying an input_tokens_reset
+// marker re-seeds the buffer to the recorded absolute, not the over-counted delta.
+func TestFixedAccumulate_CompactionReset(t *testing.T) {
+	// round0 abs=200, out=100. round1 recorded abs=120 (< 200+100), so the encoder
+	// emits delta=0 + input_tokens_reset=120. fixed-accumulate must produce input len 120.
+	reset := int64(120)
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 200, OutputTokens: 100, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 0, InputTokensReset: &reset, OutputTokens: 30, ArrivalTimeUs: 1_000_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(reqs))
+	}
+	if int(reqs[1].InputLen()) != 120 {
+		t.Errorf("round 1 (compaction) input len = %d, want reset absolute 120", reqs[1].InputLen())
+	}
+}
+
+// TestFixedAccumulate_NonSessionPassThrough (BC-6): non-session single-shot records
+// inject at their recorded arrival with their recorded absolute input.
+func TestFixedAccumulate_NonSessionPassThrough(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 50, OutputTokens: 10, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, InputTokens: 80, OutputTokens: 20, ArrivalTimeUs: 250_000, Status: "ok"}, // non-session
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// find the non-session request
+	var found *sim.Request
+	for _, r := range reqs {
+		if r.SessionID == "" {
+			found = r
+		}
+	}
+	if found == nil {
+		t.Fatal("non-session request not found")
+	}
+	if int(found.InputLen()) != 80 {
+		t.Errorf("non-session input len = %d, want 80", found.InputLen())
+	}
+	if found.ArrivalTime != 250_000 {
+		t.Errorf("non-session arrival = %d, want 250000", found.ArrivalTime)
+	}
+}
+
+// TestFixedAccumulate_NonConsecutiveRounds_Error (R1): a session with a round gap
+// must error rather than silently misreconstruct.
+func TestFixedAccumulate_NonConsecutiveRounds_Error(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 10, OutputTokens: 5, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 2, InputTokens: 5, OutputTokens: 5, ArrivalTimeUs: 1000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	if _, err := LoadTraceV2FixedAccumulateRequests(trace, 1); err == nil {
+		t.Fatal("expected error for non-consecutive round indices, got nil")
+	}
+}
+
+// TestFixedAccumulate_Deterministic (BC-4): same trace + seed → identical token IDs.
+func TestFixedAccumulate_Deterministic(t *testing.T) {
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 40, OutputTokens: 10, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 5, OutputTokens: 8, ArrivalTimeUs: 1000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	a, err := LoadTraceV2FixedAccumulateRequests(trace, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := LoadTraceV2FixedAccumulateRequests(trace, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a) != len(b) {
+		t.Fatalf("length mismatch %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		ai, bi := a[i].FullInputTokens(), b[i].FullInputTokens()
+		if len(ai) != len(bi) {
+			t.Fatalf("req %d input length mismatch", i)
+		}
+		for j := range ai {
+			if ai[j] != bi[j] {
+				t.Fatalf("req %d input token %d differs across runs", i, j)
+			}
+		}
+	}
+}

--- a/sim/workload/fixed_accumulate_test.go
+++ b/sim/workload/fixed_accumulate_test.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/inference-sim/inference-sim/sim"
@@ -236,6 +237,55 @@ func TestFixedAccumulate_PrefixMetadataParity(t *testing.T) {
 	}
 }
 
+// TestFixedAccumulate_ViewsStableAfterGrowthAndReset pins the shared-buffer view
+// contract (the memory optimization from PR review F1): each round's InputTokens is a
+// VIEW into the session buffer, not a copy, so it must remain content-correct after all
+// later growth AND after a compaction reset reallocates the backing array. We snapshot
+// every round's expected content up front, then re-read after the whole session is built.
+func TestFixedAccumulate_ViewsStableAfterGrowthAndReset(t *testing.T) {
+	// Growth rounds 0,1 then a compaction reset at round 2 (reset reallocates the buffer),
+	// then growth again at round 3 — exercises both hazards the removed copy guarded against.
+	reset := int64(50)
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 40, OutputTokens: 10, ArrivalTimeUs: 0, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 8, OutputTokens: 6, ArrivalTimeUs: 1000, Status: "ok"},
+		{RequestID: 2, SessionID: "s1", RoundIndex: 2, InputTokens: 0, InputTokensReset: &reset, OutputTokens: 5, ArrivalTimeUs: 2000, Status: "ok"},
+		{RequestID: 3, SessionID: "s1", RoundIndex: 3, InputTokens: 7, OutputTokens: 4, ArrivalTimeUs: 3000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 4 {
+		t.Fatalf("expected 4 requests, got %d", len(reqs))
+	}
+	// Expected absolute lengths: r0=40, r1=40+10+8=58, r2=reset 50, r3=50+5+7=62.
+	wantLen := []int{40, 58, 50, 62}
+	// Snapshot each round's content immediately (defensive copies) so we can detect
+	// later mutation of a shared backing array.
+	snaps := make([][]sim.TokenID, len(reqs))
+	for i, r := range reqs {
+		if int(r.InputLen()) != wantLen[i] {
+			t.Fatalf("round %d input len = %d, want %d", i, r.InputLen(), wantLen[i])
+		}
+		snaps[i] = append([]sim.TokenID(nil), r.FullInputTokens()...)
+	}
+	// Re-read every round's live view AFTER the whole session is built: it must still
+	// equal the snapshot (no shift from later Append, no orphan-corruption from Reset).
+	for i, r := range reqs {
+		live := r.FullInputTokens()
+		if len(live) != len(snaps[i]) {
+			t.Fatalf("round %d view length changed: %d != %d", i, len(live), len(snaps[i]))
+		}
+		for j := range live {
+			if live[j] != snaps[i][j] {
+				t.Fatalf("round %d view token %d mutated after session build (%d != %d)", i, j, live[j], snaps[i][j])
+			}
+		}
+	}
+}
+
 // TestFixedAccumulate_MultiSessionArrivalOrder: the returned slice must be
 // non-decreasing in ArrivalTime (the RequestSource contract) even when sessions
 // interleave in time. Sessions are built session-major (all of s1, then s2), but a
@@ -277,6 +327,88 @@ func TestFixedAccumulate_MultiSessionArrivalOrder(t *testing.T) {
 	}
 	if got["s2"][0] != 60 || got["s2"][1] != 95 {
 		t.Errorf("s2 absolute inputs = %v, want 60/95", got["s2"])
+	}
+}
+
+// TestFixedAccumulate_FieldParityWithLoadTraceV2Requests (R4/R23): guards against field
+// drift between the two TraceRecord → sim.Request construction sites. A fully-populated
+// NON-session record must map to the SAME sim.Request through both LoadTraceV2Requests
+// and the fixed-accumulate loader (both treat a non-session record as suffix-only input
+// at recorded arrival). Token-slice CONTENTS differ by RNG, so we compare all fields
+// except the token slices (compared by length) and ID. If a future field is added to one
+// loader's struct literal but not the other, this test fails.
+func TestFixedAccumulate_FieldParityWithLoadTraceV2Requests(t *testing.T) {
+	rec := TraceRecord{
+		RequestID: 7, ClientID: "c9", TenantID: "t3", SLOClass: "critical",
+		PrefixGroup: "grp", PrefixLength: 4, Streaming: true,
+		InputTokens: 30, OutputTokens: 12, TextTokens: 20, ImageTokens: 5,
+		AudioTokens: 3, VideoTokens: 2, ReasonRatio: 0.25, Model: "m1",
+		DeadlineUs: 900_000, SLOTargetUs: 120_000, Adapter: "ad1",
+		ArrivalTimeUs: 111_000, Status: "ok",
+	}
+	// No session_id → non-session record. Both loaders take the same construction path.
+	trace := buildAccumulateTrace(t, []TraceRecord{rec})
+	viaFixedAcc, err := LoadTraceV2FixedAccumulateRequests(trace, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viaFixed, err := LoadTraceV2Requests(trace, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(viaFixedAcc) != 1 || len(viaFixed) != 1 {
+		t.Fatalf("expected 1 request each, got %d / %d", len(viaFixedAcc), len(viaFixed))
+	}
+	a, b := viaFixedAcc[0], viaFixed[0]
+	// Token slice lengths must match; contents are RNG-dependent so not compared here.
+	if a.InputLen() != b.InputLen() || len(a.OutputTokens) != len(b.OutputTokens) {
+		t.Fatalf("token lengths differ: in %d/%d out %d/%d", a.InputLen(), b.InputLen(), len(a.OutputTokens), len(b.OutputTokens))
+	}
+	// Zero the fields that legitimately differ or aren't structural (ID is identical here
+	// anyway, but tokens carry RNG content), then require struct equality on the rest.
+	clear := func(r *sim.Request) sim.Request {
+		c := *r
+		c.InputTokens = nil
+		c.OutputTokens = nil
+		return c
+	}
+	if !reflect.DeepEqual(clear(a), clear(b)) {
+		t.Errorf("field drift between fixed-accumulate and LoadTraceV2Requests construction:\nfixed-acc: %+v\nfixed:     %+v", clear(a), clear(b))
+	}
+}
+
+// TestFixedAccumulate_NormalizesEpochSendOrigin (#1606): a corpus whose send_time_us is
+// epoch-scale while arrival_time_us is run-relative must inject on the arrival origin
+// (not at epoch scale), with send-delta spacing preserved — the same normalization
+// LoadTraceV2Requests applies, exercised on the fixed-accumulate loader.
+func TestFixedAccumulate_NormalizesEpochSendOrigin(t *testing.T) {
+	const epoch = int64(1_787_274_995_712_218)
+	// One session, two rounds. Round 0 waited 100ms for a slot, round 1 waited 300ms,
+	// so the SEND delta (200000) differs from the ARRIVAL delta (50000).
+	records := []TraceRecord{
+		{RequestID: 0, SessionID: "s1", RoundIndex: 0, InputTokens: 40, OutputTokens: 10,
+			ArrivalTimeUs: 0, SendTimeUs: epoch + 100_000, DeadlineUs: 300_000_000, Status: "ok"},
+		{RequestID: 1, SessionID: "s1", RoundIndex: 1, InputTokens: 5, OutputTokens: 8,
+			ArrivalTimeUs: 50_000, SendTimeUs: epoch + 300_000, DeadlineUs: 350_000_000, Status: "ok"},
+	}
+	trace := buildAccumulateTrace(t, records)
+	reqs, err := LoadTraceV2FixedAccumulateRequests(trace, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(reqs))
+	}
+	// Re-based onto the arrival origin: earliest injection is 0, not epoch-scale.
+	if reqs[0].ArrivalTime != 0 {
+		t.Errorf("round 0 ArrivalTime = %d, want 0 (arrival origin, not epoch)", reqs[0].ArrivalTime)
+	}
+	if reqs[0].ArrivalTime >= reqs[0].Deadline {
+		t.Errorf("round 0 injected at %d >= deadline %d — would instant-timeout (#1606)", reqs[0].ArrivalTime, reqs[0].Deadline)
+	}
+	// Spacing follows the SEND delta (200000), not the arrival delta (50000).
+	if gotDelta := reqs[1].ArrivalTime - reqs[0].ArrivalTime; gotDelta != 200_000 {
+		t.Errorf("injection delta = %d, want 200000 (send delta)", gotDelta)
 	}
 }
 

--- a/sim/workload/session_buffer.go
+++ b/sim/workload/session_buffer.go
@@ -101,7 +101,21 @@ func (s *sessionTokenBuffer) Slice(start, end int64) []sim.TokenID {
 // freshly-generated slice; copying keeps Reset's contract independent of caller aliasing,
 // mirroring Append.
 func (s *sessionTokenBuffer) Reset(toks []sim.TokenID) (start, end int64) {
-	nb := make([]sim.TokenID, len(toks))
+	return s.ResetWithCapacity(toks, int64(len(toks)))
+}
+
+// ResetWithCapacity is Reset with an explicit backing-array capacity for the fresh
+// segment. Use it when the caller knows how much the post-reset segment will grow (e.g.
+// a fixed-arrival accumulate loader that knows the remaining epoch's peak from the trace),
+// so the appends after a compaction boundary do not reallocate — keeping every view in
+// the new epoch aliased to ONE array. capacity is clamped up to len(toks) (a smaller
+// value would make the initial segment itself overflow). Same fresh-array safety model as
+// Reset (earlier Slice() views keep pointing at the old, unmutated array).
+func (s *sessionTokenBuffer) ResetWithCapacity(toks []sim.TokenID, capacity int64) (start, end int64) {
+	if capacity < int64(len(toks)) {
+		capacity = int64(len(toks))
+	}
+	nb := make([]sim.TokenID, len(toks), capacity)
 	copy(nb, toks)
 	s.b = nb
 	return 0, int64(len(nb))

--- a/sim/workload/session_buffer_test.go
+++ b/sim/workload/session_buffer_test.go
@@ -155,6 +155,46 @@ func TestSessionTokenBufferResetShrinksAndPreservesOrphan(t *testing.T) {
 	}
 }
 
+// TestSessionTokenBufferResetWithCapacity verifies the explicit-capacity reset (#1696):
+// the fresh segment has the requested capacity (so later appends don't reallocate), the
+// content is correct, and a capacity below len(toks) is clamped up to len(toks).
+func TestSessionTokenBufferResetWithCapacity(t *testing.T) {
+	b := newSessionTokenBuffer()
+	b.Append([]sim.TokenID{1, 2, 3})
+	prior := b.Slice(0, 3)
+
+	// Reset to [7,8] but reserve capacity for 10 tokens.
+	start, end := b.ResetWithCapacity([]sim.TokenID{7, 8}, 10)
+	if start != 0 || end != 2 {
+		t.Fatalf("ResetWithCapacity returned [%d,%d), want [0,2)", start, end)
+	}
+	if b.Len() != 2 {
+		t.Fatalf("len after ResetWithCapacity = %d, want 2", b.Len())
+	}
+	if b.bufCap() != 10 {
+		t.Errorf("cap after ResetWithCapacity = %d, want 10 (reserved)", b.bufCap())
+	}
+	// Appending up to the reserved capacity must NOT reallocate (view start address stable).
+	viewAddr := &b.Slice(0, 2)[0]
+	b.Append([]sim.TokenID{9, 10, 11, 12, 13, 14, 15, 16}) // fills to exactly cap=10
+	if newAddr := &b.Slice(0, 2)[0]; newAddr != viewAddr {
+		t.Error("append within reserved capacity reallocated — capacity reservation ineffective")
+	}
+	// Orphaned prior view stays content-correct.
+	if !reflect.DeepEqual(prior, []sim.TokenID{1, 2, 3}) {
+		t.Errorf("orphan drifted after ResetWithCapacity: got %v", prior)
+	}
+
+	// Capacity below len(toks) is clamped up to len(toks) (no truncation).
+	start2, end2 := b.ResetWithCapacity([]sim.TokenID{20, 21, 22, 23}, 2)
+	if start2 != 0 || end2 != 4 {
+		t.Fatalf("clamped ResetWithCapacity returned [%d,%d), want [0,4)", start2, end2)
+	}
+	if b.bufCap() < 4 {
+		t.Errorf("cap after clamped ResetWithCapacity = %d, want >= 4", b.bufCap())
+	}
+}
+
 func TestSessionTokenBufferForcedReallocOrphanContentCorrect(t *testing.T) {
 	// Start with cap=4. The first Slice() returns a view of [1,2,3,4].
 	b := newSessionTokenBufferWithCapacity(4)


### PR DESCRIPTION
## Summary

Adds `blis replay --session-mode fixed-accumulate` (#1692): a replay mode that injects each session round at its **recorded arrival time** (open-loop, like `--session-mode fixed`) while **reconstructing the growing accumulate-delta input** (like `--session-mode closed-loop`). It is the only faithful way to replay a high-concurrency agentic corpus (Weka/OTel).

### The problem

An accumulate corpus (`session_context_growth: accumulate`) couples two independent axes that are only individually available today:

- **closed-loop** reconstructs the growing context but *regenerates* arrivals as `completion + think` — a self-throttling feedback loop that drains the queue and collapses TTFT to compute-only (30–100× below real at concurrency ≥ 8).
- **fixed** replays recorded arrivals but is hard-rejected on an accumulate corpus (it reads per-round `input_tokens` as absolutes, not deltas).

The key realization: the growing buffer needs **no live sim output**. The trace's delta chain (`abs_N = abs_{N-1} + out_{N-1} + delta_N`) plus `input_tokens_reset` compaction markers fully determines every round's absolute input from trace data alone. So the loader walks that delta law to pre-bake every round as a request at its recorded arrival — preserving the real cross-session overlap so N large prefills pile into the scheduler at the real clock and produce genuine queue wait.

## Behavioral contracts

- **BC-1** Fixed-arrival injection + accumulate reconstruction: each round injected at recorded arrival; input length = recorded absolute `in_N`, not the delta.
- **BC-2** Growing prefix is content-consistent: round N's input is a strict prefix of round N+1's (prefix-cache fidelity).
- **BC-3** Compaction reset honored: an `input_tokens_reset` round re-seeds the buffer to the recorded absolute.
- **BC-4** Determinism (INV-6): same trace + seed → byte-identical stdout.
- **BC-5** Guards (R1): rejects a non-accumulate trace, `--concurrent-sessions` (open-loop, no pool), and keeps the think-time-requires-closed-loop guards.
- **BC-6** Non-session / single-shot records pass through unchanged.

## Files

- `sim/workload/fixed_accumulate.go` (new) — `LoadTraceV2FixedAccumulateRequests`
- `cmd/replay.go` — new mode value, guards, request-building branch (if/else → tagged switch)
- `sim/workload/fixed_accumulate_test.go`, `cmd/replay_fixed_accumulate_test.go` — property + determinism + guard tests
- `docs/contributing/standards/invariants.md` — INV-10 scoped to closed-loop; fixed-accumulate exempt by design
- `CLAUDE.md`, `docs/guide/observe-replay-calibrate.md` — mode docs + #1627 decode caveat

## Testing

`go build ./...`, `go test ./... -count=1` (all pass), `golangci-lint run ./...` (0 issues). End-to-end verified on an 8-session simultaneous-arrival corpus: warm rounds show ~2.3× the TTFT of cold rounds (growing context) and TTFT is in the seconds range from real queueing — behavior impossible in closed-loop. Conservation holds (INV-1: injected = completed + still_running).

## Notes

- **INV-10 exemption:** documented as scoped to closed-loop — chaining arrivals to sim completion is exactly the feedback loop this mode breaks.
- **Necessary, not sufficient (#1627):** BLIS's decode/step model still runs ~5–10× fast on this workload, so queue depth stays under-predicted until decode is calibrated. This mode is a precondition for high-conc fidelity, not a standalone fix — documented in the guide.

Fixes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
