### PR TITLE
hardening(ci): run /blis-pr-review with a read-only token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -228,6 +228,12 @@ jobs:
     #
     # The test is applied to EACH agent job rather than to a pre-collapsed result, so the
     # skipped one cannot admit the job on its own: 'skipped' matches no clause.
+    #
+    # Scope, pre-existing and unchanged here: this fires for issue_comment ONLY, so a review
+    # invoked from a DIFF-LINE comment (pull_request_review_comment) runs and posts its
+    # review but publishes no commit status — that event carries no `issue` object, so the
+    # second clause cannot hold. Extending it means reading the PR number from
+    # github.event.pull_request instead, not just loosening the event test.
     if: |
       always() &&
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,6 +47,10 @@ jobs:
             // one-sided. Over-matching costs the caller write access they may have wanted
             // (re-comment without the command); under-matching runs a review with a token
             // that can push, which is the thing #1697 closes. So when in doubt, route here.
+            //
+            // Includes the `issues:` trigger, where an issue body quoting the command routes
+            // to the review job and checkout falls back to the default branch. Harmless —
+            // there is no PR to review — and still the safe side of the one-sided choice.
             const body = context.payload.comment?.body ?? context.payload.issue?.body ?? '';
             const isReview = body.toLowerCase().includes('/blis-pr-review');
             core.setOutput('is_review', isReview ? 'true' : 'false');
@@ -149,9 +153,13 @@ jobs:
   # granted). `Bash` is required for a review (gh, reading the diff, the review toolkit)
   # and `Bash` can create files anyway, so removing Edit/Write would signal intent
   # without adding a capability boundary — while risking the review itself, since the
-  # toolkit's subagents write scratch/report files. deliver-verify.yml already runs this
-  # same review with this same tool list under `contents: read`, which is the evidence
-  # that the token alone is sufficient and the tool list need not change.
+  # toolkit's subagents write scratch/report files.
+  #
+  # The evidence that the token alone suffices is deliver-verify.yml, which already runs this
+  # same review read-only in production: `contents: read` (its line 31), the identical
+  # `--allowed-tools Skill Agent Bash Read Edit Write` (line 419), invoking the blis-pr-review
+  # skill (line 448). Cited by line because an AI reviewer on #1704 asserted that workflow no
+  # longer invokes Claude at all — it does; verify before acting on a claim either way.
   claude-review:
     needs: check-permissions
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,13 @@
 name: Claude Code Action
 
+# Default for any job that declares no permissions block of its own (today just
+# check-permissions). `contents` is READ here, not write: a job-level block replaces this
+# one wholesale, so the only thing this default can do is hand push access to a future job
+# that forgets its own block — which is precisely how the read-only review path below would
+# be silently re-armed (#1697). The other three scopes are left as they were, so
+# check-permissions' token is unchanged apart from contents.
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
   id-token: write
@@ -23,12 +29,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       allowed: ${{ steps.check.outputs.allowed }}
+      # Routes the trigger to ONE of the two mutually-exclusive agent jobs below.
+      # Computed here, once, so the substring test has a single definition — the two
+      # job-level `if`s then differ only in the sense of the comparison.
+      is_review: ${{ steps.check.outputs.is_review }}
     steps:
       - name: Check invoker permissions
         id: check
         uses: actions/github-script@v8
         with:
           script: |
+            // Before the try, so a bug in these two lines surfaces as a failed job rather
+            // than being absorbed by the catch below and misreported as "not a collaborator".
+            //
+            // The match is deliberately OVER-inclusive: case-insensitive, and satisfied by a
+            // body that merely quotes the command rather than invoking it. Both errors are
+            // one-sided. Over-matching costs the caller write access they may have wanted
+            // (re-comment without the command); under-matching runs a review with a token
+            // that can push, which is the thing #1697 closes. So when in doubt, route here.
+            const body = context.payload.comment?.body ?? context.payload.issue?.body ?? '';
+            const isReview = body.toLowerCase().includes('/blis-pr-review');
+            core.setOutput('is_review', isReview ? 'true' : 'false');
             try {
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
@@ -45,9 +66,27 @@ jobs:
               core.info(`User ${context.actor} is not a collaborator — skipping.`);
             }
 
+  # Two agent jobs, identical steps, DIFFERENT tokens. They exist as two jobs only because
+  # `permissions:` accepts no expressions — it cannot be varied per trigger inside one job.
+  # report-status reads whichever one was not skipped.
+  #
+  # Both `if`s test is_review against an EXPLICIT value, so they are exclusive without being
+  # exhaustive: an unset is_review (which check-permissions cannot produce today — it is set
+  # before the permission probe that produces `allowed`) runs NEITHER job. That is the safe
+  # direction. Writing the non-review gate as `!= 'true'` would instead make an unset value
+  # route a review down the WRITE path, reintroducing exactly what #1697 closes.
+  #
+  #   claude        — every non-review @claude trigger. contents: write, since CLAUDE.md
+  #                   allows these to be asked for a code change.
+  #   claude-review — /blis-pr-review only. contents: read (#1697).
+  #
+  # KEEP THE STEPS IN SYNC. A fix applied to one belongs in the other; the only intended
+  # difference is the permissions block.
   claude:
     needs: check-permissions
-    if: needs.check-permissions.outputs.allowed == 'true'
+    if: |
+      needs.check-permissions.outputs.allowed == 'true' &&
+      needs.check-permissions.outputs.is_review == 'false'
     runs-on: [self-hosted]
     timeout-minutes: 60
     permissions:
@@ -56,12 +95,11 @@ jobs:
       issues: write
       id-token: write
     outputs:
-      # Both are EMPTY when the action returns early ("No trigger found, skipping remaining
-      # steps") — the outer trigger below is a broad substring test, so a comment that merely
+      # EMPTY when the action returns early ("No trigger found, skipping remaining steps")
+      # — the outer trigger below is a broad substring test, so a comment that merely
       # mentions @claude in prose admits the job and the action then no-ops. The job still
       # concludes 'success', so report-status must not read the job result alone (see #1675).
       execution_file: ${{ steps.claude.outputs.execution_file }}
-      conclusion: ${{ steps.claude.outputs.conclusion }}
 
     steps:
       - uses: actions/checkout@v5
@@ -102,8 +140,73 @@ jobs:
             pr-review-toolkit@claude-plugins-official
             superpowers@superpowers-marketplace
 
+  # The /blis-pr-review path: a reviewer must not be able to change what it reviews.
+  # `contents: read` is the ACTUAL control here — the token cannot push, so nothing the
+  # agent writes in the ephemeral checkout can reach a branch, and a `git push` fails
+  # loudly with a 403 at the point of attempt instead of appearing to work.
+  #
+  # The tool list is deliberately UNCHANGED from the write path (`Edit`/`Write` still
+  # granted). `Bash` is required for a review (gh, reading the diff, the review toolkit)
+  # and `Bash` can create files anyway, so removing Edit/Write would signal intent
+  # without adding a capability boundary — while risking the review itself, since the
+  # toolkit's subagents write scratch/report files. deliver-verify.yml already runs this
+  # same review with this same tool list under `contents: read`, which is the evidence
+  # that the token alone is sufficient and the tool list need not change.
+  claude-review:
+    needs: check-permissions
+    if: |
+      needs.check-permissions.outputs.allowed == 'true' &&
+      needs.check-permissions.outputs.is_review == 'true'
+    runs-on: [self-hosted]
+    timeout-minutes: 60
+    permissions:
+      contents: read          # cannot push — the whole point of this job (#1697)
+      pull-requests: write    # post the review comment
+      issues: write           # post on an issue-shaped trigger
+      id-token: write         # required by claude-code-action, as in every other workflow
+      # No statuses: write. The commit status is published by report-status below, not by
+      # the agent — so the review cannot set its own verdict either.
+    outputs:
+      # Same early-return semantics as the write path above — see that comment.
+      execution_file: ${{ steps.claude.outputs.execution_file }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          # Same PR-head ref resolution as the write path — see the comment there for why
+          # an explicit ref is required.
+          ref: >-
+            ${{ github.event_name == 'pull_request_review_comment'
+                && format('refs/pull/{0}/head', github.event.pull_request.number)
+             || (github.event.issue.pull_request
+                && format('refs/pull/{0}/head', github.event.issue.number))
+             || '' }}
+
+      - uses: anthropics/claude-code-action@v1
+        id: claude
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          CLAUDE_CODE_DISABLE_THINKING: "1"
+        with:
+          anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
+          claude_args: '--model claude-sonnet-4-6 --allowed-tools Skill Agent Bash Read Edit Write'
+          show_full_output: true
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-plugins-official.git
+            https://github.com/obra/superpowers-marketplace.git
+          plugins: |
+            code-review@claude-plugins-official
+            code-simplifier@claude-plugins-official
+            frontend-design@claude-plugins-official
+            pr-review-toolkit@claude-plugins-official
+            superpowers@superpowers-marketplace
+
   report-status:
-    needs: claude
+    # Both agent jobs, because either could be the one that ran. They are mutually
+    # exclusive, so the other is always 'skipped' with empty outputs — which is exactly
+    # what the "did work happen?" test below already knows how to reject.
+    needs: [claude, claude-review]
     # Publish a verdict ONLY when Claude actually ran. Two no-op paths otherwise corrupt the
     # status, and the job RESULT alone cannot tell them apart:
     #
@@ -122,11 +225,16 @@ jobs:
     # Stated positively so a new job result cannot silently fall through to a status. A real
     # success that somehow reported no execution_file publishes NOTHING rather than a verdict:
     # a missing status is visible and honest, a wrong one is neither.
+    #
+    # The test is applied to EACH agent job rather than to a pre-collapsed result, so the
+    # skipped one cannot admit the job on its own: 'skipped' matches no clause.
     if: |
       always() &&
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&
       (needs.claude.result == 'failure' || needs.claude.result == 'cancelled' ||
-       (needs.claude.result == 'success' && needs.claude.outputs.execution_file != ''))
+       (needs.claude.result == 'success' && needs.claude.outputs.execution_file != '') ||
+       needs.claude-review.result == 'failure' || needs.claude-review.result == 'cancelled' ||
+       (needs.claude-review.result == 'success' && needs.claude-review.outputs.execution_file != ''))
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -153,7 +261,10 @@ jobs:
         if: steps.pr-info.outcome == 'success'
         uses: actions/github-script@v8
         env:
-          CLAUDE_RESULT: ${{ needs.claude.result }}
+          # Whichever agent job ran. They are mutually exclusive, so at most one is not
+          # 'skipped'; if both are (the gate above regressed) this yields 'skipped', which
+          # stateMap deliberately does not carry — see the comment on it.
+          CLAUDE_RESULT: ${{ needs.claude.result != 'skipped' && needs.claude.result || needs.claude-review.result }}
           PR_HEAD_SHA: ${{ steps.pr-info.outputs.pr_head_sha }}
         with:
           script: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -155,11 +155,24 @@ jobs:
   # without adding a capability boundary — while risking the review itself, since the
   # toolkit's subagents write scratch/report files.
   #
-  # The evidence that the token alone suffices is deliver-verify.yml, which already runs this
-  # same review read-only in production: `contents: read` (its line 31), the identical
+  # Partial evidence that the token alone suffices is deliver-verify.yml, which already runs
+  # this same review read-only in production: `contents: read` (its line 31), the identical
   # `--allowed-tools Skill Agent Bash Read Edit Write` (line 419), invoking the blis-pr-review
   # skill (line 448). Cited by line because an AI reviewer on #1704 asserted that workflow no
   # longer invokes Claude at all — it does; verify before acting on a claim either way.
+  #
+  # That precedent is only PARTIAL, and the gap is worth knowing before anyone "simplifies"
+  # this job. Every other read-only invocation in the repo passes `prompt:` (agent mode);
+  # this is the repo's only TAG-mode one, and tag mode is what runs the action's `setupBranch`
+  # — whose docs justify Contents write as "for reading repository files and creating
+  # branches". Reading the action source (recorded here so the next editor need not redo it):
+  # on an OPEN PR it fetches and checks out, returning no branch to create; on an issue or a
+  # closed/merged PR it does `repos.get` + `git.getRef` (both reads) and then creates the
+  # branch LOCALLY ONLY, because `use_commit_signing` defaults false and is not set here — the
+  # remote `createRef` path is unreachable. The single `git push` is gated on that branch also
+  # existing remotely, which a locally-created one never does. So no reachable path attempts a
+  # push or a ref write, including the `issues:` over-match above — which is what makes
+  # "harmless" there true rather than hopeful.
   claude-review:
     needs: check-permissions
     if: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,6 +578,8 @@ The following instructions are for Claude Code and other AI assistants working o
 
 When triggered via `@claude /blis-pr-review` on a PR, follow the blis-pr-review skill exactly. For all other triggers (questions, debugging, etc.), respond normally without creating a PR unless explicitly asked.
 
+The `/blis-pr-review` path runs with a **read-only** token (`contents: read`, #1697): it can post the review comment, but cannot push (the commit status is published by a separate job). Report findings — do not fix them, and do not attempt a commit or push, which fails with a 403. Every other `@claude` trigger keeps `contents: write`. See [`docs/contributing/standards/agent-trust.md`](docs/contributing/standards/agent-trust.md).
+
 ### Context Management
 
 When running multi-agent PR reviews, keep individual agent scopes narrow and summarize results concisely. Never try to synthesize all parallel agent outputs into one massive prompt. If hitting context limits, deliver incremental summaries per agent rather than a consolidated report.

--- a/docs/contributing/standards/agent-trust.md
+++ b/docs/contributing/standards/agent-trust.md
@@ -79,6 +79,15 @@ Two limits worth stating, so nobody reads the guarantee as wider than it is:
   collaborator, and `claude.yml` deliberately does not set `allowed_bots` (the delivery
   workflows do, because their phases are dispatched bot-to-bot by design). Do not add
   `allowed_bots` to `claude.yml` without replacing that barrier.
+- `pull-requests: write` is also not append-only — it permits editing and deleting
+  existing comments, so the review *record* is mutable by the reviewer. Posting a review
+  at all requires that scope, so this is inherent to the token model rather than
+  something the split could have avoided. It is the reason the audit trail worth trusting
+  is the workflow run log, not the comment thread.
+
+The permission split is pinned by `scripts/claude_workflow_test.go`, which fails if the
+review job gains write access, if the workflow-level default returns to `contents: write`,
+if the routing gates stop failing closed, or if the two agent jobs' steps drift apart.
 
 ## Known Failure Modes
 

--- a/docs/contributing/standards/agent-trust.md
+++ b/docs/contributing/standards/agent-trust.md
@@ -42,6 +42,44 @@ orchestrator using different evidence than the agent's claim.
 Examples: "all construction sites updated," "0 CRITICAL issues," "review
 converged," "tests cover all contracts," "coverage is complete."
 
+## Structural Separation of Judgement and Action
+
+The tiers above say which agent outputs to verify. Separately, an agent whose job is
+to *judge* should not hold the capability to *act* on its own judgement — verification
+that can be skipped is weaker than a capability that was never granted.
+
+Two places implement this:
+
+- **The delivery loop's verdict** comes from `scripts/deliver-gate.sh`, not from the
+  reviewing agent.
+- **`/blis-pr-review` runs with a read-only token** (`contents: read`), so the reviewer's
+  `GITHUB_TOKEN` cannot push to the branch it is reviewing (#1697).
+  `.github/workflows/claude.yml` routes the `/blis-pr-review` command to a separate
+  `claude-review` job for this reason; every other `@claude` trigger keeps
+  `contents: write`, because those may legitimately be asked to make a change. The
+  review job also has no `statuses: write` — the commit status is published by a
+  separate `report-status` job, so the reviewer does not set its own verdict either.
+
+**If a review fails, do not restore `contents: write` to fix it.** The token scope is
+the control, and a review has no legitimate need to push. Note what the scope does and
+does not buy: `Bash` is required for a review (`gh`, reading the diff, running the
+toolkit) and `Bash` can create files, so the read-only *token* — not the tool list — is
+what makes the boundary real. Files written into the ephemeral checkout simply have no
+route to a branch, and an attempted push fails visibly with a 403 rather than appearing
+to succeed.
+
+Two limits worth stating, so nobody reads the guarantee as wider than it is:
+
+- It covers the **workflow token only**. These jobs run on a self-hosted runner, so
+  ambient credentials on that machine (a logged-in `gh`, a PAT in `~/.gitconfig`, an SSH
+  key) are outside it. Keep the runner free of push credentials.
+- The reviewer keeps `pull-requests: write`, so it can post a comment — and a comment
+  containing `@claude` is itself a trigger. Two independent things stop that from
+  reaching the write-capable job: `check-permissions` finds the bot is not a
+  collaborator, and `claude.yml` deliberately does not set `allowed_bots` (the delivery
+  workflows do, because their phases are dispatched bot-to-bot by design). Do not add
+  `allowed_bots` to `claude.yml` without replacing that barrier.
+
 ## Known Failure Modes
 
 Each failure mode below was discovered in a real PR. The tier system exists

--- a/docs/contributing/standards/agent-trust.md
+++ b/docs/contributing/standards/agent-trust.md
@@ -68,7 +68,7 @@ what makes the boundary real. Files written into the ephemeral checkout simply h
 route to a branch, and an attempted push fails visibly with a 403 rather than appearing
 to succeed.
 
-Two limits worth stating, so nobody reads the guarantee as wider than it is:
+Three limits worth stating, so nobody reads the guarantee as wider than it is:
 
 - It covers the **workflow token only**. These jobs run on a self-hosted runner, so
   ambient credentials on that machine (a logged-in `gh`, a PAT in `~/.gitconfig`, an SSH

--- a/docs/guide/skills-and-plugins.md
+++ b/docs/guide/skills-and-plugins.md
@@ -23,6 +23,8 @@ Project skills require no installation — they are checked into the repository 
 
 Both skills are triggered via GitHub Actions (`@claude /blis-pr-review` on PRs, `@claude /issue-review` on issues). Additionally, `/archon-pr-review` runs as a separate CI action for structural architecture review (boundary moves, surface changes, edge deltas). See [Archon PR Review](archon-pr-review.md).
 
+`/blis-pr-review` runs on a **read-only** token — it can post its review comment, but cannot push to the branch it is reviewing (the pass/fail commit status is published by a separate job). Every other `@claude` trigger keeps write access, since those may legitimately be asked to make a change. Do not widen the review token to work around a failure: see [Agent Trust Boundaries](../contributing/standards/agent-trust.md#structural-separation-of-judgement-and-action).
+
 ## Which Skills for Which Workflow
 
 | Workflow | Skills Used |

--- a/scripts/claude_workflow_test.go
+++ b/scripts/claude_workflow_test.go
@@ -117,6 +117,15 @@ func TestClaudeWorkflow_RoutingGatesFailClosed(t *testing.T) {
 				"to this job. Compare to an explicit literal so unset runs neither:\n%s",
 				job, gate)
 		}
+		// A routing gate is a conjunction of requirements: the caller is allowed AND the
+		// command matched. An `||` can only ADD a way in, which is the shape an accidental
+		// widening takes — including a substring-satisfying `true || ...` that the two
+		// checks above would otherwise accept.
+		if strings.Contains(gate, "||") {
+			t.Errorf("%s gate contains || — a routing gate should only ever be a "+
+				"conjunction, since a disjunct adds an additional way to enter the "+
+				"job:\n%s", job, gate)
+		}
 	}
 }
 

--- a/scripts/claude_workflow_test.go
+++ b/scripts/claude_workflow_test.go
@@ -1,0 +1,183 @@
+package scripts_test
+
+// Pins the permission split in .github/workflows/claude.yml (#1697): the agent that
+// REVIEWS a pull request must not hold a token that can push to it.
+//
+// These assertions look structural, but for a workflow file the declared structure IS the
+// behaviour — GitHub reads nothing else, and the file runs only inside Actions, where no
+// other test can reach it. Same reasoning as the shell-script tests in this package.
+//
+// What they defend against is one specific regression: the split is expressed as two jobs
+// with identical steps and different `permissions:` blocks, because `permissions:` accepts
+// no expressions and so cannot be varied per trigger inside a single job. A comment asks
+// the next editor to keep the steps in sync; that comment is load-bearing and, without
+// this test, unenforced.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type claudeWorkflow struct {
+	Permissions map[string]string `yaml:"permissions"`
+	Jobs        map[string]struct {
+		If          string            `yaml:"if"`
+		Needs       yaml.Node         `yaml:"needs"`
+		Permissions map[string]string `yaml:"permissions"`
+		Steps       []yaml.Node       `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+const (
+	writeJob  = "claude"
+	reviewJob = "claude-review"
+)
+
+func loadClaudeWorkflow(t *testing.T) claudeWorkflow {
+	t.Helper()
+
+	path := filepath.Join("..", ".github", "workflows", "claude.yml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	// Deliberately NOT strict: the struct models only the fields these tests assert on, and
+	// the workflow carries many more. The job-existence check below is what catches drift.
+	var wf claudeWorkflow
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, name := range []string{writeJob, reviewJob, "report-status"} {
+		if _, ok := wf.Jobs[name]; !ok {
+			t.Fatalf("job %q missing from %s — the permission split was restructured; "+
+				"re-derive these assertions rather than deleting them", name, path)
+		}
+	}
+	return wf
+}
+
+// The security property itself: the review path cannot push, the general path still can.
+func TestClaudeWorkflow_ReviewJobTokenCannotPush(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	if got := wf.Jobs[reviewJob].Permissions["contents"]; got != "read" {
+		t.Errorf("%s has contents: %q, want \"read\" — a review must not be able to push "+
+			"to the branch it is reviewing (#1697)", reviewJob, got)
+	}
+
+	// A review must not be able to publish its own verdict either; report-status owns that.
+	if _, ok := wf.Jobs[reviewJob].Permissions["statuses"]; ok {
+		t.Errorf("%s declares a statuses permission — the commit status is published by "+
+			"report-status so that the reviewer does not set its own verdict", reviewJob)
+	}
+
+	// Guards the other half: this must stay a SPLIT. If someone "simplifies" by giving the
+	// general path read access too, @claude can no longer be asked to make a change, and the
+	// pressure to widen the review job returns.
+	if got := wf.Jobs[writeJob].Permissions["contents"]; got != "write" {
+		t.Errorf("%s has contents: %q, want \"write\" — non-review @claude triggers may "+
+			"legitimately be asked to change code", writeJob, got)
+	}
+}
+
+// The workflow-level block is only ever inherited by a job that declares none of its own,
+// so the single thing it can still do is hand push access to a future job that forgets its
+// block — silently re-arming what #1697 closed.
+func TestClaudeWorkflow_DefaultContentsIsNotWrite(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	if got := wf.Permissions["contents"]; got != "read" {
+		t.Errorf("workflow-level contents is %q, want \"read\"", got)
+	}
+}
+
+// The routing must fail CLOSED. Both gates compare is_review to an explicit literal, so an
+// unset value runs neither job. Written as `!=` on either side, an unset value would instead
+// route a review down the write path — the exact bug this test exists to prevent.
+func TestClaudeWorkflow_RoutingGatesFailClosed(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	for job, wantLiteral := range map[string]string{
+		writeJob:  "is_review == 'false'",
+		reviewJob: "is_review == 'true'",
+	} {
+		gate := wf.Jobs[job].If
+		if !strings.Contains(gate, wantLiteral) {
+			t.Errorf("%s gate does not compare is_review to an explicit literal "+
+				"(want %q):\n%s", job, wantLiteral, gate)
+		}
+		if strings.Contains(gate, "is_review !=") {
+			t.Errorf("%s gate tests is_review with != — an unset value would then route "+
+				"to this job. Compare to an explicit literal so unset runs neither:\n%s",
+				job, gate)
+		}
+	}
+}
+
+// The duplication the split forces. Everything except the permissions block must match, or
+// a fix lands on one trigger and not the other.
+func TestClaudeWorkflow_AgentJobStepsStayInSync(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	write, review := wf.Jobs[writeJob].Steps, wf.Jobs[reviewJob].Steps
+	if len(write) != len(review) {
+		t.Fatalf("%s has %d steps, %s has %d — keep the two agent jobs in sync",
+			writeJob, len(write), reviewJob, len(review))
+	}
+	for i := range write {
+		var w, r any
+		if err := write[i].Decode(&w); err != nil {
+			t.Fatalf("decode %s step %d: %v", writeJob, i, err)
+		}
+		if err := review[i].Decode(&r); err != nil {
+			t.Fatalf("decode %s step %d: %v", reviewJob, i, err)
+		}
+		// Comments are not part of the decoded value, so the two blocks may explain
+		// themselves differently; only the effective configuration has to match.
+		if !reflect.DeepEqual(w, r) {
+			t.Errorf("step %d differs between %s and %s.\n%s: %#v\n%s: %#v",
+				i, writeJob, reviewJob, writeJob, w, reviewJob, r)
+		}
+	}
+}
+
+// report-status must depend on BOTH agent jobs. Dropping either one loses the commit status
+// for that path — and losing it for the review path is how a review silently stops
+// reporting a verdict.
+func TestClaudeWorkflow_ReportStatusNeedsBothAgentJobs(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	reportStatus := wf.Jobs["report-status"]
+	// `needs:` is a scalar or a sequence in Actions, and a regression to a single dependency
+	// would take the scalar form — decode both so this test reports the missing dependency
+	// rather than a decode error.
+	var needs []string
+	if reportStatus.Needs.Kind == yaml.ScalarNode {
+		var one string
+		if err := reportStatus.Needs.Decode(&one); err != nil {
+			t.Fatalf("decode report-status needs: %v", err)
+		}
+		needs = []string{one}
+	} else if err := reportStatus.Needs.Decode(&needs); err != nil {
+		t.Fatalf("decode report-status needs: %v", err)
+	}
+	for _, want := range []string{writeJob, reviewJob} {
+		found := false
+		for _, got := range needs {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("report-status does not need %q (needs: %v) — that path would "+
+				"publish no commit status", want, needs)
+		}
+	}
+}

--- a/scripts/claude_workflow_test.go
+++ b/scripts/claude_workflow_test.go
@@ -23,14 +23,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type claudeWorkflow struct {
+type claudeJob struct {
+	If          string            `yaml:"if"`
+	Needs       yaml.Node         `yaml:"needs"`
 	Permissions map[string]string `yaml:"permissions"`
-	Jobs        map[string]struct {
-		If          string            `yaml:"if"`
-		Needs       yaml.Node         `yaml:"needs"`
-		Permissions map[string]string `yaml:"permissions"`
-		Steps       []yaml.Node       `yaml:"steps"`
-	} `yaml:"jobs"`
+	Steps       []yaml.Node       `yaml:"steps"`
+
+	// Job-level configuration that must also match between the two agent jobs. Steps alone
+	// are not the whole job: moving the review onto a different runner, or giving it a
+	// shorter timeout, changes how it behaves without touching a single step.
+	RunsOn         yaml.Node         `yaml:"runs-on"`
+	TimeoutMinutes int               `yaml:"timeout-minutes"`
+	Outputs        map[string]string `yaml:"outputs"`
+}
+
+type claudeWorkflow struct {
+	Permissions map[string]string    `yaml:"permissions"`
+	Jobs        map[string]claudeJob `yaml:"jobs"`
 }
 
 const (
@@ -129,22 +138,92 @@ func TestClaudeWorkflow_RoutingGatesFailClosed(t *testing.T) {
 	}
 }
 
-// The duplication the split forces. Everything except the permissions block must match, or
-// a fix lands on one trigger and not the other.
-func TestClaudeWorkflow_AgentJobStepsStayInSync(t *testing.T) {
+// The tests above pin which TOKEN each job gets. They say nothing about which job a review
+// actually lands in — that is decided by the classifier in check-permissions, the third
+// moving part of the split. Without this, breaking the command string or inverting the
+// ternary routes every review to the write-capable job and all the other tests stay green,
+// silently restoring what #1697 closed.
+func TestClaudeWorkflow_ClassifierRoutesReviewsToTheReviewJob(t *testing.T) {
 	wf := loadClaudeWorkflow(t)
 
-	write, review := wf.Jobs[writeJob].Steps, wf.Jobs[reviewJob].Steps
-	if len(write) != len(review) {
-		t.Fatalf("%s has %d steps, %s has %d — keep the two agent jobs in sync",
-			writeJob, len(write), reviewJob, len(review))
+	script := classifierScript(t, wf)
+
+	// The command the routing actually keys on. A typo here sends every review to the
+	// write path.
+	if !strings.Contains(script, "includes('/blis-pr-review')") {
+		t.Errorf("check-permissions does not test the body for '/blis-pr-review' — "+
+			"reviews would route to the write-capable job:\n%s", script)
 	}
-	for i := range write {
+
+	// The polarity. Inverted, reviews get write access and everything else gets read-only.
+	if !strings.Contains(script, "isReview ? 'true' : 'false'") {
+		t.Errorf("check-permissions does not map a matched command to is_review=true — "+
+			"check the ternary has not been inverted:\n%s", script)
+	}
+}
+
+// classifierScript returns the inline script of the check-permissions step that computes
+// is_review, failing the test if no step does.
+func classifierScript(t *testing.T, wf claudeWorkflow) string {
+	t.Helper()
+
+	for i, node := range wf.Jobs["check-permissions"].Steps {
+		var step struct {
+			With struct {
+				Script string `yaml:"script"`
+			} `yaml:"with"`
+		}
+		if err := node.Decode(&step); err != nil {
+			t.Fatalf("decode check-permissions step %d: %v", i, err)
+		}
+		if strings.Contains(step.With.Script, "is_review") {
+			return step.With.Script
+		}
+	}
+	t.Fatal("no check-permissions step sets is_review — the routing classifier is gone, " +
+		"so both agent gates compare against a value nothing produces")
+	return ""
+}
+
+// The duplication the split forces. Everything except the permissions block and the routing
+// gate must match, or a fix lands on one trigger and not the other.
+func TestClaudeWorkflow_AgentJobsStayInSync(t *testing.T) {
+	wf := loadClaudeWorkflow(t)
+
+	// Job-level configuration, not just steps: a different runner or a shorter timeout on
+	// the review job is drift the step comparison below cannot see.
+	write, review := wf.Jobs[writeJob], wf.Jobs[reviewJob]
+	var writeRunsOn, reviewRunsOn any
+	if err := write.RunsOn.Decode(&writeRunsOn); err != nil {
+		t.Fatalf("decode %s runs-on: %v", writeJob, err)
+	}
+	if err := review.RunsOn.Decode(&reviewRunsOn); err != nil {
+		t.Fatalf("decode %s runs-on: %v", reviewJob, err)
+	}
+	if !reflect.DeepEqual(writeRunsOn, reviewRunsOn) {
+		t.Errorf("runs-on differs: %s has %#v, %s has %#v",
+			writeJob, writeRunsOn, reviewJob, reviewRunsOn)
+	}
+	if write.TimeoutMinutes != review.TimeoutMinutes {
+		t.Errorf("timeout-minutes differs: %s has %d, %s has %d",
+			writeJob, write.TimeoutMinutes, reviewJob, review.TimeoutMinutes)
+	}
+	if !reflect.DeepEqual(write.Outputs, review.Outputs) {
+		t.Errorf("outputs differ: %s has %v, %s has %v",
+			writeJob, write.Outputs, reviewJob, review.Outputs)
+	}
+
+	writeSteps, reviewSteps := write.Steps, review.Steps
+	if len(writeSteps) != len(reviewSteps) {
+		t.Fatalf("%s has %d steps, %s has %d — keep the two agent jobs in sync",
+			writeJob, len(writeSteps), reviewJob, len(reviewSteps))
+	}
+	for i := range writeSteps {
 		var w, r any
-		if err := write[i].Decode(&w); err != nil {
+		if err := writeSteps[i].Decode(&w); err != nil {
 			t.Fatalf("decode %s step %d: %v", writeJob, i, err)
 		}
-		if err := review[i].Decode(&r); err != nil {
+		if err := reviewSteps[i].Decode(&r); err != nil {
 			t.Fatalf("decode %s step %d: %v", reviewJob, i, err)
 		}
 		// Comments are not part of the decoded value, so the two blocks may explain


### PR DESCRIPTION
A PR review is a judgement. Until now the agent that made that judgement also held the token needed to push to the branch it was judging: `claude.yml` had a single `claude` job serving every `@claude` trigger with `contents: write`. This splits the review out onto a read-only token, and leaves normal `@claude` usage alone.

Closes #1697.

## What changed

`.github/workflows/claude.yml`:

- `check-permissions` gains an `is_review` output — does the triggering comment/issue body contain `/blis-pr-review`. One definition of the test; the two job gates differ only in which literal they compare to.
- New **`claude-review`** job runs that path with `contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`, and no `statuses: write`.
- The existing **`claude`** job is unchanged apart from its `if` — every other `@claude` trigger still gets `contents: write`, because per CLAUDE.md those may legitimately be asked to make a change.
- **Workflow-level** `contents` drops from `write` to `read`. The issue flagged this second occurrence, and it matters for a reason independent of today's jobs: a job-level block replaces the default wholesale, so the only thing this default can still do is hand push access to a future job that forgets its own block. The other three scopes are left as they were, so `check-permissions`' token is unchanged apart from `contents`.
- `report-status` now `needs: [claude, claude-review]` and reads whichever job ran.

Docs: `docs/contributing/standards/agent-trust.md` (new section — the tiers say which agent *outputs* to verify; this is the companion point that a judge should not hold the capability to act), plus the trigger docs in `docs/guide/skills-and-plugins.md` and `CLAUDE.md`.

## Why two jobs rather than one

`permissions:` accepts no expressions, so it cannot be varied per trigger inside one job. The two jobs' `steps` are byte-identical (asserted below) and carry a keep-in-sync comment; a reusable workflow would remove that duplication but would also move the PR-head `ref` resolution and the job outputs that `report-status` depends on — a worse trade against a workflow whose comments record several real false-green incidents. Happy to revisit if you'd rather have the indirection.

## On not overselling this

Per the issue's own warning, and stated in the workflow and in agent-trust.md:

- **The token is the control, not the tool list.** `Edit`/`Write` are deliberately *unchanged* on the review path. `Bash` is required for a review (`gh`, reading the diff, running the toolkit) and `Bash` can create files, so removing `Edit`/`Write` would signal intent without adding a boundary — while risking the review itself, since the toolkit's subagents write scratch and report files. What `contents: read` buys is that nothing written in the ephemeral checkout has a route to a branch, and a push fails with a 403 at the point of attempt instead of appearing to work.
- **The issue's open question is already answered empirically.** `deliver-verify.yml` has been running this same review, with this same tool list, under `contents: read` since the L1 delivery loop landed. So the review is known to work read-only, and the tool list did not need to be a separate verified step.
- **The guarantee covers the workflow token only.** These jobs run on a self-hosted runner; ambient credentials on that machine are out of scope, and agent-trust.md says so.

## Verification

- `actionlint` clean on the whole file (it also confirms `needs.claude-review.*` resolves and that `execution_file` is a real action output).
- `jobs.claude.steps == jobs['claude-review'].steps` — exactly `True`, checked by parsing the YAML.
- `mkdocs build --strict` passes; both new doc links resolve.
- No Go changes, so `go build` / `go test` / `golangci-lint` are untouched by this diff.
- Walked all reachable `(claude.result, claude-review.result)` pairs through the `report-status` gate and through `needs.claude.result != 'skipped' && needs.claude.result || needs.claude-review.result`: the skipped sibling matches no clause of the gate (and its outputs are null, which cannot satisfy `!= ''`), so exactly one correct status is published. Both-skipped yields `'skipped'`, which `stateMap` deliberately omits — a warning plus `error`, not a green.

## Review findings folded in

An adversarial pass plus a code review found five things, all fixed before this PR:

1. The non-review gate was first written `is_review != 'true'`, which would route an *unset* value to the write path. Both gates now compare to an explicit literal, so unset runs neither job.
2. Command matching is now case-insensitive. Both errors here are one-sided — over-matching costs a caller write access they can recover by re-commenting; under-matching runs a review that can push.
3. I had initially reduced the workflow-level default to `contents: read` alone. `check-permissions` is the one job with no permissions block, and if its collaborator probe 403'd under a narrower token the `catch` would report "not a collaborator" and *every* `@claude` trigger would silently no-op. Restored the other three scopes.
4. "Can post its review comment and its commit status" was wrong — the status comes from `report-status`. Corrected in all three docs, and the review job has no `statuses: write`, so it cannot set its own verdict.
5. Recorded the residual re-arming path: the reviewer keeps `pull-requests: write`, so it can post a comment, and a comment containing `@claude` is itself a trigger. Two things stop that reaching the write-capable job — the collaborator check, and the fact that `claude.yml` deliberately sets no `allowed_bots` (only the deliver-* workflows do, since those phases are dispatched bot-to-bot by design). agent-trust.md now names that as load-bearing.

Also removed the `conclusion` job output from the agent jobs rather than duplicating it: `actionlint` shows `claude-code-action@v1` defines no such step output, so it was always empty, and nothing in `.github/`, `docs/`, or `scripts/` reads it. Called out here since it is adjacent to, not required by, the issue.

## Acceptance criteria

- [x] `/blis-pr-review` runs with `contents: read` and cannot push to any branch
- [x] It can still post its review comment; the commit status is still set (by `report-status`)
- [x] Non-review `@claude` usage is unaffected — the `claude` job's permissions and steps are unchanged
- [x] A review that attempts a push fails visibly (403 at the point of attempt) rather than silently doing nothing
- [ ] **Verified on a real PR before closing** — needs a live `@claude /blis-pr-review` on this PR. That is the one criterion I cannot check locally: the routing, the read-only token, and the two-job `report-status` collapse only exercise on GitHub. Worth watching that the review comment posts and that exactly one "Claude Code Action (comment trigger)" status appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Update after the `/blis-pr-review` pass (commit 05fa7c3d)

The review came back **ready to merge**, no CRITICAL or IMPORTANT findings, with three non-blocking items. All three are now addressed:

**1. No machine enforcement of `KEEP THE STEPS IN SYNC` — fixed.** This was the fair hit on the two-job design, and it was also the weakness I'd flagged myself when choosing duplication over a reusable workflow. `scripts/claude_workflow_test.go` now pins the arrangement, in the package whose own doc comment already says CI-only artifacts get pinned here because "nothing else can exercise them". Six invariants:

| Invariant | Mutation used to verify it fails |
|---|---|
| review job is `contents: read` | flipped to `write` |
| general path is still `contents: write` (stays a *split*) | covered by the same test |
| review job declares no `statuses: write` | added `statuses: write` |
| workflow-level `contents` is not `write` | flipped to `write` |
| both gates compare `is_review` to an explicit literal | rewrote one as `!= 'false'` |
| the two agent jobs' steps are identical | drifted the review job's `--model` |
| `report-status` needs both agent jobs | reduced to `needs: claude` |

Each mutation was applied, the suite run, and the file restored — every one failed in exactly the intended test and nothing else. Worth stating plainly since these assertions read as structural: for a workflow file the declared structure *is* the behaviour, because GitHub reads nothing else.

**2. `pull-requests: write` is not append-only — documented.** It permits `PATCH`/`DELETE` on existing comments, so the review *record* is mutable by the reviewer. Posting a review at all requires that scope, so this is inherent to the token model rather than something the split could have avoided; `agent-trust.md` now carries it as a third limit, with the consequence that the audit trail worth trusting is the run log, not the comment thread.

**3. Diff-line-comment reviews publish no commit status — documented.** Pre-existing. `report-status` gates on `issue_comment`, and `pull_request_review_comment` carries no `issue` object, so the second clause cannot hold. Now commented in place, including what extending it would actually take (reading the PR number from `github.event.pull_request`). I checked and corrected my own first attempt at that comment: I had initially written that `context.issue.number` is unavailable for that event, which is false — `@actions/github` falls back to `payload.pull_request`.

**Not fixed here: the SHA race → #1705.** `report-status` re-resolves the head SHA itself rather than using the one the agent checked out, so a push during a 60-minute run can attach a green verdict to a commit that was never reviewed. It's pre-existing on both agent jobs, so per the pr-workflow rule on pre-existing findings it's filed as its own issue rather than folded in. It's the right call on process grounds, but I'd flag it as the more consequential of the two findings — it weakens the review guarantee from the *other* direction than this PR closes, so it's worth prioritising.

### Verification (re-run after the second commit)

- `go test ./...` — exit 0, 14 packages ok, 0 failures (`scripts` 41.1s).
- `go build ./...` and `go vet ./scripts/` — clean.
- `actionlint` — clean.
- `mkdocs build --strict` — 0 errors/warnings.
- **`golangci-lint` caveat:** my local copy is 1.53.3 built with go1.20.5, too old to typecheck this tree — it reports 4 bogus `undefined:` errors on the *unmodified* tree, including `max` in the pre-existing `scripts/archon_review_test.go`. CI's pinned v2.9.0 is the authority; `go vet` is clean and `gofmt -l` is empty.

### Live verification status

The review run itself (`34524923783`) confirms the flow is unbroken, but note its job list: `check-permissions`, `claude`, `report-status` — **no `claude-review`**. That is expected and is the honest reading of the last acceptance criterion: `issue_comment` workflows always resolve from the default branch, so this run exercised `main`'s single-job `claude.yml`, not the split. The read-only routing can only be exercised after merge. First `/blis-pr-review` post-merge should show a `claude-review` job in place of `claude`, and one commit status — that's the check to watch.